### PR TITLE
[Reforging] Add basic Reforging UI

### DIFF
--- a/sim/core/database.go
+++ b/sim/core/database.go
@@ -419,17 +419,15 @@ func (equipment *Equipment) Stats() stats.Stats {
 		if item.Reforging != nil {
 			reforgingChanges := stats.Stats{}
 			for _, fromStat := range item.Reforging.FromStat {
-				if equipStats[fromStat] > 0 {
-					reduction := math.Floor(equipStats[fromStat] * item.Reforging.Multiplier)
+				if item.Stats[fromStat] > 0 {
+					reduction := math.Floor(item.Stats[fromStat] * item.Reforging.Multiplier)
 					reforgingChanges[fromStat] = -reduction
+					for _, toStat := range item.Reforging.ToStat {
+						reforgingChanges[toStat] = reduction
+					}
 				}
 			}
-			for _, toStat := range item.Reforging.ToStat {
-				if equipStats[toStat] > 0 {
-					increase := math.Floor(equipStats[toStat] * item.Reforging.Multiplier)
-					reforgingChanges[toStat] = +increase
-				}
-			}
+
 			equipStats = equipStats.Add(reforgingChanges)
 		}
 

--- a/sim/core/database.go
+++ b/sim/core/database.go
@@ -92,7 +92,7 @@ type Item struct {
 	Stats            stats.Stats // Stats applied to wearer
 	Quality          proto.ItemQuality
 	SetName          string // Empty string if not part of a set.
-	RandomPropPoints int32 // Used to rescale random suffix stats
+	RandomPropPoints int32  // Used to rescale random suffix stats
 
 	GemSockets  []proto.GemColor
 	SocketBonus stats.Stats
@@ -355,7 +355,6 @@ func validateReforging(item *Item, reforging ReforgeStat) bool {
 	fromStatValid := false
 	for _, fromStat := range reforging.FromStat {
 		if item.Stats[fromStat] > 0 {
-			println("hello")
 			fromStatValid = true
 			break
 		}
@@ -367,7 +366,6 @@ func validateReforging(item *Item, reforging ReforgeStat) bool {
 	toStatValid := false
 	for _, toStat := range reforging.ToStat {
 		if item.Stats[toStat] == 0 {
-			println("hello2")
 			toStatValid = true
 			break
 		}
@@ -426,7 +424,7 @@ func (equipment *Equipment) Stats() stats.Stats {
 					reforgingChanges[fromStat] = -reduction
 				}
 			}
-			for _, toStat := range item.Reforging.FromStat {
+			for _, toStat := range item.Reforging.ToStat {
 				if equipStats[toStat] > 0 {
 					increase := math.Floor(equipStats[toStat] * item.Reforging.Multiplier)
 					reforgingChanges[toStat] = +increase

--- a/ui/core/components/gear_picker.tsx
+++ b/ui/core/components/gear_picker.tsx
@@ -668,6 +668,7 @@ export class SelectorModal extends BaseModal {
 
 	private prepareReforgeData(reforge: ReforgeStat, item: EquippedItem): ReforgeData & { ep: number } {
 		const itemProto = item.item;
+
 		const fromAmount = Math.ceil(-itemProto.stats[reforge.fromStat[0]] * reforge.multiplier);
 		const toAmount = Math.floor(itemProto.stats[reforge.fromStat[0]] * reforge.multiplier);
 		const forge = {
@@ -691,11 +692,20 @@ export class SelectorModal extends BaseModal {
 		if (equippedItem == undefined) {
 			return;
 		}
+		if (equippedItem.randomSuffix !== null) {
+			equippedItem._item.stats = equippedItem.randomSuffix.stats.map(stat =>
+				stat > 0 ? Math.floor((stat * equippedItem._item.randPropPoints) / 10000) : stat,
+			);
+		}
 		const itemProto = equippedItem.item;
+
 		this.player.gearChangeEmitter.on(() => {
 			const newItem = this.player.getGear().getEquippedItem(this.config.slot);
 
 			if (newItem !== null) {
+				if (newItem.randomSuffix !== null) {
+					newItem._item.stats = newItem.randomSuffix.stats.map(stat => (stat > 0 ? Math.floor((stat * newItem._item.randPropPoints) / 10000) : stat));
+				}
 				const reforgings = this.player.getAvailableReforgings(newItem._item) ?? [];
 
 				this.updateReforgeList(

--- a/ui/core/player.ts
+++ b/ui/core/player.ts
@@ -1,3 +1,4 @@
+import { ReforgeData } from './components/gear_picker';
 import { getLanguageCode } from './constants/lang';
 import * as Mechanics from './constants/mechanics';
 import { MAX_PARTY_SIZE, Party } from './party';
@@ -1058,6 +1059,17 @@ export class Player<SpecType extends Spec> {
 		const ep = this.computeStatsEP(new Stats(randomSuffix.stats));
 		this.randomSuffixEPCache.set(randomSuffix.id, ep);
 		return ep;
+	}
+
+	computeReforgingEP(reforging: ReforgeData): number {
+		let stats = new Stats([]);
+		reforging.fromStat.forEach(stat => {
+			stats = stats.addStat(stat, reforging.fromAmount);
+		});
+		reforging.toStat.forEach(stat => {
+			stats = stats.addStat(stat, reforging.toAmount);
+		});
+		return this.computeStatsEP(stats);
 	}
 
 	computeItemEP(item: Item, slot: ItemSlot): number {

--- a/ui/core/player.ts
+++ b/ui/core/player.ts
@@ -28,6 +28,7 @@ import {
 	Profession,
 	PseudoStat,
 	Race,
+	ReforgeStat,
 	SimDatabase,
 	Spec,
 	Stat,
@@ -430,8 +431,18 @@ export class Player<SpecType extends Spec> {
 
 	// Returns all random suffixes that this player would be interested in for the given base item.
 	getRandomSuffixes(item: Item): Array<ItemRandomSuffix> {
-		const allSuffixes = item.randomSuffixOptions.map((id) => this.sim.db.getRandomSuffixById(id)!);
+		const allSuffixes = item.randomSuffixOptions.map(id => this.sim.db.getRandomSuffixById(id)!);
 		return allSuffixes.filter(suffix => this.computeRandomSuffixEP(suffix) > 0);
+	}
+
+	// Returns all reforgings that are valid with a given item
+	getAvailableReforgings(item: Item): ReforgeStat[] | undefined {
+		return this.sim.db.getAvailableReforges(item);
+	}
+
+	// Returns reforge given an id
+	getReforge(id: number): ReforgeStat | undefined {
+		return this.sim.db.getReforge(id);
 	}
 
 	// Returns all enchants that this player can wear in the given slot.
@@ -455,7 +466,7 @@ export class Player<SpecType extends Spec> {
 		this.gemEPCache = new Map();
 		this.enchantEPCache = new Map();
 		this.randomSuffixEPCache = new Map();
-		for(let i = 0; i < ItemSlot.ItemSlotRanged+1; ++i) {
+		for (let i = 0; i < ItemSlot.ItemSlotRanged + 1; ++i) {
 			this.itemEPCache[i] = new Map();
 		}
 	}
@@ -1044,9 +1055,9 @@ export class Player<SpecType extends Spec> {
 			return this.randomSuffixEPCache.get(randomSuffix.id)!;
 		}
 
-		let ep = this.computeStatsEP(new Stats(randomSuffix.stats));
+		const ep = this.computeStatsEP(new Stats(randomSuffix.stats));
 		this.randomSuffixEPCache.set(randomSuffix.id, ep);
-		return ep
+		return ep;
 	}
 
 	computeItemEP(item: Item, slot: ItemSlot): number {
@@ -1071,8 +1082,8 @@ export class Player<SpecType extends Spec> {
 		let maxSuffixEP = 0;
 
 		if (item.randomSuffixOptions.length > 0) {
-			const suffixEPs = item.randomSuffixOptions.map((id) => this.computeRandomSuffixEP(this.sim.db.getRandomSuffixById(id)!));
-			maxSuffixEP = Math.max(...suffixEPs) * item.randPropPoints / 10000;
+			const suffixEPs = item.randomSuffixOptions.map(id => this.computeRandomSuffixEP(this.sim.db.getRandomSuffixById(id)!));
+			maxSuffixEP = (Math.max(...suffixEPs) * item.randPropPoints) / 10000;
 		}
 
 		let ep = itemStats.computeEP(this.epWeights) + maxSuffixEP;
@@ -1133,6 +1144,9 @@ export class Player<SpecType extends Spec> {
 		}
 		if (equippedItem.enchant != null) {
 			parts.push('ench=' + equippedItem.enchant.effectId);
+		}
+		if (equippedItem.reforging > 0) {
+			parts.push('forg=' + equippedItem.reforging);
 		}
 		parts.push(
 			'pcs=' +
@@ -1349,8 +1363,8 @@ export class Player<SpecType extends Spec> {
 	}
 
 	private toDatabase(): SimDatabase {
-		const dbGear = this.getGear().toDatabase();
-		const dbItemSwapGear = this.getItemSwapGear().toDatabase();
+		const dbGear = this.getGear().toDatabase(this.sim.db);
+		const dbItemSwapGear = this.getItemSwapGear().toDatabase(this.sim.db);
 		return Database.mergeSimDatabases(dbGear, dbItemSwapGear);
 	}
 

--- a/ui/core/proto_utils/database.ts
+++ b/ui/core/proto_utils/database.ts
@@ -227,7 +227,6 @@ export class Database {
 		if (itemSpec.randomSuffix && !!this.getRandomSuffixById(itemSpec.randomSuffix)) {
 			randomSuffix = this.getRandomSuffixById(itemSpec.randomSuffix)!;
 		}
-		//console.log(item.id, itemSpec.reforging, itemSpec);
 
 		return new EquippedItem(item, enchant, gems, randomSuffix, itemSpec.reforging);
 	}

--- a/ui/core/proto_utils/database.ts
+++ b/ui/core/proto_utils/database.ts
@@ -1,3 +1,4 @@
+import { CHARACTER_LEVEL } from '../constants/mechanics.js';
 import {
 	EquipmentSpec,
 	GemColor,
@@ -7,28 +8,15 @@ import {
 	ItemSwap,
 	PresetEncounter,
 	PresetTarget,
+	ReforgeStat,
 	SimDatabase,
 } from '../proto/common.js';
-import {
-	GlyphID,
-	IconData,
-	UIDatabase,
-	UIEnchant as Enchant,
-	UIGem as Gem,
-	UIItem as Item,
-	UINPC as Npc,
-	UIZone as Zone,
-} from '../proto/ui.js';
-
-import {
-	getEligibleEnchantSlots,
-	getEligibleItemSlots,
-} from './utils.js';
-import { gemEligibleForSocket, gemMatchesSocket } from './gems.js';
+import { GlyphID, IconData, UIDatabase, UIEnchant as Enchant, UIGem as Gem, UIItem as Item, UINPC as Npc, UIZone as Zone } from '../proto/ui.js';
+import { distinct } from '../utils.js';
 import { EquippedItem } from './equipped_item.js';
 import { Gear, ItemSwapGear } from './gear.js';
-import { CHARACTER_LEVEL } from '../constants/mechanics.js';
-import { distinct } from '../utils.js';
+import { gemEligibleForSocket, gemMatchesSocket } from './gems.js';
+import { getEligibleEnchantSlots, getEligibleItemSlots } from './utils.js';
 
 const dbUrlJson = '/cata/assets/database/db.json';
 const dbUrlBin = '/cata/assets/database/db.bin';
@@ -84,6 +72,7 @@ export class Database {
 
 	private readonly items = new Map<number, Item>();
 	private readonly randomSuffixes = new Map<number, ItemRandomSuffix>();
+	private readonly reforgeStats = new Map<number, ReforgeStat>();
 	private readonly enchantsBySlot: Partial<Record<ItemSlot, Enchant[]>> = {};
 	private readonly gems = new Map<number, Gem>();
 	private readonly npcs = new Map<number, Npc>();
@@ -93,7 +82,7 @@ export class Database {
 	private readonly itemIcons: Record<number, Promise<IconData>> = {};
 	private readonly spellIcons: Record<number, Promise<IconData>> = {};
 	private readonly glyphIds: Array<GlyphID> = [];
-	private loadedLeftovers: boolean = false;
+	private loadedLeftovers = false;
 
 	private constructor(db: UIDatabase) {
 		this.loadProto(db);
@@ -103,6 +92,7 @@ export class Database {
 	private loadProto(db: UIDatabase) {
 		db.items.forEach(item => this.items.set(item.id, item));
 		db.randomSuffixes.forEach(randomSuffix => this.randomSuffixes.set(randomSuffix.id, randomSuffix));
+		db.reforgeStats.forEach(reforgeStat => this.reforgeStats.set(reforgeStat.id, reforgeStat));
 		db.enchants.forEach(enchant => {
 			const slots = getEligibleEnchantSlots(enchant);
 			slots.forEach(slot => {
@@ -117,20 +107,33 @@ export class Database {
 		db.npcs.forEach(npc => this.npcs.set(npc.id, npc));
 		db.zones.forEach(zone => this.zones.set(zone.id, zone));
 		db.encounters.forEach(encounter => this.presetEncounters.set(encounter.path, encounter));
-		db.encounters.map(e => e.targets).flat().forEach(target => this.presetTargets.set(target.path, target));
+		db.encounters
+			.map(e => e.targets)
+			.flat()
+			.forEach(target => this.presetTargets.set(target.path, target));
 
-		db.items.forEach(item => this.itemIcons[item.id] = Promise.resolve(IconData.create({
-			id: item.id,
-			name: item.name,
-			icon: item.icon,
-		})));
-		db.gems.forEach(gem => this.itemIcons[gem.id] = Promise.resolve(IconData.create({
-			id: gem.id,
-			name: gem.name,
-			icon: gem.icon,
-		})));
-		db.itemIcons.forEach(data => this.itemIcons[data.id] = Promise.resolve(data));
-		db.spellIcons.forEach(data => this.spellIcons[data.id] = Promise.resolve(data));
+		db.items.forEach(
+			item =>
+				(this.itemIcons[item.id] = Promise.resolve(
+					IconData.create({
+						id: item.id,
+						name: item.name,
+						icon: item.icon,
+					}),
+				)),
+		);
+		db.gems.forEach(
+			gem =>
+				(this.itemIcons[gem.id] = Promise.resolve(
+					IconData.create({
+						id: gem.id,
+						name: gem.name,
+						icon: gem.icon,
+					}),
+				)),
+		);
+		db.itemIcons.forEach(data => (this.itemIcons[data.id] = Promise.resolve(data)));
+		db.spellIcons.forEach(data => (this.spellIcons[data.id] = Promise.resolve(data)));
 		db.glyphIds.forEach(id => this.glyphIds.push(id));
 	}
 
@@ -150,18 +153,34 @@ export class Database {
 		return this.randomSuffixes.get(id);
 	}
 
+	getReforge(id: number): ReforgeStat | undefined {
+		return this.reforgeStats.get(id);
+	}
+
+	getAvailableReforges(item: Item): ReforgeStat[] | undefined {
+		const availableReforges = Array.from(this.reforgeStats.values()).filter(reforgeStat => {
+			for (let i = 0; i < reforgeStat.fromStat.length; i++) {
+				const statIndex = reforgeStat.fromStat[i];
+				if (item.stats[statIndex] > 0 && item.stats[reforgeStat.toStat[0]] <= 0) {
+					return true;
+				}
+			}
+			return false;
+		});
+
+		return availableReforges.length > 0 ? availableReforges : undefined;
+	}
+
 	getEnchants(slot: ItemSlot): Array<Enchant> {
 		return this.enchantsBySlot[slot] || [];
 	}
 
 	getGems(socketColor?: GemColor): Array<Gem> {
-		if (!socketColor)
-			return Array.from(this.gems.values());
+		if (!socketColor) return Array.from(this.gems.values());
 
-		let ret = new Array();
-		for (let g of this.gems.values()) {
-			if (gemEligibleForSocket(g, socketColor))
-				ret.push(g);
+		const ret = [];
+		for (const g of this.gems.values()) {
+			if (gemEligibleForSocket(g, socketColor)) ret.push(g);
 		}
 		return ret;
 	}
@@ -174,10 +193,9 @@ export class Database {
 	}
 
 	getMatchingGems(socketColor: GemColor): Array<Gem> {
-		let ret = new Array();
-		for (let g of this.gems.values()) {
-			if (gemMatchesSocket(g, socketColor))
-				ret.push(g);
+		const ret = [];
+		for (const g of this.gems.values()) {
+			if (gemMatchesSocket(g, socketColor)) ret.push(g);
 		}
 		return ret;
 	}
@@ -188,15 +206,15 @@ export class Database {
 
 	lookupItemSpec(itemSpec: ItemSpec): EquippedItem | null {
 		const item = this.items.get(itemSpec.id);
-		if (!item)
-			return null;
+		if (!item) return null;
 
 		let enchant: Enchant | null = null;
 		if (itemSpec.enchant) {
 			const slots = getEligibleItemSlots(item);
 			for (let i = 0; i < slots.length; i++) {
-				enchant = (this.enchantsBySlot[slots[i]] || [])
-					.find(enchant => [enchant.effectId, enchant.itemId, enchant.spellId].includes(itemSpec.enchant)) || null;
+				enchant =
+					(this.enchantsBySlot[slots[i]] || []).find(enchant => [enchant.effectId, enchant.itemId, enchant.spellId].includes(itemSpec.enchant)) ||
+					null;
 				if (enchant) {
 					break;
 				}
@@ -204,30 +222,28 @@ export class Database {
 		}
 
 		const gems = itemSpec.gems.map(gemId => this.lookupGem(gemId));
-		
+
 		let randomSuffix: ItemRandomSuffix | null = null;
 		if (itemSpec.randomSuffix && !!this.getRandomSuffixById(itemSpec.randomSuffix)) {
 			randomSuffix = this.getRandomSuffixById(itemSpec.randomSuffix)!;
 		}
+		//console.log(item.id, itemSpec.reforging, itemSpec);
 
-		return new EquippedItem(item, enchant, gems, randomSuffix);
+		return new EquippedItem(item, enchant, gems, randomSuffix, itemSpec.reforging);
 	}
 
 	lookupEquipmentSpec(equipSpec: EquipmentSpec): Gear {
 		// EquipmentSpec is supposed to be indexed by slot, but here we assume
 		// it isn't just in case.
 		const gearMap: Partial<Record<ItemSlot, EquippedItem | null>> = {};
-
 		equipSpec.items.forEach(itemSpec => {
 			const item = this.lookupItemSpec(itemSpec);
-			if (!item)
-				return;
+			if (!item) return;
 
 			const itemSlots = getEligibleItemSlots(item.item);
 
 			const assignedSlot = itemSlots.find(slot => !gearMap[slot]);
-			if (assignedSlot == null)
-				throw new Error('No slots left to equip ' + Item.toJsonString(item.item));
+			if (assignedSlot == null) throw new Error('No slots left to equip ' + Item.toJsonString(item.item));
 
 			gearMap[assignedSlot] = item;
 		});
@@ -244,7 +260,9 @@ export class Database {
 	}
 
 	enchantSpellIdToEffectId(enchantSpellId: number): number {
-		const enchant = Object.values(this.enchantsBySlot).flat().find(enchant => enchant.spellId == enchantSpellId);
+		const enchant = Object.values(this.enchantsBySlot)
+			.flat()
+			.find(enchant => enchant.spellId == enchantSpellId);
 		return enchant ? enchant.effectId : 0;
 	}
 
@@ -310,8 +328,9 @@ export class Database {
 		return SimDatabase.create({
 			items: distinct(db1.items.concat(db2.items), (a, b) => a.id == b.id),
 			randomSuffixes: distinct(db1.randomSuffixes.concat(db2.randomSuffixes), (a, b) => a.id == b.id),
+			reforgeStats: distinct(db1.reforgeStats.concat(db2.reforgeStats), (a, b) => a.id == b.id),
 			enchants: distinct(db1.enchants.concat(db2.enchants), (a, b) => a.effectId == b.effectId),
 			gems: distinct(db1.gems.concat(db2.gems), (a, b) => a.id == b.id),
-		})
+		});
 	}
 }

--- a/ui/core/proto_utils/equipped_item.ts
+++ b/ui/core/proto_utils/equipped_item.ts
@@ -1,22 +1,13 @@
-import { GemColor } from '../proto/common.js';
-import { ItemSpec } from '../proto/common.js';
-import { ItemRandomSuffix } from '../proto/common.js';
-import { ItemType } from '../proto/common.js';
-import { Profession } from '../proto/common.js';
-import {
-	UIEnchant as Enchant,
-	UIGem as Gem,
-	UIItem as Item,
-} from '../proto/ui.js';
+import { GemColor, ItemRandomSuffix, ItemSpec, ItemType, Profession } from '../proto/common.js';
+import { UIEnchant as Enchant, UIGem as Gem, UIItem as Item } from '../proto/ui.js';
 import { distinct } from '../utils.js';
-
 import { ActionId } from './action_id.js';
-import { enchantAppliesToItem } from './utils.js';
 import { gemEligibleForSocket, gemMatchesSocket } from './gems.js';
 import { Stats } from './stats.js';
+import { enchantAppliesToItem } from './utils.js';
 
 export function getWeaponDPS(item: Item): number {
-	return ((item.weaponDamageMin + item.weaponDamageMax) / 2) / (item.weaponSpeed || 1);
+	return (item.weaponDamageMin + item.weaponDamageMax) / 2 / (item.weaponSpeed || 1);
 }
 
 /**
@@ -29,14 +20,16 @@ export class EquippedItem {
 	readonly _randomSuffix: ItemRandomSuffix | null;
 	readonly _enchant: Enchant | null;
 	readonly _gems: Array<Gem | null>;
+	readonly _reforging: number;
 
 	readonly numPossibleSockets: number;
 
-	constructor(item: Item, enchant?: Enchant | null, gems?: Array<Gem | null>, randomSuffix?: ItemRandomSuffix | null) {
+	constructor(item: Item, enchant?: Enchant | null, gems?: Array<Gem | null>, randomSuffix?: ItemRandomSuffix | null, reforging?: number) {
 		this._item = item;
 		this._enchant = enchant || null;
 		this._gems = gems || [];
 		this._randomSuffix = randomSuffix || null;
+		this._reforging = reforging || 0;
 
 		this.numPossibleSockets = this.numSockets(true);
 
@@ -63,37 +56,35 @@ export class EquippedItem {
 		// Make a defensive copy
 		return this._enchant ? Enchant.clone(this._enchant) : null;
 	}
-
+	get reforging(): number {
+		return this._reforging;
+	}
 	get gems(): Array<Gem | null> {
 		// Make a defensive copy
-		return this._gems.map(gem => gem == null ? null : Gem.clone(gem));
+		return this._gems.map(gem => (gem == null ? null : Gem.clone(gem)));
 	}
 
 	equals(other: EquippedItem) {
-		if (!Item.equals(this._item, other.item))
-			return false;
+		if (!Item.equals(this._item, other.item)) return false;
 
-		if ((this._randomSuffix == null) != (other.randomSuffix == null))
-			return false;
+		if ((this._randomSuffix == null) != (other.randomSuffix == null)) return false;
 
-		if (this._randomSuffix && other.randomSuffix && !ItemRandomSuffix.equals(this._randomSuffix, other.randomSuffix))
-			return false;
+		if (this._randomSuffix && other.randomSuffix && !ItemRandomSuffix.equals(this._randomSuffix, other.randomSuffix)) return false;
 
-		if ((this._enchant == null) != (other.enchant == null))
-			return false;
+		if ((this._enchant == null) != (other.enchant == null)) return false;
 
-		if (this._enchant && other.enchant && !Enchant.equals(this._enchant, other.enchant))
+		if (this._reforging != other._reforging || this._reforging !== 0) {
 			return false;
+		}
 
-		if (this._gems.length != other.gems.length)
-			return false;
+		if (this._enchant && other.enchant && !Enchant.equals(this._enchant, other.enchant)) return false;
+
+		if (this._gems.length != other.gems.length) return false;
 
 		for (let i = 0; i < this._gems.length; i++) {
-			if ((this._gems[i] == null) != (other.gems[i] == null))
-				return false;
+			if ((this._gems[i] == null) != (other.gems[i] == null)) return false;
 
-			if (this._gems[i] && other.gems[i] && !Gem.equals(this._gems[i]!, other.gems[i]!))
-				return false;
+			if (this._gems[i] && other.gems[i] && !Gem.equals(this._gems[i]!, other.gems[i]!)) return false;
 		}
 
 		return true;
@@ -104,20 +95,24 @@ export class EquippedItem {
 	 */
 	withItem(item: Item): EquippedItem {
 		let newEnchant = null;
-		if (this._enchant && enchantAppliesToItem(this._enchant, item))
-			newEnchant = this._enchant;
+		if (this._enchant && enchantAppliesToItem(this._enchant, item)) newEnchant = this._enchant;
 
 		// Reorganize gems to match as many colors in the new item as possible.
 		const newGems = new Array(item.gemSockets.length).fill(null);
-		this._gems.slice(0, this._item.gemSockets.length).filter(gem => gem != null).forEach(gem => {
-			const firstMatchingIndex = item.gemSockets.findIndex((socketColor, socketIdx) => !newGems[socketIdx] && gemMatchesSocket(gem!, socketColor));
-			const firstEligibleIndex = item.gemSockets.findIndex((socketColor, socketIdx) => !newGems[socketIdx] && gemEligibleForSocket(gem!, socketColor));
-			if (firstMatchingIndex != -1) {
-				newGems[firstMatchingIndex] = gem;
-			} else if (firstEligibleIndex != -1) {
-				newGems[firstEligibleIndex] = gem;
-			}
-		});
+		this._gems
+			.slice(0, this._item.gemSockets.length)
+			.filter(gem => gem != null)
+			.forEach(gem => {
+				const firstMatchingIndex = item.gemSockets.findIndex((socketColor, socketIdx) => !newGems[socketIdx] && gemMatchesSocket(gem!, socketColor));
+				const firstEligibleIndex = item.gemSockets.findIndex(
+					(socketColor, socketIdx) => !newGems[socketIdx] && gemEligibleForSocket(gem!, socketColor),
+				);
+				if (firstMatchingIndex != -1) {
+					newGems[firstMatchingIndex] = gem;
+				} else if (firstEligibleIndex != -1) {
+					newGems[firstEligibleIndex] = gem;
+				}
+			});
 
 		// Copy the extra socket gem directly.
 		if (this.couldHaveExtraSocket()) {
@@ -131,7 +126,14 @@ export class EquippedItem {
 	 * Returns a new EquippedItem with the given enchant applied.
 	 */
 	withEnchant(enchant: Enchant | null): EquippedItem {
-		return new EquippedItem(this._item, enchant, this._gems, this._randomSuffix);
+		return new EquippedItem(this._item, enchant, this._gems, this._randomSuffix, this._reforging);
+	}
+
+	/**
+	 * Returns a new EquippedItem with the given enchant applied.
+	 */
+	withReforge(reforge: number): EquippedItem {
+		return new EquippedItem(this._item, this._enchant, this._gems, this._randomSuffix, reforge);
 	}
 
 	/**
@@ -145,7 +147,7 @@ export class EquippedItem {
 		const newGems = this._gems.slice();
 		newGems[socketIdx] = gem;
 
-		return new EquippedItem(this._item, this._enchant, newGems, this._randomSuffix);
+		return new EquippedItem(this._item, this._enchant, newGems, this._randomSuffix, this._reforging);
 	}
 
 	/**
@@ -183,14 +185,13 @@ export class EquippedItem {
 
 		return curItem;
 	}
-	
+
 	withRandomSuffix(randomSuffix: ItemRandomSuffix | null): EquippedItem {
-		return new EquippedItem(this._item, this._enchant, this._gems, randomSuffix);
+		return new EquippedItem(this._item, this._enchant, this._gems, randomSuffix, this._reforging);
 	}
 
 	asActionId(): ActionId {
-		if (this._randomSuffix)
-			return ActionId.fromRandomSuffix(this._item, this._randomSuffix);
+		if (this._randomSuffix) return ActionId.fromRandomSuffix(this._item, this._randomSuffix);
 
 		return ActionId.fromItemId(this._item.id);
 	}
@@ -201,6 +202,7 @@ export class EquippedItem {
 			randomSuffix: this._randomSuffix?.id,
 			enchant: this._enchant?.effectId,
 			gems: this._gems.map(gem => gem?.id || 0),
+			reforging: this._reforging,
 		});
 	}
 
@@ -222,14 +224,11 @@ export class EquippedItem {
 	}
 
 	requiresExtraSocket(): boolean {
-		return [ItemType.ItemTypeWrist, ItemType.ItemTypeHands].includes(this.item.type)
-			&& this.hasExtraGem()
-			&& this._gems[this._gems.length - 1] != null;
+		return [ItemType.ItemTypeWrist, ItemType.ItemTypeHands].includes(this.item.type) && this.hasExtraGem() && this._gems[this._gems.length - 1] != null;
 	}
 
 	hasExtraSocket(isBlacksmithing: boolean): boolean {
-		return this.item.type == ItemType.ItemTypeWaist ||
-			(isBlacksmithing && [ItemType.ItemTypeWrist, ItemType.ItemTypeHands].includes(this.item.type));
+		return this.item.type == ItemType.ItemTypeWaist || (isBlacksmithing && [ItemType.ItemTypeWrist, ItemType.ItemTypeHands].includes(this.item.type));
 	}
 
 	numSockets(isBlacksmithing: boolean): number {
@@ -237,9 +236,9 @@ export class EquippedItem {
 	}
 
 	numSocketsOfColor(color: GemColor | null): number {
-		let numSockets: number = 0;
+		let numSockets = 0;
 
-		for (var socketColor of this._item.gemSockets) {
+		for (const socketColor of this._item.gemSockets) {
 			if (socketColor == color) {
 				numSockets += 1;
 			}
@@ -263,7 +262,7 @@ export class EquippedItem {
 		return this.hasExtraSocket(isBlacksmithing) ? this._item.gemSockets.concat([GemColor.GemColorPrismatic]) : this._item.gemSockets;
 	}
 
-	curGems(isBlacksmithing: boolean): Array<Gem|null> {
+	curGems(isBlacksmithing: boolean): Array<Gem | null> {
 		return this._gems.slice(0, this.numSockets(isBlacksmithing));
 	}
 	curEquippedGems(isBlacksmithing: boolean): Array<Gem> {
@@ -271,7 +270,7 @@ export class EquippedItem {
 	}
 
 	getProfessionRequirements(): Array<Profession> {
-		let profs: Array<Profession> = [];
+		const profs: Array<Profession> = [];
 		if (this._item.requiredProfession != Profession.ProfessionUnknown) {
 			profs.push(this._item.requiredProfession);
 		}
@@ -289,11 +288,15 @@ export class EquippedItem {
 		return distinct(profs);
 	}
 	getFailedProfessionRequirements(professions: Array<Profession>): Array<Item | Gem | Enchant> {
-		let failed: Array<Item | Gem | Enchant> = [];
+		const failed: Array<Item | Gem | Enchant> = [];
 		if (this._item.requiredProfession != Profession.ProfessionUnknown && !professions.includes(this._item.requiredProfession)) {
 			failed.push(this._item);
 		}
-		if (this._enchant != null && this._enchant.requiredProfession != Profession.ProfessionUnknown && !professions.includes(this._enchant.requiredProfession)) {
+		if (
+			this._enchant != null &&
+			this._enchant.requiredProfession != Profession.ProfessionUnknown &&
+			!professions.includes(this._enchant.requiredProfession)
+		) {
 			failed.push(this._enchant);
 		}
 		this._gems.forEach(gem => {
@@ -303,4 +306,4 @@ export class EquippedItem {
 		});
 		return failed;
 	}
-};
+}

--- a/ui/core/proto_utils/gear.ts
+++ b/ui/core/proto_utils/gear.ts
@@ -1,26 +1,13 @@
-import { EquipmentSpec, ItemSwap } from '../proto/common.js';
-import { GemColor } from '../proto/common.js';
-import { ItemSlot } from '../proto/common.js';
-import { ItemSpec } from '../proto/common.js';
-import { Profession } from '../proto/common.js';
-import { SimDatabase } from '../proto/common.js';
-import { SimItem } from '../proto/common.js';
-import { SimEnchant } from '../proto/common.js';
-import { SimGem } from '../proto/common.js';
-import { equalsOrBothNull } from '../utils.js';
-import { distinct, getEnumValues } from '../utils.js';
+import { EquipmentSpec, GemColor, ItemSlot, ItemSpec, ItemSwap, Profession, SimDatabase, SimEnchant, SimGem, SimItem } from '../proto/common.js';
+import { UIEnchant as Enchant, UIGem as Gem, UIItem as Item } from '../proto/ui.js';
 import { isBluntWeaponType, isSharpWeaponType } from '../proto_utils/utils.js';
-import {
-	UIEnchant as Enchant,
-	UIGem as Gem,
-	UIItem as Item,
-} from '../proto/ui.js';
-
-import { isMetaGemActive } from './gems.js';
-import { gemMatchesSocket } from './gems.js';
+import { Sim } from '../sim';
+import { distinct, equalsOrBothNull, getEnumValues } from '../utils.js';
+import { Database } from './database';
 import { EquippedItem } from './equipped_item.js';
-import { validWeaponCombo } from './utils.js';
+import { gemMatchesSocket, isMetaGemActive } from './gems.js';
 import { Stats } from './stats.js';
+import { validWeaponCombo } from './utils.js';
 
 type InternalGear = Record<ItemSlot, EquippedItem | null>;
 
@@ -29,17 +16,16 @@ abstract class BaseGear {
 
 	constructor(gear: Partial<InternalGear>) {
 		this.getItemSlots().forEach(slot => {
-			if (!gear[slot as ItemSlot])
-				gear[slot as ItemSlot] = null;
+			if (!gear[slot as ItemSlot]) gear[slot as ItemSlot] = null;
 		});
 		this.gear = gear as InternalGear;
 	}
 
-	abstract getItemSlots(): ItemSlot[]
+	abstract getItemSlots(): ItemSlot[];
 
 	equals(other: BaseGear): boolean {
 		const otherArray = other.asArray();
-		return this.asArray().every((thisItem, slot) => equalsOrBothNull(thisItem, otherArray[slot], (a, b) => a.equals(b)))
+		return this.asArray().every((thisItem, slot) => equalsOrBothNull(thisItem, otherArray[slot], (a, b) => a.equals(b)));
 	}
 
 	getEquippedItem(slot: ItemSlot): EquippedItem | null {
@@ -52,9 +38,11 @@ abstract class BaseGear {
 
 	asMap(): Partial<InternalGear> {
 		const newInternalGear: Partial<InternalGear> = {};
-		this.getItemSlots().map(slot => Number(slot) as ItemSlot).forEach(slot => {
-			newInternalGear[slot] = this.getEquippedItem(slot);
-		});
+		this.getItemSlots()
+			.map(slot => Number(slot) as ItemSlot)
+			.forEach(slot => {
+				newInternalGear[slot] = this.getEquippedItem(slot);
+			});
 		return newInternalGear;
 	}
 
@@ -85,19 +73,23 @@ abstract class BaseGear {
 		newItem.gems
 			.filter(gem => gem?.unique)
 			.forEach(gem => {
-				this.getItemSlots().map(slot => Number(slot) as ItemSlot).forEach(slot => {
-					gear[slot] = gear[slot]?.removeGemsWithId(gem!.id) || null;
-				});
+				this.getItemSlots()
+					.map(slot => Number(slot) as ItemSlot)
+					.forEach(slot => {
+						gear[slot] = gear[slot]?.removeGemsWithId(gem!.id) || null;
+					});
 			});
 	}
 
 	private removeUniqueItems(gear: Partial<InternalGear>, newItem: EquippedItem) {
 		if (newItem.item.unique) {
-			this.getItemSlots().map(slot => Number(slot) as ItemSlot).forEach(slot => {
-				if (gear[slot]?.item.id == newItem.item.id) {
-					gear[slot] = null;
-				}
-			});
+			this.getItemSlots()
+				.map(slot => Number(slot) as ItemSlot)
+				.forEach(slot => {
+					if (gear[slot]?.item.id == newItem.item.id) {
+						gear[slot] = null;
+					}
+				});
 		}
 	}
 
@@ -112,11 +104,12 @@ abstract class BaseGear {
 		}
 	}
 
-	toDatabase(): SimDatabase {
+	toDatabase(db: Database): SimDatabase {
 		const equippedItems = this.asArray().filter(ei => ei != null) as Array<EquippedItem>;
 		return SimDatabase.create({
 			items: distinct(equippedItems.map(ei => BaseGear.itemToDB(ei.item))),
 			randomSuffixes: distinct(equippedItems.filter(ei => ei.randomSuffix).map(ei => ei.randomSuffix!)),
+			reforgeStats: distinct(equippedItems.filter(ei => ei.reforging).map(ei => db.getReforge(ei.reforging) ?? {})),
 			enchants: distinct(equippedItems.filter(ei => ei.enchant).map(ei => BaseGear.enchantToDB(ei.enchant!))),
 			gems: distinct(equippedItems.map(ei => (ei._gems.filter(g => g != null) as Array<Gem>).map(gem => BaseGear.gemToDB(gem))).flat()),
 		});
@@ -141,7 +134,6 @@ abstract class BaseGear {
  * This is an immutable type.
  */
 export class Gear extends BaseGear {
-
 	constructor(gear: Partial<InternalGear>) {
 		super(gear);
 	}
@@ -155,14 +147,13 @@ export class Gear extends BaseGear {
 	}
 
 	getTrinkets(): Array<EquippedItem | null> {
-		return [
-			this.getEquippedItem(ItemSlot.ItemSlotTrinket1),
-			this.getEquippedItem(ItemSlot.ItemSlotTrinket2),
-		];
+		return [this.getEquippedItem(ItemSlot.ItemSlotTrinket1), this.getEquippedItem(ItemSlot.ItemSlotTrinket2)];
 	}
 
 	hasTrinket(itemId: number): boolean {
-		return this.getTrinkets().map(t => t?.item.id).includes(itemId);
+		return this.getTrinkets()
+			.map(t => t?.item.id)
+			.includes(itemId);
 	}
 
 	hasRelic(itemId: number): boolean {
@@ -177,13 +168,13 @@ export class Gear extends BaseGear {
 
 	asSpec(): EquipmentSpec {
 		return EquipmentSpec.create({
-			items: this.asArray().map(ei => ei ? ei.asSpec() : ItemSpec.create()),
+			items: this.asArray().map(ei => (ei ? ei.asSpec() : ItemSpec.create())),
 		});
 	}
 
 	getAllGems(isBlacksmithing: boolean): Array<Gem> {
 		return this.asArray()
-			.map(ei => ei == null ? [] : ei.curEquippedGems(isBlacksmithing))
+			.map(ei => (ei == null ? [] : ei.curEquippedGems(isBlacksmithing)))
 			.flat();
 	}
 
@@ -221,7 +212,7 @@ export class Gear extends BaseGear {
 		return this.getGemsOfColor(GemColor.GemColorMeta, true)[0] || null;
 	}
 
-	gemColorCounts(isBlacksmithing: boolean): ({ red: number, yellow: number, blue: number }) {
+	gemColorCounts(isBlacksmithing: boolean): { red: number; yellow: number; blue: number } {
 		const gems = this.getAllGems(isBlacksmithing);
 		return {
 			red: gems.filter(gem => gemMatchesSocket(gem, GemColor.GemColorRed)).length,
@@ -238,9 +229,7 @@ export class Gear extends BaseGear {
 		}
 
 		const gemColorCounts = this.gemColorCounts(isBlacksmithing);
-		return isMetaGemActive(
-			metaGem,
-			gemColorCounts.red, gemColorCounts.yellow, gemColorCounts.blue);
+		return isMetaGemActive(metaGem, gemColorCounts.red, gemColorCounts.yellow, gemColorCounts.blue);
 	}
 
 	hasInactiveMetaGem(isBlacksmithing: boolean): boolean {
@@ -258,7 +247,7 @@ export class Gear extends BaseGear {
 	}
 
 	withSingleGemSubstitution(oldGem: Gem | null, newGem: Gem | null, isBlacksmithing: boolean): Gear {
-		for (var slot of this.getItemSlots()) {
+		for (const slot of this.getItemSlots()) {
 			const item = this.getEquippedItem(slot);
 
 			if (!item) {
@@ -303,7 +292,7 @@ export class Gear extends BaseGear {
 	withoutGems(): Gear {
 		let curGear: Gear = this;
 
-		for (var slot of this.getItemSlots()) {
+		for (const slot of this.getItemSlots()) {
 			const item = this.getEquippedItem(slot);
 
 			if (item) {
@@ -349,14 +338,10 @@ export class Gear extends BaseGear {
 	}
 
 	getProfessionRequirements(): Array<Profession> {
-		return distinct((this.asArray().filter(ei => ei != null) as Array<EquippedItem>)
-			.map(ei => ei.getProfessionRequirements())
-			.flat());
+		return distinct((this.asArray().filter(ei => ei != null) as Array<EquippedItem>).map(ei => ei.getProfessionRequirements()).flat());
 	}
 	getFailedProfessionRequirements(professions: Array<Profession>): Array<Item | Gem | Enchant> {
-		return (this.asArray().filter(ei => ei != null) as Array<EquippedItem>)
-			.map(ei => ei.getFailedProfessionRequirements(professions))
-			.flat();
+		return (this.asArray().filter(ei => ei != null) as Array<EquippedItem>).map(ei => ei.getFailedProfessionRequirements(professions)).flat();
 	}
 }
 
@@ -366,7 +351,6 @@ export class Gear extends BaseGear {
  * This is an immutable type.
  */
 export class ItemSwapGear extends BaseGear {
-
 	constructor(gear: Partial<InternalGear>) {
 		super(gear);
 	}
@@ -384,6 +368,6 @@ export class ItemSwapGear extends BaseGear {
 			mhItem: this.gear[ItemSlot.ItemSlotMainHand]?.asSpec(),
 			ohItem: this.gear[ItemSlot.ItemSlotOffHand]?.asSpec(),
 			rangedItem: this.gear[ItemSlot.ItemSlotRanged]?.asSpec(),
-		})
+		});
 	}
 }

--- a/ui/core/proto_utils/names.ts
+++ b/ui/core/proto_utils/names.ts
@@ -179,6 +179,24 @@ export const statNames: Map<Stat, string> = new Map([
 	[Stat.StatNatureResistance, 'Nature Resistance'],
 	[Stat.StatShadowResistance, 'Shadow Resistance'],
 	[Stat.StatBonusArmor, 'Bonus Armor'],
+	[Stat.StatMastery, 'Mastery'],
+]);
+
+export const shortSecondaryStatNames: Map<Stat, string> = new Map([
+	[Stat.StatSpirit, 'Spirit'],
+	[Stat.StatSpellHit, 'Hit'],
+	[Stat.StatSpellCrit, 'Crit'],
+	[Stat.StatSpellHaste, 'Haste'],
+	[Stat.StatMeleeHit, 'Hit'],
+	[Stat.StatMeleeCrit, 'Crit'],
+	[Stat.StatMeleeHaste, 'Haste'],
+	[Stat.StatExpertise, 'Expertise'],
+	[Stat.StatMastery, 'Mastery'],
+	[Stat.StatDefense, 'Defense'],
+	[Stat.StatBlock, 'Block'],
+	[Stat.StatBlockValue, 'Block Value'],
+	[Stat.StatDodge, 'Dodge'],
+	[Stat.StatParry, 'Parry'],
 ]);
 
 export const pseudoStatOrder: Array<PseudoStat> = [

--- a/ui/scss/core/components/_gear_picker.scss
+++ b/ui/scss/core/components/_gear_picker.scss
@@ -98,7 +98,11 @@ $favorite-cell-width: 2rem;
 			font-size: map-get($font-sizes, 6);
 			letter-spacing: normal;
 		}
-
+		.item-picker-reforge {
+			color: $item-quality-uncommon;
+			font-size: $content-font-size;
+			letter-spacing: normal;
+		}
 		.item-picker-enchant {
 			color: $item-quality-uncommon;
 			font-size: $content-font-size;
@@ -197,6 +201,7 @@ $favorite-cell-width: 2rem;
 	margin-right: map-get($spacers, 3);
 	margin-bottom: map-get($spacers, 2);
 	font-size: 1.125rem;
+	justify-content: space-between; // Ensures labels are evenly spaced
 
 	label {
 		font-weight: normal;
@@ -210,7 +215,10 @@ $favorite-cell-width: 2rem;
 		width: $source-cell-width;
 		margin-left: map-get($spacers, 3);
 	}
-
+	.reforge-label {
+		flex-grow: 1; // Allows it to stay centered by taking more space
+		justify-content: center; // Centers the content inside the label
+	}
 	.ep-label {
 		width: $ep-cell-width;
 		margin-left: map-get($spacers, 3);
@@ -264,7 +272,38 @@ $favorite-cell-width: 2rem;
 			outline: 2px solid $success;
 		}
 	}
+	&.reforge {
+		display: flex;
+		justify-content: space-between; /* Adjusts children to start and end */
+		width: 100%; /* Ensure it fills its container */
+		color: green;
 
+		.loss,
+		.gain {
+			flex-shrink: 0; /* Prevents shrinking */
+		}
+
+		.loss {
+			color: red;
+		}
+
+		.gain {
+			margin-left: 5px;
+			color: green;
+		}
+
+		.ep {
+			margin-left: auto; /* Pushes the EP to the far right */
+			padding-left: 20px; /* Ensures some space between it and any preceding content */
+			color: blue; /* Example color */
+		}
+	}
+
+	&.reforge.selected {
+		// Style for the selected reforge item
+		opacity: 1; // Reset opacity to full for visibility
+		border: 1px solid #f0f0f0; // Off-white border
+	}
 	.selector-modal-list-item-link {
 		display: flex;
 		align-items: center;


### PR DESCRIPTION
This commit is a proposal on how we can add Reforging to the UI.
**(Some eslint/prettier stuff snuck through in some files, but its according to the config file so should be fine)**
First, I've added a visualisation on reforged items in the character display:
![image](https://github.com/wowsims/cata/assets/95472394/c709d914-90d4-49ff-89d5-d670c064c788)
I went with not showing stats at this stage because its not that relevant.

Then I added a new tab on the gear picker for reforging:
![image](https://github.com/wowsims/cata/assets/95472394/e764bf25-f2ca-4aeb-abbc-871347457d5e)
Now, I know the design leaves something to be desired here, especially in the gear picker. So I eagerly accept PRs with nicer UI :D
I also fixed some bugs that made reforged stats not calculate properly. The reforged stat now also exports to json etc. like
```    "equipment": {
      "items": [
        {"id":65206,"enchant":3817,"gems":[41398,52258]},
        {"id":67137},
        {"id":65208,"enchant":3808,"gems":[52212],"reforging":138},
        {"id":71388,"enchant":3605,"reforging":140},
        {"id":65084,"enchant":3832,"gems":[52258,52212],"reforging":147},
        {"id":65028,"enchant":3845,"gems":[0]},
        {"id":65205,"enchant":3604,"gems":[52212,0]},
        {"id":65132,"enchant":3601,"gems":[52212,52212]},
        {"id":71504,"enchant":3823,"gems":[52212,49110],"reforging":152},
        {"id":65063,"enchant":3606,"gems":[52212]},
        {"id":65082},
        {"id":71209},
        {"id":65140},
        {"id":65026},
        {"id":65139,"enchant":3827,"reforging":146},
        {},
        {"id":65058,"enchant":3608}
      ]
    },
    
