### PR TITLE
Added default consumes/buffs/debuffs for Feral sim

### DIFF
--- a/ui/core/components/inputs/buffs_debuffs.ts
+++ b/ui/core/components/inputs/buffs_debuffs.ts
@@ -80,13 +80,13 @@ export const DamagePercentBuff = InputHelpers.makeMultiIconInput(
 // 	'Defensive CDs',
 // );
 
-export const HastePercentBuff = InputHelpers.makeMultiIconInput(
+export const SpellHasteBuff = InputHelpers.makeMultiIconInput(
 	[
 		makeBooleanRaidBuffInput({ actionId: ActionId.fromSpellId(15473), fieldName: 'shadowForm' }),
 		makeBooleanRaidBuffInput({ actionId: ActionId.fromSpellId(24858), fieldName: 'moonkinForm' }),
 		makeBooleanRaidBuffInput({ actionId: ActionId.fromSpellId(3738), fieldName: 'wrathOfAirTotem' }),
 	],
-	'Haste %',
+	'Spell Haste',
 );
 
 export const ManaBuff = InputHelpers.makeMultiIconInput(
@@ -316,9 +316,9 @@ export const RAID_BUFFS_CONFIG = [
 		stats: [Stat.StatSpellPower],
 	},
 	{
-		config: HastePercentBuff,
+		config: SpellHasteBuff,
 		picker: MultiIconPicker,
-		stats: [Stat.StatMeleeHaste, Stat.StatSpellHaste],
+		stats: [Stat.StatSpellHaste],
 	},
 	{
 		config: DamagePercentBuff,
@@ -389,7 +389,7 @@ export const DEBUFFS_CONFIG = [
 	{
 		config: MajorArmorDebuff,
 		picker: MultiIconPicker,
-		stats: [Stat.StatArmorPenetration],
+		stats: [Stat.StatAttackPower, Stat.StatRangedAttackPower],
 	},
 	{
 		config: PhysicalDamageDebuff,

--- a/ui/druid/feral/presets.ts
+++ b/ui/druid/feral/presets.ts
@@ -81,4 +81,8 @@ export const DefaultOptions = FeralDruidOptions.create({
 });
 
 export const DefaultConsumes = Consumes.create({
+	flask: Flask.FlaskOfTheWinds,
+	food: Food.FoodSkeweredEel,
+	defaultPotion: Potions.PotionOfTheTolvir,
+	prepopPotion: Potions.PotionOfTheTolvir,
 });

--- a/ui/druid/feral/sim.ts
+++ b/ui/druid/feral/sim.ts
@@ -64,7 +64,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFeralDruid, {
 				[Stat.StatMastery]: 0.58,
 			},
 			{
-				[PseudoStat.PseudoStatMainHandDps]: 1.94,
+				[PseudoStat.PseudoStatMainHandDps]: 1.55,
 			},
 		),
 		// Default consumes settings.
@@ -75,30 +75,22 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFeralDruid, {
 		specOptions: Presets.DefaultOptions,
 		// Default raid/party buffs settings.
 		raidBuffs: RaidBuffs.create({
-			arcaneBrilliance: true,
-			bloodlust: true,
 			markOfTheWild: true,
-			icyTalons: true,
-			moonkinForm: true,
-			leaderOfThePack: true,
-			powerWordFortitude: true,
 			strengthOfEarthTotem: true,
-			trueshotAura: true,
-			wrathOfAirTotem: true,
-			demonicPact: true,
-			blessingOfKings: true,
-			blessingOfMight: true,
+			abominationsMight: true,
+			windfuryTotem: true,
+			bloodlust: true,
 			communion: true,
+			leaderOfThePack: true,
+			arcaneBrilliance: true,
+			manaSpringTotem: true,
 		}),
 		partyBuffs: PartyBuffs.create({
 		}),
 		individualBuffs: IndividualBuffs.create({
 		}),
 		debuffs: Debuffs.create({
-			judgement: true,
-			bloodFrenzy: true,
-			exposeArmor: true,
-			sunderArmor: true,
+			savageCombat: true,
 		}),
 	},
 

--- a/ui/shaman/enhancement/sim.ts
+++ b/ui/shaman/enhancement/sim.ts
@@ -124,7 +124,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecEnhancementShaman, {
 	// IconInputs to include in the 'Player' section on the settings tab.
 	playerIconInputs: [ShamanInputs.ShamanShieldInput(), ShamanInputs.ShamanImbueMH(), EnhancementInputs.ShamanImbueOH],
 	// Buff and Debuff inputs to include/exclude, overriding the EP-based defaults.
-	includeBuffDebuffInputs: [BuffDebuffInputs.ReplenishmentBuff, BuffDebuffInputs.MP5Buff, BuffDebuffInputs.HastePercentBuff],
+	includeBuffDebuffInputs: [BuffDebuffInputs.ReplenishmentBuff, BuffDebuffInputs.MP5Buff, BuffDebuffInputs.SpellHasteBuff],
 	excludeBuffDebuffInputs: [BuffDebuffInputs.BleedDebuff],
 	// Inputs to include in the 'Other' section on the settings tab.
 	otherInputs: {


### PR DESCRIPTION
 On branch feral

 Changes to be committed:
	modified:   ui/core/components/inputs/buffs_debuffs.ts
	modified:   ui/druid/feral/presets.ts
	modified:   ui/druid/feral/sim.ts
	modified:   ui/shaman/enhancement/sim.ts