### PR TITLE
Rename MasteryRatingPerMasteryPercent to MasteryRatingPerMasteryPoint

### DIFF
--- a/sim/core/base_stats_auto_gen.go
+++ b/sim/core/base_stats_auto_gen.go
@@ -1,4 +1,3 @@
-
 package core
 
 // **************************************
@@ -20,70 +19,71 @@ const DodgeRatingPerDodgeChance = 45.250187
 const ParryRatingPerParryChance = 45.250187
 const BlockRatingPerBlockChance = 22.625093
 const ResilienceRatingPerCritReductionChance = 0.000000
-const MasteryRatingPerMasteryPercent = 45.905987
+const MasteryRatingPerMasteryPoint = 45.905987
+
 var CritPerAgiMaxLevel = map[proto.Class]float64{
-proto.Class_ClassUnknown: 0.0,
-proto.Class_ClassWarrior: 0.0160,
-proto.Class_ClassPaladin: 0.0192,
-proto.Class_ClassHunter: 0.0120,
-proto.Class_ClassRogue: 0.0120,
-proto.Class_ClassPriest: 0.0192,
-proto.Class_ClassDeathKnight: 0.0160,
-proto.Class_ClassShaman: 0.0120,
-proto.Class_ClassMage: 0.0196,
-proto.Class_ClassWarlock: 0.0198,
-proto.Class_ClassDruid: 0.0120,
+	proto.Class_ClassUnknown:     0.0,
+	proto.Class_ClassWarrior:     0.0160,
+	proto.Class_ClassPaladin:     0.0192,
+	proto.Class_ClassHunter:      0.0120,
+	proto.Class_ClassRogue:       0.0120,
+	proto.Class_ClassPriest:      0.0192,
+	proto.Class_ClassDeathKnight: 0.0160,
+	proto.Class_ClassShaman:      0.0120,
+	proto.Class_ClassMage:        0.0196,
+	proto.Class_ClassWarlock:     0.0198,
+	proto.Class_ClassDruid:       0.0120,
 }
 var ExtraClassBaseStats = map[proto.Class]stats.Stats{
-proto.Class_ClassUnknown: {},
-proto.Class_ClassWarrior: {
- stats.Mana: 0.0000,
- stats.SpellCrit: 0.0000*CritRatingPerCritChance,
- stats.MeleeCrit: 0.0000*CritRatingPerCritChance,
-},
-proto.Class_ClassPaladin: {
- stats.Mana: 4394.0000,
- stats.SpellCrit: 3.3355*CritRatingPerCritChance,
- stats.MeleeCrit: 0.6520*CritRatingPerCritChance,
-},
-proto.Class_ClassHunter: {
- stats.Mana: 0.0000,
- stats.SpellCrit: 0.0000*CritRatingPerCritChance,
- stats.MeleeCrit: -1.5320*CritRatingPerCritChance,
-},
-proto.Class_ClassRogue: {
- stats.Mana: 0.0000,
- stats.SpellCrit: 0.0000*CritRatingPerCritChance,
- stats.MeleeCrit: -0.2950*CritRatingPerCritChance,
-},
-proto.Class_ClassPriest: {
- stats.Mana: 3863.0000,
- stats.SpellCrit: 1.2375*CritRatingPerCritChance,
- stats.MeleeCrit: 3.1765*CritRatingPerCritChance,
-},
-proto.Class_ClassDeathKnight: {
- stats.Mana: 0.0000,
- stats.SpellCrit: 0.0000*CritRatingPerCritChance,
- stats.MeleeCrit: 0.0000*CritRatingPerCritChance,
-},
-proto.Class_ClassShaman: {
- stats.Mana: 4396.0000,
- stats.SpellCrit: 2.2010*CritRatingPerCritChance,
- stats.MeleeCrit: 2.9220*CritRatingPerCritChance,
-},
-proto.Class_ClassMage: {
- stats.Mana: 3268.0000,
- stats.SpellCrit: 0.9075*CritRatingPerCritChance,
- stats.MeleeCrit: 3.4540*CritRatingPerCritChance,
-},
-proto.Class_ClassWarlock: {
- stats.Mana: 3856.0000,
- stats.SpellCrit: 1.7000*CritRatingPerCritChance,
- stats.MeleeCrit: 2.6220*CritRatingPerCritChance,
-},
-proto.Class_ClassDruid: {
- stats.Mana: 3496.0000,
- stats.SpellCrit: 1.8515*CritRatingPerCritChance,
- stats.MeleeCrit: 7.4755*CritRatingPerCritChance,
-},
+	proto.Class_ClassUnknown: {},
+	proto.Class_ClassWarrior: {
+		stats.Mana:      0.0000,
+		stats.SpellCrit: 0.0000 * CritRatingPerCritChance,
+		stats.MeleeCrit: 0.0000 * CritRatingPerCritChance,
+	},
+	proto.Class_ClassPaladin: {
+		stats.Mana:      4394.0000,
+		stats.SpellCrit: 3.3355 * CritRatingPerCritChance,
+		stats.MeleeCrit: 0.6520 * CritRatingPerCritChance,
+	},
+	proto.Class_ClassHunter: {
+		stats.Mana:      0.0000,
+		stats.SpellCrit: 0.0000 * CritRatingPerCritChance,
+		stats.MeleeCrit: -1.5320 * CritRatingPerCritChance,
+	},
+	proto.Class_ClassRogue: {
+		stats.Mana:      0.0000,
+		stats.SpellCrit: 0.0000 * CritRatingPerCritChance,
+		stats.MeleeCrit: -0.2950 * CritRatingPerCritChance,
+	},
+	proto.Class_ClassPriest: {
+		stats.Mana:      3863.0000,
+		stats.SpellCrit: 1.2375 * CritRatingPerCritChance,
+		stats.MeleeCrit: 3.1765 * CritRatingPerCritChance,
+	},
+	proto.Class_ClassDeathKnight: {
+		stats.Mana:      0.0000,
+		stats.SpellCrit: 0.0000 * CritRatingPerCritChance,
+		stats.MeleeCrit: 0.0000 * CritRatingPerCritChance,
+	},
+	proto.Class_ClassShaman: {
+		stats.Mana:      4396.0000,
+		stats.SpellCrit: 2.2010 * CritRatingPerCritChance,
+		stats.MeleeCrit: 2.9220 * CritRatingPerCritChance,
+	},
+	proto.Class_ClassMage: {
+		stats.Mana:      3268.0000,
+		stats.SpellCrit: 0.9075 * CritRatingPerCritChance,
+		stats.MeleeCrit: 3.4540 * CritRatingPerCritChance,
+	},
+	proto.Class_ClassWarlock: {
+		stats.Mana:      3856.0000,
+		stats.SpellCrit: 1.7000 * CritRatingPerCritChance,
+		stats.MeleeCrit: 2.6220 * CritRatingPerCritChance,
+	},
+	proto.Class_ClassDruid: {
+		stats.Mana:      3496.0000,
+		stats.SpellCrit: 1.8515 * CritRatingPerCritChance,
+		stats.MeleeCrit: 7.4755 * CritRatingPerCritChance,
+	},
 }

--- a/sim/death_knight/unholy/unholy.go
+++ b/sim/death_knight/unholy/unholy.go
@@ -62,7 +62,7 @@ func NewUnholyDeathKnight(character *core.Character, player *proto.Player) *Unho
 }
 
 func (uhdk UnholyDeathKnight) getMasteryShadowBonus(mastery float64) float64 {
-	return 1.2 + 0.025 * (mastery / core.MasteryRatingPerMasteryPercent)
+	return 1.2 + 0.025*(mastery/core.MasteryRatingPerMasteryPoint)
 }
 
 func (uhdk *UnholyDeathKnight) GetDeathKnight() *death_knight.DeathKnight {

--- a/tools/base_stats_parser.py
+++ b/tools/base_stats_parser.py
@@ -89,7 +89,7 @@ import (
     output += f"const ParryRatingPerParryChance = {cs.CombatRatings['parry'][BASE_LEVEL-1]}\n"
     output += f"const BlockRatingPerBlockChance = {cs.CombatRatings['block'][BASE_LEVEL-1]}\n"
     output += f"const ResilienceRatingPerCritReductionChance = {cs.CombatRatings['crit taken melee'][BASE_LEVEL-1]}\n"
-    output += f"const MasteryRatingPerMasteryPercent = {cs.CombatRatings['mastery'][BASE_LEVEL-1]}\n"
+    output += f"const MasteryRatingPerMasteryPoint = {cs.CombatRatings['mastery'][BASE_LEVEL-1]}\n"
 
     output += '''var CritPerAgiMaxLevel = map[proto.Class]float64{
 proto.Class_ClassUnknown: 0.0,'''


### PR DESCRIPTION
Mastery isn't converted directly to a percentage until Mists. This conversion factor is for Mastery Rating -> Mastery Points in Cataclysm, so the names should match. Figured this might cause some confusion once more people start looking into implementing masteries.

This was part of a change to add the arms warrior mastery but I wanted to get this in now before more code depends on the existing naming.
