### PR TITLE
Update social_links.tsx

### DIFF
--- a/ui/core/components/social_links.tsx
+++ b/ui/core/components/social_links.tsx
@@ -22,7 +22,7 @@ export class SocialLinks extends Component {
 	static buildGitHubLink(): Element {
 		const anchor = (
 			<a
-				href="https://github.com/wowsims/sod"
+				href="https://github.com/wowsims/cata"
 				target="_blank"
 				className="github-link link-alt"
 				dataset={{ bsToggle: 'tooltip', bsTitle: 'Contribute on GitHub' }}>


### PR DESCRIPTION
fixed github link to point to cata repo, not the SoD repo.