### PR TITLE
Use friendly name for talents

### DIFF
--- a/ui/core/player_classes/death_knight.ts
+++ b/ui/core/player_classes/death_knight.ts
@@ -9,9 +9,9 @@ export class DeathKnight extends PlayerClass<Class.ClassDeathKnight> {
 	static friendlyName = 'Death Knight';
 	static hexColor = '#c41e3a';
 	static specs: Record<string, PlayerSpec<DeathKnightSpecs>> = {
-		[BloodDeathKnight.name]: BloodDeathKnight,
-		[FrostDeathKnight.name]: FrostDeathKnight,
-		[UnholyDeathKnight.name]: UnholyDeathKnight,
+		[BloodDeathKnight.friendlyName]: BloodDeathKnight,
+		[FrostDeathKnight.friendlyName]: FrostDeathKnight,
+		[UnholyDeathKnight.friendlyName]: UnholyDeathKnight,
 	};
 	static races: Race[] = [
 		Race.RaceBloodElf,

--- a/ui/core/player_classes/druid.ts
+++ b/ui/core/player_classes/druid.ts
@@ -9,10 +9,11 @@ export class Druid extends PlayerClass<Class.ClassDruid> {
 	static friendlyName = 'Druid';
 	static hexColor = '#ff7d0a';
 	static specs: Record<string, PlayerSpec<DruidSpecs>> = {
-		[PlayerSpecs.BalanceDruid.name]: PlayerSpecs.BalanceDruid,
-		[PlayerSpecs.FeralDruid.name]: PlayerSpecs.FeralDruid,
-		[PlayerSpecs.RestorationDruid.name]: PlayerSpecs.RestorationDruid,
+		[PlayerSpecs.BalanceDruid.friendlyName]: PlayerSpecs.BalanceDruid,
+		[PlayerSpecs.FeralDruid.friendlyName]: PlayerSpecs.FeralDruid,
+		[PlayerSpecs.RestorationDruid.friendlyName]: PlayerSpecs.RestorationDruid,
 	};
+	
 	static races: Race[] = [
 		// [A]
 		Race.RaceNightElf,

--- a/ui/core/player_classes/hunter.ts
+++ b/ui/core/player_classes/hunter.ts
@@ -9,9 +9,9 @@ export class Hunter extends PlayerClass<Class.ClassHunter> {
 	static friendlyName = 'Hunter';
 	static hexColor = '#abd473';
 	static specs: Record<string, PlayerSpec<HunterSpecs>> = {
-		[PlayerSpecs.BeastMasteryHunter.name]: PlayerSpecs.BeastMasteryHunter,
-		[PlayerSpecs.MarksmanshipHunter.name]: PlayerSpecs.MarksmanshipHunter,
-		[PlayerSpecs.SurvivalHunter.name]: PlayerSpecs.SurvivalHunter,
+		[PlayerSpecs.BeastMasteryHunter.friendlyName]: PlayerSpecs.BeastMasteryHunter,
+		[PlayerSpecs.MarksmanshipHunter.friendlyName]: PlayerSpecs.MarksmanshipHunter,
+		[PlayerSpecs.SurvivalHunter.friendlyName]: PlayerSpecs.SurvivalHunter,
 	};
 	static races: Race[] = [
 		// [A]

--- a/ui/core/player_classes/index.ts
+++ b/ui/core/player_classes/index.ts
@@ -43,7 +43,7 @@ export const PlayerClasses = {
 		if (protoId == Class.ClassUnknown) {
 			throw new Error('Invalid Class');
 		}
-
+		
 		return protoToPlayerClass[protoId] as PlayerClass<ClassType>;
 	},
 	naturalOrder: [DeathKnight, Druid, Hunter, Mage, Paladin, Priest, Rogue, Shaman, Warlock, Warrior],

--- a/ui/core/player_classes/mage.ts
+++ b/ui/core/player_classes/mage.ts
@@ -9,9 +9,9 @@ export class Mage extends PlayerClass<Class.ClassMage> {
 	static friendlyName = 'Mage';
 	static hexColor = '#69ccf0';
 	static specs: Record<string, PlayerSpec<MageSpecs>> = {
-		[PlayerSpecs.ArcaneMage.name]: PlayerSpecs.ArcaneMage,
-		[PlayerSpecs.FireMage.name]: PlayerSpecs.FireMage,
-		[PlayerSpecs.FrostMage.name]: PlayerSpecs.FrostMage,
+		[PlayerSpecs.ArcaneMage.friendlyName]: PlayerSpecs.ArcaneMage,
+		[PlayerSpecs.FireMage.friendlyName]: PlayerSpecs.FireMage,
+		[PlayerSpecs.FrostMage.friendlyName]: PlayerSpecs.FrostMage,
 	};
 	static races: Race[] = [
 		// [A]

--- a/ui/core/player_classes/paladin.ts
+++ b/ui/core/player_classes/paladin.ts
@@ -10,9 +10,9 @@ export class Paladin extends PlayerClass<Class.ClassPaladin> {
 	static cssClass = 'paladin';
 	static hexColor = '#f58cba';
 	static specs: Record<string, PlayerSpec<PaladinSpecs>> = {
-		[PlayerSpecs.HolyPaladin.name]: PlayerSpecs.HolyPaladin,
-		[PlayerSpecs.ProtectionPaladin.name]: PlayerSpecs.ProtectionPaladin,
-		[PlayerSpecs.RetributionPaladin.name]: PlayerSpecs.RetributionPaladin,
+		[PlayerSpecs.HolyPaladin.friendlyName]: PlayerSpecs.HolyPaladin,
+		[PlayerSpecs.ProtectionPaladin.friendlyName]: PlayerSpecs.ProtectionPaladin,
+		[PlayerSpecs.RetributionPaladin.friendlyName]: PlayerSpecs.RetributionPaladin,
 	};
 	static races: Race[] = [
 		// [A]

--- a/ui/core/player_classes/priest.ts
+++ b/ui/core/player_classes/priest.ts
@@ -9,9 +9,9 @@ export class Priest extends PlayerClass<Class.ClassPriest> {
 	static friendlyName = 'Priest';
 	static hexColor = '#fff';
 	static specs: Record<string, PlayerSpec<PriestSpecs>> = {
-		[PlayerSpecs.DisciplinePriest.name]: PlayerSpecs.DisciplinePriest,
-		[PlayerSpecs.HolyPriest.name]: PlayerSpecs.HolyPriest,
-		[PlayerSpecs.ShadowPriest.name]: PlayerSpecs.ShadowPriest,
+		[PlayerSpecs.DisciplinePriest.friendlyName]: PlayerSpecs.DisciplinePriest,
+		[PlayerSpecs.HolyPriest.friendlyName]: PlayerSpecs.HolyPriest,
+		[PlayerSpecs.ShadowPriest.friendlyName]: PlayerSpecs.ShadowPriest,
 	};
 	static races: Race[] = [
 		// [A]

--- a/ui/core/player_classes/rogue.ts
+++ b/ui/core/player_classes/rogue.ts
@@ -9,9 +9,9 @@ export class Rogue extends PlayerClass<Class.ClassRogue> {
 	static friendlyName = 'Rogue';
 	static hexColor = '#fff569';
 	static specs: Record<string, PlayerSpec<RogueSpecs>> = {
-		[PlayerSpecs.AssassinationRogue.name]: PlayerSpecs.AssassinationRogue,
-		[PlayerSpecs.CombatRogue.name]: PlayerSpecs.CombatRogue,
-		[PlayerSpecs.SubtletyRogue.name]: PlayerSpecs.SubtletyRogue,
+		[PlayerSpecs.AssassinationRogue.friendlyName]: PlayerSpecs.AssassinationRogue,
+		[PlayerSpecs.CombatRogue.friendlyName]: PlayerSpecs.CombatRogue,
+		[PlayerSpecs.SubtletyRogue.friendlyName]: PlayerSpecs.SubtletyRogue,
 	};
 	static races: Race[] = [
 		// [A]

--- a/ui/core/player_classes/shaman.ts
+++ b/ui/core/player_classes/shaman.ts
@@ -9,9 +9,9 @@ export class Shaman extends PlayerClass<Class.ClassShaman> {
 	static friendlyName = 'Shaman';
 	static hexColor = '#2459ff';
 	static specs: Record<string, PlayerSpec<ShamanSpecs>> = {
-		[PlayerSpecs.ElementalShaman.name]: PlayerSpecs.ElementalShaman,
-		[PlayerSpecs.EnhancementShaman.name]: PlayerSpecs.EnhancementShaman,
-		[PlayerSpecs.RestorationShaman.name]: PlayerSpecs.RestorationShaman,
+		[PlayerSpecs.ElementalShaman.friendlyName]: PlayerSpecs.ElementalShaman,
+		[PlayerSpecs.EnhancementShaman.friendlyName]: PlayerSpecs.EnhancementShaman,
+		[PlayerSpecs.RestorationShaman.friendlyName]: PlayerSpecs.RestorationShaman,
 	};
 	static races: Race[] = [
 		// [A]

--- a/ui/core/player_classes/warlock.ts
+++ b/ui/core/player_classes/warlock.ts
@@ -9,9 +9,9 @@ export class Warlock extends PlayerClass<Class.ClassWarlock> {
 	static friendlyName = 'Warlock';
 	static hexColor = '#9482c9';
 	static specs: Record<string, PlayerSpec<WarlockSpecs>> = {
-		[PlayerSpecs.AfflictionWarlock.name]: PlayerSpecs.AfflictionWarlock,
-		[PlayerSpecs.DemonologyWarlock.name]: PlayerSpecs.DemonologyWarlock,
-		[PlayerSpecs.DestructionWarlock.name]: PlayerSpecs.DestructionWarlock,
+		[PlayerSpecs.AfflictionWarlock.friendlyName]: PlayerSpecs.AfflictionWarlock,
+		[PlayerSpecs.DemonologyWarlock.friendlyName]: PlayerSpecs.DemonologyWarlock,
+		[PlayerSpecs.DestructionWarlock.friendlyName]: PlayerSpecs.DestructionWarlock,
 	};
 	static races: Race[] = [
 		// [A]

--- a/ui/core/player_classes/warrior.ts
+++ b/ui/core/player_classes/warrior.ts
@@ -9,9 +9,9 @@ export class Warrior extends PlayerClass<Class.ClassWarrior> {
 	static friendlyName = 'Warrior';
 	static hexColor = '#c79c6e';
 	static specs: Record<string, PlayerSpec<WarriorSpecs>> = {
-		[PlayerSpecs.ArmsWarrior.name]: PlayerSpecs.ArmsWarrior,
-		[PlayerSpecs.FuryWarrior.name]: PlayerSpecs.FuryWarrior,
-		[PlayerSpecs.ProtectionWarrior.name]: PlayerSpecs.ProtectionWarrior,
+		[PlayerSpecs.ArmsWarrior.friendlyName]: PlayerSpecs.ArmsWarrior,
+		[PlayerSpecs.FuryWarrior.friendlyName]: PlayerSpecs.FuryWarrior,
+		[PlayerSpecs.ProtectionWarrior.friendlyName]: PlayerSpecs.ProtectionWarrior,
 	};
 	static races: Race[] = [
 		// [A]

--- a/ui/core/talents/talents_picker.tsx
+++ b/ui/core/talents/talents_picker.tsx
@@ -105,7 +105,7 @@ export class TalentsPicker<TalentsProto> extends Input<Player<any>, string> {
 			if (treeConfig.name === 'Ferocity') i += 3;
 			if (treeConfig.name === 'Tenacity') i += 4;
 			if (treeConfig.name === 'Cunning') i += 5;
-
+			console.log(carouselItem, treeConfig, this, config.klass, i);
 			return new TalentTreePicker(carouselItem, treeConfig, this, config.klass, i);
 		});
 		this.trees.forEach(tree => tree.talents.forEach(talent => talent.setPoints(0, false)));
@@ -145,6 +145,7 @@ export class TalentsPicker<TalentsProto> extends Input<Player<any>, string> {
 
 	setInputValue(newValue: string) {
 		const parts = newValue.split('-');
+		console.log(this.trees);
 		this.trees.forEach((tree, idx) => tree.setTalentsString(parts[idx] || ''));
 		this.updateTrees();
 	}

--- a/ui/core/talents/talents_picker.tsx
+++ b/ui/core/talents/talents_picker.tsx
@@ -105,7 +105,7 @@ export class TalentsPicker<TalentsProto> extends Input<Player<any>, string> {
 			if (treeConfig.name === 'Ferocity') i += 3;
 			if (treeConfig.name === 'Tenacity') i += 4;
 			if (treeConfig.name === 'Cunning') i += 5;
-			
+
 			return new TalentTreePicker(carouselItem, treeConfig, this, config.klass, i);
 		});
 		this.trees.forEach(tree => tree.talents.forEach(talent => talent.setPoints(0, false)));
@@ -145,7 +145,6 @@ export class TalentsPicker<TalentsProto> extends Input<Player<any>, string> {
 
 	setInputValue(newValue: string) {
 		const parts = newValue.split('-');
-		console.log(this.trees);
 		this.trees.forEach((tree, idx) => tree.setTalentsString(parts[idx] || ''));
 		this.updateTrees();
 	}

--- a/ui/core/talents/talents_picker.tsx
+++ b/ui/core/talents/talents_picker.tsx
@@ -105,7 +105,7 @@ export class TalentsPicker<TalentsProto> extends Input<Player<any>, string> {
 			if (treeConfig.name === 'Ferocity') i += 3;
 			if (treeConfig.name === 'Tenacity') i += 4;
 			if (treeConfig.name === 'Cunning') i += 5;
-			console.log(carouselItem, treeConfig, this, config.klass, i);
+			
 			return new TalentTreePicker(carouselItem, treeConfig, this, config.klass, i);
 		});
 		this.trees.forEach(tree => tree.talents.forEach(talent => talent.setPoints(0, false)));

--- a/ui/druid/_feral_tank/index.html
+++ b/ui/druid/_feral_tank/index.html
@@ -10,7 +10,7 @@
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
 		<link rel="preload" href="/cata/assets/database/db.json" as="fetch" crossorigin="anonymous" />
-
+		<link rel="stylesheet" href="../../scss/core/individual_sim_ui/index.scss" />
 		<link rel="stylesheet" href="../../scss/sims/druid/_feral_tank/index.scss" />
 		<link
 			rel="stylesheet"


### PR DESCRIPTION
`name` was not a property existing on the spec class.

It's a bit iffy why this was even allowed through the tsc typechecker. 