### PR TITLE
Update stat measurement to include const haste auras

### DIFF
--- a/sim/core/character.go
+++ b/sim/core/character.go
@@ -248,10 +248,14 @@ func (character *Character) applyAllEffects(agent Agent, raidBuffs *proto.RaidBu
 	playerStats := &proto.PlayerStats{}
 
 	measureStats := func() *proto.UnitStats {
-		return &proto.UnitStats{
+		base := &proto.UnitStats{
 			Stats:       character.SortAndApplyStatDependencies(character.stats).ToFloatArray(),
 			PseudoStats: character.GetPseudoStatsProto(),
 		}
+
+		base.Stats[stats.MeleeHaste] += (character.PseudoStats.MeleeSpeedMultiplier - 1) * 100 * HasteRatingPerHastePercent
+		base.Stats[stats.SpellHaste] += (character.PseudoStats.CastSpeedMultiplier - 1) * 100 * HasteRatingPerHastePercent
+		return base
 	}
 
 	applyRaceEffects(agent)
@@ -478,6 +482,8 @@ func (character *Character) FillPlayerStats(playerStats *proto.PlayerStats) {
 		Stats:       character.GetStats().ToFloatArray(),
 		PseudoStats: character.GetPseudoStatsProto(),
 	}
+	playerStats.FinalStats.Stats[stats.MeleeHaste] += (character.PseudoStats.MeleeSpeedMultiplier - 1) * 100 * HasteRatingPerHastePercent
+	playerStats.FinalStats.Stats[stats.SpellHaste] += (character.PseudoStats.CastSpeedMultiplier - 1) * 100 * HasteRatingPerHastePercent
 	character.clearBuildPhaseAuras(CharacterBuildPhaseAll)
 	playerStats.Sets = character.GetActiveSetBonusNames()
 

--- a/sim/death_knight/frost/TestFrost.results
+++ b/sim/death_knight/frost/TestFrost.results
@@ -10,12 +10,12 @@ character_stats_results: {
   final_stats: 326
   final_stats: 1633.01166
   final_stats: 2251.4002
-  final_stats: 1810
+  final_stats: 2450.2858
   final_stats: 0
   final_stats: 13167.84834
   final_stats: 1071.3264
   final_stats: 2803.27117
-  final_stats: 1810
+  final_stats: 3794.88598
   final_stats: 0
   final_stats: 512
   final_stats: 2126

--- a/sim/death_knight/unholy/TestUnholy.results
+++ b/sim/death_knight/unholy/TestUnholy.results
@@ -10,12 +10,12 @@ character_stats_results: {
   final_stats: 326
   final_stats: 1890.01166
   final_stats: 2365.68024
-  final_stats: 1692
+  final_stats: 2332.2858
   final_stats: 0
   final_stats: 16326.69552
   final_stats: 968
   final_stats: 2921.41342
-  final_stats: 1692
+  final_stats: 2972.5716
   final_stats: 0
   final_stats: 512
   final_stats: 2126

--- a/sim/hunter/survival/TestSV.results
+++ b/sim/hunter/survival/TestSV.results
@@ -10,12 +10,12 @@ character_stats_results: {
   final_stats: 326
   final_stats: 991
   final_stats: 2881.4002
-  final_stats: 912
+  final_stats: 1552.2858
   final_stats: 0
   final_stats: 14644.33749
   final_stats: 991
   final_stats: 5968.80858
-  final_stats: 912
+  final_stats: 2192.5716
   final_stats: 0
   final_stats: 160.07143
   final_stats: 2126

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -10,12 +10,12 @@ character_stats_results: {
   final_stats: 326
   final_stats: 1739
   final_stats: 3625.5272
-  final_stats: 2205
+  final_stats: 3248.66585
   final_stats: 0
   final_stats: 0
   final_stats: 110
   final_stats: 2265.88325
-  final_stats: 2205
+  final_stats: 3485.5716
   final_stats: 0
   final_stats: 0
   final_stats: 115128.6875


### PR DESCRIPTION
Was the most efficient option to correctly reflect haste auras for melee and spell in the UI as they're also included in the blizzard character frame. Should only inlcude static haste mods that are present during build phase. So primarily talents and buffs.