### PR TITLE
Port SoD movement and add new Is Moving APL Value check

### DIFF
--- a/proto/apl.proto
+++ b/proto/apl.proto
@@ -41,7 +41,7 @@ message APLListItem {
     APLAction action = 3; // The action to be performed.
 }
 
-// NextIndex: 20
+// NextIndex: 21
 message APLAction {
     APLValue condition = 1; // If set, action will only execute if value is true or != 0.
 
@@ -69,16 +69,17 @@ message APLAction {
         APLActionCancelAura cancel_aura = 10;
         APLActionTriggerICD trigger_icd = 11;
         APLActionItemSwap item_swap = 17;
+		APLActionMove move = 18;
 
         // Class or Spec-specific actions
-        APLActionCatOptimalRotationAction cat_optimal_rotation_action = 18;
+        APLActionCatOptimalRotationAction cat_optimal_rotation_action = 19;
 
         // Internal use only, not exposed in UI.
-        APLActionCustomRotation custom_rotation = 19;
+        APLActionCustomRotation custom_rotation = 20;
     }
 }
 
-// NextIndex: 67
+// NextIndex: 68
 message APLValue {
     oneof value {
         // Operators
@@ -113,6 +114,9 @@ message APLValue {
         APLValueCurrentFocus current_focus = 66;
         APLValueCurrentComboPoints current_combo_points = 16;
         APLValueCurrentRunicPower current_runic_power = 25;
+
+		// Unit values
+		APLValueUnitIsMoving unit_is_moving = 67;
 
         // Rune Resource values
         APLValueCurrentRuneCount current_rune_count = 29;
@@ -274,6 +278,10 @@ message APLActionCatOptimalRotationAction {
     bool flower_weave = 9;
 }
 
+message APLActionMove {
+    APLValue range_from_target = 1;
+}
+
 message APLActionCustomRotation {
 }
 
@@ -362,7 +370,9 @@ message APLValueBossSpellIsCasting {
     UnitReference target_unit = 1;
     ActionID spell_id = 2;
 }
-
+message APLValueUnitIsMoving {
+    UnitReference source_unit = 1;
+}
 message APLValueCurrentHealth {
     UnitReference source_unit = 1;
 }

--- a/proto/common.proto
+++ b/proto/common.proto
@@ -823,6 +823,7 @@ enum OtherAction {
 	OtherActionUnholyRuneGain  = 15; // Indicates healing received from healing model.
 	OtherActionDeathRuneGain  = 16; // Indicates healing received from healing model.
 	OtherActionPotion = 17; // Used by APL to generically refer to either the prepull or combat potion.
+	OtherActionMove = 18; // Used by movement to be able to show it in timeline
 }
 
 message ActionID {

--- a/sim/core/apl_action.go
+++ b/sim/core/apl_action.go
@@ -177,7 +177,8 @@ func (rot *APLRotation) newAPLActionImpl(config *proto.APLAction) APLActionImpl 
 		return rot.newActionTriggerICD(config.GetTriggerIcd())
 	case *proto.APLAction_ItemSwap:
 		return rot.newActionItemSwap(config.GetItemSwap())
-
+	case *proto.APLAction_Move:
+		return rot.newActionMove(config.GetMove())
 	case *proto.APLAction_CustomRotation:
 		return rot.newActionCustomRotation(config.GetCustomRotation())
 

--- a/sim/core/apl_actions_misc.go
+++ b/sim/core/apl_actions_misc.go
@@ -163,6 +163,34 @@ func (action *APLActionItemSwap) String() string {
 	return fmt.Sprintf("Item Swap(%s)", action.swapSet)
 }
 
+type APLActionMove struct {
+	defaultAPLActionImpl
+	unit      *Unit
+	moveRange APLValue
+}
+
+func (rot *APLRotation) newActionMove(config *proto.APLActionMove) APLActionImpl {
+	return &APLActionMove{
+		unit:      rot.unit,
+		moveRange: rot.newAPLValue(config.RangeFromTarget),
+	}
+}
+func (action *APLActionMove) IsReady(sim *Simulation) bool {
+	isPrepull := sim.CurrentTime < 0
+	return !action.unit.Moving && (action.moveRange.GetFloat(sim) != action.unit.DistanceFromTarget || isPrepull) && action.unit.Hardcast.Expires < sim.CurrentTime
+}
+func (action *APLActionMove) Execute(sim *Simulation) {
+	moveRange := action.moveRange.GetFloat(sim)
+	if sim.Log != nil {
+		action.unit.Log(sim, "Moving to %s", moveRange)
+	}
+
+	action.unit.MoveTo(moveRange, sim)
+}
+func (action *APLActionMove) String() string {
+	return fmt.Sprintf("Move(%s)", action.moveRange)
+}
+
 type APLActionCustomRotation struct {
 	defaultAPLActionImpl
 	unit  *Unit

--- a/sim/core/apl_value.go
+++ b/sim/core/apl_value.go
@@ -113,7 +113,7 @@ func (rot *APLRotation) newAPLValue(config *proto.APLValue) APLValue {
 		return rot.newValueCurrentRage(config.GetCurrentRage())
 	case *proto.APLValue_CurrentEnergy:
 		return rot.newValueCurrentEnergy(config.GetCurrentEnergy())
-		case *proto.APLValue_CurrentFocus:
+	case *proto.APLValue_CurrentFocus:
 		return rot.newValueCurrentFocus(config.GetCurrentFocus())
 	case *proto.APLValue_CurrentComboPoints:
 		return rot.newValueCurrentComboPoints(config.GetCurrentComboPoints())
@@ -139,6 +139,10 @@ func (rot *APLRotation) newAPLValue(config *proto.APLValue) APLValue {
 		return rot.newValueRuneGrace(config.GetRuneGrace())
 	case *proto.APLValue_RuneSlotGrace:
 		return rot.newValueRuneSlotGrace(config.GetRuneSlotGrace())
+
+	//Unit
+	case *proto.APLValue_UnitIsMoving:
+		return rot.newValueCharacterIsMoving(config.GetUnitIsMoving())
 
 	// GCD
 	case *proto.APLValue_GcdIsReady:

--- a/sim/core/apl_values_unit.go
+++ b/sim/core/apl_values_unit.go
@@ -1,0 +1,29 @@
+package core
+
+import (
+	"github.com/wowsims/cata/sim/core/proto"
+)
+
+type APLValueUnitIsMoving struct {
+	DefaultAPLValueImpl
+	unit UnitReference
+}
+
+func (rot *APLRotation) newValueCharacterIsMoving(config *proto.APLValueUnitIsMoving) APLValue {
+	unit := rot.GetSourceUnit(config.SourceUnit)
+	if unit.Get() == nil {
+		return nil
+	}
+	return &APLValueUnitIsMoving{
+		unit: unit,
+	}
+}
+func (value *APLValueUnitIsMoving) Type() proto.APLValueType {
+	return proto.APLValueType_ValueTypeBool
+}
+func (value *APLValueUnitIsMoving) GetBool(sim *Simulation) bool {
+	return value.unit.Get().Moving
+}
+func (value *APLValueUnitIsMoving) String() string {
+	return "Is Moving"
+}

--- a/ui/core/components/individual_sim_ui/apl_actions.ts
+++ b/ui/core/components/individual_sim_ui/apl_actions.ts
@@ -12,6 +12,7 @@ import {
 	APLActionCustomRotation,
 	APLActionItemSwap,
 	APLActionItemSwap_SwapSet as ItemSwapSet,
+	APLActionMove,
 	APLActionMultidot,
 	APLActionMultishield,
 	APLActionResetSequence,
@@ -559,7 +560,18 @@ const actionKindFactories: { [f in NonNullable<APLActionKind>]: ActionKindConfig
 		newValue: () => APLActionItemSwap.create(),
 		fields: [itemSwapSetFieldConfig('swapSet')],
 	}),
-
+	['move']: inputBuilder({
+		label: 'Move',
+		submenu: ['Misc'],
+		shortDescription: 'Starts a move to the desired range from target.',
+		newValue: () => APLActionMove.create(),
+		fields: [
+			AplValues.valueFieldConfig('rangeFromTarget', {
+				label: 'to Range',
+				labelTooltip: 'Desired range from target.',
+			}),
+		],
+	}),
 	['customRotation']: inputBuilder({
 		label: 'Custom Rotation',
 		//submenu: ['Misc'],

--- a/ui/core/components/individual_sim_ui/apl_values.ts
+++ b/ui/core/components/individual_sim_ui/apl_values.ts
@@ -67,6 +67,7 @@ import {
 	APLValueSpellTimeToReady,
 	APLValueSpellTravelTime,
 	APLValueTotemRemainingTime,
+	APLValueUnitIsMoving,
 	APLValueWarlockShouldRecastDrainSoul,
 	APLValueWarlockShouldRefreshCorruption,
 } from '../../proto/apl.js';
@@ -569,6 +570,15 @@ const valueKindFactories: { [f in NonNullable<APLValueKind>]: ValueKindConfig<AP
 		shortDescription: '',
 		newValue: APLValueBossSpellTimeToReady.create,
 		fields: [AplHelpers.unitFieldConfig('targetUnit', 'targets'), AplHelpers.actionIdFieldConfig('spellId', 'spells', 'targetUnit', 'currentTarget')],
+	}),
+
+	// Unit
+	unitIsMoving: inputBuilder({
+		label: 'Is moving',
+		submenu: ['Unit'],
+		shortDescription: '',
+		newValue: APLValueUnitIsMoving.create,
+		fields: [AplHelpers.unitFieldConfig('sourceUnit', 'aura_sources')],
 	}),
 
 	// Resources


### PR DESCRIPTION
Ported the SoD implementation 1:1, but also added a "Is Moving" APL value because hunters and other classes that have conditions where they can cast on the move might want to implement those.

Take Hunter as an example, it'd be interesting to sim a fight with intermittent movement and when it's worth swapping to Fox to cast something along with focus management. Can just remove it from the list if we dont want it though.