### PR TITLE
[Core] Implement DoT haste scaling for Cataclysm

### DIFF
--- a/proto/apl.proto
+++ b/proto/apl.proto
@@ -78,7 +78,7 @@ message APLAction {
     }
 }
 
-// NextIndex: 67
+// NextIndex: 68
 message APLValue {
     oneof value {
         // Operators
@@ -155,6 +155,7 @@ message APLValue {
         // Dot values
         APLValueDotIsActive dot_is_active = 6;
         APLValueDotRemainingTime dot_remaining_time = 13;
+        APLValueDotTickFrequency dot_tick_frequency = 67;
 
         // Sequence values
         APLValueSequenceIsComplete sequence_is_complete = 44;
@@ -499,6 +500,10 @@ message APLValueDotIsActive {
     ActionID spell_id = 1;
 }
 message APLValueDotRemainingTime {
+    UnitReference target_unit = 2;
+    ActionID spell_id = 1;
+}
+message APLValueDotTickFrequency {
     UnitReference target_unit = 2;
     ActionID spell_id = 1;
 }

--- a/sim/core/apl_value.go
+++ b/sim/core/apl_value.go
@@ -113,7 +113,7 @@ func (rot *APLRotation) newAPLValue(config *proto.APLValue) APLValue {
 		return rot.newValueCurrentRage(config.GetCurrentRage())
 	case *proto.APLValue_CurrentEnergy:
 		return rot.newValueCurrentEnergy(config.GetCurrentEnergy())
-		case *proto.APLValue_CurrentFocus:
+	case *proto.APLValue_CurrentFocus:
 		return rot.newValueCurrentFocus(config.GetCurrentFocus())
 	case *proto.APLValue_CurrentComboPoints:
 		return rot.newValueCurrentComboPoints(config.GetCurrentComboPoints())
@@ -189,6 +189,8 @@ func (rot *APLRotation) newAPLValue(config *proto.APLValue) APLValue {
 		return rot.newValueDotIsActive(config.GetDotIsActive())
 	case *proto.APLValue_DotRemainingTime:
 		return rot.newValueDotRemainingTime(config.GetDotRemainingTime())
+	case *proto.APLValue_DotTickFrequency:
+		return rot.newValueDotTickFrequency(config.GetDotTickFrequency())
 
 	// Sequences
 	case *proto.APLValue_SequenceIsComplete:

--- a/sim/core/apl_values_core.go
+++ b/sim/core/apl_values_core.go
@@ -54,3 +54,28 @@ func (value *APLValueDotRemainingTime) GetDuration(sim *Simulation) time.Duratio
 func (value *APLValueDotRemainingTime) String() string {
 	return fmt.Sprintf("Dot Remaining Time(%s)", value.dot.Spell.ActionID)
 }
+
+type APLValueDotTickFrequency struct {
+	DefaultAPLValueImpl
+	dot *Dot
+}
+
+func (rot *APLRotation) newValueDotTickFrequency(config *proto.APLValueDotTickFrequency) APLValue {
+	dot := rot.GetAPLDot(rot.GetTargetUnit(config.TargetUnit), config.SpellId)
+	if dot == nil {
+		return nil
+	}
+	return &APLValueDotTickFrequency{
+		dot: dot,
+	}
+}
+
+func (value *APLValueDotTickFrequency) Type() proto.APLValueType {
+	return proto.APLValueType_ValueTypeDuration
+}
+func (value *APLValueDotTickFrequency) GetDuration(_ *Simulation) time.Duration {
+	return value.dot.tickPeriod
+}
+func (value *APLValueDotTickFrequency) String() string {
+	return fmt.Sprintf("Dot Tick Frequency(%s)", value.dot.tickPeriod)
+}

--- a/sim/core/dot.go
+++ b/sim/core/dot.go
@@ -144,6 +144,9 @@ func (dot *Dot) Apply(sim *Simulation) {
 		nextTick := dot.TimeUntilNextTick(sim)
 		dot.RecomputeAuraDuration()
 		dot.Aura.Duration += nextTick
+
+		// add extra tick
+		dot.TickCount--
 	} else {
 		dot.RecomputeAuraDuration()
 	}

--- a/sim/core/dot.go
+++ b/sim/core/dot.go
@@ -136,8 +136,8 @@ func (dot *Dot) Apply(sim *Simulation) {
 
 	// we a have running dot tick
 	// the next tick never get's clipped and is added onto the dot's time for hasted dots
-	// see: https://github.com/wowsims/cata/issues/50
-	if dot.tickAction != nil {
+	// see: https://github.com/wowsims/cata/issues/50git
+	if dot.tickAction != nil && !dot.tickAction.cancelled {
 
 		// save next tick timer as timer is computed based on tick time
 		// which we update in RecomputeAuraDuration

--- a/ui/core/components/individual_sim_ui/apl_values.ts
+++ b/ui/core/components/individual_sim_ui/apl_values.ts
@@ -69,6 +69,7 @@ import {
 	APLValueTotemRemainingTime,
 	APLValueWarlockShouldRecastDrainSoul,
 	APLValueWarlockShouldRefreshCorruption,
+	APLValueDotTickFrequency,
 } from '../../proto/apl.js';
 import { Class, Spec } from '../../proto/common.js';
 import { ShamanTotems_TotemType as TotemType } from '../../proto/shaman.js';
@@ -899,6 +900,13 @@ const valueKindFactories: { [f in NonNullable<APLValueKind>]: ValueKindConfig<AP
 		shortDescription: 'Time remaining before the last tick of this DoT will occur, or 0 if the DoT is not currently ticking.',
 		newValue: APLValueDotRemainingTime.create,
 		fields: [AplHelpers.unitFieldConfig('targetUnit', 'targets'), AplHelpers.actionIdFieldConfig('spellId', 'dot_spells', '')],
+	}),
+	dotTickFrequency: inputBuilder({
+		label: "Dot Tick Frequency",
+		submenu: ['DoT'],
+		shortDescription: 'The time between each tick.',
+		newValue: APLValueDotTickFrequency.create,
+		fields: [AplHelpers.unitFieldConfig('targetUnit', 'targets'), AplHelpers.actionIdFieldConfig('spellId', 'dot_spells', '')]
 	}),
 	sequenceIsComplete: inputBuilder({
 		label: 'Sequence Is Complete',


### PR DESCRIPTION
* Added a new APL to query the DoT frequency. This should allow for easy checks (Remaining Time < DoT Frequency) to allow re-applying DoTs without clipping them.
* All player DoTs should be affected by haste and thus automatically be affected by the patch
* The tick that gets carried over to the new dot also profits from the new snapshots - see sources in the commit

## Todo
* Further reasearch if all DoTs in general are affected by these changes or if there are exeptions and how HoTs behave