### PR TITLE
Reaction time and Energy/Focus tick refactor

### DIFF
--- a/proto/druid.proto
+++ b/proto/druid.proto
@@ -179,7 +179,6 @@ message FeralDruid {
 
   message Options {
     DruidOptions class_options = 1;
-    int32 latency_ms = 2;
     bool assume_bleed_active = 4;
   }
   Options options = 3;

--- a/sim/core/apl.go
+++ b/sim/core/apl.go
@@ -234,7 +234,7 @@ func (apl *APLRotation) DoNextAction(sim *Simulation) {
 
 	gcdReady := apl.unit.GCD.IsReady(sim)
 	if gcdReady {
-		apl.unit.WaitUntil(sim, sim.CurrentTime+time.Millisecond*50)
+		apl.unit.WaitUntil(sim, sim.CurrentTime + apl.unit.ReactionTime)
 	}
 }
 

--- a/sim/core/character.go
+++ b/sim/core/character.go
@@ -102,7 +102,7 @@ func NewCharacter(party *Party, partyIndex int, player *proto.Player) Character 
 
 			StatDependencyManager: stats.NewStatDependencyManager(),
 
-			ReactionTime:       max(0, time.Duration(player.ReactionTimeMs)*time.Millisecond),
+			ReactionTime:       time.Duration(max(player.ReactionTimeMs, 10))*time.Millisecond,
 			ChannelClipDelay:   max(0, time.Duration(player.ChannelClipDelayMs)*time.Millisecond),
 			DistanceFromTarget: player.DistanceFromTarget,
 		},

--- a/sim/core/character.go
+++ b/sim/core/character.go
@@ -459,12 +459,6 @@ func (character *Character) Finalize() {
 
 	character.Unit.finalize()
 
-	if character.Class == proto.Class_ClassHunter {
-		character.Env.RegisterPostFinalizeEffect(func() {
-			character.focusBar.setupFocusThresholds()
-		})
-	}
-
 	character.majorCooldownManager.finalize()
 }
 

--- a/sim/core/character.go
+++ b/sim/core/character.go
@@ -459,13 +459,6 @@ func (character *Character) Finalize() {
 
 	character.Unit.finalize()
 
-	// For now, restrict this optimization to rogues only. Ferals will require
-	// some extra logic to handle their ExcessEnergy() calc.
-	if character.Class == proto.Class_ClassRogue {
-		character.Env.RegisterPostFinalizeEffect(func() {
-			character.energyBar.setupEnergyThresholds()
-		})
-	}
 	if character.Class == proto.Class_ClassHunter {
 		character.Env.RegisterPostFinalizeEffect(func() {
 			character.focusBar.setupFocusThresholds()

--- a/sim/core/energy.go
+++ b/sim/core/energy.go
@@ -103,7 +103,11 @@ func (eb *energyBar) ResetEnergyTick(sim *Simulation) {
 	sim.RescheduleTask(eb.nextEnergyTick)
 }
 
-func (eb *energyBar) ProcessDynamicHasteRatingChange(sim *Simulation) {
+func (eb *energyBar) processDynamicHasteRatingChange(sim *Simulation) {
+	if eb.unit == nil {
+		return
+	}
+
 	eb.ResetEnergyTick(sim)
 	eb.hasteRatingMultiplier = 1.0 + eb.unit.GetStat(stats.MeleeHaste)/(100*HasteRatingPerHastePercent)
 }

--- a/sim/core/focus.go
+++ b/sim/core/focus.go
@@ -2,16 +2,11 @@ package core
 
 import (
 	"fmt"
-	"math"
-	"slices"
 	"time"
 
 	"github.com/wowsims/cata/sim/core/proto"
 	"github.com/wowsims/cata/sim/core/stats"
 )
-
-// Time between focus ticks.
-const FocusTickDuration = time.Millisecond * 100
 
 type focusBar struct {
 	unit *Unit
@@ -19,21 +14,13 @@ type focusBar struct {
 	maxFocus           float64
 	currentFocus       float64
 	baseFocusPerSecond float64
+	focusTickDuration  time.Duration
+	nextFocusTick      time.Duration
+	isPlayer           bool
 
-	// List of focus levels that might affect APL decisions. E.g:
-	// [10, 15, 20, 30, 60, 85]
-	focusDecisionThresholds []int
-
-	// Slice with len == maxFocus+1 with each index corresponding to an amount of focus. Looks like this:
-	// [0, 0, 0, 0, 1, 1, 1, 2, 2, 2, 2, 2, 3, 3, ...]
-	// Increments by 1 at each value of focusDecisionThresholds.
-	cumulativeFocusDecisionThresholds []int
-
-	nextFocusTick time.Duration
-	isPlayer      bool
-
-	// Multiplies focus regen from ticks.
-	focusRegenMultiplier float64
+	// These two terms are multiplied together to scale the total Focus regen from ticks.
+	focusRegenMultiplier  float64
+	hasteRatingMultiplier float64
 
 	regenMetrics       *ResourceMetrics
 	focusRefundMetrics *ResourceMetrics
@@ -43,81 +30,15 @@ func (unit *Unit) EnableFocusBar(maxFocus float64, baseFocusPerSecond float64, i
 	unit.SetCurrentPowerBar(FocusBar)
 
 	unit.focusBar = focusBar{
-		unit:                 unit,
-		maxFocus:             max(100, maxFocus),
-		focusRegenMultiplier: 1,
-		isPlayer:             isPlayer,
-		baseFocusPerSecond:   baseFocusPerSecond,
-		regenMetrics:         unit.NewFocusMetrics(ActionID{OtherID: proto.OtherAction_OtherActionFocusRegen}),
-		focusRefundMetrics:   unit.NewFocusMetrics(ActionID{OtherID: proto.OtherAction_OtherActionRefund}),
-	}
-}
-
-// Computes the focus thresholds.
-// Computes the focus thresholds.
-func (fb *focusBar) setupFocusThresholds() {
-	if fb.unit == nil {
-		return
-	}
-	var focusThresholds []int
-
-	// Focus thresholds from spell costs.
-	for _, action := range fb.unit.Rotation.allAPLActions() {
-		for _, spell := range action.GetAllSpells() {
-			if _, ok := spell.Cost.(*FocusCost); ok {
-				focusThresholds = append(focusThresholds, int(math.Ceil(spell.DefaultCast.Cost)))
-			}
-		}
-	}
-
-	// Focus thresholds from conditional comparisons.
-	for _, action := range fb.unit.Rotation.allAPLActions() {
-		for _, value := range action.GetAllAPLValues() {
-			if cmpValue, ok := value.(*APLValueCompare); ok {
-				_, lhsIsFocus := cmpValue.lhs.(*APLValueCurrentFocus)
-				_, rhsIsFocus := cmpValue.rhs.(*APLValueCurrentFocus)
-				if !lhsIsFocus && !rhsIsFocus {
-					continue
-				}
-
-				lhsConstVal := getConstAPLFloatValue(cmpValue.lhs)
-				rhsConstVal := getConstAPLFloatValue(cmpValue.rhs)
-
-				if lhsIsFocus && rhsConstVal != -1 {
-					focusThresholds = append(focusThresholds, int(math.Ceil(rhsConstVal)))
-				} else if rhsIsFocus && lhsConstVal != -1 {
-					focusThresholds = append(focusThresholds, int(math.Ceil(lhsConstVal)))
-				}
-			}
-		}
-	}
-
-	slices.SortStableFunc(focusThresholds, func(t1, t2 int) int {
-		return t1 - t2
-	})
-
-	// Add each unique value to the final thresholds list.
-	curVal := 0
-	for _, threshold := range focusThresholds {
-		if threshold > curVal {
-			fb.focusDecisionThresholds = append(fb.focusDecisionThresholds, threshold)
-			curVal = threshold
-		}
-	}
-
-	curFocus := 0
-	cumulativeVal := 0
-	fb.cumulativeFocusDecisionThresholds = make([]int, int(fb.maxFocus)+1)
-	for _, threshold := range fb.focusDecisionThresholds {
-		for curFocus < threshold {
-			fb.cumulativeFocusDecisionThresholds[curFocus] = cumulativeVal
-			curFocus++
-		}
-		cumulativeVal++
-	}
-	for curFocus < len(fb.cumulativeFocusDecisionThresholds) {
-		fb.cumulativeFocusDecisionThresholds[curFocus] = cumulativeVal
-		curFocus++
+		unit:                  unit,
+		maxFocus:              max(100, maxFocus),
+		focusTickDuration:     unit.ReactionTime,
+		focusRegenMultiplier:  1,
+		hasteRatingMultiplier: 1,
+		isPlayer:              isPlayer,
+		baseFocusPerSecond:    baseFocusPerSecond,
+		regenMetrics:          unit.NewFocusMetrics(ActionID{OtherID: proto.OtherAction_OtherActionFocusRegen}),
+		focusRefundMetrics:    unit.NewFocusMetrics(ActionID{OtherID: proto.OtherAction_OtherActionRefund}),
 	}
 }
 
@@ -134,11 +55,12 @@ func (fb *focusBar) NextFocusTickAt() time.Duration {
 }
 
 func (fb *focusBar) MultiplyFocusRegenSpeed(sim *Simulation, multiplier float64) {
+	fb.ResetFocusTick(sim)
 	fb.focusRegenMultiplier *= multiplier
 }
 
 func (fb *focusBar) FocusRegenPerTick() float64 {
-	ticksPerSecond := float64(time.Second) / float64(FocusTickDuration)
+	ticksPerSecond := float64(time.Second) / float64(fb.focusTickDuration)
 	return fb.FocusRegenPerSecond() / ticksPerSecond
 }
 
@@ -151,22 +73,10 @@ func (fb *focusBar) FocusRegenPerSecond() float64 {
 }
 
 func (fb *focusBar) getTotalRegenMultiplier() float64 {
-	hasteMultiplier := 1.0 + fb.unit.GetStat(stats.MeleeHaste)/(100*HasteRatingPerHastePercent)
-	totalMultiplier := hasteMultiplier * fb.focusRegenMultiplier
-	return totalMultiplier
+	return fb.hasteRatingMultiplier * fb.focusRegenMultiplier
 }
 
-func (fb *focusBar) onFocusGain(sim *Simulation, crossedThreshold bool) {
-	if sim.CurrentTime < 0 {
-		return
-	}
-
-	if !sim.Options.Interactive && crossedThreshold {
-		fb.unit.Rotation.DoNextAction(sim)
-	}
-}
-
-func (fb *focusBar) addFocusInternal(sim *Simulation, amount float64, metrics *ResourceMetrics) bool {
+func (fb *focusBar) AddFocus(sim *Simulation, amount float64, metrics *ResourceMetrics) {
 	if amount < 0 {
 		panic("Trying to add negative focus!")
 	}
@@ -179,14 +89,7 @@ func (fb *focusBar) addFocusInternal(sim *Simulation, amount float64, metrics *R
 		metrics.AddEvent(amount, newFocus-fb.currentFocus)
 	}
 
-	crossedThreshold := fb.cumulativeFocusDecisionThresholds == nil || fb.cumulativeFocusDecisionThresholds[int(fb.currentFocus)] != fb.cumulativeFocusDecisionThresholds[int(newFocus)]
 	fb.currentFocus = newFocus
-
-	return crossedThreshold
-}
-func (fb *focusBar) AddFocus(sim *Simulation, amount float64, metrics *ResourceMetrics) {
-	crossedThreshold := fb.addFocusInternal(sim, amount, metrics)
-	fb.onFocusGain(sim, crossedThreshold)
 }
 
 func (fb *focusBar) SpendFocus(sim *Simulation, amount float64, metrics *ResourceMetrics) {
@@ -204,14 +107,30 @@ func (fb *focusBar) SpendFocus(sim *Simulation, amount float64, metrics *Resourc
 	fb.currentFocus = newFocus
 }
 
+// Gives an immediate partial Focus tick and restarts the tick timer.
+func (fb *focusBar) ResetFocusTick(sim *Simulation) {
+	timeSinceLastTick := max(sim.CurrentTime-(fb.NextFocusTickAt()-fb.focusTickDuration), 0)
+	partialTickAmount := fb.FocusRegenPerSecond() * timeSinceLastTick.Seconds()
+	fb.AddFocus(sim, partialTickAmount, fb.regenMetrics)
+	fb.nextFocusTick = sim.CurrentTime + fb.focusTickDuration
+	sim.RescheduleTask(fb.nextFocusTick)
+}
+
+func (fb *focusBar) processDynamicHasteRatingChange(sim *Simulation) {
+	if fb.unit == nil {
+		return
+	}
+
+	fb.ResetFocusTick(sim)
+	fb.hasteRatingMultiplier = 1.0 + fb.unit.GetStat(stats.MeleeHaste)/(100*HasteRatingPerHastePercent)
+}
+
 func (fb *focusBar) RunTask(sim *Simulation) time.Duration {
 	if sim.CurrentTime < fb.nextFocusTick {
 		return fb.nextFocusTick
 	}
-	crossedThreshold := fb.addFocusInternal(sim, fb.FocusRegenPerTick(), fb.regenMetrics)
-	fb.onFocusGain(sim, crossedThreshold)
-
-	fb.nextFocusTick = sim.CurrentTime + FocusTickDuration
+	fb.AddFocus(sim, fb.FocusRegenPerTick(), fb.regenMetrics)
+	fb.nextFocusTick = sim.CurrentTime + fb.focusTickDuration
 	return fb.nextFocusTick
 }
 
@@ -221,6 +140,8 @@ func (fb *focusBar) reset(sim *Simulation) {
 	}
 
 	fb.currentFocus = fb.maxFocus
+	fb.hasteRatingMultiplier = 1.0 + fb.unit.GetStat(stats.MeleeHaste)/(100*HasteRatingPerHastePercent)
+
 	if fb.unit.Type != PetUnit {
 		fb.enable(sim, sim.Environment.PrepullStartTime())
 	}
@@ -228,12 +149,8 @@ func (fb *focusBar) reset(sim *Simulation) {
 
 func (fb *focusBar) enable(sim *Simulation, startAt time.Duration) {
 	sim.AddTask(fb)
-	fb.nextFocusTick = startAt + time.Duration(sim.RandomFloat("Focus Tick")*float64(FocusTickDuration))
+	fb.nextFocusTick = startAt + time.Duration(sim.RandomFloat("Focus Tick")*float64(fb.focusTickDuration))
 	sim.RescheduleTask(fb.nextFocusTick)
-
-	if fb.cumulativeFocusDecisionThresholds != nil && sim.Log != nil {
-		fb.unit.Log(sim, "[DEBUG] APL Focus decision thresholds: %v", fb.focusDecisionThresholds)
-	}
 }
 
 func (fb *focusBar) disable(sim *Simulation) {

--- a/sim/core/pet.go
+++ b/sim/core/pet.go
@@ -65,6 +65,8 @@ func NewPet(name string, owner *Character, baseStats stats.Stats, statInheritanc
 				Metrics:     NewUnitMetrics(),
 
 				StatDependencyManager: stats.NewStatDependencyManager(),
+
+				ReactionTime: owner.ReactionTime,
 			},
 			Name:       name,
 			Party:      owner.Party,

--- a/sim/core/test_generators.go
+++ b/sim/core/test_generators.go
@@ -175,7 +175,7 @@ func (combos *SettingsCombos) GetTest(testIdx int) (string, *proto.ComputeStatsR
 				Cooldowns:          combos.Cooldowns,
 				Rotation:           rotationsCombo.Rotation,
 				DistanceFromTarget: 30,
-				ReactionTimeMs:     150,
+				ReactionTimeMs:     100,
 				ChannelClipDelayMs: 50,
 			}, specOptionsCombo.SpecOptions),
 			buffsCombo.Party,
@@ -475,7 +475,7 @@ func FullCharacterTestSuiteGenerator(config CharacterSuiteConfig) TestGenerator 
 
 			InFrontOfTarget:    config.InFrontOfTarget,
 			DistanceFromTarget: 30,
-			ReactionTimeMs:     150,
+			ReactionTimeMs:     100,
 			ChannelClipDelayMs: 50,
 		},
 		config.SpecOptions.SpecOptions)

--- a/sim/core/unit.go
+++ b/sim/core/unit.go
@@ -320,10 +320,8 @@ func (unit *Unit) processDynamicBonus(sim *Simulation, bonus stats.Stats) {
 	if bonus[stats.MeleeHaste] != 0 {
 		unit.AutoAttacks.UpdateSwingTimers(sim)
 		unit.runicPowerBar.updateRegenTimes(sim)
-
-		if unit.HasEnergyBar() {
-			unit.ProcessDynamicHasteRatingChange(sim)
-		}
+		unit.energyBar.processDynamicHasteRatingChange(sim)
+		unit.focusBar.processDynamicHasteRatingChange(sim)
 	}
 	if bonus[stats.SpellHaste] != 0 {
 		unit.updateCastSpeed()

--- a/sim/death_knight/frost/TestFrost.results
+++ b/sim/death_knight/frost/TestFrost.results
@@ -40,1922 +40,1922 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 25419.35151
-  tps: 23424.21432
+  dps: 25409.70319
+  tps: 23410.79589
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 24321.1582
-  tps: 22534.97199
+  dps: 24364.63855
+  tps: 22574.62102
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 24401.46729
-  tps: 22616.15291
+  dps: 24427.65763
+  tps: 22638.47918
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 25048.90403
-  tps: 23056.21359
+  dps: 25043.25514
+  tps: 23046.71257
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 25048.90403
-  tps: 23056.21359
+  dps: 25043.25514
+  tps: 23046.71257
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 24420.77553
-  tps: 22626.3985
+  dps: 24438.13476
+  tps: 22649.44607
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
   hps: 84.91645
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
   hps: 84.91645
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 25053.18473
-  tps: 23059.53161
+  dps: 25047.18031
+  tps: 23049.67507
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 24520.93046
-  tps: 22696.41455
+  dps: 24488.07778
+  tps: 22672.18188
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 24540.11856
-  tps: 22713.4259
+  dps: 24522.1139
+  tps: 22703.66827
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BindingPromise-67037"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 19964.11599
-  tps: 18305.46964
+  dps: 19899.51109
+  tps: 18244.93165
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 19160.34008
-  tps: 17560.26406
+  dps: 19138.36562
+  tps: 17544.43011
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 18812.35069
-  tps: 17235.84656
+  dps: 18849.79131
+  tps: 17278.86467
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 24553.95398
-  tps: 22756.03597
+  dps: 24529.71438
+  tps: 22737.2553
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 24449.43156
-  tps: 22651.51355
+  dps: 24424.16121
+  tps: 22632.86534
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 24481.89991
-  tps: 22683.98189
+  dps: 24456.74607
+  tps: 22665.45019
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 24476.00282
-  tps: 22637.01783
+  dps: 24447.28607
+  tps: 22611.51253
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 25264.22794
-  tps: 23332.0799
+  dps: 25234.04582
+  tps: 23313.70936
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 24505.14619
-  tps: 22681.91488
+  dps: 24474.78143
+  tps: 22660.56472
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 24410.88794
-  tps: 22587.19523
+  dps: 24384.19843
+  tps: 22567.44938
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 25238.61032
-  tps: 23317.27391
+  dps: 25216.62095
+  tps: 23307.11081
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BottledLightning-66879"
  value: {
-  dps: 24342.80092
-  tps: 22531.05496
+  dps: 24320.3821
+  tps: 22515.23476
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 25034.33823
-  tps: 22580.81483
+  dps: 25028.69568
+  tps: 22571.51006
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 25034.33823
-  tps: 22580.81483
+  dps: 25028.69568
+  tps: 22571.51006
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 25549.98882
-  tps: 23546.68197
+  dps: 25543.62478
+  tps: 23536.45591
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 25549.98882
-  tps: 23546.68197
+  dps: 25543.62478
+  tps: 23536.45591
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 25390.81654
-  tps: 23398.12609
+  dps: 25384.54799
+  tps: 23388.00543
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 25445.89778
-  tps: 23449.9698
+  dps: 25434.49279
+  tps: 23435.11021
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 25410.73607
-  tps: 23417.08295
+  dps: 25404.08394
+  tps: 23406.5787
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
   hps: 64
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CrushingWeight-59506"
  value: {
-  dps: 25592.11696
-  tps: 23677.41332
+  dps: 25611.88922
+  tps: 23691.60975
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CrushingWeight-65118"
  value: {
-  dps: 26052.22692
-  tps: 24149.5756
+  dps: 26049.90957
+  tps: 24147.62024
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 24305.43231
-  tps: 22501.85377
+  dps: 24278.02814
+  tps: 22483.37763
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 24312.17931
-  tps: 22504.58928
+  dps: 24334.33085
+  tps: 22533.90345
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 24488.80285
-  tps: 22684.30484
+  dps: 24461.78601
+  tps: 22661.30191
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 25921.14394
-  tps: 24069.16725
+  dps: 25891.9708
+  tps: 24038.79935
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 25175.5242
-  tps: 23367.54604
+  dps: 25146.48389
+  tps: 23337.21094
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 24555.76219
-  tps: 22757.84417
+  dps: 24535.90163
+  tps: 22744.60576
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Death'sChoice-47464"
  value: {
-  dps: 24995.44146
-  tps: 23181.8297
+  dps: 24975.05236
+  tps: 23161.53798
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 24281.74894
-  tps: 22475.94042
+  dps: 24249.20703
+  tps: 22450.79753
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 24849.03928
-  tps: 23055.64232
+  dps: 24829.25323
+  tps: 23023.89519
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 25056.00938
-  tps: 23204.52835
+  dps: 25083.31149
+  tps: 23227.89919
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Defender'sCode-40257"
  value: {
-  dps: 24231.09534
-  tps: 22433.17732
+  dps: 24204.9093
+  tps: 22413.61342
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 25086.48492
-  tps: 23090.55694
+  dps: 25075.97417
+  tps: 23076.5916
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 25058.22212
-  tps: 23064.56899
+  dps: 25050.09037
+  tps: 23052.58513
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 24283.30515
-  tps: 22478.64764
+  dps: 24298.90642
+  tps: 22493.98478
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 24279.09157
-  tps: 22476.23188
+  dps: 24211.67806
+  tps: 22399.76432
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 25034.33823
-  tps: 23041.64778
+  dps: 25028.69568
+  tps: 23032.15312
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 25034.33823
-  tps: 23041.64778
+  dps: 25028.69568
+  tps: 23032.15312
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 25034.33823
-  tps: 23041.64778
+  dps: 25028.69568
+  tps: 23032.15312
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 25034.33823
-  tps: 23041.64778
+  dps: 25028.69568
+  tps: 23032.15312
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 25086.48492
-  tps: 23090.55694
+  dps: 25075.97417
+  tps: 23076.5916
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 25053.18473
-  tps: 23059.53161
+  dps: 25047.18031
+  tps: 23049.67507
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 25050.29644
-  tps: 23057.35317
+  dps: 25044.04231
+  tps: 23047.24691
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 24392.85681
-  tps: 22575.48474
+  dps: 24291.26249
+  tps: 22480.35916
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 24675.76533
-  tps: 22853.93651
+  dps: 24656.43061
+  tps: 22841.47735
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 24775.06532
-  tps: 22951.35861
+  dps: 24740.24495
+  tps: 22922.61128
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 25034.33823
-  tps: 23041.64778
+  dps: 25028.69568
+  tps: 23032.15312
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 25034.33823
-  tps: 23041.64778
+  dps: 25028.69568
+  tps: 23032.15312
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 24338.80509
-  tps: 22530.55481
+  dps: 24342.9233
+  tps: 22543.82508
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 24297.19364
-  tps: 22492.61511
+  dps: 24271.1641
+  tps: 22474.79673
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FallofMortality-59500"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FallofMortality-65124"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 24664.65903
-  tps: 22842.68905
+  dps: 24671.69752
+  tps: 22841.05729
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 25489.0162
-  tps: 23565.25753
+  dps: 25460.12184
+  tps: 23547.85043
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 25088.72587
-  tps: 23096.03542
+  dps: 25082.95695
+  tps: 23086.41439
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FluidDeath-58181"
  value: {
-  dps: 24656.0545
-  tps: 22855.53836
+  dps: 24668.86348
+  tps: 22865.22482
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForgeEmber-37660"
  value: {
-  dps: 24277.92983
-  tps: 22474.15684
+  dps: 24249.63984
+  tps: 22454.07801
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 25034.33823
-  tps: 23041.64778
+  dps: 25028.69568
+  tps: 23032.15312
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 25034.33823
-  tps: 23041.64778
+  dps: 25028.69568
+  tps: 23032.15312
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 25034.33823
-  tps: 23041.64778
+  dps: 25028.69568
+  tps: 23032.15312
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 28129.96225
-  tps: 26139.54933
+  dps: 28075.43601
+  tps: 26105.44718
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 24529.90201
-  tps: 22731.984
+  dps: 24503.44835
+  tps: 22712.15248
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuturesightRune-38763"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GaleofShadows-56138"
  value: {
-  dps: 24407.77424
-  tps: 22591.36665
+  dps: 24453.9167
+  tps: 22636.38535
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GaleofShadows-56462"
  value: {
-  dps: 24574.53242
-  tps: 22767.49094
+  dps: 24573.61207
+  tps: 22745.29669
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GearDetector-61462"
  value: {
-  dps: 24471.17415
-  tps: 22643.27861
+  dps: 24434.47857
+  tps: 22593.0823
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 24384.0946
-  tps: 22562.90257
+  dps: 24392.75141
+  tps: 22579.95879
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 24434.18285
-  tps: 22622.18672
+  dps: 24391.41026
+  tps: 22587.50567
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 24530.95411
-  tps: 22706.47184
+  dps: 24487.74227
+  tps: 22673.52979
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HarmlightToken-63839"
  value: {
-  dps: 24306.96511
-  tps: 22509.0471
+  dps: 24279.95815
+  tps: 22488.66227
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 25083.59766
-  tps: 23239.48399
+  dps: 25056.15954
+  tps: 23218.92747
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 24496.09849
-  tps: 22675.77968
+  dps: 24539.78857
+  tps: 22726.80203
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 24667.082
-  tps: 22853.44994
+  dps: 24613.43421
+  tps: 22793.88657
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartofRage-65072"
  value: {
-  dps: 25819.80926
-  tps: 23782.94645
+  dps: 25722.24501
+  tps: 23681.07665
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartofSolace-55868"
  value: {
-  dps: 24407.77424
-  tps: 22591.36665
+  dps: 24453.9167
+  tps: 22636.38535
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartofSolace-56393"
  value: {
-  dps: 25715.85841
-  tps: 23725.55
+  dps: 25714.27549
+  tps: 23716.93949
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartofThunder-55845"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartofThunder-56370"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 24456.82169
-  tps: 22635.39934
+  dps: 24410.35669
+  tps: 22599.04623
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 25086.48492
-  tps: 23090.55694
+  dps: 25075.97417
+  tps: 23076.5916
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 25053.18473
-  tps: 23059.53161
+  dps: 25047.18031
+  tps: 23049.67507
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 25050.29644
-  tps: 23057.35317
+  dps: 25044.04231
+  tps: 23047.24691
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 25653.18755
-  tps: 23713.53322
+  dps: 25623.95211
+  tps: 23696.39957
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 25653.18755
-  tps: 23713.53322
+  dps: 25623.95211
+  tps: 23696.39957
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 24449.43156
-  tps: 22651.51355
+  dps: 24424.16121
+  tps: 22632.86534
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 24481.89991
-  tps: 22683.98189
+  dps: 24456.74607
+  tps: 22665.45019
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IncisorFragment-37723"
  value: {
-  dps: 24530.0451
-  tps: 22732.12709
+  dps: 24503.78903
+  tps: 22712.49315
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 25034.33823
-  tps: 23041.64778
+  dps: 25028.69568
+  tps: 23032.15312
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 24392.36599
-  tps: 22594.44797
+  dps: 24366.89087
+  tps: 22575.595
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 25077.75447
-  tps: 23085.06402
-  hps: 55.56791
+  dps: 25072.09299
+  tps: 23075.55043
+  hps: 55.9538
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 24553.95398
-  tps: 22756.03597
+  dps: 24529.71438
+  tps: 22737.2553
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 24493.72811
-  tps: 22678.94747
+  dps: 24449.99015
+  tps: 22639.51491
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 24622.99238
-  tps: 22811.79729
+  dps: 24634.582
+  tps: 22822.01302
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 24669.12797
-  tps: 22875.73084
+  dps: 24600.19579
+  tps: 22799.98698
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 24669.12797
-  tps: 22875.73084
+  dps: 24600.19579
+  tps: 22799.98698
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 24364.902
-  tps: 22570.88852
+  dps: 24417.55126
+  tps: 22599.02074
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LastWord-50179"
  value: {
-  dps: 25549.98882
-  tps: 23546.68197
+  dps: 25543.62478
+  tps: 23536.45591
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LastWord-50708"
  value: {
-  dps: 25549.98882
-  tps: 23546.68197
+  dps: 25543.62478
+  tps: 23536.45591
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LeadenDespair-55816"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LeadenDespair-56347"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 24399.71798
-  tps: 22598.07672
+  dps: 24387.69061
+  tps: 22584.89686
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 24459.78497
-  tps: 22652.08867
+  dps: 24389.90721
+  tps: 22584.46099
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MagmaPlatedBattlegear"
  value: {
-  dps: 24744.26334
-  tps: 22763.84346
+  dps: 24806.69784
+  tps: 22844.89036
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 24791.67628
-  tps: 22993.20404
+  dps: 24853.43094
+  tps: 23045.90702
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 25104.69622
-  tps: 23307.05646
+  dps: 25021.399
+  tps: 23215.51025
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 25195.39397
-  tps: 23347.72678
+  dps: 25169.07721
+  tps: 23328.31158
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 25326.71501
-  tps: 23472.53305
+  dps: 25300.38224
+  tps: 23453.13843
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 24287.44204
-  tps: 22435.06565
+  dps: 24348.02476
+  tps: 22513.66383
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 24729.23652
-  tps: 22939.10851
+  dps: 24705.91464
+  tps: 22915.49583
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 25217.03149
-  tps: 23431.71711
+  dps: 25234.52041
+  tps: 23445.34196
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 24517.31992
-  tps: 22719.4019
+  dps: 24492.29318
+  tps: 22700.9973
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 24517.31992
-  tps: 22719.4019
+  dps: 24492.29318
+  tps: 22700.9973
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 24559.06617
-  tps: 22761.14816
+  dps: 24534.93149
+  tps: 22743.63562
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 24372.19224
-  tps: 22546.84649
+  dps: 24350.47333
+  tps: 22530.27287
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 24220.64692
-  tps: 22422.72891
+  dps: 24194.47005
+  tps: 22403.17418
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 25010.60918
-  tps: 23146.21099
+  dps: 24994.61781
+  tps: 23137.4501
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 25069.48471
-  tps: 23076.79426
+  dps: 25063.82684
+  tps: 23067.28427
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 25077.75447
-  tps: 23085.06402
+  dps: 25072.09299
+  tps: 23075.55043
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 24280.96912
-  tps: 22483.05111
+  dps: 24254.73928
+  tps: 22463.44341
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 24291.20857
-  tps: 22493.29056
+  dps: 24264.96974
+  tps: 22473.67387
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 24386.25966
-  tps: 22588.34165
+  dps: 24363.31525
+  tps: 22572.01937
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 24545.33912
-  tps: 22747.42111
+  dps: 24522.07428
+  tps: 22730.77841
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 25034.33823
-  tps: 23041.64778
+  dps: 25028.69568
+  tps: 23032.15312
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 25034.33823
-  tps: 23041.64778
+  dps: 25028.69568
+  tps: 23032.15312
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 25034.33823
-  tps: 23041.64778
+  dps: 25028.69568
+  tps: 23032.15312
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 24926.89578
-  tps: 23078.59861
+  dps: 24886.8685
+  tps: 23034.00629
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 25100.27643
-  tps: 23232.25208
+  dps: 25082.20355
+  tps: 23221.00545
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Rainsong-55854"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Rainsong-56377"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 24201.54433
-  tps: 22406.15856
+  dps: 24191.46695
+  tps: 22401.88165
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 24202.84596
-  tps: 22407.46019
+  dps: 24192.76859
+  tps: 22403.18329
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 25401.88243
-  tps: 23408.93915
+  dps: 25394.9656
+  tps: 23398.1702
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 25549.98882
-  tps: 23546.68197
+  dps: 25543.62478
+  tps: 23536.45591
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 25390.81654
-  tps: 23398.12609
+  dps: 25384.54799
+  tps: 23388.00543
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 25034.33823
-  tps: 23041.64778
+  dps: 25028.69568
+  tps: 23032.15312
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 25107.81038
-  tps: 23304.92359
+  dps: 25155.53856
+  tps: 23353.79867
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 25284.92557
-  tps: 23493.18519
+  dps: 25321.92424
+  tps: 23518.81941
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 24534.8541
-  tps: 22722.16522
+  dps: 24501.47079
+  tps: 22697.64218
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SeaStar-55256"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SeaStar-56290"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 24226.79798
-  tps: 22428.87996
+  dps: 24200.67837
+  tps: 22409.3825
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Shadowmourne-49623"
  value: {
-  dps: 25549.98882
-  tps: 23546.68197
+  dps: 25543.62478
+  tps: 23536.45591
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 25331.3295
-  tps: 23448.00465
+  dps: 25274.49066
+  tps: 23389.94307
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 24621.55155
-  tps: 22806.59112
+  dps: 24590.24018
+  tps: 22784.23423
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 24675.28279
-  tps: 22859.71167
+  dps: 24645.17793
+  tps: 22838.5613
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sorrowsong-55879"
  value: {
-  dps: 24449.43156
-  tps: 22651.51355
+  dps: 24424.16121
+  tps: 22632.86534
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sorrowsong-56400"
  value: {
-  dps: 24481.89991
-  tps: 22683.98189
+  dps: 24456.74607
+  tps: 22665.45019
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 24757.18618
-  tps: 22970.99996
+  dps: 24797.20969
+  tps: 23007.19217
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SoulCasket-58183"
  value: {
-  dps: 24517.31992
-  tps: 22719.4019
+  dps: 24492.29318
+  tps: 22700.9973
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SoulPreserver-37111"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SouloftheDead-40382"
  value: {
-  dps: 24302.40578
-  tps: 22497.76483
+  dps: 24276.37623
+  tps: 22479.94645
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SparkofLife-37657"
  value: {
-  dps: 24038.48245
-  tps: 22225.0711
+  dps: 24142.4872
+  tps: 22322.0632
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 24342.40487
-  tps: 22545.40569
+  dps: 24350.37062
+  tps: 22555.64072
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 24353.90667
-  tps: 22544.39113
+  dps: 24341.08339
+  tps: 22538.18654
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-StumpofTime-62465"
  value: {
-  dps: 24408.58458
-  tps: 22623.84684
+  dps: 24452.77353
+  tps: 22663.83319
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-StumpofTime-62470"
  value: {
-  dps: 24408.58458
-  tps: 22623.84684
+  dps: 24452.77353
+  tps: 22663.83319
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 25077.75447
-  tps: 23085.06402
+  dps: 25072.09299
+  tps: 23075.55043
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 25069.48471
-  tps: 23076.79426
+  dps: 25063.82684
+  tps: 23067.28427
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 25055.01263
-  tps: 23062.32218
+  dps: 25049.36107
+  tps: 23052.81851
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 24388.41195
-  tps: 22590.49393
+  dps: 24363.06893
+  tps: 22571.77306
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 25246.72675
-  tps: 23343.66589
+  dps: 25313.83956
+  tps: 23401.67415
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TearofBlood-55819"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TearofBlood-56351"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 24413.02766
-  tps: 22615.10965
+  dps: 24387.62668
+  tps: 22596.33081
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 24481.89991
-  tps: 22683.98189
+  dps: 24456.74607
+  tps: 22665.45019
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 24437.80336
-  tps: 22639.88535
+  dps: 24413.36885
+  tps: 22622.07298
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 24484.43132
-  tps: 22686.5133
+  dps: 24455.08884
+  tps: 22663.79296
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 25141.27013
-  tps: 23117.37262
+  dps: 25086.86657
+  tps: 23068.06188
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 24628.64194
-  tps: 22817.3659
+  dps: 24595.02298
+  tps: 22792.70142
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 24677.76335
-  tps: 22864.75817
+  dps: 24650.66515
+  tps: 22846.51392
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 24575.21417
-  tps: 22762.19996
+  dps: 24661.87414
+  tps: 22838.87668
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 24524.57664
-  tps: 22703.35555
+  dps: 24544.42928
+  tps: 22734.08611
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 25034.33823
-  tps: 23041.64778
+  dps: 25028.69568
+  tps: 23032.15312
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 25034.33823
-  tps: 23041.64778
+  dps: 25028.69568
+  tps: 23032.15312
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 24157.94474
-  tps: 22339.40202
+  dps: 24123.78701
+  tps: 22298.69028
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 25034.33823
-  tps: 23041.64778
+  dps: 25028.69568
+  tps: 23032.15312
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 25034.33823
-  tps: 23041.64778
+  dps: 25028.69568
+  tps: 23032.15312
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 24256.63454
-  tps: 22442.1437
+  dps: 24267.51085
+  tps: 22459.83041
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 19194.70347
-  tps: 17595.59404
+  dps: 19166.16305
+  tps: 17565.38669
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UnheededWarning-59520"
  value: {
-  dps: 24783.01663
-  tps: 22965.03134
+  dps: 24747.14393
+  tps: 22938.4404
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 24747.11632
-  tps: 22911.77386
+  dps: 24731.48297
+  tps: 22903.49357
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 24747.11632
-  tps: 22911.77386
+  dps: 24731.48297
+  tps: 22903.49357
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 21076.11302
-  tps: 19130.3494
+  dps: 21073.43443
+  tps: 19128.47201
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 24429.70852
-  tps: 22594.36606
+  dps: 24412.79957
+  tps: 22584.81017
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 25323.65729
-  tps: 23384.00296
+  dps: 25293.25024
+  tps: 23365.6977
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 24415.91967
-  tps: 22630.37741
+  dps: 24429.6592
+  tps: 22639.92768
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 24631.59703
-  tps: 22838.81363
+  dps: 24583.06028
+  tps: 22787.16782
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 24526.4624
-  tps: 22700.97043
+  dps: 24499.94048
+  tps: 22682.69495
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 24349.03404
-  tps: 22557.72904
+  dps: 24213.81499
+  tps: 22417.72226
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 24536.01381
-  tps: 22738.0958
+  dps: 24511.05415
+  tps: 22719.75828
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 24423.68788
-  tps: 22602.78754
+  dps: 24405.3565
+  tps: 22589.86753
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 25283.63837
-  tps: 23387.09409
+  dps: 25264.71165
+  tps: 23366.7929
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WingedTalisman-37844"
  value: {
-  dps: 24201.49148
-  tps: 22403.57347
+  dps: 24175.33144
+  tps: 22384.03557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 24309.14774
-  tps: 22495.99161
+  dps: 24281.17427
+  tps: 22469.10163
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 24422.05272
-  tps: 22574.13694
+  dps: 24431.01551
+  tps: 22575.89241
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 24416.96322
-  tps: 22619.0452
+  dps: 24391.57636
+  tps: 22600.28049
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 24414.4423
-  tps: 22616.52429
+  dps: 24389.1783
+  tps: 22597.88243
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 24414.4423
-  tps: 22616.52429
+  dps: 24389.1783
+  tps: 22597.88243
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 25594.78523
-  tps: 23572.7339
+  dps: 25593.62188
+  tps: 23572.17275
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p1-Basic-st-FullBuffs-LongMultiTarget"
  value: {
-  dps: 57743.52267
-  tps: 55837.21476
+  dps: 57683.67589
+  tps: 55775.81618
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p1-Basic-st-FullBuffs-LongSingleTarget"
  value: {
-  dps: 25311.03831
-  tps: 23344.00098
+  dps: 25257.29536
+  tps: 23284.75473
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p1-Basic-st-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 34235.87791
-  tps: 28696.16233
+  dps: 34242.93955
+  tps: 28701.94535
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p1-Basic-st-NoBuffs-LongMultiTarget"
  value: {
-  dps: 38031.42112
-  tps: 36596.21263
+  dps: 37938.35459
+  tps: 36488.11283
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p1-Basic-st-NoBuffs-LongSingleTarget"
  value: {
-  dps: 17393.00191
-  tps: 15912.96621
+  dps: 17442.80968
+  tps: 15954.87571
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p1-Basic-st-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 21706.28013
-  tps: 17547.99716
+  dps: 21756.47708
+  tps: 17597.44514
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p1-Basic-st-FullBuffs-LongMultiTarget"
  value: {
-  dps: 57879.3767
-  tps: 56013.80904
+  dps: 57671.32398
+  tps: 55783.8692
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p1-Basic-st-FullBuffs-LongSingleTarget"
  value: {
-  dps: 25549.98882
-  tps: 23546.68197
+  dps: 25543.62478
+  tps: 23536.45591
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p1-Basic-st-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 34576.59168
-  tps: 29158.46152
+  dps: 34593.88052
+  tps: 29174.59104
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p1-Basic-st-NoBuffs-LongMultiTarget"
  value: {
-  dps: 38306.42084
-  tps: 36772.26402
+  dps: 38272.98939
+  tps: 36768.0627
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p1-Basic-st-NoBuffs-LongSingleTarget"
  value: {
-  dps: 17491.35273
-  tps: 15961.73221
+  dps: 17539.41755
+  tps: 16013.86201
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p1-Basic-st-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 22128.60753
-  tps: 17792.66529
+  dps: 22208.5072
+  tps: 17867.18417
  }
 }
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 24652.76757
-  tps: 22804.11889
+  dps: 24692.56873
+  tps: 22849.96049
  }
 }

--- a/sim/death_knight/frost/TestFrost.results
+++ b/sim/death_knight/frost/TestFrost.results
@@ -40,1846 +40,1846 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 25409.70319
-  tps: 23410.79589
+  dps: 25408.48764
+  tps: 23414.38662
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 24364.63855
-  tps: 22574.62102
+  dps: 24346.30814
+  tps: 22554.94891
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 24427.65763
-  tps: 22638.47918
+  dps: 24420.65501
+  tps: 22630.21287
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 25043.25514
-  tps: 23046.71257
+  dps: 25041.39903
+  tps: 23049.67518
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 25043.25514
-  tps: 23046.71257
+  dps: 25041.39903
+  tps: 23049.67518
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 24438.13476
-  tps: 22649.44607
+  dps: 24433.4308
+  tps: 22644.53959
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
   hps: 84.91645
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
   hps: 84.91645
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 25047.18031
-  tps: 23049.67507
+  dps: 25045.31928
+  tps: 23052.63275
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 24488.07778
-  tps: 22672.18188
+  dps: 24484.78761
+  tps: 22667.7144
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 24522.1139
-  tps: 22703.66827
+  dps: 24518.73543
+  tps: 22699.1125
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BindingPromise-67037"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 19899.51109
-  tps: 18244.93165
+  dps: 19889.89551
+  tps: 18237.53478
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 19138.36562
-  tps: 17544.43011
+  dps: 19125.14206
+  tps: 17535.7025
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 18849.79131
-  tps: 17278.86467
+  dps: 18846.44655
+  tps: 17273.85491
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 24529.71438
-  tps: 22737.2553
+  dps: 24525.90546
+  tps: 22732.75029
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 24424.16121
-  tps: 22632.86534
+  dps: 24418.34224
+  tps: 22626.35027
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 24456.74607
-  tps: 22665.45019
+  dps: 24450.89641
+  tps: 22658.90444
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 24447.28607
-  tps: 22611.51253
+  dps: 24443.17369
+  tps: 22606.68618
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 25234.04582
-  tps: 23313.70936
+  dps: 25226.50298
+  tps: 23305.47043
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 24474.78143
-  tps: 22660.56472
+  dps: 24472.00106
+  tps: 22656.92677
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 24384.19843
-  tps: 22567.44938
+  dps: 24381.94146
+  tps: 22564.53758
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 25216.62095
-  tps: 23307.11081
+  dps: 25209.49901
+  tps: 23299.44864
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BottledLightning-66879"
  value: {
-  dps: 24320.3821
-  tps: 22515.23476
+  dps: 24315.55788
+  tps: 22509.71444
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 25028.69568
-  tps: 22571.51006
+  dps: 25026.83465
+  tps: 22574.40858
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 25028.69568
-  tps: 22571.51006
+  dps: 25026.83465
+  tps: 22574.40858
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 25543.62478
-  tps: 23536.45591
+  dps: 25542.37568
+  tps: 23540.07062
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 25543.62478
-  tps: 23536.45591
+  dps: 25542.37568
+  tps: 23540.07062
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 25384.54799
-  tps: 23388.00543
+  dps: 25383.32001
+  tps: 23391.59616
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 25434.49279
-  tps: 23435.11021
+  dps: 25433.27724
+  tps: 23438.70094
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 25404.08394
-  tps: 23406.5787
+  dps: 25402.85596
+  tps: 23410.16943
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
   hps: 64
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CrushingWeight-59506"
  value: {
-  dps: 25611.88922
-  tps: 23691.60975
+  dps: 25628.65022
+  tps: 23706.66886
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CrushingWeight-65118"
  value: {
-  dps: 26049.90957
-  tps: 24147.62024
+  dps: 26066.25429
+  tps: 24161.95265
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 24278.02814
-  tps: 22483.37763
+  dps: 24274.71762
+  tps: 22479.69131
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 24334.33085
-  tps: 22533.90345
+  dps: 24337.3077
+  tps: 22536.47103
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 24461.78601
-  tps: 22661.30191
+  dps: 24455.91836
+  tps: 22654.77942
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 25891.9708
-  tps: 24038.79935
+  dps: 25842.86744
+  tps: 23990.65037
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 25146.48389
-  tps: 23337.21094
+  dps: 25104.87806
+  tps: 23296.82777
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 24535.90163
-  tps: 22744.60576
+  dps: 24530.01851
+  tps: 22738.02654
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Death'sChoice-47464"
  value: {
-  dps: 24975.05236
-  tps: 23161.53798
+  dps: 24968.78048
+  tps: 23154.59324
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 24249.20703
-  tps: 22450.79753
+  dps: 24244.24032
+  tps: 22445.45501
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 24829.25323
-  tps: 23023.89519
+  dps: 24783.67787
+  tps: 22975.98459
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 25083.31149
-  tps: 23227.89919
+  dps: 25075.78619
+  tps: 23220.49364
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Defender'sCode-40257"
  value: {
-  dps: 24204.9093
-  tps: 22413.61342
+  dps: 24199.3115
+  tps: 22407.31953
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 25075.97417
-  tps: 23076.5916
+  dps: 25074.12557
+  tps: 23079.54928
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 25050.09037
-  tps: 23052.58513
+  dps: 25048.22934
+  tps: 23055.5428
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 24298.90642
-  tps: 22493.98478
+  dps: 24285.94272
+  tps: 22480.37937
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 24211.67806
-  tps: 22399.76432
+  dps: 24182.56825
+  tps: 22370.75819
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 25028.69568
-  tps: 23032.15312
+  dps: 25026.83465
+  tps: 23035.1108
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 25028.69568
-  tps: 23032.15312
+  dps: 25026.83465
+  tps: 23035.1108
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 25028.69568
-  tps: 23032.15312
+  dps: 25026.83465
+  tps: 23035.1108
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 25028.69568
-  tps: 23032.15312
+  dps: 25026.83465
+  tps: 23035.1108
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 25075.97417
-  tps: 23076.5916
+  dps: 25074.12557
+  tps: 23079.54928
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 25047.18031
-  tps: 23049.67507
+  dps: 25045.31928
+  tps: 23052.63275
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 25044.04231
-  tps: 23047.24691
+  dps: 25042.18128
+  tps: 23050.20459
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 24291.26249
-  tps: 22480.35916
+  dps: 24273.934
+  tps: 22468.95314
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 24656.43061
-  tps: 22841.47735
+  dps: 24660.66463
+  tps: 22845.33557
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 24740.24495
-  tps: 22922.61128
+  dps: 24740.94769
+  tps: 22922.89081
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 25028.69568
-  tps: 23032.15312
+  dps: 25026.83465
+  tps: 23035.1108
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 25028.69568
-  tps: 23032.15312
+  dps: 25026.83465
+  tps: 23035.1108
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 24342.9233
-  tps: 22543.82508
+  dps: 24326.96592
+  tps: 22530.10173
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 24271.1641
-  tps: 22474.79673
+  dps: 24267.85358
+  tps: 22471.11041
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FallofMortality-59500"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FallofMortality-65124"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 24671.69752
-  tps: 22841.05729
+  dps: 24666.02461
+  tps: 22834.8812
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 25460.12184
-  tps: 23547.85043
+  dps: 25452.37057
+  tps: 23539.40305
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 25082.95695
-  tps: 23086.41439
+  dps: 25081.15595
+  tps: 23089.43209
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FluidDeath-58181"
  value: {
-  dps: 24668.86348
-  tps: 22865.22482
+  dps: 24657.19006
+  tps: 22852.70657
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForgeEmber-37660"
  value: {
-  dps: 24249.63984
-  tps: 22454.07801
+  dps: 24246.32932
+  tps: 22450.3917
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 25028.69568
-  tps: 23032.15312
+  dps: 25026.83465
+  tps: 23035.1108
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 25028.69568
-  tps: 23032.15312
+  dps: 25026.83465
+  tps: 23035.1108
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 25028.69568
-  tps: 23032.15312
+  dps: 25026.83465
+  tps: 23035.1108
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 28075.43601
-  tps: 26105.44718
+  dps: 28072.13754
+  tps: 26100.47407
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 24503.44835
-  tps: 22712.15248
+  dps: 24497.71553
+  tps: 22705.72356
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuturesightRune-38763"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GaleofShadows-56138"
  value: {
-  dps: 24453.9167
-  tps: 22636.38535
+  dps: 24452.42308
+  tps: 22638.8544
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GaleofShadows-56462"
  value: {
-  dps: 24573.61207
-  tps: 22745.29669
+  dps: 24550.47748
+  tps: 22717.18381
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GearDetector-61462"
  value: {
-  dps: 24434.47857
-  tps: 22593.0823
+  dps: 24464.21021
+  tps: 22625.1041
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 24392.75141
-  tps: 22579.95879
+  dps: 24388.95219
+  tps: 22575.98129
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 24391.41026
-  tps: 22587.50567
+  dps: 24388.41776
+  tps: 22583.79805
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 24487.74227
-  tps: 22673.52979
+  dps: 24483.28315
+  tps: 22668.03564
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HarmlightToken-63839"
  value: {
-  dps: 24279.95815
-  tps: 22488.66227
+  dps: 24274.35104
+  tps: 22482.35907
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 25056.15954
-  tps: 23218.92747
+  dps: 25049.67702
+  tps: 23211.71795
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 24539.78857
-  tps: 22726.80203
+  dps: 24527.80974
+  tps: 22714.09307
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 24613.43421
-  tps: 22793.88657
+  dps: 24637.96835
+  tps: 22822.71651
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartofRage-65072"
  value: {
-  dps: 25722.24501
-  tps: 23681.07665
+  dps: 25717.22331
+  tps: 23679.91209
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartofSolace-55868"
  value: {
-  dps: 24453.9167
-  tps: 22636.38535
+  dps: 24452.42308
+  tps: 22638.8544
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartofSolace-56393"
  value: {
-  dps: 25714.27549
-  tps: 23716.93949
+  dps: 25688.23171
+  tps: 23685.61334
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartofThunder-55845"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartofThunder-56370"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 24410.35669
-  tps: 22599.04623
+  dps: 24410.77502
+  tps: 22598.75854
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 25075.97417
-  tps: 23076.5916
+  dps: 25074.12557
+  tps: 23079.54928
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 25047.18031
-  tps: 23049.67507
+  dps: 25045.31928
+  tps: 23052.63275
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 25044.04231
-  tps: 23047.24691
+  dps: 25042.18128
+  tps: 23050.20459
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 25623.95211
-  tps: 23696.39957
+  dps: 25615.91779
+  tps: 23687.66915
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 25623.95211
-  tps: 23696.39957
+  dps: 25615.91779
+  tps: 23687.66915
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 24424.16121
-  tps: 22632.86534
+  dps: 24418.34224
+  tps: 22626.35027
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 24456.74607
-  tps: 22665.45019
+  dps: 24450.89641
+  tps: 22658.90444
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IncisorFragment-37723"
  value: {
-  dps: 24503.78903
-  tps: 22712.49315
+  dps: 24498.12175
+  tps: 22706.12979
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 25028.69568
-  tps: 23032.15312
+  dps: 25026.83465
+  tps: 23035.1108
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 24366.89087
-  tps: 22575.595
+  dps: 24361.12582
+  tps: 22569.13385
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 25072.09299
-  tps: 23075.55043
+  dps: 25070.24664
+  tps: 23078.52279
   hps: 55.9538
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 24529.71438
-  tps: 22737.2553
+  dps: 24525.90546
+  tps: 22732.75029
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 24449.99015
-  tps: 22639.51491
+  dps: 24434.04572
+  tps: 22621.87939
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 24634.582
-  tps: 22822.01302
+  dps: 24630.66384
+  tps: 22816.51302
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 24600.19579
-  tps: 22799.98698
+  dps: 24602.9332
+  tps: 22801.66217
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 24600.19579
-  tps: 22799.98698
+  dps: 24602.9332
+  tps: 22801.66217
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 24417.55126
-  tps: 22599.02074
+  dps: 24410.22946
+  tps: 22593.87987
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LastWord-50179"
  value: {
-  dps: 25543.62478
-  tps: 23536.45591
+  dps: 25542.37568
+  tps: 23540.07062
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LastWord-50708"
  value: {
-  dps: 25543.62478
-  tps: 23536.45591
+  dps: 25542.37568
+  tps: 23540.07062
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LeadenDespair-55816"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LeadenDespair-56347"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 24387.69061
-  tps: 22584.89686
+  dps: 24391.98615
+  tps: 22591.22256
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 24389.90721
-  tps: 22584.46099
+  dps: 24365.27404
+  tps: 22564.54477
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MagmaPlatedBattlegear"
  value: {
-  dps: 24806.69784
-  tps: 22844.89036
+  dps: 24816.1507
+  tps: 22851.03657
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 24853.43094
-  tps: 23045.90702
+  dps: 24891.3318
+  tps: 23086.75171
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 25021.399
-  tps: 23215.51025
+  dps: 25003.60119
+  tps: 23202.54685
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 25169.07721
-  tps: 23328.31158
+  dps: 25163.21127
+  tps: 23321.71627
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 25300.38224
-  tps: 23453.13843
+  dps: 25294.4792
+  tps: 23446.50166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 24348.02476
-  tps: 22513.66383
+  dps: 24398.61857
+  tps: 22562.91468
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 24705.91464
-  tps: 22915.49583
+  dps: 24694.08472
+  tps: 22902.34694
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 25234.52041
-  tps: 23445.34196
+  dps: 25230.20921
+  tps: 23439.76708
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 24492.29318
-  tps: 22700.9973
+  dps: 24486.41005
+  tps: 22694.41808
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 24492.29318
-  tps: 22700.9973
+  dps: 24486.41005
+  tps: 22694.41808
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 24534.93149
-  tps: 22743.63562
+  dps: 24527.27681
+  tps: 22735.28484
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 24350.47333
-  tps: 22530.27287
+  dps: 24344.55586
+  tps: 22523.99209
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 24194.47005
-  tps: 22403.17418
+  dps: 24188.87689
+  tps: 22396.88492
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 24994.61781
-  tps: 23137.4501
+  dps: 24990.88008
+  tps: 23132.99066
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 25063.82684
-  tps: 23067.28427
+  dps: 25061.97769
+  tps: 23070.25384
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 25072.09299
-  tps: 23075.55043
+  dps: 25070.24664
+  tps: 23078.52279
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 24254.73928
-  tps: 22463.44341
+  dps: 24249.11939
+  tps: 22457.12742
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 24264.96974
-  tps: 22473.67387
+  dps: 24259.34531
+  tps: 22467.35334
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 24363.31525
-  tps: 22572.01937
+  dps: 24358.0367
+  tps: 22566.04474
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 24522.07428
-  tps: 22730.77841
+  dps: 24517.3728
+  tps: 22725.38083
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 25028.69568
-  tps: 23032.15312
+  dps: 25026.83465
+  tps: 23035.1108
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 25028.69568
-  tps: 23032.15312
+  dps: 25026.83465
+  tps: 23035.1108
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 25028.69568
-  tps: 23032.15312
+  dps: 25026.83465
+  tps: 23035.1108
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 24886.8685
-  tps: 23034.00629
+  dps: 24883.12265
+  tps: 23024.51225
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 25082.20355
-  tps: 23221.00545
+  dps: 25017.85353
+  tps: 23155.51819
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Rainsong-55854"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Rainsong-56377"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 24191.46695
-  tps: 22401.88165
+  dps: 24185.97924
+  tps: 22395.69254
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 24192.76859
-  tps: 22403.18329
+  dps: 24187.28088
+  tps: 22396.99417
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 25394.9656
-  tps: 23398.1702
+  dps: 25393.73762
+  tps: 23401.76093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 25543.62478
-  tps: 23536.45591
+  dps: 25542.37568
+  tps: 23540.07062
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 25384.54799
-  tps: 23388.00543
+  dps: 25383.32001
+  tps: 23391.59616
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 25028.69568
-  tps: 23032.15312
+  dps: 25026.83465
+  tps: 23035.1108
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 25155.53856
-  tps: 23353.79867
+  dps: 25136.37228
+  tps: 23333.05768
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 25321.92424
-  tps: 23518.81941
+  dps: 25312.71352
+  tps: 23508.34501
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 24501.47079
-  tps: 22697.64218
+  dps: 24497.58347
+  tps: 22693.37905
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SeaStar-55256"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SeaStar-56290"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 24200.67837
-  tps: 22409.3825
+  dps: 24195.04202
+  tps: 22403.05005
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Shadowmourne-49623"
  value: {
-  dps: 25543.62478
-  tps: 23536.45591
+  dps: 25542.37568
+  tps: 23540.07062
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 25274.49066
-  tps: 23389.94307
+  dps: 25283.34941
+  tps: 23400.47048
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 24590.24018
-  tps: 22784.23423
+  dps: 24584.74831
+  tps: 22778.36655
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 24645.17793
-  tps: 22838.5613
+  dps: 24638.32443
+  tps: 22831.332
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sorrowsong-55879"
  value: {
-  dps: 24424.16121
-  tps: 22632.86534
+  dps: 24418.34224
+  tps: 22626.35027
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sorrowsong-56400"
  value: {
-  dps: 24456.74607
-  tps: 22665.45019
+  dps: 24450.89641
+  tps: 22658.90444
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 24797.20969
-  tps: 23007.19217
+  dps: 24779.49421
+  tps: 22988.13498
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SoulCasket-58183"
  value: {
-  dps: 24492.29318
-  tps: 22700.9973
+  dps: 24486.41005
+  tps: 22694.41808
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SoulPreserver-37111"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SouloftheDead-40382"
  value: {
-  dps: 24276.37623
-  tps: 22479.94645
+  dps: 24273.06572
+  tps: 22476.26013
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SparkofLife-37657"
  value: {
-  dps: 24142.4872
-  tps: 22322.0632
+  dps: 24167.75209
+  tps: 22346.09319
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 24350.37062
-  tps: 22555.64072
+  dps: 24313.75995
+  tps: 22518.88048
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 24341.08339
-  tps: 22538.18654
+  dps: 24335.51363
+  tps: 22531.92068
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-StumpofTime-62465"
  value: {
-  dps: 24452.77353
-  tps: 22663.83319
+  dps: 24438.18745
+  tps: 22648.0655
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-StumpofTime-62470"
  value: {
-  dps: 24452.77353
-  tps: 22663.83319
+  dps: 24438.18745
+  tps: 22648.0655
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 25072.09299
-  tps: 23075.55043
+  dps: 25070.24664
+  tps: 23078.52279
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 25063.82684
-  tps: 23067.28427
+  dps: 25061.97769
+  tps: 23070.25384
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 25049.36107
-  tps: 23052.81851
+  dps: 25047.50703
+  tps: 23055.78318
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 24363.06893
-  tps: 22571.77306
+  dps: 24356.97035
+  tps: 22564.97838
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 25313.83956
-  tps: 23401.67415
+  dps: 25304.56982
+  tps: 23390.00161
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TearofBlood-55819"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TearofBlood-56351"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 24387.62668
-  tps: 22596.33081
+  dps: 24381.84211
+  tps: 22589.85014
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 24456.74607
-  tps: 22665.45019
+  dps: 24450.89641
+  tps: 22658.90444
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 24413.36885
-  tps: 22622.07298
+  dps: 24406.92354
+  tps: 22614.93157
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 24455.08884
-  tps: 22663.79296
+  dps: 24448.93914
+  tps: 22656.94717
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 25086.86657
-  tps: 23068.06188
+  dps: 25077.12928
+  tps: 23058.24767
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 24595.02298
-  tps: 22792.70142
+  dps: 24589.76152
+  tps: 22787.06415
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 24650.66515
-  tps: 22846.51392
+  dps: 24647.34648
+  tps: 22842.81945
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 24661.87414
-  tps: 22838.87668
+  dps: 24684.65206
+  tps: 22864.56529
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 24544.42928
-  tps: 22734.08611
+  dps: 24538.26466
+  tps: 22726.87047
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 25028.69568
-  tps: 23032.15312
+  dps: 25026.83465
+  tps: 23035.1108
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 25028.69568
-  tps: 23032.15312
+  dps: 25026.83465
+  tps: 23035.1108
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 24123.78701
-  tps: 22298.69028
+  dps: 24122.47008
+  tps: 22298.03462
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 25028.69568
-  tps: 23032.15312
+  dps: 25026.83465
+  tps: 23035.1108
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 25028.69568
-  tps: 23032.15312
+  dps: 25026.83465
+  tps: 23035.1108
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 24267.51085
-  tps: 22459.83041
+  dps: 24261.43746
+  tps: 22453.25845
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 19166.16305
-  tps: 17565.38669
+  dps: 19166.37811
+  tps: 17567.96472
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UnheededWarning-59520"
  value: {
-  dps: 24747.14393
-  tps: 22938.4404
+  dps: 24744.52093
+  tps: 22935.4416
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 24731.48297
-  tps: 22903.49357
+  dps: 24728.89331
+  tps: 22900.20782
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 24731.48297
-  tps: 22903.49357
+  dps: 24728.89331
+  tps: 22900.20782
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 21073.43443
-  tps: 19128.47201
+  dps: 21072.16562
+  tps: 19123.00078
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 24412.79957
-  tps: 22584.81017
+  dps: 24410.38832
+  tps: 22581.70283
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 25293.25024
-  tps: 23365.6977
+  dps: 25285.5979
+  tps: 23357.34926
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 24429.6592
-  tps: 22639.92768
+  dps: 24407.00059
+  tps: 22615.99859
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 24583.06028
-  tps: 22787.16782
+  dps: 24594.68798
+  tps: 22797.33548
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 24499.94048
-  tps: 22682.69495
+  dps: 24496.56201
+  tps: 22678.13917
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 24213.81499
-  tps: 22417.72226
+  dps: 24211.98976
+  tps: 22419.76125
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 24511.05415
-  tps: 22719.75828
+  dps: 24505.15336
+  tps: 22713.16139
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 24405.3565
-  tps: 22589.86753
+  dps: 24400.63123
+  tps: 22584.11595
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 25264.71165
-  tps: 23366.7929
+  dps: 25258.71704
+  tps: 23360.15977
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WingedTalisman-37844"
  value: {
-  dps: 24175.33144
-  tps: 22384.03557
+  dps: 24169.74676
+  tps: 22377.75479
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 24281.17427
-  tps: 22469.10163
+  dps: 24263.97943
+  tps: 22449.40734
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 24431.01551
-  tps: 22575.89241
+  dps: 24404.61081
+  tps: 22547.44426
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 24391.57636
-  tps: 22600.28049
+  dps: 24385.78807
+  tps: 22593.7961
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 24389.1783
-  tps: 22597.88243
+  dps: 24383.65771
+  tps: 22591.66575
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 24389.1783
-  tps: 22597.88243
+  dps: 24383.65771
+  tps: 22591.66575
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 25593.62188
-  tps: 23572.17275
+  dps: 25594.25415
+  tps: 23572.81927
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p1-Basic-st-FullBuffs-LongMultiTarget"
  value: {
-  dps: 57683.67589
-  tps: 55775.81618
+  dps: 57676.11508
+  tps: 55769.58284
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p1-Basic-st-FullBuffs-LongSingleTarget"
  value: {
-  dps: 25257.29536
-  tps: 23284.75473
+  dps: 25249.11555
+  tps: 23278.72655
  }
 }
 dps_results: {
@@ -1892,15 +1892,15 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Human-p1-Basic-st-NoBuffs-LongMultiTarget"
  value: {
-  dps: 37938.35459
-  tps: 36488.11283
+  dps: 37919.618
+  tps: 36469.62881
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p1-Basic-st-NoBuffs-LongSingleTarget"
  value: {
-  dps: 17442.80968
-  tps: 15954.87571
+  dps: 17444.77554
+  tps: 15957.47381
  }
 }
 dps_results: {
@@ -1913,15 +1913,15 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Orc-p1-Basic-st-FullBuffs-LongMultiTarget"
  value: {
-  dps: 57671.32398
-  tps: 55783.8692
+  dps: 57655.98387
+  tps: 55773.19664
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p1-Basic-st-FullBuffs-LongSingleTarget"
  value: {
-  dps: 25543.62478
-  tps: 23536.45591
+  dps: 25542.37568
+  tps: 23540.07062
  }
 }
 dps_results: {
@@ -1934,15 +1934,15 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Orc-p1-Basic-st-NoBuffs-LongMultiTarget"
  value: {
-  dps: 38272.98939
-  tps: 36768.0627
+  dps: 38261.46413
+  tps: 36757.35802
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p1-Basic-st-NoBuffs-LongSingleTarget"
  value: {
-  dps: 17539.41755
-  tps: 16013.86201
+  dps: 17544.94494
+  tps: 16020.06756
  }
 }
 dps_results: {
@@ -1955,7 +1955,7 @@ dps_results: {
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 24692.56873
-  tps: 22849.96049
+  dps: 24698.01871
+  tps: 22854.23516
  }
 }

--- a/sim/death_knight/unholy/TestUnholy.results
+++ b/sim/death_knight/unholy/TestUnholy.results
@@ -40,1922 +40,1922 @@ character_stats_results: {
 dps_results: {
  key: "TestUnholy-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 28046.69167
-  tps: 19915.00219
+  dps: 28032.93426
+  tps: 19910.22214
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 27882.44285
-  tps: 19755.49775
+  dps: 27870.16429
+  tps: 19751.59785
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 27882.44285
-  tps: 19755.49775
+  dps: 27870.16429
+  tps: 19751.59785
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 26668.19975
-  tps: 19182.41853
+  dps: 26634.58748
+  tps: 19152.75091
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
   hps: 85.60947
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
   hps: 85.60947
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 27908.08942
-  tps: 19777.8737
+  dps: 27892.65546
+  tps: 19771.65706
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 26832.59987
-  tps: 19214.7261
+  dps: 26818.19073
+  tps: 19219.72818
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 26881.30231
-  tps: 19251.88979
+  dps: 26863.01668
+  tps: 19253.11111
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BindingPromise-67037"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 21276.3455
-  tps: 15041.13392
+  dps: 21333.22201
+  tps: 15067.93715
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 20239.81118
-  tps: 14370.76775
+  dps: 20149.68539
+  tps: 14285.32217
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 19974.48994
-  tps: 14141.95749
+  dps: 19963.12998
+  tps: 14115.33457
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 26815.64375
-  tps: 19280.77633
+  dps: 26784.0427
+  tps: 19268.39203
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 26699.14904
-  tps: 19219.3293
+  dps: 26685.19658
+  tps: 19225.73576
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 26737.24218
-  tps: 19261.01178
+  dps: 26723.29246
+  tps: 19267.41874
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 26713.76194
-  tps: 19105.40027
+  dps: 26666.86043
+  tps: 19085.72281
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 27730.0764
-  tps: 19803.01338
+  dps: 27738.26941
+  tps: 19810.97204
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 26810.78517
-  tps: 19197.3655
+  dps: 26801.08914
+  tps: 19206.39966
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 26628.44153
-  tps: 19034.78319
+  dps: 26608.57928
+  tps: 19033.93062
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 26408.55655
-  tps: 18901.23279
+  dps: 26394.58499
+  tps: 18907.63734
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 27589.06161
-  tps: 19681.72293
+  dps: 27564.31619
+  tps: 19675.65371
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BottledLightning-66879"
  value: {
-  dps: 26566.25314
-  tps: 19015.89042
+  dps: 26550.73344
+  tps: 19023.86408
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 27870.39272
-  tps: 19348.84929
+  dps: 27858.10993
+  tps: 19345.02824
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 27870.39272
-  tps: 19348.84929
+  dps: 27858.10993
+  tps: 19345.02824
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 29168.77631
-  tps: 20821.37884
+  dps: 29224.12462
+  tps: 20881.65951
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 29268.6283
-  tps: 20902.83108
+  dps: 29323.24044
+  tps: 20962.37248
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 28010.69651
-  tps: 19892.21861
+  dps: 28000.35305
+  tps: 19889.89521
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 28085.11447
-  tps: 19948.25782
+  dps: 28073.18674
+  tps: 19946.87294
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 28050.34436
-  tps: 19928.41755
+  dps: 28036.71068
+  tps: 19923.63748
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
   hps: 64
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CrushingWeight-59506"
  value: {
-  dps: 28060.97227
-  tps: 20022.20159
+  dps: 28090.48963
+  tps: 19990.41269
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CrushingWeight-65118"
  value: {
-  dps: 28305.48657
-  tps: 20177.47813
+  dps: 28332.81344
+  tps: 20200.30316
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 26531.70425
-  tps: 18984.5565
+  dps: 26511.85097
+  tps: 18988.71005
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 26629.99632
-  tps: 19110.5999
+  dps: 26588.01785
+  tps: 19082.34775
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 26788.17384
-  tps: 19171.09625
+  dps: 26773.29145
+  tps: 19177.28736
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 28023.82377
-  tps: 20155.68396
+  dps: 27947.01057
+  tps: 20078.59753
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 27072.36894
-  tps: 19483.22806
+  dps: 26997.74898
+  tps: 19408.3116
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 26851.64588
-  tps: 19403.48562
+  dps: 26819.70624
+  tps: 19375.26762
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Death'sChoice-47464"
  value: {
-  dps: 27306.4291
-  tps: 19607.58213
+  dps: 27294.42959
+  tps: 19611.65407
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 26489.46596
-  tps: 18964.63939
+  dps: 26474.41194
+  tps: 18971.49335
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 27143.93981
-  tps: 19520.6298
+  dps: 27052.81021
+  tps: 19410.11915
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 27236.66474
-  tps: 19556.89685
+  dps: 27167.66427
+  tps: 19519.38738
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Defender'sCode-40257"
  value: {
-  dps: 26432.95115
-  tps: 18925.1586
+  dps: 26418.96529
+  tps: 18931.56803
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 27941.83938
-  tps: 19796.59095
+  dps: 27927.89677
+  tps: 19793.57731
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 27909.84726
-  tps: 19777.8737
+  dps: 27894.4133
+  tps: 19771.65706
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 26667.23275
-  tps: 19081.31096
+  dps: 26690.73346
+  tps: 19106.35078
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 26678.54446
-  tps: 19099.19157
+  dps: 26622.05356
+  tps: 19059.12417
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 27870.39272
-  tps: 19743.72376
+  dps: 27858.10993
+  tps: 19739.82473
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 27870.39272
-  tps: 19743.72376
+  dps: 27858.10993
+  tps: 19739.82473
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 27870.39272
-  tps: 19743.72376
+  dps: 27858.10993
+  tps: 19739.82473
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 27870.39272
-  tps: 19743.72376
+  dps: 27858.10993
+  tps: 19739.82473
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 27941.83938
-  tps: 19796.59095
+  dps: 27927.89677
+  tps: 19793.57731
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 27908.08942
-  tps: 19777.8737
+  dps: 27892.65546
+  tps: 19771.65706
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 27902.64785
-  tps: 19772.61041
+  dps: 27886.85389
+  tps: 19765.20021
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 26467.94335
-  tps: 18922.41027
+  dps: 26464.41633
+  tps: 18923.69762
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 27017.76467
-  tps: 19319.07072
+  dps: 26987.99756
+  tps: 19313.518
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 27142.1019
-  tps: 19404.89934
+  dps: 27117.96669
+  tps: 19409.78809
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 27870.39272
-  tps: 19743.72376
+  dps: 27858.10993
+  tps: 19739.82473
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 27870.39272
-  tps: 19743.72376
+  dps: 27858.10993
+  tps: 19739.82473
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 26656.2119
-  tps: 19138.31272
+  dps: 26609.51905
+  tps: 19100.85759
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 26531.38599
-  tps: 18986.71601
+  dps: 26512.56495
+  tps: 18990.90659
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FallofMortality-59500"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FallofMortality-65124"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 26690.99509
-  tps: 19086.35012
+  dps: 26647.85652
+  tps: 19070.51695
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 27991.31435
-  tps: 20123.48102
+  dps: 27998.21962
+  tps: 20131.34273
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 27935.26224
-  tps: 19814.79953
+  dps: 27923.00501
+  tps: 19810.87166
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FluidDeath-58181"
  value: {
-  dps: 26674.24684
-  tps: 19067.58442
+  dps: 26660.32865
+  tps: 19073.2658
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForgeEmber-37660"
  value: {
-  dps: 26497.91082
-  tps: 18961.54717
+  dps: 26476.89999
+  tps: 18964.6931
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 27870.39272
-  tps: 19743.72376
+  dps: 27858.10993
+  tps: 19739.82473
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 27870.39272
-  tps: 19743.72376
+  dps: 27858.10993
+  tps: 19739.82473
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 27870.39272
-  tps: 19743.72376
+  dps: 27858.10993
+  tps: 19739.82473
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 30666.20613
-  tps: 21994.12484
+  dps: 30594.03484
+  tps: 21973.2476
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 26659.96717
-  tps: 19147.03026
+  dps: 26645.79228
+  tps: 19153.44806
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuturesightRune-38763"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GaleofShadows-56138"
  value: {
-  dps: 26906.64165
-  tps: 19274.54812
+  dps: 26908.22092
+  tps: 19291.49815
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GaleofShadows-56462"
  value: {
-  dps: 26924.33602
-  tps: 19311.73409
+  dps: 26897.41794
+  tps: 19271.44041
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GearDetector-61462"
  value: {
-  dps: 26701.12158
-  tps: 19027.17284
+  dps: 26713.19453
+  tps: 19033.3865
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 26591.47128
-  tps: 19086.55282
+  dps: 26576.83815
+  tps: 19077.4661
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 26698.35683
-  tps: 19101.27059
+  dps: 26672.89351
+  tps: 19098.22914
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 26866.87663
-  tps: 19218.89053
+  dps: 26843.25113
+  tps: 19217.80526
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HarmlightToken-63839"
  value: {
-  dps: 26538.90298
-  tps: 19031.67373
+  dps: 26525.79067
+  tps: 19038.93753
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 27485.68912
-  tps: 19725.26913
+  dps: 27471.55345
+  tps: 19731.41605
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 26952.21459
-  tps: 19251.97557
+  dps: 26942.19922
+  tps: 19252.5765
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 26852.31526
-  tps: 19143.45881
+  dps: 26901.64758
+  tps: 19195.27402
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HeartofRage-65072"
  value: {
-  dps: 28423.53838
-  tps: 20199.36317
+  dps: 28502.62219
+  tps: 20246.30949
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HeartofSolace-55868"
  value: {
-  dps: 26906.64165
-  tps: 19274.54812
+  dps: 26908.22092
+  tps: 19291.49815
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HeartofSolace-56393"
  value: {
-  dps: 28381.75932
-  tps: 20200.48862
+  dps: 28356.82773
+  tps: 20159.17576
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HeartofThunder-55845"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HeartofThunder-56370"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 26690.59093
-  tps: 19089.08957
+  dps: 26675.28516
+  tps: 19094.78664
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 27941.83938
-  tps: 19796.59095
+  dps: 27927.89677
+  tps: 19793.57731
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 27908.08942
-  tps: 19777.8737
+  dps: 27892.65546
+  tps: 19771.65706
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 27902.64785
-  tps: 19772.61041
+  dps: 27886.85389
+  tps: 19765.20021
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 28193.46588
-  tps: 20280.36585
+  dps: 28203.01935
+  tps: 20288.41167
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 28193.46588
-  tps: 20280.36585
+  dps: 28203.01935
+  tps: 20288.41167
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 26699.14904
-  tps: 19219.3293
+  dps: 26685.19658
+  tps: 19225.73576
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 26737.24218
-  tps: 19261.01178
+  dps: 26723.29246
+  tps: 19267.41874
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IncisorFragment-37723"
  value: {
-  dps: 26678.85242
-  tps: 19168.68075
+  dps: 26665.80289
+  tps: 19176.10749
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 27870.39272
-  tps: 19743.72376
+  dps: 27858.10993
+  tps: 19739.82473
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 26632.22727
-  tps: 19146.09899
+  dps: 26618.27011
+  tps: 19152.50471
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 27906.31048
-  tps: 19778.81843
-  hps: 39.37558
+  dps: 27894.04032
+  tps: 19774.91684
+  hps: 38.98573
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 26815.64375
-  tps: 19280.77633
+  dps: 26784.0427
+  tps: 19268.39203
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 26592.56099
-  tps: 19014.34044
+  dps: 26574.97516
+  tps: 19013.85066
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 26652.33931
-  tps: 19061.14381
+  dps: 26642.43882
+  tps: 19073.46586
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 27292.38868
-  tps: 19549.68421
+  dps: 27287.92022
+  tps: 19525.05845
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 27292.38868
-  tps: 19549.68421
+  dps: 27287.92022
+  tps: 19525.05845
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 26545.65481
-  tps: 18988.35452
+  dps: 26464.96455
+  tps: 18910.52343
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LastWord-50179"
  value: {
-  dps: 28560.93975
-  tps: 20264.99553
+  dps: 28500.14867
+  tps: 20215.43919
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LastWord-50708"
  value: {
-  dps: 28624.04508
-  tps: 20311.20389
+  dps: 28563.00768
+  tps: 20261.44704
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 26408.55655
-  tps: 18901.23279
+  dps: 26394.58499
+  tps: 18907.63734
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LeadenDespair-55816"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LeadenDespair-56347"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 26705.2336
-  tps: 19118.77966
+  dps: 26638.55539
+  tps: 19064.22829
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 26799.43002
-  tps: 19175.84352
+  dps: 26770.65579
+  tps: 19164.05517
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MagmaPlatedBattlegear"
  value: {
-  dps: 27175.52797
-  tps: 19390.23357
+  dps: 27161.15026
+  tps: 19394.40736
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 27284.26607
-  tps: 19607.62965
+  dps: 27264.06388
+  tps: 19604.35422
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 27727.35531
-  tps: 19950.62205
+  dps: 27696.33444
+  tps: 19926.85395
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 27714.6939
-  tps: 19953.22951
+  dps: 27691.88231
+  tps: 19950.00067
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 27887.84922
-  tps: 20093.32658
+  dps: 27863.8253
+  tps: 20088.76996
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 26571.06317
-  tps: 19065.55382
+  dps: 26633.45853
+  tps: 19118.50737
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 27028.40485
-  tps: 19391.98966
+  dps: 27002.53296
+  tps: 19386.87547
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 27563.08534
-  tps: 19815.21562
+  dps: 27526.94649
+  tps: 19800.16367
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 26778.81236
-  tps: 19306.4976
+  dps: 26764.86571
+  tps: 19312.90517
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 26778.81236
-  tps: 19306.4976
+  dps: 26764.86571
+  tps: 19312.90517
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 26860.59429
-  tps: 19401.63631
+  dps: 26850.25424
+  tps: 19409.90672
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 26584.46097
-  tps: 19043.14901
+  dps: 26564.62857
+  tps: 19045.77662
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 26424.37835
-  tps: 18916.78462
+  dps: 26410.39754
+  tps: 18923.19233
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 27406.58056
-  tps: 19609.0024
+  dps: 27377.38002
+  tps: 19608.49277
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 27899.469
-  tps: 19772.13373
+  dps: 27887.19644
+  tps: 19768.23263
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 27906.31048
-  tps: 19778.81843
+  dps: 27894.04032
+  tps: 19774.91684
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 26408.55655
-  tps: 18901.23279
+  dps: 26394.58499
+  tps: 18907.63734
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 26473.87197
-  tps: 18965.13042
+  dps: 26459.86202
+  tps: 18971.54807
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 26482.27331
-  tps: 18973.33693
+  dps: 26468.25842
+  tps: 18979.75626
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 26611.17624
-  tps: 19124.02482
+  dps: 26598.94619
+  tps: 19132.24062
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 26776.71998
-  tps: 19300.6789
+  dps: 26768.48757
+  tps: 19313.62054
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 27870.39272
-  tps: 19743.72376
+  dps: 27858.10993
+  tps: 19739.82473
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 27870.39272
-  tps: 19743.72376
+  dps: 27858.10993
+  tps: 19739.82473
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 27870.39272
-  tps: 19743.72376
+  dps: 27858.10993
+  tps: 19739.82473
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 27046.99533
-  tps: 19306.83556
+  dps: 27030.33096
+  tps: 19289.71343
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 27142.12583
-  tps: 19372.32773
+  dps: 27194.52398
+  tps: 19410.94059
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Rainsong-55854"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Rainsong-56377"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 26468.17482
-  tps: 18985.7315
+  dps: 26433.50935
+  tps: 18960.22596
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 26473.39411
-  tps: 18990.95079
+  dps: 26438.82471
+  tps: 18965.54132
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 28031.04743
-  tps: 19909.98479
+  dps: 28016.98216
+  tps: 19903.93957
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 28212.73569
-  tps: 20031.49531
+  dps: 28202.36686
+  tps: 20029.24056
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 28010.69651
-  tps: 19892.21861
+  dps: 28000.35305
+  tps: 19889.89521
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 27870.39272
-  tps: 19743.72376
+  dps: 27858.10993
+  tps: 19739.82473
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 27239.33035
-  tps: 19447.36069
+  dps: 27226.76174
+  tps: 19429.68925
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 27342.10619
-  tps: 19480.26655
+  dps: 27351.20506
+  tps: 19483.90964
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 26787.17883
-  tps: 19230.70281
+  dps: 26769.98416
+  tps: 19233.4798
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SeaStar-55256"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SeaStar-56290"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 26434.20967
-  tps: 18924.96886
+  dps: 26420.74172
+  tps: 18931.42574
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Shadowmourne-49623"
  value: {
-  dps: 30684.61393
-  tps: 21983.12415
+  dps: 30640.49816
+  tps: 21973.75419
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 27508.60693
-  tps: 19616.44218
+  dps: 27562.18573
+  tps: 19658.47767
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 26934.03539
-  tps: 19388.24717
+  dps: 26920.73377
+  tps: 19396.11497
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 27003.59917
-  tps: 19452.13269
+  dps: 26988.26251
+  tps: 19458.21377
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Sorrowsong-55879"
  value: {
-  dps: 26699.14904
-  tps: 19219.3293
+  dps: 26685.19658
+  tps: 19225.73576
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Sorrowsong-56400"
  value: {
-  dps: 26737.13379
-  tps: 19260.80583
+  dps: 26723.18407
+  tps: 19267.21279
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 27028.40485
-  tps: 19391.98966
+  dps: 27002.53296
+  tps: 19386.87547
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SoulCasket-58183"
  value: {
-  dps: 26778.81236
-  tps: 19306.4976
+  dps: 26764.86571
+  tps: 19312.90517
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SoulPreserver-37111"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SouloftheDead-40382"
  value: {
-  dps: 26535.75866
-  tps: 18989.97083
+  dps: 26514.69104
+  tps: 18993.03268
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SparkofLife-37657"
  value: {
-  dps: 26569.57248
-  tps: 19061.37271
+  dps: 26534.09484
+  tps: 19041.56566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 26552.50386
-  tps: 19033.94901
+  dps: 26541.36777
+  tps: 19040.64818
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 26709.04187
-  tps: 19118.62007
+  dps: 26664.95934
+  tps: 19094.52224
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-StumpofTime-62465"
  value: {
-  dps: 26408.55655
-  tps: 18901.23279
+  dps: 26394.58499
+  tps: 18907.63734
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-StumpofTime-62470"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 27906.31048
-  tps: 19778.81843
+  dps: 27894.04032
+  tps: 19774.91684
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 27899.469
-  tps: 19772.13373
+  dps: 27887.19644
+  tps: 19768.23263
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 27887.49642
-  tps: 19760.43551
+  dps: 27875.21964
+  tps: 19756.53526
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 26616.08614
-  tps: 19128.19881
+  dps: 26601.9372
+  tps: 19135.01207
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 27558.69697
-  tps: 19688.26132
+  dps: 27580.06202
+  tps: 19726.03352
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TearofBlood-55819"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TearofBlood-56351"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 26656.34561
-  tps: 19172.40465
+  dps: 26642.39013
+  tps: 19178.81062
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 26737.24218
-  tps: 19261.01178
+  dps: 26723.29246
+  tps: 19267.41874
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 26828.51324
-  tps: 19365.15425
+  dps: 26813.86394
+  tps: 19370.99766
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 26893.28765
-  tps: 19430.57116
+  dps: 26877.37353
+  tps: 19434.02253
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 27905.01892
-  tps: 19747.91681
+  dps: 27921.25144
+  tps: 19735.30902
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 26924.5119
-  tps: 19362.99271
+  dps: 26904.6487
+  tps: 19366.6959
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 26980.28345
-  tps: 19417.79463
+  dps: 26963.93031
+  tps: 19420.25813
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 26831.24032
-  tps: 19294.47316
+  dps: 26789.3254
+  tps: 19250.38136
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 26845.26003
-  tps: 19312.0206
+  dps: 26764.73767
+  tps: 19260.75412
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 27870.39272
-  tps: 19743.72376
+  dps: 27858.10993
+  tps: 19739.82473
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 27870.39272
-  tps: 19743.72376
+  dps: 27858.10993
+  tps: 19739.82473
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 26528.08605
-  tps: 19026.99667
+  dps: 26514.96576
+  tps: 19019.33598
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 27870.39272
-  tps: 19743.72376
+  dps: 27858.10993
+  tps: 19739.82473
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 27870.39272
-  tps: 19743.72376
+  dps: 27858.10993
+  tps: 19739.82473
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 26445.11501
-  tps: 18967.96239
+  dps: 26429.51515
+  tps: 18956.3792
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 20265.77074
-  tps: 14399.3633
+  dps: 20199.23382
+  tps: 14330.51106
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-UnheededWarning-59520"
  value: {
-  dps: 26947.52582
-  tps: 19336.06236
+  dps: 26926.22216
+  tps: 19341.9487
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 27024.99247
-  tps: 19457.2336
+  dps: 27000.99859
+  tps: 19463.89786
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 27024.99247
-  tps: 19457.2336
+  dps: 27000.99859
+  tps: 19463.89786
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 19377.0367
-  tps: 12656.52372
+  dps: 19362.02038
+  tps: 12677.37087
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 26653.30586
-  tps: 19050.6325
+  dps: 26629.33666
+  tps: 19057.34333
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 27803.97131
-  tps: 19853.43074
+  dps: 27813.40379
+  tps: 19861.47631
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 26880.03548
-  tps: 19250.38882
+  dps: 26853.61004
+  tps: 19229.01359
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 26856.99355
-  tps: 19235.1784
+  dps: 26840.8445
+  tps: 19237.53519
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 26621.56792
-  tps: 19094.84052
+  dps: 26655.94993
+  tps: 19117.37334
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 26800.75808
-  tps: 19330.50991
+  dps: 26786.81307
+  tps: 19336.91783
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 26634.77539
-  tps: 19041.57352
+  dps: 26622.61488
+  tps: 19047.85515
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 26408.55655
-  tps: 18901.23279
+  dps: 26394.58499
+  tps: 18907.63734
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 27645.32826
-  tps: 19715.34174
+  dps: 27632.80808
+  tps: 19711.59882
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WingedTalisman-37844"
  value: {
-  dps: 26408.66156
-  tps: 18901.43231
+  dps: 26394.69
+  tps: 18907.83687
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 26640.29496
-  tps: 19053.28193
+  dps: 26560.90884
+  tps: 19010.65736
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 26872.18783
-  tps: 19202.03466
+  dps: 26842.56552
+  tps: 19161.24855
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 26661.0682
-  tps: 19177.65912
+  dps: 26647.11304
+  tps: 19184.06514
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 26717.65961
-  tps: 19242.01064
+  dps: 26697.00085
+  tps: 19240.27586
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 26717.65961
-  tps: 19242.01064
+  dps: 26697.00085
+  tps: 19240.27586
  }
 }
 dps_results: {
  key: "TestUnholy-Average-Default"
  value: {
-  dps: 28243.77832
-  tps: 20068.64798
+  dps: 28233.83175
+  tps: 20063.52733
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Goblin-p1-Basic-st-FullBuffs-LongMultiTarget"
  value: {
-  dps: 49057.05874
-  tps: 56990.32806
+  dps: 49135.81875
+  tps: 57162.29805
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Goblin-p1-Basic-st-FullBuffs-LongSingleTarget"
  value: {
-  dps: 27947.70545
-  tps: 19831.58387
+  dps: 28011.08124
+  tps: 19896.33613
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Goblin-p1-Basic-st-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 38944.55778
-  tps: 24049.68287
+  dps: 38933.69004
+  tps: 24039.16672
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Goblin-p1-Basic-st-NoBuffs-LongMultiTarget"
  value: {
-  dps: 31174.06289
-  tps: 35899.73377
+  dps: 31175.0915
+  tps: 35928.42894
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Goblin-p1-Basic-st-NoBuffs-LongSingleTarget"
  value: {
-  dps: 17877.28663
-  tps: 12800.78436
+  dps: 17877.48412
+  tps: 12798.01311
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Goblin-p1-Basic-st-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 22566.5557
-  tps: 14382.16881
+  dps: 22574.63194
+  tps: 14388.90347
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Worgen-p1-Basic-st-FullBuffs-LongMultiTarget"
  value: {
-  dps: 49454.94754
-  tps: 57822.80415
+  dps: 49576.76868
+  tps: 57914.24003
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Worgen-p1-Basic-st-FullBuffs-LongSingleTarget"
  value: {
-  dps: 28212.73569
-  tps: 20031.49531
+  dps: 28202.36686
+  tps: 20029.24056
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Worgen-p1-Basic-st-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 39269.08865
-  tps: 24167.32753
+  dps: 39266.33508
+  tps: 24171.96629
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Worgen-p1-Basic-st-NoBuffs-LongMultiTarget"
  value: {
-  dps: 31426.01189
-  tps: 36273.45185
+  dps: 31474.05156
+  tps: 36340.69589
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Worgen-p1-Basic-st-NoBuffs-LongSingleTarget"
  value: {
-  dps: 17897.26753
-  tps: 12829.34921
+  dps: 17916.66225
+  tps: 12828.34617
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Worgen-p1-Basic-st-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 22604.15937
-  tps: 14433.11989
+  dps: 22612.78248
+  tps: 14448.95693
  }
 }
 dps_results: {
  key: "TestUnholy-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 26926.38367
-  tps: 19182.0294
+  dps: 26974.21327
+  tps: 19252.76154
  }
 }

--- a/sim/death_knight/unholy/TestUnholy.results
+++ b/sim/death_knight/unholy/TestUnholy.results
@@ -40,1846 +40,1846 @@ character_stats_results: {
 dps_results: {
  key: "TestUnholy-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 28032.93426
-  tps: 19910.22214
+  dps: 28020.66134
+  tps: 19911.57043
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 27870.16429
-  tps: 19751.59785
+  dps: 27855.22403
+  tps: 19750.50833
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 27870.16429
-  tps: 19751.59785
+  dps: 27855.22403
+  tps: 19750.50833
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 26634.58748
-  tps: 19152.75091
+  dps: 26679.9464
+  tps: 19217.11374
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
   hps: 85.60947
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
   hps: 85.60947
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 27892.65546
-  tps: 19771.65706
+  dps: 27875.7152
+  tps: 19767.58717
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 26818.19073
-  tps: 19219.72818
+  dps: 26868.2344
+  tps: 19274.96133
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 26863.01668
-  tps: 19253.11111
+  dps: 26913.78504
+  tps: 19310.36162
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BindingPromise-67037"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedBattlegearofUndeadSlaying"
  value: {
-  dps: 21333.22201
-  tps: 15067.93715
+  dps: 21331.94429
+  tps: 15073.4542
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 20149.68539
-  tps: 14285.32217
+  dps: 20173.07471
+  tps: 14305.94638
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 19963.12998
-  tps: 14115.33457
+  dps: 19914.76915
+  tps: 14068.84011
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 26784.0427
-  tps: 19268.39203
+  dps: 26817.84548
+  tps: 19313.37501
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 26685.19658
-  tps: 19225.73576
+  dps: 26719.56449
+  tps: 19270.2115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 26723.29246
-  tps: 19267.41874
+  dps: 26757.71454
+  tps: 19311.94495
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 26666.86043
-  tps: 19085.72281
+  dps: 26694.39273
+  tps: 19127.46365
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 27738.26941
-  tps: 19810.97204
+  dps: 27775.02661
+  tps: 19856.89485
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 26801.08914
-  tps: 19206.39966
+  dps: 26852.53876
+  tps: 19263.05268
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 26608.57928
-  tps: 19033.93062
+  dps: 26649.06365
+  tps: 19081.64161
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 26394.58499
-  tps: 18907.63734
+  dps: 26428.53829
+  tps: 18951.72664
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 27564.31619
-  tps: 19675.65371
+  dps: 27598.43472
+  tps: 19724.31039
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BottledLightning-66879"
  value: {
-  dps: 26550.73344
-  tps: 19023.86408
+  dps: 26590.04905
+  tps: 19068.91057
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 27858.10993
-  tps: 19345.02824
+  dps: 27843.17018
+  tps: 19343.95897
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 27858.10993
-  tps: 19345.02824
+  dps: 27843.17018
+  tps: 19343.95897
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 29224.12462
-  tps: 20881.65951
+  dps: 29211.22051
+  tps: 20867.00805
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 29323.24044
-  tps: 20962.37248
+  dps: 29312.91719
+  tps: 20950.29659
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 28000.35305
-  tps: 19889.89521
+  dps: 27986.22361
+  tps: 19889.54176
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 28073.18674
-  tps: 19946.87294
+  dps: 28057.28408
+  tps: 19945.21316
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 28036.71068
-  tps: 19923.63748
+  dps: 28020.40201
+  tps: 19920.1265
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
   hps: 64
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CrushingWeight-59506"
  value: {
-  dps: 28090.48963
-  tps: 19990.41269
+  dps: 28136.71774
+  tps: 20029.58505
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CrushingWeight-65118"
  value: {
-  dps: 28332.81344
-  tps: 20200.30316
+  dps: 28349.52141
+  tps: 20231.481
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 26511.85097
-  tps: 18988.71005
+  dps: 26557.48044
+  tps: 19039.01557
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 26588.01785
-  tps: 19082.34775
+  dps: 26644.16671
+  tps: 19149.04752
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 26773.29145
-  tps: 19177.28736
+  dps: 26803.86883
+  tps: 19220.03087
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 27947.01057
-  tps: 20078.59753
+  dps: 27994.50867
+  tps: 20146.73035
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 26997.74898
-  tps: 19408.3116
+  dps: 27053.00775
+  tps: 19478.85838
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 26819.70624
-  tps: 19375.26762
+  dps: 26857.07495
+  tps: 19430.59587
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Death'sChoice-47464"
  value: {
-  dps: 27294.42959
-  tps: 19611.65407
+  dps: 27323.1527
+  tps: 19654.43932
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 26474.41194
-  tps: 18971.49335
+  dps: 26514.82031
+  tps: 19017.8089
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 27052.81021
-  tps: 19410.11915
+  dps: 27100.17398
+  tps: 19445.99724
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 27167.66427
-  tps: 19519.38738
+  dps: 27195.39095
+  tps: 19538.72506
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Defender'sCode-40257"
  value: {
-  dps: 26418.96529
-  tps: 18931.56803
+  dps: 26452.9623
+  tps: 18975.69482
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 27927.89677
-  tps: 19793.57731
+  dps: 27911.25773
+  tps: 19791.25383
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 27894.4133
-  tps: 19771.65706
+  dps: 27880.27317
+  tps: 19770.38731
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 26690.73346
-  tps: 19106.35078
+  dps: 26705.17269
+  tps: 19136.57369
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 26622.05356
-  tps: 19059.12417
+  dps: 26626.26896
+  tps: 19060.73653
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 27858.10993
-  tps: 19739.82473
+  dps: 27843.17018
+  tps: 19738.73365
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 27858.10993
-  tps: 19739.82473
+  dps: 27843.17018
+  tps: 19738.73365
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 27858.10993
-  tps: 19739.82473
+  dps: 27843.17018
+  tps: 19738.73365
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 27858.10993
-  tps: 19739.82473
+  dps: 27843.17018
+  tps: 19738.73365
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 27927.89677
-  tps: 19793.57731
+  dps: 27911.25773
+  tps: 19791.25383
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 27892.65546
-  tps: 19771.65706
+  dps: 27875.7152
+  tps: 19767.58717
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 27886.85389
-  tps: 19765.20021
+  dps: 27870.13006
+  tps: 19762.32505
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 26464.41633
-  tps: 18923.69762
+  dps: 26451.46425
+  tps: 18912.51449
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 26987.99756
-  tps: 19313.518
+  dps: 27047.27623
+  tps: 19375.15357
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 27117.96669
-  tps: 19409.78809
+  dps: 27171.77484
+  tps: 19468.63644
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 27858.10993
-  tps: 19739.82473
+  dps: 27843.17018
+  tps: 19738.73365
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 27858.10993
-  tps: 19739.82473
+  dps: 27843.17018
+  tps: 19738.73365
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 26609.51905
-  tps: 19100.85759
+  dps: 26651.33829
+  tps: 19151.3412
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 26512.56495
-  tps: 18990.90659
+  dps: 26558.19442
+  tps: 19041.21211
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FallofMortality-59500"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FallofMortality-65124"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 26647.85652
-  tps: 19070.51695
+  dps: 26676.23502
+  tps: 19112.25779
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 27998.21962
-  tps: 20131.34273
+  dps: 28035.25192
+  tps: 20177.55904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 27923.00501
-  tps: 19810.87166
+  dps: 27908.07367
+  tps: 19809.77603
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FluidDeath-58181"
  value: {
-  dps: 26660.32865
-  tps: 19073.2658
+  dps: 26702.23373
+  tps: 19121.34262
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForgeEmber-37660"
  value: {
-  dps: 26476.89999
-  tps: 18964.6931
+  dps: 26520.69308
+  tps: 19013.97983
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 27858.10993
-  tps: 19739.82473
+  dps: 27843.17018
+  tps: 19738.73365
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 27858.10993
-  tps: 19739.82473
+  dps: 27843.17018
+  tps: 19738.73365
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 27858.10993
-  tps: 19739.82473
+  dps: 27843.17018
+  tps: 19738.73365
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 30594.03484
-  tps: 21973.2476
+  dps: 30648.16856
+  tps: 22042.98376
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 26645.79228
-  tps: 19153.44806
+  dps: 26680.2391
+  tps: 19197.96069
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuturesightRune-38763"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GaleofShadows-56138"
  value: {
-  dps: 26908.22092
-  tps: 19291.49815
+  dps: 26912.22991
+  tps: 19295.22779
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GaleofShadows-56462"
  value: {
-  dps: 26897.41794
-  tps: 19271.44041
+  dps: 26893.71126
+  tps: 19266.08692
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GearDetector-61462"
  value: {
-  dps: 26713.19453
-  tps: 19033.3865
+  dps: 26751.36511
+  tps: 19050.98967
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 26576.83815
-  tps: 19077.4661
+  dps: 26616.10638
+  tps: 19134.78029
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 26672.89351
-  tps: 19098.22914
+  dps: 26720.27028
+  tps: 19149.78349
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 26843.25113
-  tps: 19217.80526
+  dps: 26884.89238
+  tps: 19266.11697
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HarmlightToken-63839"
  value: {
-  dps: 26525.79067
-  tps: 19038.93753
+  dps: 26559.34477
+  tps: 19082.62763
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 27471.55345
-  tps: 19731.41605
+  dps: 27504.95927
+  tps: 19774.88613
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 26942.19922
-  tps: 19252.5765
+  dps: 26920.36832
+  tps: 19235.1279
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 26901.64758
-  tps: 19195.27402
+  dps: 26879.74717
+  tps: 19174.93244
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HeartofRage-65072"
  value: {
-  dps: 28502.62219
-  tps: 20246.30949
+  dps: 28461.66379
+  tps: 20204.62467
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HeartofSolace-55868"
  value: {
-  dps: 26908.22092
-  tps: 19291.49815
+  dps: 26912.22991
+  tps: 19295.22779
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HeartofSolace-56393"
  value: {
-  dps: 28356.82773
-  tps: 20159.17576
+  dps: 28343.46652
+  tps: 20153.46805
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HeartofThunder-55845"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HeartofThunder-56370"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 26675.28516
-  tps: 19094.78664
+  dps: 26719.47443
+  tps: 19145.41726
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 27927.89677
-  tps: 19793.57731
+  dps: 27911.25773
+  tps: 19791.25383
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 27892.65546
-  tps: 19771.65706
+  dps: 27875.7152
+  tps: 19767.58717
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 27886.85389
-  tps: 19765.20021
+  dps: 27870.13006
+  tps: 19762.32505
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 28203.01935
-  tps: 20288.41167
+  dps: 28240.43774
+  tps: 20334.89235
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 28203.01935
-  tps: 20288.41167
+  dps: 28240.43774
+  tps: 20334.89235
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 26685.19658
-  tps: 19225.73576
+  dps: 26719.56449
+  tps: 19270.2115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 26723.29246
-  tps: 19267.41874
+  dps: 26757.71454
+  tps: 19311.94495
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IncisorFragment-37723"
  value: {
-  dps: 26665.80289
-  tps: 19176.10749
+  dps: 26699.42004
+  tps: 19219.82818
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 27858.10993
-  tps: 19739.82473
+  dps: 27843.17018
+  tps: 19738.73365
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 26618.27011
-  tps: 19152.50471
+  dps: 26652.54276
+  tps: 19196.89167
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 27894.04032
-  tps: 19774.91684
-  hps: 38.98573
+  dps: 27879.09904
+  tps: 19773.83041
+  hps: 39.76544
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 26784.0427
-  tps: 19268.39203
+  dps: 26817.84548
+  tps: 19313.37501
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 26574.97516
-  tps: 19013.85066
+  dps: 26605.93799
+  tps: 19057.78727
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 26642.43882
-  tps: 19073.46586
+  dps: 26679.22524
+  tps: 19116.25248
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 27287.92022
-  tps: 19525.05845
+  dps: 27275.79617
+  tps: 19517.66526
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 27287.92022
-  tps: 19525.05845
+  dps: 27275.79617
+  tps: 19517.66526
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 26464.96455
-  tps: 18910.52343
+  dps: 26440.14646
+  tps: 18897.83794
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LastWord-50179"
  value: {
-  dps: 28500.14867
-  tps: 20215.43919
+  dps: 28446.87696
+  tps: 20191.56396
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LastWord-50708"
  value: {
-  dps: 28563.00768
-  tps: 20261.44704
+  dps: 28509.57105
+  tps: 20237.43561
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 26394.58499
-  tps: 18907.63734
+  dps: 26428.53829
+  tps: 18951.72664
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LeadenDespair-55816"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LeadenDespair-56347"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 26638.55539
-  tps: 19064.22829
+  dps: 26619.03136
+  tps: 19054.39524
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 26770.65579
-  tps: 19164.05517
+  dps: 26761.83306
+  tps: 19163.90419
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MagmaPlatedBattlegear"
  value: {
-  dps: 27161.15026
-  tps: 19394.40736
+  dps: 27146.864
+  tps: 19368.75165
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 27264.06388
-  tps: 19604.35422
+  dps: 27234.19021
+  tps: 19577.84308
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 27696.33444
-  tps: 19926.85395
+  dps: 27683.64497
+  tps: 19923.76271
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 27691.88231
-  tps: 19950.00067
+  dps: 27727.1176
+  tps: 19995.71779
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 27863.8253
-  tps: 20088.76996
+  dps: 27899.22714
+  tps: 20134.69863
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 26633.45853
-  tps: 19118.50737
+  dps: 26731.36822
+  tps: 19166.91146
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 27002.53296
-  tps: 19386.87547
+  dps: 27035.61872
+  tps: 19430.86522
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 27526.94649
-  tps: 19800.16367
+  dps: 27559.28378
+  tps: 19844.06753
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 26764.86571
-  tps: 19312.90517
+  dps: 26799.34683
+  tps: 19357.48641
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 26764.86571
-  tps: 19312.90517
+  dps: 26799.34683
+  tps: 19357.48641
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 26850.25424
-  tps: 19409.90672
+  dps: 26882.80011
+  tps: 19452.35158
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 26564.62857
-  tps: 19045.77662
+  dps: 26603.11063
+  tps: 19093.52137
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 26410.39754
-  tps: 18923.19233
+  dps: 26444.37912
+  tps: 18967.30588
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 27377.38002
-  tps: 19608.49277
+  dps: 27421.92497
+  tps: 19659.034
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 27887.19644
-  tps: 19768.23263
+  dps: 27872.25545
+  tps: 19767.14532
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 27894.04032
-  tps: 19774.91684
+  dps: 27879.09904
+  tps: 19773.83041
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 26394.58499
-  tps: 18907.63734
+  dps: 26428.53829
+  tps: 18951.72664
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 26459.86202
-  tps: 18971.54807
+  dps: 26493.93264
+  tps: 19015.738
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 26468.25842
-  tps: 18979.75626
+  dps: 26502.34415
+  tps: 19023.95916
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 26598.94619
-  tps: 19132.24062
+  dps: 26633.40292
+  tps: 19176.72087
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 26768.48757
-  tps: 19313.62054
+  dps: 26800.96434
+  tps: 19356.17857
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 27858.10993
-  tps: 19739.82473
+  dps: 27843.17018
+  tps: 19738.73365
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 27858.10993
-  tps: 19739.82473
+  dps: 27843.17018
+  tps: 19738.73365
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 27858.10993
-  tps: 19739.82473
+  dps: 27843.17018
+  tps: 19738.73365
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 27030.33096
-  tps: 19289.71343
+  dps: 27013.42136
+  tps: 19267.56212
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 27194.52398
-  tps: 19410.94059
+  dps: 27146.8191
+  tps: 19392.99684
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Rainsong-55854"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Rainsong-56377"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 26433.50935
-  tps: 18960.22596
+  dps: 26463.55468
+  tps: 19004.12952
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 26438.82471
-  tps: 18965.54132
+  dps: 26468.75868
+  tps: 19009.33351
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 28016.98216
-  tps: 19903.93957
+  dps: 28002.85272
+  tps: 19903.58612
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 28202.36686
-  tps: 20029.24056
+  dps: 28188.11584
+  tps: 20028.90663
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 28000.35305
-  tps: 19889.89521
+  dps: 27986.22361
+  tps: 19889.54176
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 27858.10993
-  tps: 19739.82473
+  dps: 27843.17018
+  tps: 19738.73365
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 27226.76174
-  tps: 19429.68925
+  dps: 27282.99083
+  tps: 19499.06117
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 27351.20506
-  tps: 19483.90964
+  dps: 27377.69221
+  tps: 19515.93636
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 26769.98416
-  tps: 19233.4798
+  dps: 26812.76763
+  tps: 19282.18672
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SeaStar-55256"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SeaStar-56290"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 26420.74172
-  tps: 18931.42574
+  dps: 26454.74253
+  tps: 18975.55232
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Shadowmourne-49623"
  value: {
-  dps: 30640.49816
-  tps: 21973.75419
+  dps: 30646.0066
+  tps: 21976.96102
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 27562.18573
-  tps: 19658.47767
+  dps: 27610.594
+  tps: 19675.62966
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 26920.73377
-  tps: 19396.11497
+  dps: 26963.86056
+  tps: 19445.37333
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 26988.26251
-  tps: 19458.21377
+  dps: 27032.5378
+  tps: 19507.31057
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Sorrowsong-55879"
  value: {
-  dps: 26685.19658
-  tps: 19225.73576
+  dps: 26719.56449
+  tps: 19270.2115
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Sorrowsong-56400"
  value: {
-  dps: 26723.18407
-  tps: 19267.21279
+  dps: 26757.60614
+  tps: 19311.739
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 27002.53296
-  tps: 19386.87547
+  dps: 27035.61872
+  tps: 19430.86522
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SoulCasket-58183"
  value: {
-  dps: 26764.86571
-  tps: 19312.90517
+  dps: 26799.34683
+  tps: 19357.48641
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SoulPreserver-37111"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SouloftheDead-40382"
  value: {
-  dps: 26514.69104
-  tps: 18993.03268
+  dps: 26560.32051
+  tps: 19043.3382
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SparkofLife-37657"
  value: {
-  dps: 26534.09484
-  tps: 19041.56566
+  dps: 26519.10416
+  tps: 19032.11821
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 26541.36777
-  tps: 19040.64818
+  dps: 26575.58852
+  tps: 19084.94735
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 26664.95934
-  tps: 19094.52224
+  dps: 26720.64563
+  tps: 19161.87328
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-StumpofTime-62465"
  value: {
-  dps: 26394.58499
-  tps: 18907.63734
+  dps: 26428.53829
+  tps: 18951.72664
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-StumpofTime-62470"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 27894.04032
-  tps: 19774.91684
+  dps: 27879.09904
+  tps: 19773.83041
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 27887.19644
-  tps: 19768.23263
+  dps: 27872.25545
+  tps: 19767.14532
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 27875.21964
-  tps: 19756.53526
+  dps: 27860.27916
+  tps: 19755.44639
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 26601.9372
-  tps: 19135.01207
+  dps: 26637.54742
+  tps: 19180.94708
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 27580.06202
-  tps: 19726.03352
+  dps: 27506.93017
+  tps: 19648.19702
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TearofBlood-55819"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TearofBlood-56351"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 26642.39013
-  tps: 19178.81062
+  dps: 26676.69728
+  tps: 19223.22974
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 26723.29246
-  tps: 19267.41874
+  dps: 26757.71454
+  tps: 19311.94495
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 26813.86394
-  tps: 19370.99766
+  dps: 26852.079
+  tps: 19419.90051
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 26877.37353
-  tps: 19434.02253
+  dps: 26921.62699
+  tps: 19489.99043
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 27921.25144
-  tps: 19735.30902
+  dps: 27941.05689
+  tps: 19776.90234
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 26904.6487
-  tps: 19366.6959
+  dps: 26949.45994
+  tps: 19416.49914
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 26963.93031
-  tps: 19420.25813
+  dps: 27009.3889
+  tps: 19471.13487
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 26789.3254
-  tps: 19250.38136
+  dps: 26790.84249
+  tps: 19265.38157
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 26764.73767
-  tps: 19260.75412
+  dps: 26782.85128
+  tps: 19278.59327
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 27858.10993
-  tps: 19739.82473
+  dps: 27843.17018
+  tps: 19738.73365
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 27858.10993
-  tps: 19739.82473
+  dps: 27843.17018
+  tps: 19738.73365
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 26514.96576
-  tps: 19019.33598
+  dps: 26510.42172
+  tps: 19018.41369
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 27858.10993
-  tps: 19739.82473
+  dps: 27843.17018
+  tps: 19738.73365
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 27858.10993
-  tps: 19739.82473
+  dps: 27843.17018
+  tps: 19738.73365
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 26429.51515
-  tps: 18956.3792
+  dps: 26461.07765
+  tps: 19009.66167
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 20199.23382
-  tps: 14330.51106
+  dps: 20197.36334
+  tps: 14326.144
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-UnheededWarning-59520"
  value: {
-  dps: 26926.22216
-  tps: 19341.9487
+  dps: 26971.80156
+  tps: 19393.10631
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 27000.99859
-  tps: 19463.89786
+  dps: 27041.59122
+  tps: 19507.82469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 27000.99859
-  tps: 19463.89786
+  dps: 27041.59122
+  tps: 19507.82469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 19362.02038
-  tps: 12677.37087
+  dps: 19389.72606
+  tps: 12694.15845
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 26629.33666
-  tps: 19057.34333
+  dps: 26669.39817
+  tps: 19100.77493
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 27813.40379
-  tps: 19861.47631
+  dps: 27850.31779
+  tps: 19907.50165
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 26853.61004
-  tps: 19229.01359
+  dps: 26856.72849
+  tps: 19225.51864
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 26840.8445
-  tps: 19237.53519
+  dps: 26892.08842
+  tps: 19295.72355
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 26655.94993
-  tps: 19117.37334
+  dps: 26609.93631
+  tps: 19081.81012
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 26786.81307
-  tps: 19336.91783
+  dps: 26821.32534
+  tps: 19381.52809
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 26622.61488
-  tps: 19047.85515
+  dps: 26654.24915
+  tps: 19086.83252
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 26394.58499
-  tps: 18907.63734
+  dps: 26428.53829
+  tps: 18951.72664
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 27632.80808
-  tps: 19711.59882
+  dps: 27674.17852
+  tps: 19768.43163
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WingedTalisman-37844"
  value: {
-  dps: 26394.69
-  tps: 18907.83687
+  dps: 26428.64331
+  tps: 18951.92617
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 26560.90884
-  tps: 19010.65736
+  dps: 26574.86914
+  tps: 19013.48248
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 26842.56552
-  tps: 19161.24855
+  dps: 26816.72744
+  tps: 19143.34345
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 26647.11304
-  tps: 19184.06514
+  dps: 26681.42677
+  tps: 19228.49038
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 26697.00085
-  tps: 19240.27586
+  dps: 26731.27319
+  tps: 19284.64914
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 26697.00085
-  tps: 19240.27586
+  dps: 26731.27319
+  tps: 19284.64914
  }
 }
 dps_results: {
  key: "TestUnholy-Average-Default"
  value: {
-  dps: 28233.83175
-  tps: 20063.52733
+  dps: 28231.61076
+  tps: 20061.55525
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Goblin-p1-Basic-st-FullBuffs-LongMultiTarget"
  value: {
-  dps: 49135.81875
-  tps: 57162.29805
+  dps: 49165.56619
+  tps: 57201.63932
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Goblin-p1-Basic-st-FullBuffs-LongSingleTarget"
  value: {
-  dps: 28011.08124
-  tps: 19896.33613
+  dps: 27986.25397
+  tps: 19861.47979
  }
 }
 dps_results: {
@@ -1913,15 +1913,15 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Worgen-p1-Basic-st-FullBuffs-LongMultiTarget"
  value: {
-  dps: 49576.76868
-  tps: 57914.24003
+  dps: 49590.57613
+  tps: 57910.20677
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Worgen-p1-Basic-st-FullBuffs-LongSingleTarget"
  value: {
-  dps: 28202.36686
-  tps: 20029.24056
+  dps: 28188.11584
+  tps: 20028.90663
  }
 }
 dps_results: {
@@ -1955,7 +1955,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 26974.21327
-  tps: 19252.76154
+  dps: 26952.89682
+  tps: 19233.75093
  }
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -40,1894 +40,1894 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 16242.64903
-  tps: 11533.55218
+  dps: 16171.73086
+  tps: 11483.20028
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 15334.04742
-  tps: 10888.51983
+  dps: 15316.48021
+  tps: 10876.04711
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 15334.04742
-  tps: 10888.51983
+  dps: 15316.48021
+  tps: 10876.04711
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 15851.28569
-  tps: 11255.68421
+  dps: 15788.75222
+  tps: 11211.28545
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 15851.28569
-  tps: 11255.68421
+  dps: 15788.75222
+  tps: 11211.28545
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 15469.88338
-  tps: 10984.96336
+  dps: 15438.32876
+  tps: 10962.55958
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
   hps: 85.60947
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
   hps: 85.60947
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 15866.96954
-  tps: 11266.81975
+  dps: 15797.77762
+  tps: 11217.69348
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 15469.79562
-  tps: 10984.82626
+  dps: 15392.71264
+  tps: 10930.09735
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 15500.05089
-  tps: 11006.30751
+  dps: 15427.86451
+  tps: 10955.05518
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BindingPromise-67037"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 11550.89528
-  tps: 8202.33224
+  dps: 11554.71402
+  tps: 8205.04354
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 15960.70413
-  tps: 11333.37131
+  dps: 15902.99011
+  tps: 11292.39435
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 15449.14838
-  tps: 10970.16672
+  dps: 15415.82868
+  tps: 10946.50974
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 15473.71382
-  tps: 10987.60819
+  dps: 15440.13292
+  tps: 10963.76575
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 16275.93885
-  tps: 11557.18795
+  dps: 16198.52435
+  tps: 11502.22366
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 15575.43016
-  tps: 11059.82679
+  dps: 15542.11038
+  tps: 11036.16974
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 15454.70475
-  tps: 10974.11175
+  dps: 15375.40633
+  tps: 10917.80987
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 15997.67639
-  tps: 11359.62161
+  dps: 15942.61287
+  tps: 11320.52651
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 15546.63291
-  tps: 11039.38074
+  dps: 15509.48696
+  tps: 11013.00711
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledLightning-66879"
  value: {
-  dps: 15313.34247
-  tps: 10873.74453
+  dps: 15310.07874
+  tps: 10871.42728
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 15851.28569
-  tps: 11030.57053
+  dps: 15788.75222
+  tps: 10987.05974
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 15851.28569
-  tps: 11030.57053
+  dps: 15788.75222
+  tps: 10987.05974
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 16119.07962
-  tps: 11445.8179
+  dps: 16054.35275
+  tps: 11399.86182
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 16159.54883
-  tps: 11474.55104
+  dps: 16088.28848
+  tps: 11423.9562
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 16135.7045
-  tps: 11457.62157
+  dps: 16064.20057
+  tps: 11406.85378
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
   hps: 64
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-59506"
  value: {
-  dps: 15709.28175
-  tps: 11154.86142
+  dps: 15717.82038
+  tps: 11160.92384
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-65118"
  value: {
-  dps: 15794.97168
-  tps: 11215.70126
+  dps: 15771.01937
+  tps: 11198.69513
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 15329.15219
-  tps: 10884.96943
+  dps: 15281.16619
+  tps: 10850.89937
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 15373.38883
-  tps: 10916.52702
+  dps: 15329.95666
+  tps: 10885.69017
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 15494.52697
-  tps: 11002.38553
+  dps: 15463.21614
+  tps: 10980.15483
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 15762.77375
-  tps: 11192.84074
+  dps: 15730.15673
+  tps: 11169.68265
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 16209.40652
-  tps: 11509.95
+  dps: 16140.34919
+  tps: 11460.9193
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 15501.44432
-  tps: 11009.22174
+  dps: 15467.57848
+  tps: 10985.17699
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Death'sChoice-47464"
  value: {
-  dps: 15864.57531
-  tps: 11265.11984
+  dps: 15852.85965
+  tps: 11256.80173
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 15315.59408
-  tps: 10875.34317
+  dps: 15279.28859
+  tps: 10849.56628
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 15768.62884
-  tps: 11196.99785
+  dps: 15763.40032
+  tps: 11193.2856
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 15811.15181
-  tps: 11227.18916
+  dps: 15819.64405
+  tps: 11233.21865
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Defender'sCode-40257"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 15889.46419
-  tps: 11282.79095
+  dps: 15820.50206
+  tps: 11233.82784
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 15869.59292
-  tps: 11268.68235
+  dps: 15801.45214
+  tps: 11220.30239
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 15319.13228
-  tps: 10877.85529
+  dps: 15284.64018
+  tps: 10853.3659
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 15284.95641
-  tps: 10853.59042
+  dps: 15255.44134
+  tps: 10832.63473
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 15851.28569
-  tps: 11255.68421
+  dps: 15788.75222
+  tps: 11211.28545
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 15851.28569
-  tps: 11255.68421
+  dps: 15788.75222
+  tps: 11211.28545
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 15261.55775
-  tps: 10867.1789
+  dps: 15230.23267
+  tps: 10845.47313
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 15851.28569
-  tps: 11255.68421
+  dps: 15788.75222
+  tps: 11211.28545
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 15851.28569
-  tps: 11255.68421
+  dps: 15788.75222
+  tps: 11211.28545
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 15889.46419
-  tps: 11282.79095
+  dps: 15820.50206
+  tps: 11233.82784
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 15866.96954
-  tps: 11266.81975
+  dps: 15797.77762
+  tps: 11217.69348
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 15864.4248
-  tps: 11265.01298
+  dps: 15803.41751
+  tps: 11221.69781
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 15267.23224
-  tps: 10841.00626
+  dps: 15201.37694
+  tps: 10794.249
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 16238.48935
-  tps: 11530.59881
+  dps: 16175.73245
+  tps: 11486.04141
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 16358.0953
-  tps: 11615.51904
+  dps: 16351.70265
+  tps: 11610.98025
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 15851.28569
-  tps: 11255.68421
+  dps: 15788.75222
+  tps: 11211.28545
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 15851.28569
-  tps: 11255.68421
+  dps: 15788.75222
+  tps: 11211.28545
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 15369.43588
-  tps: 10913.57085
+  dps: 15322.09501
+  tps: 10879.95883
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 15321.87701
-  tps: 10879.80405
+  dps: 15277.40227
+  tps: 10848.22698
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-59500"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-65124"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 16344.97735
-  tps: 11606.28008
+  dps: 16298.32263
+  tps: 11573.15522
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 15772.64734
-  tps: 11199.85099
+  dps: 15737.12607
+  tps: 11174.63088
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 15892.58461
-  tps: 11285.00645
+  dps: 15829.52175
+  tps: 11240.23182
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FluidDeath-58181"
  value: {
-  dps: 16168.23695
-  tps: 11480.79439
+  dps: 16160.54874
+  tps: 11475.33576
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForgeEmber-37660"
  value: {
-  dps: 15298.78886
-  tps: 10863.41146
+  dps: 15265.91375
+  tps: 10840.07013
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 15851.28569
-  tps: 11255.68421
+  dps: 15788.75222
+  tps: 11211.28545
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 15851.28569
-  tps: 11255.68421
+  dps: 15788.75222
+  tps: 11211.28545
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 15851.28569
-  tps: 11255.68421
+  dps: 15788.75222
+  tps: 11211.28545
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 16518.43448
-  tps: 11729.35986
+  dps: 16477.1301
+  tps: 11700.03374
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 15523.41125
-  tps: 11022.89336
+  dps: 15491.14118
+  tps: 10999.98161
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuturesightRune-38763"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56138"
  value: {
-  dps: 15399.36424
-  tps: 10934.81998
+  dps: 15391.40435
+  tps: 10929.16846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56462"
  value: {
-  dps: 15365.97833
-  tps: 10911.11599
+  dps: 15403.97515
+  tps: 10938.09373
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GearDetector-61462"
  value: {
-  dps: 15782.70745
-  tps: 11207.06845
+  dps: 15671.42077
+  tps: 11128.05491
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 15352.52737
-  tps: 10901.64059
+  dps: 15309.04263
+  tps: 10870.76643
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 15735.77942
-  tps: 11173.67476
+  dps: 15732.23718
+  tps: 11171.15977
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 16028.12
-  tps: 11381.23658
+  dps: 16014.16241
+  tps: 11371.32669
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HarmlightToken-63839"
  value: {
-  dps: 15273.68811
-  tps: 10845.58993
+  dps: 15237.57738
+  tps: 10819.95132
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 15624.78327
-  tps: 11094.86749
+  dps: 15590.22199
+  tps: 11070.32899
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-59224"
  value: {
-  dps: 15724.24449
-  tps: 11165.48496
+  dps: 15796.18581
+  tps: 11216.5633
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-65072"
  value: {
-  dps: 15810.1815
-  tps: 11226.50024
+  dps: 15843.96587
+  tps: 11250.48714
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-55868"
  value: {
-  dps: 15399.36424
-  tps: 10934.81998
+  dps: 15391.40435
+  tps: 10929.16846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-56393"
  value: {
-  dps: 15700.21013
-  tps: 11148.42057
+  dps: 15736.06121
+  tps: 11173.87483
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-55845"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-56370"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 15865.6901
-  tps: 11265.91134
+  dps: 15811.25115
+  tps: 11227.25969
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-49982"
  value: {
-  dps: 16319.07201
-  tps: 11587.8125
+  dps: 16343.23932
+  tps: 11604.97129
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-50641"
  value: {
-  dps: 16394.64753
-  tps: 11641.47112
+  dps: 16370.54985
+  tps: 11624.36177
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 15889.46419
-  tps: 11282.79095
+  dps: 15820.50206
+  tps: 11233.82784
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 15866.96954
-  tps: 11266.81975
+  dps: 15797.77762
+  tps: 11217.69348
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 15864.4248
-  tps: 11265.01298
+  dps: 15803.41751
+  tps: 11221.69781
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 15837.87159
-  tps: 11246.1602
+  dps: 15801.81027
+  tps: 11220.55666
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 15837.87159
-  tps: 11246.1602
+  dps: 15801.81027
+  tps: 11220.55666
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 15449.14838
-  tps: 10970.16672
+  dps: 15415.82868
+  tps: 10946.50974
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 15473.71382
-  tps: 10987.60819
+  dps: 15440.13292
+  tps: 10963.76575
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IncisorFragment-37723"
  value: {
-  dps: 15513.05453
-  tps: 11015.54009
+  dps: 15481.73822
+  tps: 10993.30551
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 15851.28569
-  tps: 11255.68421
+  dps: 15788.75222
+  tps: 11211.28545
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 15405.97276
-  tps: 10939.51203
+  dps: 15373.11214
+  tps: 10916.18099
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 15886.75478
-  tps: 11280.86727
+  dps: 15824.04303
+  tps: 11236.34192
   hps: 61.58075
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 15960.70413
-  tps: 11333.37131
+  dps: 15902.99011
+  tps: 11292.39435
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 15972.16836
-  tps: 11341.51091
+  dps: 15930.29055
+  tps: 11311.77766
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 16175.75645
-  tps: 11486.13324
+  dps: 16161.78652
+  tps: 11476.21459
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 15406.62677
-  tps: 10939.97638
+  dps: 15488.20233
+  tps: 10997.89503
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 15406.62677
-  tps: 10939.97638
+  dps: 15488.20233
+  tps: 10997.89503
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 15330.64508
-  tps: 10886.02938
+  dps: 15334.66771
+  tps: 10888.88545
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50179"
  value: {
-  dps: 16332.4925
-  tps: 11597.34105
+  dps: 16261.06647
+  tps: 11546.62857
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50708"
  value: {
-  dps: 16345.83882
-  tps: 11606.81693
+  dps: 16274.36048
+  tps: 11556.06732
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-55816"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-56347"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 16079.58532
-  tps: 11417.77695
+  dps: 16107.02084
+  tps: 11437.25617
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 16145.75449
-  tps: 11464.75706
+  dps: 16175.59455
+  tps: 11485.94351
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 15665.43459
-  tps: 11123.80472
+  dps: 15647.26629
+  tps: 11110.90522
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 15565.52011
-  tps: 11052.79065
+  dps: 15547.01248
+  tps: 11039.65024
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 15645.22034
-  tps: 11109.37782
+  dps: 15684.03368
+  tps: 11136.93529
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 15695.98345
-  tps: 11145.41962
+  dps: 15662.22775
+  tps: 11121.45308
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 15753.34654
-  tps: 11186.14742
+  dps: 15719.26661
+  tps: 11161.95067
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 15315.4333
-  tps: 10875.22902
+  dps: 15308.59158
+  tps: 10870.37139
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 15488.25471
-  tps: 10997.93222
+  dps: 15470.79124
+  tps: 10985.53315
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 15621.4132
-  tps: 11092.54953
+  dps: 15604.03924
+  tps: 11080.21402
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 15500.51248
-  tps: 11006.63524
+  dps: 15466.64664
+  tps: 10982.59049
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 15500.51248
-  tps: 11006.63524
+  dps: 15466.64664
+  tps: 10982.59049
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 15588.39096
-  tps: 11069.02895
+  dps: 15551.89129
+  tps: 11043.11419
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 15289.60237
-  tps: 10856.88906
+  dps: 15327.82937
+  tps: 10884.03023
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 15555.69693
-  tps: 11045.81619
+  dps: 15552.31345
+  tps: 11043.41392
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 15879.99876
-  tps: 11276.07049
+  dps: 15817.32097
+  tps: 11231.56926
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 15886.75478
-  tps: 11280.86727
+  dps: 15824.04303
+  tps: 11236.34192
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 15420.57909
-  tps: 10949.88253
+  dps: 15378.48523
+  tps: 10919.99588
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 15536.99234
-  tps: 11032.53593
+  dps: 15501.41147
+  tps: 11007.27352
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 15851.28569
-  tps: 11255.68421
+  dps: 15788.75222
+  tps: 11211.28545
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 15851.28569
-  tps: 11255.68421
+  dps: 15788.75222
+  tps: 11211.28545
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 15851.28569
-  tps: 11255.68421
+  dps: 15788.75222
+  tps: 11211.28545
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 16283.88211
-  tps: 11562.82767
+  dps: 16229.473
+  tps: 11524.1972
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 16315.7303
-  tps: 11585.43989
+  dps: 16235.68348
+  tps: 11528.60665
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-55854"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-56377"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 16169.65859
-  tps: 11481.72897
+  dps: 16105.77953
+  tps: 11436.37484
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 16167.77058
-  tps: 11480.38848
+  dps: 16102.79444
+  tps: 11434.25543
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 16119.07962
-  tps: 11445.8179
+  dps: 16054.35275
+  tps: 11399.86182
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 15851.28569
-  tps: 11255.68421
+  dps: 15788.75222
+  tps: 11211.28545
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 15616.09412
-  tps: 11088.77298
+  dps: 15592.64839
+  tps: 11072.12652
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 15640.86641
-  tps: 11106.36131
+  dps: 15618.60649
+  tps: 11090.55677
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 15955.21631
-  tps: 11329.47496
+  dps: 15898.64769
+  tps: 11289.31123
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-55256"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-56290"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 15686.43487
-  tps: 11138.71492
+  dps: 15590.36787
+  tps: 11070.50735
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 16088.3491
-  tps: 11423.99923
+  dps: 16030.19695
+  tps: 11382.71121
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 16194.74069
-  tps: 11499.53727
+  dps: 16129.56161
+  tps: 11453.26012
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-55879"
  value: {
-  dps: 15449.14838
-  tps: 10970.16672
+  dps: 15415.82868
+  tps: 10946.50974
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-56400"
  value: {
-  dps: 15473.71382
-  tps: 10987.60819
+  dps: 15440.13292
+  tps: 10963.76575
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 15488.31747
-  tps: 10998.05156
+  dps: 15470.854
+  tps: 10985.6525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulCasket-58183"
  value: {
-  dps: 15500.51248
-  tps: 11006.63524
+  dps: 15466.64664
+  tps: 10982.59049
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulPreserver-37111"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SouloftheDead-40382"
  value: {
-  dps: 15326.67146
-  tps: 10883.20811
+  dps: 15279.63367
+  tps: 10849.81128
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SparkofLife-37657"
  value: {
-  dps: 15257.84876
-  tps: 10834.34399
+  dps: 15301.87556
+  tps: 10865.60302
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 15363.9145
-  tps: 10909.65067
+  dps: 15317.27705
+  tps: 10876.53808
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 15246.59643
-  tps: 10826.35484
+  dps: 15244.15887
+  tps: 10824.62417
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62465"
  value: {
-  dps: 15334.04742
-  tps: 10888.51983
+  dps: 15316.48021
+  tps: 10876.04711
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62470"
  value: {
-  dps: 15334.04742
-  tps: 10888.51983
+  dps: 15316.48021
+  tps: 10876.04711
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 15886.75478
-  tps: 11280.86727
+  dps: 15824.04303
+  tps: 11236.34192
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 15879.99876
-  tps: 11276.07049
+  dps: 15817.32097
+  tps: 11231.56926
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 15868.17573
-  tps: 11267.67614
+  dps: 15805.55737
+  tps: 11223.2171
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 15269.69801
-  tps: 10842.75696
+  dps: 15238.37292
+  tps: 10820.51615
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 15633.72356
-  tps: 11101.2151
+  dps: 15608.06598
+  tps: 11082.99822
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-55819"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-56351"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 15421.60531
-  tps: 10950.61114
+  dps: 15388.57847
+  tps: 10927.16209
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 15473.71382
-  tps: 10987.60819
+  dps: 15440.13292
+  tps: 10963.76575
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 15280.69952
-  tps: 10850.56803
+  dps: 15249.37444
+  tps: 10828.32723
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 15797.57869
-  tps: 11217.55224
+  dps: 15819.59654
+  tps: 11233.18492
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 16131.12539
-  tps: 11454.3704
+  dps: 16066.57684
+  tps: 11408.54093
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 15296.60007
-  tps: 10861.85742
+  dps: 15341.80656
+  tps: 10893.95403
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 15487.41008
-  tps: 10997.33253
+  dps: 15412.49176
+  tps: 10944.14052
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 15851.28569
-  tps: 11255.68421
+  dps: 15788.75222
+  tps: 11211.28545
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 15851.28569
-  tps: 11255.68421
+  dps: 15788.75222
+  tps: 11211.28545
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 15228.90841
-  tps: 10813.79635
+  dps: 15232.13759
+  tps: 10816.08906
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 15851.28569
-  tps: 11255.68421
+  dps: 15788.75222
+  tps: 11211.28545
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 15851.28569
-  tps: 11255.68421
+  dps: 15788.75222
+  tps: 11211.28545
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 15339.21958
-  tps: 10892.19206
+  dps: 15309.441
+  tps: 10871.04927
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 12453.8312
-  tps: 8843.41674
+  dps: 12422.27113
+  tps: 8821.00909
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 16360.15484
-  tps: 11616.98131
+  dps: 16354.79464
+  tps: 11613.17557
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 16360.15484
-  tps: 11616.98131
+  dps: 16354.79464
+  tps: 11613.17557
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 13472.62906
-  tps: 9566.76322
+  dps: 13509.66823
+  tps: 9593.06103
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 16107.07667
-  tps: 11437.29581
+  dps: 16103.3439
+  tps: 11434.64554
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 15592.98223
-  tps: 11072.28876
+  dps: 15559.5509
+  tps: 11048.55252
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 15334.04742
-  tps: 10888.51983
+  dps: 15316.48021
+  tps: 10876.04711
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 15457.42984
-  tps: 10976.04656
+  dps: 15455.14783
+  tps: 10974.42633
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 15483.5076
-  tps: 10994.56177
+  dps: 15421.08578
+  tps: 10950.24228
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 15349.76666
-  tps: 10899.6057
+  dps: 15424.33917
+  tps: 10952.55218
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 15514.65622
-  tps: 11016.67729
+  dps: 15480.63999
+  tps: 10992.52576
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 16021.30612
-  tps: 11376.39872
+  dps: 16028.63142
+  tps: 11381.59968
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 15568.82626
-  tps: 11055.13802
+  dps: 15541.5504
+  tps: 11035.77216
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WingedTalisman-37844"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 15261.55775
-  tps: 10836.97738
+  dps: 15230.23267
+  tps: 10814.73657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 15424.58294
-  tps: 10952.72526
+  dps: 15391.52444
+  tps: 10929.25373
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 15443.13
-  tps: 10965.89367
+  dps: 15410.40679
+  tps: 10942.66019
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 15443.13
-  tps: 10965.89367
+  dps: 15410.40679
+  tps: 10942.66019
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 16248.95669
-  tps: 11538.05053
+  dps: 16246.98286
+  tps: 11536.64911
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 16242.64903
-  tps: 11533.55218
+  dps: 16171.73086
+  tps: 11483.20028
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 16242.64903
-  tps: 11533.55218
+  dps: 16171.73086
+  tps: 11483.20028
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 18107.64813
-  tps: 12862.78704
+  dps: 18147.39859
+  tps: 12891.00986
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10243.05006
-  tps: 7275.25786
+  dps: 10236.75864
+  tps: 7270.79095
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 10243.05006
-  tps: 7275.25786
+  dps: 10236.75864
+  tps: 7270.79095
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 9989.74029
-  tps: 7100.19427
+  dps: 10002.93627
+  tps: 7109.56342
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 16242.64903
-  tps: 11533.55218
+  dps: 16171.73086
+  tps: 11483.20028
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 16242.64903
-  tps: 11533.55218
+  dps: 16171.73086
+  tps: 11483.20028
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 18107.64813
-  tps: 12862.78704
+  dps: 18147.39859
+  tps: 12891.00986
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10243.05006
-  tps: 7275.25786
+  dps: 10236.75864
+  tps: 7270.79095
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 10243.05006
-  tps: 7275.25786
+  dps: 10236.75864
+  tps: 7270.79095
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 9989.74029
-  tps: 7100.19427
+  dps: 10002.93627
+  tps: 7109.56342
  }
 }
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 16810.69383
-  tps: 11936.86399
+  dps: 16808.44934
+  tps: 11935.27041
  }
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -40,1894 +40,1894 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 16171.73086
-  tps: 11483.20028
+  dps: 16143.71548
+  tps: 11463.30937
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 15316.48021
-  tps: 10876.04711
+  dps: 15396.52961
+  tps: 10932.88219
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 15316.48021
-  tps: 10876.04711
+  dps: 15396.52961
+  tps: 10932.88219
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 15788.75222
-  tps: 11211.28545
+  dps: 15757.61784
+  tps: 11189.18004
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 15788.75222
-  tps: 11211.28545
+  dps: 15757.61784
+  tps: 11189.18004
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 15438.32876
-  tps: 10962.55958
+  dps: 15410.61791
+  tps: 10942.88487
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
   hps: 85.60947
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
   hps: 85.60947
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 15797.77762
-  tps: 11217.69348
+  dps: 15770.87641
+  tps: 11198.59363
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 15392.71264
-  tps: 10930.09735
+  dps: 15360.83476
+  tps: 10907.46406
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 15427.86451
-  tps: 10955.05518
+  dps: 15384.21259
+  tps: 10924.06231
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BindingPromise-67037"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 11554.71402
-  tps: 8205.04354
+  dps: 11576.45141
+  tps: 8220.47709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 15902.99011
-  tps: 11292.39435
+  dps: 15931.17839
+  tps: 11312.40803
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 15415.82868
-  tps: 10946.50974
+  dps: 15387.54192
+  tps: 10926.42613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 15440.13292
-  tps: 10963.76575
+  dps: 15411.76533
+  tps: 10943.62476
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 16198.52435
-  tps: 11502.22366
+  dps: 16252.75492
+  tps: 11540.72736
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 15542.11038
-  tps: 11036.16974
+  dps: 15513.57258
+  tps: 11015.90791
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 15375.40633
-  tps: 10917.80987
+  dps: 15334.64332
+  tps: 10888.86813
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 15942.61287
-  tps: 11320.52651
+  dps: 15884.18865
+  tps: 11279.04531
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 15509.48696
-  tps: 11013.00711
+  dps: 15484.49205
+  tps: 10995.26073
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledLightning-66879"
  value: {
-  dps: 15310.07874
-  tps: 10871.42728
+  dps: 15262.80677
+  tps: 10837.86418
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 15788.75222
-  tps: 10987.05974
+  dps: 15757.61784
+  tps: 10965.39644
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 15788.75222
-  tps: 10987.05974
+  dps: 15757.61784
+  tps: 10965.39644
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 16054.35275
-  tps: 11399.86182
+  dps: 16023.87948
+  tps: 11378.2258
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 16088.28848
-  tps: 11423.9562
+  dps: 16051.34301
+  tps: 11397.72491
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 16064.20057
-  tps: 11406.85378
+  dps: 16038.10342
+  tps: 11388.3248
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
   hps: 64
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-59506"
  value: {
-  dps: 15717.82038
-  tps: 11160.92384
+  dps: 15813.89419
+  tps: 11229.13625
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-65118"
  value: {
-  dps: 15771.01937
-  tps: 11198.69513
+  dps: 15809.92914
+  tps: 11226.32106
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 15281.16619
-  tps: 10850.89937
+  dps: 15243.79072
+  tps: 10824.36278
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 15329.95666
-  tps: 10885.69017
+  dps: 15287.26379
+  tps: 10855.37824
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 15463.21614
-  tps: 10980.15483
+  dps: 15435.1489
+  tps: 10960.22709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 15730.15673
-  tps: 11169.68265
+  dps: 15700.92764
+  tps: 11148.93
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 16140.34919
-  tps: 11460.9193
+  dps: 16113.79858
+  tps: 11442.06837
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 15467.57848
-  tps: 10985.17699
+  dps: 15439.12271
+  tps: 10964.9734
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Death'sChoice-47464"
  value: {
-  dps: 15852.85965
-  tps: 11256.80173
+  dps: 15833.0059
+  tps: 11242.70557
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 15279.28859
-  tps: 10849.56628
+  dps: 15244.02874
+  tps: 10824.53178
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 15763.40032
-  tps: 11193.2856
+  dps: 15784.12931
+  tps: 11208.00319
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 15819.64405
-  tps: 11233.21865
+  dps: 15863.9956
+  tps: 11264.70825
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Defender'sCode-40257"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 15820.50206
-  tps: 11233.82784
+  dps: 15783.16654
+  tps: 11207.31962
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 15801.45214
-  tps: 11220.30239
+  dps: 15772.51759
+  tps: 11199.75887
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 15284.64018
-  tps: 10853.3659
+  dps: 15362.76768
+  tps: 10908.83643
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 15255.44134
-  tps: 10832.63473
+  dps: 15293.50711
+  tps: 10859.66142
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 15788.75222
-  tps: 11211.28545
+  dps: 15757.61784
+  tps: 11189.18004
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 15788.75222
-  tps: 11211.28545
+  dps: 15757.61784
+  tps: 11189.18004
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 15230.23267
-  tps: 10845.47313
+  dps: 15202.56313
+  tps: 10826.72854
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 15788.75222
-  tps: 11211.28545
+  dps: 15757.61784
+  tps: 11189.18004
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 15788.75222
-  tps: 11211.28545
+  dps: 15757.61784
+  tps: 11189.18004
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 15820.50206
-  tps: 11233.82784
+  dps: 15783.16654
+  tps: 11207.31962
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 15797.77762
-  tps: 11217.69348
+  dps: 15770.87641
+  tps: 11198.59363
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 15803.41751
-  tps: 11221.69781
+  dps: 15773.1831
+  tps: 11200.23137
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 15201.37694
-  tps: 10794.249
+  dps: 15253.40331
+  tps: 10831.18772
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 16175.73245
-  tps: 11486.04141
+  dps: 16183.3894
+  tps: 11491.47785
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 16351.70265
-  tps: 11610.98025
+  dps: 16285.31385
+  tps: 11563.8442
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 15788.75222
-  tps: 11211.28545
+  dps: 15757.61784
+  tps: 11189.18004
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 15788.75222
-  tps: 11211.28545
+  dps: 15757.61784
+  tps: 11189.18004
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 15322.09501
-  tps: 10879.95883
+  dps: 15282.5882
+  tps: 10851.909
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 15277.40227
-  tps: 10848.22698
+  dps: 15237.70248
+  tps: 10820.04013
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-59500"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-65124"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 16298.32263
-  tps: 11573.15522
+  dps: 16375.79697
+  tps: 11628.16201
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 15737.12607
-  tps: 11174.63088
+  dps: 15707.9203
+  tps: 11153.89478
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 15829.52175
-  tps: 11240.23182
+  dps: 15798.23125
+  tps: 11218.01556
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FluidDeath-58181"
  value: {
-  dps: 16160.54874
-  tps: 11475.33576
+  dps: 16175.79214
+  tps: 11486.15858
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForgeEmber-37660"
  value: {
-  dps: 15265.91375
-  tps: 10840.07013
+  dps: 15221.93602
+  tps: 10808.84595
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 15788.75222
-  tps: 11211.28545
+  dps: 15757.61784
+  tps: 11189.18004
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 15788.75222
-  tps: 11211.28545
+  dps: 15757.61784
+  tps: 11189.18004
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 15788.75222
-  tps: 11211.28545
+  dps: 15757.61784
+  tps: 11189.18004
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 16477.1301
-  tps: 11700.03374
+  dps: 16404.94058
+  tps: 11648.77919
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 15491.14118
-  tps: 10999.98161
+  dps: 15462.88905
+  tps: 10979.9226
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuturesightRune-38763"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56138"
  value: {
-  dps: 15391.40435
-  tps: 10929.16846
+  dps: 15313.02352
+  tps: 10873.51807
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56462"
  value: {
-  dps: 15403.97515
-  tps: 10938.09373
+  dps: 15343.75029
+  tps: 10895.33408
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GearDetector-61462"
  value: {
-  dps: 15671.42077
-  tps: 11128.05491
+  dps: 15722.53876
+  tps: 11164.27389
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 15309.04263
-  tps: 10870.76643
+  dps: 15266.07359
+  tps: 10840.25841
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 15732.23718
-  tps: 11171.15977
+  dps: 15671.3078
+  tps: 11127.89991
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 16014.16241
-  tps: 11371.32669
+  dps: 15926.55766
+  tps: 11309.12731
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HarmlightToken-63839"
  value: {
-  dps: 15237.57738
-  tps: 10819.95132
+  dps: 15209.05842
+  tps: 10799.70285
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 15590.22199
-  tps: 11070.32899
+  dps: 15556.07303
+  tps: 11046.08322
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-59224"
  value: {
-  dps: 15796.18581
-  tps: 11216.5633
+  dps: 15730.41326
+  tps: 11169.86478
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-65072"
  value: {
-  dps: 15843.96587
-  tps: 11250.48714
+  dps: 15820.63772
+  tps: 11233.92415
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-55868"
  value: {
-  dps: 15391.40435
-  tps: 10929.16846
+  dps: 15313.02352
+  tps: 10873.51807
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-56393"
  value: {
-  dps: 15736.06121
-  tps: 11173.87483
+  dps: 15667.828
+  tps: 11125.42926
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-55845"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-56370"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 15811.25115
-  tps: 11227.25969
+  dps: 15770.66934
+  tps: 11198.44661
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-49982"
  value: {
-  dps: 16343.23932
-  tps: 11604.97129
+  dps: 16300.72188
+  tps: 11574.78391
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-50641"
  value: {
-  dps: 16370.54985
-  tps: 11624.36177
+  dps: 16349.50616
+  tps: 11609.42075
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 15820.50206
-  tps: 11233.82784
+  dps: 15783.16654
+  tps: 11207.31962
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 15797.77762
-  tps: 11217.69348
+  dps: 15770.87641
+  tps: 11198.59363
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 15803.41751
-  tps: 11221.69781
+  dps: 15773.1831
+  tps: 11200.23137
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 15801.81027
-  tps: 11220.55666
+  dps: 15772.407
+  tps: 11199.68035
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 15801.81027
-  tps: 11220.55666
+  dps: 15772.407
+  tps: 11199.68035
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 15415.82868
-  tps: 10946.50974
+  dps: 15387.54192
+  tps: 10926.42613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 15440.13292
-  tps: 10963.76575
+  dps: 15411.76533
+  tps: 10943.62476
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IncisorFragment-37723"
  value: {
-  dps: 15481.73822
-  tps: 10993.30551
+  dps: 15453.66021
+  tps: 10973.37012
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 15788.75222
-  tps: 11211.28545
+  dps: 15757.61784
+  tps: 11189.18004
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 15373.11214
-  tps: 10916.18099
+  dps: 15344.96743
+  tps: 10896.19825
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 15824.04303
-  tps: 11236.34192
+  dps: 15792.81503
+  tps: 11214.17004
   hps: 61.58075
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 15902.99011
-  tps: 11292.39435
+  dps: 15931.17839
+  tps: 11312.40803
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 15930.29055
-  tps: 11311.77766
+  dps: 15990.0039
+  tps: 11354.17414
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 16161.78652
-  tps: 11476.21459
+  dps: 16242.81053
+  tps: 11533.74164
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 15488.20233
-  tps: 10997.89503
+  dps: 15513.38573
+  tps: 11015.77524
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 15488.20233
-  tps: 10997.89503
+  dps: 15513.38573
+  tps: 11015.77524
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 15334.66771
-  tps: 10888.88545
+  dps: 15324.21581
+  tps: 10881.4646
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50179"
  value: {
-  dps: 16261.06647
-  tps: 11546.62857
+  dps: 16232.7522
+  tps: 11526.52543
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50708"
  value: {
-  dps: 16274.36048
-  tps: 11556.06732
+  dps: 16246.11288
+  tps: 11536.01152
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-55816"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-56347"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 16107.02084
-  tps: 11437.25617
+  dps: 16101.27463
+  tps: 11433.17636
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 16175.59455
-  tps: 11485.94351
+  dps: 16161.65326
+  tps: 11476.04519
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 15647.26629
-  tps: 11110.90522
+  dps: 15728.81745
+  tps: 11168.80655
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 15547.01248
-  tps: 11039.65024
+  dps: 15608.25654
+  tps: 11083.13352
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 15684.03368
-  tps: 11136.93529
+  dps: 15625.68214
+  tps: 11095.5057
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 15662.22775
-  tps: 11121.45308
+  dps: 15632.7521
+  tps: 11100.52536
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 15719.26661
-  tps: 11161.95067
+  dps: 15689.55257
+  tps: 11140.8537
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 15308.59158
-  tps: 10870.37139
+  dps: 15262.38131
+  tps: 10837.5621
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 15470.79124
-  tps: 10985.53315
+  dps: 15548.42726
+  tps: 11040.65473
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 15604.03924
-  tps: 11080.21402
+  dps: 15679.56125
+  tps: 11133.83465
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 15466.64664
-  tps: 10982.59049
+  dps: 15438.19087
+  tps: 10962.38689
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 15466.64664
-  tps: 10982.59049
+  dps: 15438.19087
+  tps: 10962.38689
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 15551.89129
-  tps: 11043.11419
+  dps: 15522.65348
+  tps: 11022.35535
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 15327.82937
-  tps: 10884.03023
+  dps: 15268.58384
+  tps: 10841.9659
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 15552.31345
-  tps: 11043.41392
+  dps: 15466.41551
+  tps: 10982.42639
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 15817.32097
-  tps: 11231.56926
+  dps: 15786.1108
+  tps: 11209.41004
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 15824.04303
-  tps: 11236.34192
+  dps: 15792.81503
+  tps: 11214.17004
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 15378.48523
-  tps: 10919.99588
+  dps: 15359.46156
+  tps: 10906.48908
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 15501.41147
-  tps: 11007.27352
+  dps: 15484.44664
+  tps: 10995.22849
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 15788.75222
-  tps: 11211.28545
+  dps: 15757.61784
+  tps: 11189.18004
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 15788.75222
-  tps: 11211.28545
+  dps: 15757.61784
+  tps: 11189.18004
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 15788.75222
-  tps: 11211.28545
+  dps: 15757.61784
+  tps: 11189.18004
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 16229.473
-  tps: 11524.1972
+  dps: 16232.76719
+  tps: 11526.53608
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 16235.68348
-  tps: 11528.60665
+  dps: 16285.22677
+  tps: 11563.78238
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-55854"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-56377"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 16105.77953
-  tps: 11436.37484
+  dps: 16076.06908
+  tps: 11415.28042
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 16102.79444
-  tps: 11434.25543
+  dps: 16072.19691
+  tps: 11412.53118
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 16054.35275
-  tps: 11399.86182
+  dps: 16023.87948
+  tps: 11378.2258
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 15788.75222
-  tps: 11211.28545
+  dps: 15757.61784
+  tps: 11189.18004
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 15592.64839
-  tps: 11072.12652
+  dps: 15669.78405
+  tps: 11126.89284
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 15618.60649
-  tps: 11090.55677
+  dps: 15704.33636
+  tps: 11151.42498
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 15898.64769
-  tps: 11289.31123
+  dps: 15849.86157
+  tps: 11254.67309
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-55256"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-56290"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 15590.36787
-  tps: 11070.50735
+  dps: 15552.62206
+  tps: 11043.63304
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 16030.19695
-  tps: 11382.71121
+  dps: 15985.53123
+  tps: 11350.99855
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 16129.56161
-  tps: 11453.26012
+  dps: 16094.93558
+  tps: 11428.67563
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-55879"
  value: {
-  dps: 15415.82868
-  tps: 10946.50974
+  dps: 15387.54192
+  tps: 10926.42613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-56400"
  value: {
-  dps: 15440.13292
-  tps: 10963.76575
+  dps: 15411.76533
+  tps: 10943.62476
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 15470.854
-  tps: 10985.6525
+  dps: 15548.47292
+  tps: 11040.76193
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulCasket-58183"
  value: {
-  dps: 15466.64664
-  tps: 10982.59049
+  dps: 15438.19087
+  tps: 10962.38689
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulPreserver-37111"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SouloftheDead-40382"
  value: {
-  dps: 15279.63367
-  tps: 10849.81128
+  dps: 15240.53004
+  tps: 10822.0477
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SparkofLife-37657"
  value: {
-  dps: 15301.87556
-  tps: 10865.60302
+  dps: 15250.73266
+  tps: 10829.29156
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 15317.27705
-  tps: 10876.53808
+  dps: 15353.11555
+  tps: 10901.98341
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 15244.15887
-  tps: 10824.62417
+  dps: 15200.22149
+  tps: 10793.42863
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62465"
  value: {
-  dps: 15316.48021
-  tps: 10876.04711
+  dps: 15396.52961
+  tps: 10932.88219
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62470"
  value: {
-  dps: 15316.48021
-  tps: 10876.04711
+  dps: 15396.52961
+  tps: 10932.88219
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 15824.04303
-  tps: 11236.34192
+  dps: 15792.81503
+  tps: 11214.17004
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 15817.32097
-  tps: 11231.56926
+  dps: 15786.1108
+  tps: 11209.41004
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 15805.55737
-  tps: 11223.2171
+  dps: 15774.3784
+  tps: 11201.08004
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 15238.37292
-  tps: 10820.51615
+  dps: 15210.58504
+  tps: 10800.78675
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 15608.06598
-  tps: 11082.99822
+  dps: 15538.15502
+  tps: 11033.36144
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-55819"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-56351"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 15388.57847
-  tps: 10927.16209
+  dps: 15360.38233
+  tps: 10907.14283
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 15440.13292
-  tps: 10963.76575
+  dps: 15411.76533
+  tps: 10943.62476
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 15249.37444
-  tps: 10828.32723
+  dps: 15221.7049
+  tps: 10808.68185
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 15819.59654
-  tps: 11233.18492
+  dps: 15772.80828
+  tps: 11199.96525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 16066.57684
-  tps: 11408.54093
+  dps: 16036.60772
+  tps: 11387.26285
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 15341.80656
-  tps: 10893.95403
+  dps: 15381.41395
+  tps: 10922.07527
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 15412.49176
-  tps: 10944.14052
+  dps: 15404.63276
+  tps: 10938.56063
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 15788.75222
-  tps: 11211.28545
+  dps: 15757.61784
+  tps: 11189.18004
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 15788.75222
-  tps: 11211.28545
+  dps: 15757.61784
+  tps: 11189.18004
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 15232.13759
-  tps: 10816.08906
+  dps: 15185.42162
+  tps: 10782.92072
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 15788.75222
-  tps: 11211.28545
+  dps: 15757.61784
+  tps: 11189.18004
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 15788.75222
-  tps: 11211.28545
+  dps: 15757.61784
+  tps: 11189.18004
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 15309.441
-  tps: 10871.04927
+  dps: 15279.43565
+  tps: 10849.74547
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 12422.27113
-  tps: 8821.00909
+  dps: 12397.94915
+  tps: 8803.74048
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 16354.79464
-  tps: 11613.17557
+  dps: 16265.59599
+  tps: 11549.84452
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 16354.79464
-  tps: 11613.17557
+  dps: 16265.59599
+  tps: 11549.84452
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 13509.66823
-  tps: 9593.06103
+  dps: 13439.89535
+  tps: 9543.52229
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 16103.3439
-  tps: 11434.64554
+  dps: 16016.70899
+  tps: 11373.13475
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 15559.5509
-  tps: 11048.55252
+  dps: 15530.96456
+  tps: 11028.25621
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 15316.48021
-  tps: 10876.04711
+  dps: 15396.52961
+  tps: 10932.88219
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 15455.14783
-  tps: 10974.42633
+  dps: 15337.96752
+  tps: 10891.22831
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 15421.08578
-  tps: 10950.24228
+  dps: 15377.33641
+  tps: 10919.18022
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 15424.33917
-  tps: 10952.55218
+  dps: 15372.1331
+  tps: 10915.48588
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 15480.63999
-  tps: 10992.52576
+  dps: 15452.13769
+  tps: 10972.28913
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 16028.63142
-  tps: 11381.59968
+  dps: 15945.3056
+  tps: 11322.43835
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 15541.5504
-  tps: 11035.77216
+  dps: 15518.21958
+  tps: 11019.20728
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WingedTalisman-37844"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 15230.23267
-  tps: 10814.73657
+  dps: 15202.56313
+  tps: 10795.09119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 15391.52444
-  tps: 10929.25373
+  dps: 15363.3185
+  tps: 10909.22751
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 15410.40679
-  tps: 10942.66019
+  dps: 15381.61779
+  tps: 10922.22
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 15410.40679
-  tps: 10942.66019
+  dps: 15381.61779
+  tps: 10922.22
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 16246.98286
-  tps: 11536.64911
+  dps: 16223.42837
+  tps: 11519.92542
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 16171.73086
-  tps: 11483.20028
+  dps: 16143.71548
+  tps: 11463.30937
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 16171.73086
-  tps: 11483.20028
+  dps: 16143.71548
+  tps: 11463.30937
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 18147.39859
-  tps: 12891.00986
+  dps: 18192.91944
+  tps: 12923.32967
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10236.75864
-  tps: 7270.79095
+  dps: 10160.30516
+  tps: 7216.50899
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 10236.75864
-  tps: 7270.79095
+  dps: 10160.30516
+  tps: 7216.50899
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 10002.93627
-  tps: 7109.56342
+  dps: 9986.70165
+  tps: 7098.03684
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 16171.73086
-  tps: 11483.20028
+  dps: 16143.71548
+  tps: 11463.30937
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 16171.73086
-  tps: 11483.20028
+  dps: 16143.71548
+  tps: 11463.30937
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 18147.39859
-  tps: 12891.00986
+  dps: 18192.91944
+  tps: 12923.32967
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10236.75864
-  tps: 7270.79095
+  dps: 10160.30516
+  tps: 7216.50899
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 10236.75864
-  tps: 7270.79095
+  dps: 10160.30516
+  tps: 7216.50899
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 10002.93627
-  tps: 7109.56342
+  dps: 9986.70165
+  tps: 7098.03684
  }
 }
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 16808.44934
-  tps: 11935.27041
+  dps: 16723.92242
+  tps: 11875.25629
  }
 }

--- a/sim/druid/feral/apl_values.go
+++ b/sim/druid/feral/apl_values.go
@@ -139,7 +139,7 @@ func (action *APLActionCatOptimalRotationAction) Execute(sim *core.Simulation) {
 	if cat.ClearcastingAura.RemainingDuration(sim) == cat.ClearcastingAura.Duration {
 		// Kick gcd loop, also need to account for any gcd 'left'
 		// otherwise it breaks gcd logic
-		kickTime := max(cat.NextGCDAt(), sim.CurrentTime+cat.latency)
+		kickTime := max(cat.NextGCDAt(), sim.CurrentTime+cat.ReactionTime)
 		cat.NextRotationAction(sim, kickTime)
 	}
 

--- a/sim/druid/feral/feral.go
+++ b/sim/druid/feral/feral.go
@@ -27,12 +27,10 @@ func RegisterFeralDruid() {
 }
 
 func NewFeralDruid(character *core.Character, options *proto.Player) *FeralDruid {
-	feralOptions := options.GetFeralDruid()
 	selfBuffs := druid.SelfBuffs{}
 
 	cat := &FeralDruid{
 		Druid:   druid.New(character, druid.Cat, selfBuffs, options.TalentsString),
-		latency: time.Duration(max(feralOptions.Options.LatencyMs, 1)) * time.Millisecond,
 	}
 
 	// cat.SelfBuffs.InnervateTarget = &proto.UnitReference{}
@@ -66,7 +64,6 @@ type FeralDruid struct {
 	readyToShift      bool
 	readyToGift       bool
 	waitingForTick    bool
-	latency           time.Duration
 	maxRipTicks       int32
 	berserkUsed       bool
 	bleedAura         *core.Aura

--- a/sim/druid/feral/feral_test.go
+++ b/sim/druid/feral/feral_test.go
@@ -101,7 +101,6 @@ var StandardGlyphs = &proto.Glyphs{
 var PlayerOptionsMonoCat = &proto.Player_FeralDruid{
 	FeralDruid: &proto.FeralDruid{
 		Options: &proto.FeralDruid_Options{
-			LatencyMs:         100,
 			AssumeBleedActive: true,
 		},
 	},
@@ -110,7 +109,6 @@ var PlayerOptionsMonoCat = &proto.Player_FeralDruid{
 var PlayerOptionsMonoCatNoBleed = &proto.Player_FeralDruid{
 	FeralDruid: &proto.FeralDruid{
 		Options: &proto.FeralDruid_Options{
-			LatencyMs:         100,
 			AssumeBleedActive: false,
 		},
 	},
@@ -120,7 +118,6 @@ var PlayerOptionsMonoCatNoBleed = &proto.Player_FeralDruid{
 // 	FeralDruid: &proto.FeralDruid{
 // 		Options: &proto.FeralDruid_Options{
 // 			InnervateTarget:   &proto.UnitReference{}, // no Innervate
-// 			LatencyMs:         100,
 // 			AssumeBleedActive: false,
 // 		},
 // 		Rotation: &proto.FeralDruid_Rotation{

--- a/sim/druid/feral/pooling_actions.go
+++ b/sim/druid/feral/pooling_actions.go
@@ -36,7 +36,7 @@ func (pa *PoolingActions) calcFloatingEnergy(cat *FeralDruid, sim *core.Simulati
 	tfPending := false
 
 	for _, s := range pa.actions {
-		delta_t := float64((s.refreshTime - previousTime) / core.EnergyTickDuration)
+		delta_t := float64((s.refreshTime - previousTime) / cat.EnergyTickDuration)
 		if !tfPending {
 			tfPending = cat.tfExpectedBefore(sim, s.refreshTime)
 			if tfPending {
@@ -48,7 +48,7 @@ func (pa *PoolingActions) calcFloatingEnergy(cat *FeralDruid, sim *core.Simulati
 			floatingEnergy += s.cost - delta_t
 			previousTime = s.refreshTime
 		} else {
-			previousTime += time.Duration(s.cost * float64(core.EnergyTickDuration))
+			previousTime += time.Duration(s.cost * float64(cat.EnergyTickDuration))
 		}
 	}
 

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -279,7 +279,7 @@ func (cat *FeralDruid) doRotation(sim *core.Simulation) (bool, time.Duration) {
 	if rakeNow && ripDot.IsActive() {
 		maxRipDur := time.Duration(cat.maxRipTicks) * ripDot.TickLength
 		remainingExt := cat.maxRipTicks - ripDot.NumberOfTicks
-		energyForShreds := curEnergy - cat.CurrentRakeCost() - 30 + float64((ripDot.StartedAt()+maxRipDur-sim.CurrentTime)/core.EnergyTickDuration) + core.Ternary(cat.tfExpectedBefore(sim, ripDot.StartedAt()+maxRipDur), 60.0, 0.0)
+		energyForShreds := curEnergy - cat.CurrentRakeCost() - 30 + float64((ripDot.StartedAt()+maxRipDur-sim.CurrentTime)/cat.EnergyTickDuration) + core.Ternary(cat.tfExpectedBefore(sim, ripDot.StartedAt()+maxRipDur), 60.0, 0.0)
 		maxShredsPossible := min(energyForShreds/cat.Shred.DefaultCast.Cost, (ripDot.ExpiresAt() - (sim.CurrentTime + time.Second)).Seconds())
 		rakeNow = remainingExt == 0 || (maxShredsPossible > float64(remainingExt))
 	}
@@ -470,31 +470,31 @@ func (cat *FeralDruid) doRotation(sim *core.Simulation) (bool, time.Duration) {
 			cat.SavageRoar.Cast(sim, nil)
 			return false, 0
 		}
-		timeToNextAction = time.Duration((cat.CurrentSavageRoarCost() - curEnergy) * float64(core.EnergyTickDuration))
+		timeToNextAction = time.Duration((cat.CurrentSavageRoarCost() - curEnergy) * float64(cat.EnergyTickDuration))
 	} else if ripNow {
 		if cat.Rip.CanCast(sim, cat.CurrentTarget) {
 			cat.Rip.Cast(sim, cat.CurrentTarget)
 			return false, 0
 		}
-		timeToNextAction = time.Duration((cat.CurrentRipCost() - curEnergy) * float64(core.EnergyTickDuration))
+		timeToNextAction = time.Duration((cat.CurrentRipCost() - curEnergy) * float64(cat.EnergyTickDuration))
 	} else if biteNow {
 		if cat.FerociousBite.CanCast(sim, cat.CurrentTarget) {
 			cat.FerociousBite.Cast(sim, cat.CurrentTarget)
 			return false, 0
 		}
-		timeToNextAction = time.Duration((cat.CurrentFerociousBiteCost() - curEnergy) * float64(core.EnergyTickDuration))
+		timeToNextAction = time.Duration((cat.CurrentFerociousBiteCost() - curEnergy) * float64(cat.EnergyTickDuration))
 	} else if mangleNow {
 		if cat.MangleCat.CanCast(sim, cat.CurrentTarget) {
 			cat.MangleCat.Cast(sim, cat.CurrentTarget)
 			return false, 0
 		}
-		timeToNextAction = time.Duration((cat.CurrentMangleCatCost() - curEnergy) * float64(core.EnergyTickDuration))
+		timeToNextAction = time.Duration((cat.CurrentMangleCatCost() - curEnergy) * float64(cat.EnergyTickDuration))
 	} else if rakeNow {
 		if cat.Rake.CanCast(sim, cat.CurrentTarget) {
 			cat.Rake.Cast(sim, cat.CurrentTarget)
 			return false, 0
 		}
-		timeToNextAction = time.Duration((cat.CurrentRakeCost() - curEnergy) * float64(core.EnergyTickDuration))
+		timeToNextAction = time.Duration((cat.CurrentRakeCost() - curEnergy) * float64(cat.EnergyTickDuration))
 	} else if bearweaveNow {
 		cat.readyToShift = true
 	} else if (rotation.MangleSpam && !isClearcast) || cat.PseudoStats.InFrontOfTarget {
@@ -502,7 +502,7 @@ func (cat *FeralDruid) doRotation(sim *core.Simulation) (bool, time.Duration) {
 			cat.MangleCat.Cast(sim, cat.CurrentTarget)
 			return false, 0
 		}
-		timeToNextAction = time.Duration((cat.CurrentMangleCatCost() - excessE) * float64(core.EnergyTickDuration))
+		timeToNextAction = time.Duration((cat.CurrentMangleCatCost() - excessE) * float64(cat.EnergyTickDuration))
 	} else {
 		if excessE >= cat.CurrentShredCost() || isClearcast {
 			cat.Shred.Cast(sim, cat.CurrentTarget)
@@ -515,7 +515,7 @@ func (cat *FeralDruid) doRotation(sim *core.Simulation) (bool, time.Duration) {
 			return false, 0
 		}
 
-		timeToNextAction = time.Duration((cat.CurrentShredCost() - excessE) * float64(core.EnergyTickDuration))
+		timeToNextAction = time.Duration((cat.CurrentShredCost() - excessE) * float64(cat.EnergyTickDuration))
 
 		// When Lacerateweaving, there are scenarios where Lacerate is
 		// synced with other pending actions. When this happens, pooling for
@@ -531,7 +531,7 @@ func (cat *FeralDruid) doRotation(sim *core.Simulation) (bool, time.Duration) {
 				cat.Shred.Cast(sim, cat.CurrentTarget)
 				return false, 0
 			}
-			timeToNextAction = time.Duration((cat.CurrentShredCost() - curEnergy) * float64(core.EnergyTickDuration))
+			timeToNextAction = time.Duration((cat.CurrentShredCost() - curEnergy) * float64(cat.EnergyTickDuration))
 		}
 	}
 

--- a/sim/druid/feral/rotation_aoe.go
+++ b/sim/druid/feral/rotation_aoe.go
@@ -58,25 +58,25 @@ func (cat *FeralDruid) doAoeRotation(sim *core.Simulation) (bool, time.Duration)
 			cat.SavageRoar.Cast(sim, nil)
 			return false, 0
 		}
-		timeToNextAction = time.Duration((cat.CurrentSavageRoarCost() - curEnergy) * float64(core.EnergyTickDuration))
+		timeToNextAction = time.Duration((cat.CurrentSavageRoarCost() - curEnergy) * float64(cat.EnergyTickDuration))
 	} else if mangleNow {
 		if cat.MangleCat.CanCast(sim, cat.CurrentTarget) {
 			cat.MangleCat.Cast(sim, cat.CurrentTarget)
 			return false, 0
 		}
-		timeToNextAction = time.Duration((cat.CurrentMangleCatCost() - curEnergy) * float64(core.EnergyTickDuration))
+		timeToNextAction = time.Duration((cat.CurrentMangleCatCost() - curEnergy) * float64(cat.EnergyTickDuration))
 	} else if rakeNow {
 		if cat.Rake.CanCast(sim, cat.CurrentTarget) {
 			cat.Rake.Cast(sim, cat.CurrentTarget)
 			return false, 0
 		}
-		timeToNextAction = time.Duration((cat.CurrentRakeCost() - curEnergy) * float64(core.EnergyTickDuration))
+		timeToNextAction = time.Duration((cat.CurrentRakeCost() - curEnergy) * float64(cat.EnergyTickDuration))
 	} else {
 		if excessE > cat.CurrentSwipeCatCost() || isClearcast {
 			cat.SwipeCat.Cast(sim, cat.CurrentTarget)
 			return false, 0
 		}
-		timeToNextAction = time.Duration((cat.CurrentSwipeCatCost() - excessE) * float64(core.EnergyTickDuration))
+		timeToNextAction = time.Duration((cat.CurrentSwipeCatCost() - excessE) * float64(cat.EnergyTickDuration))
 	}
 
 	// Model in latency when waiting on Energy for our next action

--- a/sim/hunter/beast_mastery/TestBM.results
+++ b/sim/hunter/beast_mastery/TestBM.results
@@ -40,2076 +40,2076 @@ character_stats_results: {
 dps_results: {
  key: "TestBM-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 18211.60788
-  tps: 15833.27161
+  dps: 18157.71966
+  tps: 15789.16495
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
-  dps: 16301.41796
-  tps: 14243.86782
+  dps: 16218.16135
+  tps: 14156.21426
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 17478.89066
-  tps: 15214.33196
+  dps: 17428.36377
+  tps: 15165.51321
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 17479.39237
-  tps: 15214.33196
+  dps: 17428.74851
+  tps: 15165.51321
  }
 }
 dps_results: {
  key: "TestBM-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 17871.03362
-  tps: 15517.97254
+  dps: 17834.85393
+  tps: 15480.60416
  }
 }
 dps_results: {
  key: "TestBM-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 17871.03362
-  tps: 15517.97254
+  dps: 17834.85393
+  tps: 15480.60416
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 17363.95739
-  tps: 15133.4237
+  dps: 17284.96445
+  tps: 15043.32924
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 17169.87828
-  tps: 14957.39612
-  hps: 97.67152
+  dps: 17090.93285
+  tps: 14867.71591
+  hps: 97.78642
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 17169.87828
-  tps: 14957.39612
-  hps: 97.67152
+  dps: 17090.93285
+  tps: 14867.71591
+  hps: 97.78642
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 17880.0604
-  tps: 15525.52244
+  dps: 17847.62893
+  tps: 15492.33943
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 17343.75325
-  tps: 15125.98866
+  dps: 17380.09402
+  tps: 15160.59665
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 17393.43516
-  tps: 15183.91703
+  dps: 17400.5977
+  tps: 15183.38839
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BindingPromise-67037"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlackBruise-50035"
  value: {
-  dps: 17192.37235
-  tps: 14981.52764
+  dps: 17227.34619
+  tps: 15021.08814
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlackBruise-50692"
  value: {
-  dps: 17177.25117
-  tps: 14968.43406
+  dps: 17212.64484
+  tps: 15008.41132
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 14424.07867
-  tps: 12561.65037
+  dps: 14437.12286
+  tps: 12583.62674
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 13582.86794
-  tps: 11821.90498
+  dps: 13661.81525
+  tps: 11900.65525
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 17635.89077
-  tps: 15313.19511
+  dps: 17628.8098
+  tps: 15310.00622
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 17211.52805
-  tps: 14957.39612
+  dps: 17132.98009
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 17216.98245
-  tps: 14957.39612
+  dps: 17138.46143
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 18033.03571
-  tps: 15684.06606
+  dps: 18054.23697
+  tps: 15708.08871
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 17309.06679
-  tps: 15088.7821
+  dps: 17366.86845
+  tps: 15144.01504
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 17839.60973
-  tps: 15540.70515
+  dps: 17824.95335
+  tps: 15517.28289
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BottledLightning-66879"
  value: {
-  dps: 17220.07866
-  tps: 14996.40372
+  dps: 17159.08412
+  tps: 14933.50277
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 17871.03362
-  tps: 15207.61309
+  dps: 17834.85393
+  tps: 15170.99208
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 17871.03362
-  tps: 15207.61309
+  dps: 17834.85393
+  tps: 15170.99208
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 18258.86597
-  tps: 15880.37032
+  dps: 18205.45979
+  tps: 15837.13323
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 18265.90739
-  tps: 15887.42542
+  dps: 18212.69053
+  tps: 15844.26315
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 18087.46412
-  tps: 15734.40304
+  dps: 18049.84307
+  tps: 15695.5933
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 18132.29892
-  tps: 15771.24705
+  dps: 18083.16183
+  tps: 15730.82553
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 18096.89034
-  tps: 15742.35239
+  dps: 18063.47859
+  tps: 15708.18909
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
   hps: 64
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CrushingWeight-59506"
  value: {
-  dps: 17248.28893
-  tps: 15030.29912
+  dps: 17177.62774
+  tps: 14959.14943
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CrushingWeight-65118"
  value: {
-  dps: 17303.95451
-  tps: 15068.15347
+  dps: 17226.75625
+  tps: 14992.56943
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CryptstalkerBattlegear"
  value: {
-  dps: 14300.11754
-  tps: 12366.34631
+  dps: 14356.05665
+  tps: 12412.91685
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 17214.81539
-  tps: 14991.99815
+  dps: 17191.17811
+  tps: 14974.1979
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 17263.98509
-  tps: 15051.89442
+  dps: 17258.77667
+  tps: 15047.19843
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 17378.65639
-  tps: 15127.28203
+  dps: 17342.89293
+  tps: 15091.07061
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 17628.885
-  tps: 15416.65849
+  dps: 17550.77646
+  tps: 15327.89351
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 18241.58609
-  tps: 15936.9933
+  dps: 18246.41316
+  tps: 15934.40206
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 17222.9327
-  tps: 14957.39612
+  dps: 17144.44106
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Death'sChoice-47464"
  value: {
-  dps: 17762.56476
-  tps: 15455.77606
+  dps: 17772.53105
+  tps: 15454.62176
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 17204.24856
-  tps: 14993.14734
+  dps: 17203.26179
+  tps: 14975.47928
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 17583.39111
-  tps: 15332.33101
+  dps: 17569.0077
+  tps: 15321.91094
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 17667.78557
-  tps: 15417.1373
+  dps: 17629.97997
+  tps: 15377.49736
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Defender'sCode-40257"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 17914.60273
-  tps: 15553.55087
+  dps: 17866.03106
+  tps: 15513.69476
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 17881.46276
-  tps: 15526.9248
+  dps: 17847.62893
+  tps: 15492.33943
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 17249.10433
-  tps: 15033.71194
+  dps: 17228.56347
+  tps: 15028.54587
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 17186.07518
-  tps: 14987.10484
+  dps: 17254.28427
+  tps: 15032.16838
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 17871.03362
-  tps: 15517.97254
+  dps: 17834.85393
+  tps: 15480.60416
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 17871.03362
-  tps: 15517.97254
+  dps: 17834.85393
+  tps: 15480.60416
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 17871.03362
-  tps: 15517.97254
+  dps: 17834.85393
+  tps: 15480.60416
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 17871.03362
-  tps: 15517.97254
+  dps: 17834.85393
+  tps: 15480.60416
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 17914.60273
-  tps: 15553.55087
+  dps: 17866.03106
+  tps: 15513.69476
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 17880.0604
-  tps: 15525.52244
+  dps: 17847.62893
+  tps: 15492.33943
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 17874.52536
-  tps: 15520.59882
+  dps: 17843.90297
+  tps: 15488.61347
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 17215.95118
-  tps: 15010.74982
+  dps: 17233.5006
+  tps: 15031.93361
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 18020.02408
-  tps: 15701.89041
+  dps: 17980.79676
+  tps: 15667.2308
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 18190.89681
-  tps: 15844.02442
+  dps: 18195.16628
+  tps: 15853.47797
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 17871.03362
-  tps: 15517.97254
+  dps: 17834.85393
+  tps: 15480.60416
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 17871.03362
-  tps: 15517.97254
+  dps: 17834.85393
+  tps: 15480.60416
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 17237.00398
-  tps: 15014.61994
+  dps: 17223.65437
+  tps: 15005.19931
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 17205.76617
-  tps: 14982.76584
+  dps: 17194.01408
+  tps: 14975.43673
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FallofMortality-59500"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FallofMortality-65124"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 18270.1706
-  tps: 15877.94793
+  dps: 18220.71371
+  tps: 15846.5076
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 17216.98245
-  tps: 14957.39612
+  dps: 17138.46143
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 17880.52612
-  tps: 15517.97254
+  dps: 17844.35123
+  tps: 15480.60416
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FluidDeath-58181"
  value: {
-  dps: 18258.78151
-  tps: 15886.23042
+  dps: 18154.86078
+  tps: 15770.04415
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ForgeEmber-37660"
  value: {
-  dps: 17198.20094
-  tps: 14983.24671
+  dps: 17197.31302
+  tps: 14983.21569
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 17871.03362
-  tps: 15517.97254
+  dps: 17834.85393
+  tps: 15480.60416
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 17871.03362
-  tps: 15517.97254
+  dps: 17834.85393
+  tps: 15480.60416
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 17871.03362
-  tps: 15517.97254
+  dps: 17834.85393
+  tps: 15480.60416
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 17343.75325
-  tps: 15125.98866
+  dps: 17380.09402
+  tps: 15160.59665
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 17394.67151
-  tps: 15152.56869
+  dps: 17314.9471
+  tps: 15061.7592
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FuturesightRune-38763"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GaleofShadows-56138"
  value: {
-  dps: 17315.89615
-  tps: 15113.71748
+  dps: 17290.92896
+  tps: 15080.60422
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GaleofShadows-56462"
  value: {
-  dps: 17232.49275
-  tps: 15000.48821
+  dps: 17216.12573
+  tps: 14989.96863
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GearDetector-61462"
  value: {
-  dps: 17689.94112
-  tps: 15414.84316
+  dps: 17655.94512
+  tps: 15380.83697
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 16116.34921
-  tps: 13958.57607
+  dps: 16040.89772
+  tps: 13885.86498
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 17237.07995
-  tps: 15024.9145
+  dps: 17231.13541
+  tps: 15019.52572
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 17604.84488
-  tps: 15324.68379
+  dps: 17598.44847
+  tps: 15336.70391
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 17897.53012
-  tps: 15597.80044
+  dps: 17812.57049
+  tps: 15519.87274
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HarmlightToken-63839"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 17193.2108
-  tps: 14957.39612
+  dps: 17114.89235
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HeartofRage-59224"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HeartofRage-65072"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HeartofSolace-55868"
  value: {
-  dps: 17315.89615
-  tps: 15113.71748
+  dps: 17290.92896
+  tps: 15080.60422
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HeartofSolace-56393"
  value: {
-  dps: 17232.49275
-  tps: 15000.48821
+  dps: 17216.12573
+  tps: 14989.96863
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HeartofThunder-55845"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HeartofThunder-56370"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 17660.00814
-  tps: 15388.96855
+  dps: 17684.02564
+  tps: 15404.8633
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Heartpierce-49982"
  value: {
-  dps: 18280.99393
-  tps: 15893.34449
+  dps: 18226.89261
+  tps: 15849.06277
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Heartpierce-50641"
  value: {
-  dps: 18282.4861
-  tps: 15894.63638
+  dps: 18228.3802
+  tps: 15850.3509
  }
 }
 dps_results: {
  key: "TestBM-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 17914.60273
-  tps: 15553.55087
+  dps: 17866.03106
+  tps: 15513.69476
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 17880.0604
-  tps: 15525.52244
+  dps: 17847.62893
+  tps: 15492.33943
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 17874.52536
-  tps: 15520.59882
+  dps: 17843.90297
+  tps: 15488.61347
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 17222.9327
-  tps: 14957.39612
+  dps: 17144.44106
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 17222.9327
-  tps: 14957.39612
+  dps: 17144.44106
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 17211.52805
-  tps: 14957.39612
+  dps: 17132.98009
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 17216.98245
-  tps: 14957.39612
+  dps: 17138.46143
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-IncisorFragment-37723"
  value: {
-  dps: 17380.08284
-  tps: 15153.3236
+  dps: 17301.14844
+  tps: 15063.38933
  }
 }
 dps_results: {
  key: "TestBM-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 17871.03362
-  tps: 15517.97254
+  dps: 17834.85393
+  tps: 15480.60416
  }
 }
 dps_results: {
  key: "TestBM-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 17201.94153
-  tps: 14957.39612
+  dps: 17123.34623
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 17901.93369
-  tps: 15544.69149
-  hps: 63.16222
+  dps: 17865.69551
+  tps: 15507.26222
+  hps: 63.3878
  }
 }
 dps_results: {
  key: "TestBM-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 17635.89077
-  tps: 15313.19511
+  dps: 17628.8098
+  tps: 15310.00622
  }
 }
 dps_results: {
  key: "TestBM-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 18053.28113
-  tps: 15704.14752
+  dps: 18056.132
+  tps: 15714.31475
  }
 }
 dps_results: {
  key: "TestBM-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 17250.73211
-  tps: 15028.65852
+  dps: 17286.95925
+  tps: 15077.44864
  }
 }
 dps_results: {
  key: "TestBM-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 17250.73211
-  tps: 15028.65852
+  dps: 17286.95925
+  tps: 15077.44864
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 17207.37135
-  tps: 14988.43772
+  dps: 17237.28145
+  tps: 15006.0204
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LastWord-50179"
  value: {
-  dps: 18211.60788
-  tps: 15833.27161
+  dps: 18157.71966
+  tps: 15789.16495
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LastWord-50708"
  value: {
-  dps: 18211.60788
-  tps: 15833.27161
+  dps: 18157.71966
+  tps: 15789.16495
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LeadenDespair-55816"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LeadenDespair-56347"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 17813.26571
-  tps: 15500.38275
+  dps: 17770.20716
+  tps: 15452.80252
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 17838.05369
-  tps: 15516.9068
+  dps: 17858.21587
+  tps: 15541.09022
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 17479.39237
-  tps: 15214.33196
+  dps: 17428.74851
+  tps: 15165.51321
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Lightning-ChargedBattlegear"
  value: {
-  dps: 17857.01904
-  tps: 15482.62903
+  dps: 17866.81584
+  tps: 15476.00794
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 17217.32073
-  tps: 14957.39612
+  dps: 17137.94794
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 17223.53369
-  tps: 14957.39612
+  dps: 17144.07983
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 17164.2148
-  tps: 14946.87551
+  dps: 17227.0469
+  tps: 15004.9238
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 17410.99023
-  tps: 15154.22684
+  dps: 17419.51796
+  tps: 15156.14133
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 17479.39237
-  tps: 15214.33196
+  dps: 17428.74851
+  tps: 15165.51321
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 17222.9327
-  tps: 14957.39612
+  dps: 17144.44106
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 17222.9327
-  tps: 14957.39612
+  dps: 17144.44106
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 17238.9466
-  tps: 14957.39612
+  dps: 17160.12247
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 17266.49218
-  tps: 15050.79718
+  dps: 17201.55184
+  tps: 14979.73276
  }
 }
 dps_results: {
  key: "TestBM-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 17237.46313
-  tps: 15015.22608
+  dps: 17230.35809
+  tps: 15018.59976
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 17896.04796
-  tps: 15539.60216
+  dps: 17859.82092
+  tps: 15502.18449
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 17901.93369
-  tps: 15544.69149
+  dps: 17865.69551
+  tps: 15507.26222
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 17190.40315
-  tps: 14957.39612
+  dps: 17111.82131
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 17206.41144
-  tps: 14957.39612
+  dps: 17127.98068
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 17871.03362
-  tps: 15517.97254
+  dps: 17834.85393
+  tps: 15480.60416
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 17871.03362
-  tps: 15517.97254
+  dps: 17834.85393
+  tps: 15480.60416
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 17871.03362
-  tps: 15517.97254
+  dps: 17834.85393
+  tps: 15480.60416
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 18169.82611
-  tps: 15853.07135
+  dps: 18125.39086
+  tps: 15799.44904
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 18102.80159
-  tps: 15771.87298
+  dps: 18179.29114
+  tps: 15854.76549
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Rainsong-55854"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Rainsong-56377"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 18141.9185
-  tps: 15776.77944
+  dps: 18098.43535
+  tps: 15735.40268
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 18087.46412
-  tps: 15734.40304
+  dps: 18049.84307
+  tps: 15695.5933
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 18087.46412
-  tps: 15734.40304
+  dps: 18049.84307
+  tps: 15695.5933
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 17871.03362
-  tps: 15517.97254
+  dps: 17834.85393
+  tps: 15480.60416
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 17478.89066
-  tps: 15214.33196
+  dps: 17428.36377
+  tps: 15165.51321
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 17479.39237
-  tps: 15214.33196
+  dps: 17428.74851
+  tps: 15165.51321
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 17626.63742
-  tps: 15324.08821
+  dps: 17647.2583
+  tps: 15345.69016
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ScourgestalkerBattlegear"
  value: {
-  dps: 14566.48879
-  tps: 12674.35542
+  dps: 14502.13642
+  tps: 12607.11845
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SeaStar-55256"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SeaStar-56290"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Shadowmourne-49623"
  value: {
-  dps: 18492.83372
-  tps: 16122.71271
+  dps: 18426.52455
+  tps: 16053.24479
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 17217.59009
-  tps: 15010.0649
+  dps: 17257.67105
+  tps: 15034.30773
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 17688.3749
-  tps: 15350.57263
+  dps: 17709.8514
+  tps: 15373.27255
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 17776.77555
-  tps: 15422.8168
+  dps: 17798.02686
+  tps: 15443.35943
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Sorrowsong-55879"
  value: {
-  dps: 17211.52805
-  tps: 14957.39612
+  dps: 17132.98009
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Sorrowsong-56400"
  value: {
-  dps: 17216.98245
-  tps: 14957.39612
+  dps: 17138.46143
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 17478.89066
-  tps: 15214.33196
+  dps: 17428.36377
+  tps: 15165.51321
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SoulCasket-58183"
  value: {
-  dps: 17222.9327
-  tps: 14957.39612
+  dps: 17144.44106
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SoulPreserver-37111"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SouloftheDead-40382"
  value: {
-  dps: 17206.85076
-  tps: 14984.15521
+  dps: 17194.01408
+  tps: 14975.43673
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SparkofLife-37657"
  value: {
-  dps: 17189.41684
-  tps: 14982.12448
+  dps: 17153.50862
+  tps: 14936.69576
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 17314.10316
-  tps: 15076.92225
+  dps: 17364.82731
+  tps: 15124.42178
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-StumpofTime-62465"
  value: {
-  dps: 17479.39237
-  tps: 15214.33196
+  dps: 17428.74851
+  tps: 15165.51321
  }
 }
 dps_results: {
  key: "TestBM-AllItems-StumpofTime-62470"
  value: {
-  dps: 17479.39237
-  tps: 15214.33196
+  dps: 17428.74851
+  tps: 15165.51321
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 17901.93369
-  tps: 15544.69149
+  dps: 17865.69551
+  tps: 15507.26222
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 17896.04796
-  tps: 15539.60216
+  dps: 17859.82092
+  tps: 15502.18449
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 17885.74794
-  tps: 15530.69585
+  dps: 17849.5404
+  tps: 15493.29848
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 17254.08893
-  tps: 15037.92028
+  dps: 17284.59355
+  tps: 15080.72758
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TearofBlood-55819"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TearofBlood-56351"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 17205.41251
-  tps: 14957.39612
+  dps: 17126.83435
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 17216.98245
-  tps: 14957.39612
+  dps: 17138.46143
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 17874.97068
-  tps: 15525.67148
+  dps: 17834.49701
+  tps: 15469.97794
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 17779.31715
-  tps: 15442.2484
+  dps: 17776.83378
+  tps: 15441.52576
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 17261.02384
-  tps: 15052.25257
+  dps: 17304.10353
+  tps: 15078.84841
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 17261.02384
-  tps: 15052.25257
+  dps: 17304.10353
+  tps: 15078.84841
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 17871.03362
-  tps: 15517.97254
+  dps: 17834.85393
+  tps: 15480.60416
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 17871.03362
-  tps: 15517.97254
+  dps: 17834.85393
+  tps: 15480.60416
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 17136.98579
-  tps: 14925.52918
+  dps: 17142.01488
+  tps: 14918.19064
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 17871.03362
-  tps: 15517.97254
+  dps: 17834.85393
+  tps: 15480.60416
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 17871.03362
-  tps: 15517.97254
+  dps: 17834.85393
+  tps: 15480.60416
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 13946.14985
-  tps: 12136.66209
+  dps: 13980.29328
+  tps: 12177.9363
  }
 }
 dps_results: {
  key: "TestBM-AllItems-UnheededWarning-59520"
  value: {
-  dps: 17905.95172
-  tps: 15583.8721
+  dps: 17914.83714
+  tps: 15585.06708
  }
 }
 dps_results: {
  key: "TestBM-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 17963.91619
-  tps: 15582.59637
+  dps: 17941.58155
+  tps: 15567.81432
  }
 }
 dps_results: {
  key: "TestBM-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 17963.91619
-  tps: 15582.59637
+  dps: 17941.58155
+  tps: 15567.81432
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 17225.4633
-  tps: 15023.57875
+  dps: 17194.02795
+  tps: 14992.71319
  }
 }
 dps_results: {
  key: "TestBM-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 17908.14825
-  tps: 15582.59637
+  dps: 17885.99049
+  tps: 15567.81432
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 17479.39237
-  tps: 15214.33196
+  dps: 17428.74851
+  tps: 15165.51321
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 17331.93518
-  tps: 15123.10621
+  dps: 17416.17064
+  tps: 15194.40876
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 17377.20924
-  tps: 15162.49733
+  dps: 17405.76879
+  tps: 15188.68879
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 17226.07311
-  tps: 14957.39612
+  dps: 17147.59698
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 17853.18717
-  tps: 15530.02388
+  dps: 17859.02748
+  tps: 15530.72982
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Windrunner'sPursuit"
  value: {
-  dps: 14624.82526
-  tps: 12635.74974
+  dps: 14621.13076
+  tps: 12631.57128
  }
 }
 dps_results: {
  key: "TestBM-AllItems-WingedTalisman-37844"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 17169.87628
-  tps: 14957.39612
+  dps: 17091.12262
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 17206.07365
-  tps: 14957.39612
+  dps: 17127.49876
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 17211.10776
-  tps: 14957.39612
+  dps: 17131.81605
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 17211.10776
-  tps: 14957.39612
+  dps: 17131.81605
+  tps: 14867.71591
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Zod'sRepeatingLongbow-50034"
  value: {
-  dps: 15700.61364
-  tps: 13455.05438
+  dps: 15728.02189
+  tps: 13486.10316
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 15942.34116
-  tps: 13689.25549
+  dps: 15935.80411
+  tps: 13682.78556
  }
 }
 dps_results: {
  key: "TestBM-Average-Default"
  value: {
-  dps: 18214.523
-  tps: 15858.19847
+  dps: 18212.93054
+  tps: 15857.38916
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm-FullBuffs-LongMultiTarget"
  value: {
-  dps: 17935.32431
-  tps: 15691.78933
+  dps: 17890.08543
+  tps: 15654.20574
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm-FullBuffs-LongSingleTarget"
  value: {
-  dps: 17935.32431
-  tps: 15691.78933
+  dps: 17890.08543
+  tps: 15654.20574
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 21559.93905
-  tps: 18630.22397
+  dps: 21565.00763
+  tps: 18632.69716
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11877.76587
-  tps: 10352.27097
+  dps: 11933.89274
+  tps: 10399.32979
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm-NoBuffs-LongSingleTarget"
  value: {
-  dps: 11877.76587
-  tps: 10352.27097
+  dps: 11933.89274
+  tps: 10399.32979
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 12585.10904
-  tps: 10847.38912
+  dps: 12602.37452
+  tps: 10864.16126
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm_advanced-FullBuffs-LongMultiTarget"
  value: {
-  dps: 17935.32431
-  tps: 15691.78933
+  dps: 17890.08543
+  tps: 15654.20574
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm_advanced-FullBuffs-LongSingleTarget"
  value: {
-  dps: 17935.32431
-  tps: 15691.78933
+  dps: 17890.08543
+  tps: 15654.20574
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm_advanced-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 21559.93905
-  tps: 18630.22397
+  dps: 21565.00763
+  tps: 18632.69716
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm_advanced-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11877.76587
-  tps: 10352.27097
+  dps: 11933.89274
+  tps: 10399.32979
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm_advanced-NoBuffs-LongSingleTarget"
  value: {
-  dps: 11877.76587
-  tps: 10352.27097
+  dps: 11933.89274
+  tps: 10399.32979
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm_advanced-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 12585.10904
-  tps: 10847.38912
+  dps: 12602.37452
+  tps: 10864.16126
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18211.60788
-  tps: 15833.27161
+  dps: 18157.71966
+  tps: 15789.16495
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm-FullBuffs-LongSingleTarget"
  value: {
-  dps: 18211.60788
-  tps: 15833.27161
+  dps: 18157.71966
+  tps: 15789.16495
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 22034.19945
-  tps: 18904.59878
+  dps: 22039.39823
+  tps: 18907.07214
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12066.21963
-  tps: 10449.45204
+  dps: 12124.11081
+  tps: 10497.95394
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm-NoBuffs-LongSingleTarget"
  value: {
-  dps: 12066.21963
-  tps: 10449.45204
+  dps: 12124.11081
+  tps: 10497.95394
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 12889.40841
-  tps: 11030.69003
+  dps: 12906.70023
+  tps: 11047.46378
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm_advanced-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18211.60788
-  tps: 15833.27161
+  dps: 18157.71966
+  tps: 15789.16495
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm_advanced-FullBuffs-LongSingleTarget"
  value: {
-  dps: 18211.60788
-  tps: 15833.27161
+  dps: 18157.71966
+  tps: 15789.16495
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm_advanced-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 22034.19945
-  tps: 18904.59878
+  dps: 22039.39823
+  tps: 18907.07214
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm_advanced-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12066.21963
-  tps: 10449.45204
+  dps: 12124.11081
+  tps: 10497.95394
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm_advanced-NoBuffs-LongSingleTarget"
  value: {
-  dps: 12066.21963
-  tps: 10449.45204
+  dps: 12124.11081
+  tps: 10497.95394
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm_advanced-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 12889.40841
-  tps: 11030.69003
+  dps: 12906.70023
+  tps: 11047.46378
  }
 }
 dps_results: {
  key: "TestBM-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 18204.35661
-  tps: 15829.68961
+  dps: 18151.98457
+  tps: 15785.61895
  }
 }

--- a/sim/hunter/beast_mastery/TestBM.results
+++ b/sim/hunter/beast_mastery/TestBM.results
@@ -40,2076 +40,2076 @@ character_stats_results: {
 dps_results: {
  key: "TestBM-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 18157.71966
-  tps: 15789.16495
+  dps: 18250.78753
+  tps: 15863.6469
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
-  dps: 16218.16135
-  tps: 14156.21426
+  dps: 16284.50248
+  tps: 14227.51475
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 17428.36377
-  tps: 15165.51321
+  dps: 17443.11454
+  tps: 15162.92437
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 17428.74851
-  tps: 15165.51321
+  dps: 17442.8015
+  tps: 15160.25673
  }
 }
 dps_results: {
  key: "TestBM-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 17834.85393
-  tps: 15480.60416
+  dps: 17892.06682
+  tps: 15522.15295
  }
 }
 dps_results: {
  key: "TestBM-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 17834.85393
-  tps: 15480.60416
+  dps: 17892.06682
+  tps: 15522.15295
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 17284.96445
-  tps: 15043.32924
+  dps: 17333.09937
+  tps: 15095.93277
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 17090.93285
-  tps: 14867.71591
-  hps: 97.78642
+  dps: 17139.13925
+  tps: 14919.69675
+  hps: 97.76507
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 17090.93285
-  tps: 14867.71591
-  hps: 97.78642
+  dps: 17139.13925
+  tps: 14919.69675
+  hps: 97.76507
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 17847.62893
-  tps: 15492.33943
+  dps: 17903.21661
+  tps: 15531.91392
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 17380.09402
-  tps: 15160.59665
+  dps: 17301.90138
+  tps: 15067.23903
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 17400.5977
-  tps: 15183.38839
+  dps: 17312.84463
+  tps: 15082.87738
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BindingPromise-67037"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlackBruise-50035"
  value: {
-  dps: 17227.34619
-  tps: 15021.08814
+  dps: 17236.0897
+  tps: 15008.08195
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlackBruise-50692"
  value: {
-  dps: 17212.64484
-  tps: 15008.41132
+  dps: 17220.79297
+  tps: 14994.82764
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 14437.12286
-  tps: 12583.62674
+  dps: 14414.22832
+  tps: 12542.60851
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 13661.81525
-  tps: 11900.65525
+  dps: 13614.43348
+  tps: 11857.20761
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 17628.8098
-  tps: 15310.00622
+  dps: 17683.11572
+  tps: 15355.20808
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 17132.98009
-  tps: 14867.71591
+  dps: 17180.83237
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 17138.46143
-  tps: 14867.71591
+  dps: 17186.30372
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 18054.23697
-  tps: 15708.08871
+  dps: 18053.27719
+  tps: 15717.97771
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 17366.86845
-  tps: 15144.01504
+  dps: 17319.65259
+  tps: 15083.36421
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 17824.95335
-  tps: 15517.28289
+  dps: 17815.51845
+  tps: 15515.51466
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BottledLightning-66879"
  value: {
-  dps: 17159.08412
-  tps: 14933.50277
+  dps: 17166.97667
+  tps: 14953.95077
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 17834.85393
-  tps: 15170.99208
+  dps: 17892.06682
+  tps: 15211.70989
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 17834.85393
-  tps: 15170.99208
+  dps: 17892.06682
+  tps: 15211.70989
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 18205.45979
-  tps: 15837.13323
+  dps: 18299.56075
+  tps: 15912.49453
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 18212.69053
-  tps: 15844.26315
+  dps: 18306.48021
+  tps: 15919.35472
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 18049.84307
-  tps: 15695.5933
+  dps: 18109.76834
+  tps: 15739.85447
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 18083.16183
-  tps: 15730.82553
+  dps: 18182.9574
+  tps: 15805.38955
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 18063.47859
-  tps: 15708.18909
+  dps: 18121.38817
+  tps: 15750.08548
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
   hps: 64
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CrushingWeight-59506"
  value: {
-  dps: 17177.62774
-  tps: 14959.14943
+  dps: 17226.1813
+  tps: 14997.32482
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CrushingWeight-65118"
  value: {
-  dps: 17226.75625
-  tps: 14992.56943
+  dps: 17194.01766
+  tps: 14979.23083
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CryptstalkerBattlegear"
  value: {
-  dps: 14356.05665
-  tps: 12412.91685
+  dps: 14248.39632
+  tps: 12299.78248
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 17191.17811
-  tps: 14974.1979
+  dps: 17167.11911
+  tps: 14946.3757
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 17258.77667
-  tps: 15047.19843
+  dps: 17225.96737
+  tps: 15006.87988
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 17342.89293
-  tps: 15091.07061
+  dps: 17351.31667
+  tps: 15106.49807
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 17550.77646
-  tps: 15327.89351
+  dps: 17599.71349
+  tps: 15380.50818
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 18246.41316
-  tps: 15934.40206
+  dps: 18266.5186
+  tps: 15964.84143
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 17144.44106
-  tps: 14867.71591
+  dps: 17192.27246
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Death'sChoice-47464"
  value: {
-  dps: 17772.53105
-  tps: 15454.62176
+  dps: 17725.8696
+  tps: 15416.82785
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 17203.26179
-  tps: 14975.47928
+  dps: 17186.90252
+  tps: 14976.96819
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 17569.0077
-  tps: 15321.91094
+  dps: 17581.18877
+  tps: 15328.98576
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 17629.97997
-  tps: 15377.49736
+  dps: 17646.17705
+  tps: 15402.10914
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Defender'sCode-40257"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 17866.03106
-  tps: 15513.69476
+  dps: 17962.54952
+  tps: 15584.98167
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 17847.62893
-  tps: 15492.33943
+  dps: 17904.61897
+  tps: 15533.31628
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 17228.56347
-  tps: 15028.54587
+  dps: 17231.7562
+  tps: 15025.29166
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 17254.28427
-  tps: 15032.16838
+  dps: 17234.2639
+  tps: 15009.13628
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 17834.85393
-  tps: 15480.60416
+  dps: 17892.06682
+  tps: 15522.15295
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 17834.85393
-  tps: 15480.60416
+  dps: 17892.06682
+  tps: 15522.15295
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 17834.85393
-  tps: 15480.60416
+  dps: 17892.06682
+  tps: 15522.15295
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 17834.85393
-  tps: 15480.60416
+  dps: 17892.06682
+  tps: 15522.15295
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 17866.03106
-  tps: 15513.69476
+  dps: 17962.54952
+  tps: 15584.98167
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 17847.62893
-  tps: 15492.33943
+  dps: 17903.21661
+  tps: 15531.91392
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 17843.90297
-  tps: 15488.61347
+  dps: 17896.44798
+  tps: 15524.52806
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 17233.5006
-  tps: 15031.93361
+  dps: 17096.16632
+  tps: 14868.80068
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 17980.79676
-  tps: 15667.2308
+  dps: 18083.45129
+  tps: 15760.83899
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 18195.16628
-  tps: 15853.47797
+  dps: 18211.82401
+  tps: 15874.8486
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 17834.85393
-  tps: 15480.60416
+  dps: 17892.06682
+  tps: 15522.15295
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 17834.85393
-  tps: 15480.60416
+  dps: 17892.06682
+  tps: 15522.15295
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 17223.65437
-  tps: 15005.19931
+  dps: 17178.80779
+  tps: 14959.78497
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 17194.01408
-  tps: 14975.43673
+  dps: 17147.2973
+  tps: 14928.10244
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FallofMortality-59500"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FallofMortality-65124"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 18220.71371
-  tps: 15846.5076
+  dps: 18312.16618
+  tps: 15902.95615
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 17138.46143
-  tps: 14867.71591
+  dps: 17186.30372
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 17844.35123
-  tps: 15480.60416
+  dps: 17901.62731
+  tps: 15522.15295
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FluidDeath-58181"
  value: {
-  dps: 18154.86078
-  tps: 15770.04415
+  dps: 18251.34052
+  tps: 15860.72639
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ForgeEmber-37660"
  value: {
-  dps: 17197.31302
-  tps: 14983.21569
+  dps: 17154.15072
+  tps: 14937.16509
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 17834.85393
-  tps: 15480.60416
+  dps: 17892.06682
+  tps: 15522.15295
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 17834.85393
-  tps: 15480.60416
+  dps: 17892.06682
+  tps: 15522.15295
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 17834.85393
-  tps: 15480.60416
+  dps: 17892.06682
+  tps: 15522.15295
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 17380.09402
-  tps: 15160.59665
+  dps: 17301.90138
+  tps: 15067.23903
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 17314.9471
-  tps: 15061.7592
+  dps: 17363.59821
+  tps: 15114.50962
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FuturesightRune-38763"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GaleofShadows-56138"
  value: {
-  dps: 17290.92896
-  tps: 15080.60422
+  dps: 17278.75765
+  tps: 15060.7194
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GaleofShadows-56462"
  value: {
-  dps: 17216.12573
-  tps: 14989.96863
+  dps: 17373.41774
+  tps: 15142.43952
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GearDetector-61462"
  value: {
-  dps: 17655.94512
-  tps: 15380.83697
+  dps: 17571.97947
+  tps: 15301.71984
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 16040.89772
-  tps: 13885.86498
+  dps: 16153.99602
+  tps: 13979.20353
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 17231.13541
-  tps: 15019.52572
+  dps: 17200.66109
+  tps: 14981.37848
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 17598.44847
-  tps: 15336.70391
+  dps: 17567.59887
+  tps: 15298.52468
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 17812.57049
-  tps: 15519.87274
+  dps: 17859.89167
+  tps: 15555.68271
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HarmlightToken-63839"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 17114.89235
-  tps: 14867.71591
+  dps: 17162.53841
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HeartofRage-59224"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HeartofRage-65072"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HeartofSolace-55868"
  value: {
-  dps: 17290.92896
-  tps: 15080.60422
+  dps: 17278.75765
+  tps: 15060.7194
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HeartofSolace-56393"
  value: {
-  dps: 17216.12573
-  tps: 14989.96863
+  dps: 17373.41774
+  tps: 15142.43952
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HeartofThunder-55845"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HeartofThunder-56370"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 17684.02564
-  tps: 15404.8633
+  dps: 17674.74872
+  tps: 15386.43373
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Heartpierce-49982"
  value: {
-  dps: 18226.89261
-  tps: 15849.06277
+  dps: 18320.36691
+  tps: 15923.87512
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Heartpierce-50641"
  value: {
-  dps: 18228.3802
-  tps: 15850.3509
+  dps: 18321.86324
+  tps: 15925.17035
  }
 }
 dps_results: {
  key: "TestBM-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 17866.03106
-  tps: 15513.69476
+  dps: 17962.54952
+  tps: 15584.98167
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 17847.62893
-  tps: 15492.33943
+  dps: 17903.21661
+  tps: 15531.91392
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 17843.90297
-  tps: 15488.61347
+  dps: 17896.44798
+  tps: 15524.52806
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 17144.44106
-  tps: 14867.71591
+  dps: 17192.27246
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 17144.44106
-  tps: 14867.71591
+  dps: 17192.27246
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 17132.98009
-  tps: 14867.71591
+  dps: 17180.83237
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 17138.46143
-  tps: 14867.71591
+  dps: 17186.30372
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-IncisorFragment-37723"
  value: {
-  dps: 17301.14844
-  tps: 15063.38933
+  dps: 17347.74358
+  tps: 15114.05849
  }
 }
 dps_results: {
  key: "TestBM-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 17834.85393
-  tps: 15480.60416
+  dps: 17892.06682
+  tps: 15522.15295
  }
 }
 dps_results: {
  key: "TestBM-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 17123.34623
-  tps: 14867.71591
+  dps: 17171.21607
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 17865.69551
-  tps: 15507.26222
-  hps: 63.3878
+  dps: 17923.03998
+  tps: 15548.91279
+  hps: 61.80874
  }
 }
 dps_results: {
  key: "TestBM-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 17628.8098
-  tps: 15310.00622
+  dps: 17683.11572
+  tps: 15355.20808
  }
 }
 dps_results: {
  key: "TestBM-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 18056.132
-  tps: 15714.31475
+  dps: 18055.18615
+  tps: 15687.01931
  }
 }
 dps_results: {
  key: "TestBM-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 17286.95925
-  tps: 15077.44864
+  dps: 17181.88493
+  tps: 14973.49802
  }
 }
 dps_results: {
  key: "TestBM-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 17286.95925
-  tps: 15077.44864
+  dps: 17181.88493
+  tps: 14973.49802
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 17237.28145
-  tps: 15006.0204
+  dps: 17271.98756
+  tps: 15055.39356
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LastWord-50179"
  value: {
-  dps: 18157.71966
-  tps: 15789.16495
+  dps: 18250.78753
+  tps: 15863.6469
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LastWord-50708"
  value: {
-  dps: 18157.71966
-  tps: 15789.16495
+  dps: 18250.78753
+  tps: 15863.6469
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LeadenDespair-55816"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LeadenDespair-56347"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 17770.20716
-  tps: 15452.80252
+  dps: 17786.69876
+  tps: 15469.61507
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 17858.21587
-  tps: 15541.09022
+  dps: 17880.73437
+  tps: 15549.62245
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 17428.74851
-  tps: 15165.51321
+  dps: 17442.8015
+  tps: 15160.25673
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Lightning-ChargedBattlegear"
  value: {
-  dps: 17866.81584
-  tps: 15476.00794
+  dps: 17832.06003
+  tps: 15446.37048
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 17137.94794
-  tps: 14867.71591
+  dps: 17185.8597
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 17144.07983
-  tps: 14867.71591
+  dps: 17191.98939
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 17227.0469
-  tps: 15004.9238
+  dps: 17170.64032
+  tps: 14953.06393
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 17419.51796
-  tps: 15156.14133
+  dps: 17410.58788
+  tps: 15130.31707
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 17428.74851
-  tps: 15165.51321
+  dps: 17442.8015
+  tps: 15160.25673
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 17144.44106
-  tps: 14867.71591
+  dps: 17192.27246
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 17144.44106
-  tps: 14867.71591
+  dps: 17192.27246
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 17160.12247
-  tps: 14867.71591
+  dps: 17208.4583
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 17201.55184
-  tps: 14979.73276
+  dps: 17189.18602
+  tps: 14986.63543
  }
 }
 dps_results: {
  key: "TestBM-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 17230.35809
-  tps: 15018.59976
+  dps: 17199.74267
+  tps: 14985.86216
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 17859.82092
-  tps: 15502.18449
+  dps: 17917.14033
+  tps: 15543.81568
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 17865.69551
-  tps: 15507.26222
+  dps: 17923.03998
+  tps: 15548.91279
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 17111.82131
-  tps: 14867.71591
+  dps: 17159.82458
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 17127.98068
-  tps: 14867.71591
+  dps: 17176.96788
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 17834.85393
-  tps: 15480.60416
+  dps: 17892.06682
+  tps: 15522.15295
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 17834.85393
-  tps: 15480.60416
+  dps: 17892.06682
+  tps: 15522.15295
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 17834.85393
-  tps: 15480.60416
+  dps: 17892.06682
+  tps: 15522.15295
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 18125.39086
-  tps: 15799.44904
+  dps: 18087.30862
+  tps: 15762.6516
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 18179.29114
-  tps: 15854.76549
+  dps: 18133.16078
+  tps: 15797.90407
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Rainsong-55854"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Rainsong-56377"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 18098.43535
-  tps: 15735.40268
+  dps: 18156.91855
+  tps: 15789.76887
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 18049.84307
-  tps: 15695.5933
+  dps: 18109.76834
+  tps: 15739.85447
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 18049.84307
-  tps: 15695.5933
+  dps: 18109.76834
+  tps: 15739.85447
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 17834.85393
-  tps: 15480.60416
+  dps: 17892.06682
+  tps: 15522.15295
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 17428.36377
-  tps: 15165.51321
+  dps: 17443.11454
+  tps: 15162.92437
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 17428.74851
-  tps: 15165.51321
+  dps: 17442.8015
+  tps: 15160.25673
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 17647.2583
-  tps: 15345.69016
+  dps: 17672.04625
+  tps: 15365.2346
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ScourgestalkerBattlegear"
  value: {
-  dps: 14502.13642
-  tps: 12607.11845
+  dps: 14494.99633
+  tps: 12579.58281
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SeaStar-55256"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SeaStar-56290"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Shadowmourne-49623"
  value: {
-  dps: 18426.52455
-  tps: 16053.24479
+  dps: 18512.28047
+  tps: 16118.90148
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 17257.67105
-  tps: 15034.30773
+  dps: 17171.20101
+  tps: 14967.59139
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 17709.8514
-  tps: 15373.27255
+  dps: 17726.09767
+  tps: 15395.35843
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 17798.02686
-  tps: 15443.35943
+  dps: 17800.9547
+  tps: 15451.88475
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Sorrowsong-55879"
  value: {
-  dps: 17132.98009
-  tps: 14867.71591
+  dps: 17180.83237
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Sorrowsong-56400"
  value: {
-  dps: 17138.46143
-  tps: 14867.71591
+  dps: 17186.30372
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 17428.36377
-  tps: 15165.51321
+  dps: 17443.11454
+  tps: 15162.92437
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SoulCasket-58183"
  value: {
-  dps: 17144.44106
-  tps: 14867.71591
+  dps: 17192.27246
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SoulPreserver-37111"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SouloftheDead-40382"
  value: {
-  dps: 17194.01408
-  tps: 14975.43673
+  dps: 17148.87289
+  tps: 14929.67802
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SparkofLife-37657"
  value: {
-  dps: 17153.50862
-  tps: 14936.69576
+  dps: 17181.61861
+  tps: 14983.08757
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 17364.82731
-  tps: 15124.42178
+  dps: 17313.43695
+  tps: 15067.85869
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-StumpofTime-62465"
  value: {
-  dps: 17428.74851
-  tps: 15165.51321
+  dps: 17442.8015
+  tps: 15160.25673
  }
 }
 dps_results: {
  key: "TestBM-AllItems-StumpofTime-62470"
  value: {
-  dps: 17428.74851
-  tps: 15165.51321
+  dps: 17442.8015
+  tps: 15160.25673
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 17865.69551
-  tps: 15507.26222
+  dps: 17923.03998
+  tps: 15548.91279
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 17859.82092
-  tps: 15502.18449
+  dps: 17917.14033
+  tps: 15543.81568
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 17849.5404
-  tps: 15493.29848
+  dps: 17906.81595
+  tps: 15534.89573
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 17284.59355
-  tps: 15080.72758
+  dps: 17156.79238
+  tps: 14941.86748
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TearofBlood-55819"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TearofBlood-56351"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 17126.83435
-  tps: 14867.71591
+  dps: 17174.69784
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 17138.46143
-  tps: 14867.71591
+  dps: 17186.30372
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 17834.49701
-  tps: 15469.97794
+  dps: 17928.86532
+  tps: 15573.66805
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 17776.83378
-  tps: 15441.52576
+  dps: 17799.14296
+  tps: 15465.94651
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 17304.10353
-  tps: 15078.84841
+  dps: 17188.36901
+  tps: 14952.38687
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 17304.10353
-  tps: 15078.84841
+  dps: 17188.36901
+  tps: 14952.38687
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 17834.85393
-  tps: 15480.60416
+  dps: 17892.06682
+  tps: 15522.15295
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 17834.85393
-  tps: 15480.60416
+  dps: 17892.06682
+  tps: 15522.15295
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 17142.01488
-  tps: 14918.19064
+  dps: 17152.06899
+  tps: 14964.73196
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 17834.85393
-  tps: 15480.60416
+  dps: 17892.06682
+  tps: 15522.15295
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 17834.85393
-  tps: 15480.60416
+  dps: 17892.06682
+  tps: 15522.15295
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 13980.29328
-  tps: 12177.9363
+  dps: 14023.4251
+  tps: 12205.80538
  }
 }
 dps_results: {
  key: "TestBM-AllItems-UnheededWarning-59520"
  value: {
-  dps: 17914.83714
-  tps: 15585.06708
+  dps: 17927.96761
+  tps: 15608.51985
  }
 }
 dps_results: {
  key: "TestBM-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 17941.58155
-  tps: 15567.81432
+  dps: 17892.12146
+  tps: 15522.65021
  }
 }
 dps_results: {
  key: "TestBM-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 17941.58155
-  tps: 15567.81432
+  dps: 17892.12146
+  tps: 15522.65021
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 17194.02795
-  tps: 14992.71319
+  dps: 17171.8712
+  tps: 14977.74848
  }
 }
 dps_results: {
  key: "TestBM-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 17885.99049
-  tps: 15567.81432
+  dps: 17836.631
+  tps: 15522.65021
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 17428.74851
-  tps: 15165.51321
+  dps: 17442.8015
+  tps: 15160.25673
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 17416.17064
-  tps: 15194.40876
+  dps: 17397.40188
+  tps: 15182.06202
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 17405.76879
-  tps: 15188.68879
+  dps: 17305.46404
+  tps: 15074.02385
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 17147.59698
-  tps: 14867.71591
+  dps: 17195.42263
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 17859.02748
-  tps: 15530.72982
+  dps: 17882.57899
+  tps: 15558.32458
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Windrunner'sPursuit"
  value: {
-  dps: 14621.13076
-  tps: 12631.57128
+  dps: 14559.6698
+  tps: 12571.33209
  }
 }
 dps_results: {
  key: "TestBM-AllItems-WingedTalisman-37844"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 17091.12262
-  tps: 14867.71591
+  dps: 17139.05119
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 17127.49876
-  tps: 14867.71591
+  dps: 17175.36103
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 17131.81605
-  tps: 14867.71591
+  dps: 17179.73002
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 17131.81605
-  tps: 14867.71591
+  dps: 17179.73002
+  tps: 14919.69675
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Zod'sRepeatingLongbow-50034"
  value: {
-  dps: 15728.02189
-  tps: 13486.10316
+  dps: 15675.33271
+  tps: 13425.77941
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 15935.80411
-  tps: 13682.78556
+  dps: 15989.14346
+  tps: 13718.27622
  }
 }
 dps_results: {
  key: "TestBM-Average-Default"
  value: {
-  dps: 18212.93054
-  tps: 15857.38916
+  dps: 18186.02536
+  tps: 15830.17902
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm-FullBuffs-LongMultiTarget"
  value: {
-  dps: 17890.08543
-  tps: 15654.20574
+  dps: 17999.94424
+  tps: 15747.9337
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm-FullBuffs-LongSingleTarget"
  value: {
-  dps: 17890.08543
-  tps: 15654.20574
+  dps: 17999.94424
+  tps: 15747.9337
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 21565.00763
-  tps: 18632.69716
+  dps: 21475.28731
+  tps: 18539.97271
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11933.89274
-  tps: 10399.32979
+  dps: 11904.5384
+  tps: 10374.6644
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm-NoBuffs-LongSingleTarget"
  value: {
-  dps: 11933.89274
-  tps: 10399.32979
+  dps: 11904.5384
+  tps: 10374.6644
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 12602.37452
-  tps: 10864.16126
+  dps: 12590.26299
+  tps: 10852.61933
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm_advanced-FullBuffs-LongMultiTarget"
  value: {
-  dps: 17890.08543
-  tps: 15654.20574
+  dps: 17999.94424
+  tps: 15747.9337
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm_advanced-FullBuffs-LongSingleTarget"
  value: {
-  dps: 17890.08543
-  tps: 15654.20574
+  dps: 17999.94424
+  tps: 15747.9337
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm_advanced-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 21565.00763
-  tps: 18632.69716
+  dps: 21475.28731
+  tps: 18539.97271
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm_advanced-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11933.89274
-  tps: 10399.32979
+  dps: 11904.5384
+  tps: 10374.6644
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm_advanced-NoBuffs-LongSingleTarget"
  value: {
-  dps: 11933.89274
-  tps: 10399.32979
+  dps: 11904.5384
+  tps: 10374.6644
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm_advanced-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 12602.37452
-  tps: 10864.16126
+  dps: 12590.26299
+  tps: 10852.61933
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18157.71966
-  tps: 15789.16495
+  dps: 18250.78753
+  tps: 15863.6469
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm-FullBuffs-LongSingleTarget"
  value: {
-  dps: 18157.71966
-  tps: 15789.16495
+  dps: 18250.78753
+  tps: 15863.6469
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 22039.39823
-  tps: 18907.07214
+  dps: 21949.81881
+  tps: 18814.3381
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12124.11081
-  tps: 10497.95394
+  dps: 12091.53229
+  tps: 10470.07288
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm-NoBuffs-LongSingleTarget"
  value: {
-  dps: 12124.11081
-  tps: 10497.95394
+  dps: 12091.53229
+  tps: 10470.07288
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 12906.70023
-  tps: 11047.46378
+  dps: 12894.12337
+  tps: 11035.48528
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm_advanced-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18157.71966
-  tps: 15789.16495
+  dps: 18250.78753
+  tps: 15863.6469
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm_advanced-FullBuffs-LongSingleTarget"
  value: {
-  dps: 18157.71966
-  tps: 15789.16495
+  dps: 18250.78753
+  tps: 15863.6469
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm_advanced-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 22039.39823
-  tps: 18907.07214
+  dps: 21949.81881
+  tps: 18814.3381
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm_advanced-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12124.11081
-  tps: 10497.95394
+  dps: 12091.53229
+  tps: 10470.07288
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm_advanced-NoBuffs-LongSingleTarget"
  value: {
-  dps: 12124.11081
-  tps: 10497.95394
+  dps: 12091.53229
+  tps: 10470.07288
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm_advanced-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 12906.70023
-  tps: 11047.46378
+  dps: 12894.12337
+  tps: 11035.48528
  }
 }
 dps_results: {
  key: "TestBM-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 18151.98457
-  tps: 15785.61895
+  dps: 18241.59067
+  tps: 15860.1639
  }
 }

--- a/sim/hunter/beast_mastery/beast_mastery_test.go
+++ b/sim/hunter/beast_mastery/beast_mastery_test.go
@@ -55,14 +55,15 @@ func BenchmarkSimulate(b *testing.B) {
 	rsr := &proto.RaidSimRequest{
 		Raid: core.SinglePlayerRaidProto(
 			&proto.Player{
-				Race:          proto.Race_RaceOrc,
-				Class:         proto.Class_ClassHunter,
-				Equipment:     core.GetGearSet("../../../ui/hunter/beast_mastery/gear_sets", "preraid_bm").GearSet,
-				Consumes:      FullConsumes,
-				Spec:          PlayerOptionsBasic,
-				Glyphs:        BMGlyphs,
-				TalentsString: BMTalents,
-				Buffs:         core.FullIndividualBuffs,
+				Race:           proto.Race_RaceOrc,
+				Class:          proto.Class_ClassHunter,
+				Equipment:      core.GetGearSet("../../../ui/hunter/beast_mastery/gear_sets", "preraid_bm").GearSet,
+				Consumes:       FullConsumes,
+				Spec:           PlayerOptionsBasic,
+				Glyphs:         BMGlyphs,
+				TalentsString:  BMTalents,
+				Buffs:          core.FullIndividualBuffs,
+				ReactionTimeMs: 100,
 			},
 			core.FullPartyBuffs,
 			core.FullRaidBuffs,

--- a/sim/hunter/marksmanship/TestMM.results
+++ b/sim/hunter/marksmanship/TestMM.results
@@ -40,2076 +40,2076 @@ character_stats_results: {
 dps_results: {
  key: "TestMM-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 19254.7044
-  tps: 17775.36196
+  dps: 19333.46281
+  tps: 17863.24458
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
-  dps: 16669.72707
-  tps: 15418.22122
+  dps: 16570.58857
+  tps: 15316.90764
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 18235.23896
-  tps: 16858.57721
+  dps: 18234.20494
+  tps: 16856.48209
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 18239.8372
-  tps: 16863.17546
+  dps: 18238.85614
+  tps: 16861.13329
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 18289.82744
-  tps: 16883.35707
+  dps: 18215.39125
+  tps: 16813.29499
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 18283.89803
-  tps: 16878.32232
+  dps: 18218.86908
+  tps: 16817.25421
  }
 }
 dps_results: {
  key: "TestMM-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 18836.87878
-  tps: 17365.10193
+  dps: 18890.78494
+  tps: 17427.5473
  }
 }
 dps_results: {
  key: "TestMM-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 18836.87878
-  tps: 17365.10193
+  dps: 18890.78494
+  tps: 17427.5473
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 18358.04558
-  tps: 16976.08967
+  dps: 18333.67011
+  tps: 16943.36635
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 18197.55477
-  tps: 16821.16421
-  hps: 88.7218
+  dps: 18196.14892
+  tps: 16818.63825
+  hps: 88.88772
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 18197.55477
-  tps: 16821.16421
-  hps: 88.7218
+  dps: 18196.14892
+  tps: 16818.63825
+  hps: 88.88772
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 18831.46374
-  tps: 17360.75031
+  dps: 18884.60912
+  tps: 17422.33595
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 18479.18737
-  tps: 17095.63893
+  dps: 18416.64722
+  tps: 17031.69015
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 18497.3858
-  tps: 17110.31984
+  dps: 18386.50841
+  tps: 16992.54733
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BindingPromise-67037"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlackBruise-50035"
  value: {
-  dps: 18266.78382
-  tps: 16860.25873
+  dps: 18252.1199
+  tps: 16851.76368
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlackBruise-50692"
  value: {
-  dps: 18249.79889
-  tps: 16844.54926
+  dps: 18235.15625
+  tps: 16836.07038
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 15222.80622
-  tps: 14048.77144
+  dps: 15193.83151
+  tps: 14021.03503
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 14397.56571
-  tps: 13291.94473
+  dps: 14410.41802
+  tps: 13300.82885
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 18795.56538
-  tps: 17384.78261
+  dps: 18891.68342
+  tps: 17476.31882
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 18091.14417
-  tps: 16718.7425
+  dps: 18185.95432
+  tps: 16810.00527
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 18132.16876
-  tps: 16764.84676
+  dps: 18109.0932
+  tps: 16738.17594
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 19373.32077
-  tps: 17926.21701
+  dps: 19363.96984
+  tps: 17912.68303
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 18271.62195
-  tps: 16894.9602
+  dps: 18272.07646
+  tps: 16894.35361
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 18457.89435
-  tps: 17074.53408
+  dps: 18456.8645
+  tps: 17068.5996
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 18869.31526
-  tps: 17428.89811
+  dps: 18915.19247
+  tps: 17480.96311
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 18210.14342
-  tps: 16833.48168
+  dps: 18208.67857
+  tps: 16830.95572
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BottledLightning-66879"
  value: {
-  dps: 18374.49892
-  tps: 16999.34944
+  dps: 18356.67514
+  tps: 16979.38747
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 18842.18524
-  tps: 17023.00022
+  dps: 18896.09879
+  tps: 17084.20392
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 18836.87878
-  tps: 17017.79989
+  dps: 18890.78494
+  tps: 17078.99635
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 19254.7044
-  tps: 17775.36196
+  dps: 19333.46281
+  tps: 17863.24458
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 19254.7044
-  tps: 17775.36196
+  dps: 19333.46281
+  tps: 17863.24458
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 19137.39558
-  tps: 17665.61872
+  dps: 19194.59162
+  tps: 17731.35397
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 19132.26834
-  tps: 17663.20126
+  dps: 19187.63657
+  tps: 17727.14676
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 19131.88101
-  tps: 17661.16757
+  dps: 19188.25785
+  tps: 17725.98468
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
   hps: 64
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CrushingWeight-59506"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CrushingWeight-65118"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CryptstalkerBattlegear"
  value: {
-  dps: 14836.1629
-  tps: 13619.01064
+  dps: 14842.29509
+  tps: 13621.6991
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 18178.72193
-  tps: 16798.72334
+  dps: 18167.29462
+  tps: 16780.78077
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 18139.40563
-  tps: 16764.86424
+  dps: 18127.97168
+  tps: 16748.71553
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 18391.23558
-  tps: 16998.58812
+  dps: 18408.27942
+  tps: 17007.14819
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 18450.17915
-  tps: 17087.52103
+  dps: 18441.33065
+  tps: 17072.02956
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 19178.57742
-  tps: 17754.26216
+  dps: 19237.85839
+  tps: 17814.07755
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 18138.76022
-  tps: 16771.67769
+  dps: 18069.1485
+  tps: 16698.23906
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Death'sChoice-47464"
  value: {
-  dps: 18757.35573
-  tps: 17337.82219
+  dps: 18771.12974
+  tps: 17340.79813
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 18207.66253
-  tps: 16829.67126
+  dps: 18190.60501
+  tps: 16807.82247
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 18793.01777
-  tps: 17389.65414
+  dps: 18748.55358
+  tps: 17333.20259
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 19065.98552
-  tps: 17663.34951
+  dps: 18966.58262
+  tps: 17557.1604
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Defender'sCode-40257"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 18830.68865
-  tps: 17361.62157
+  dps: 18883.03688
+  tps: 17422.54708
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 18857.4587
-  tps: 17386.96673
+  dps: 18910.81179
+  tps: 17448.7685
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 18229.67527
-  tps: 16857.65992
+  dps: 18082.83009
+  tps: 16709.77855
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 18152.8004
-  tps: 16769.33619
+  dps: 18262.41179
+  tps: 16884.74419
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 18836.87878
-  tps: 17365.10193
+  dps: 18890.78494
+  tps: 17427.5473
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 18836.87878
-  tps: 17365.10193
+  dps: 18890.78494
+  tps: 17427.5473
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 18836.87878
-  tps: 17365.10193
+  dps: 18890.78494
+  tps: 17427.5473
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 18842.18524
-  tps: 17370.40839
+  dps: 18896.09879
+  tps: 17432.86114
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 18830.68865
-  tps: 17361.62157
+  dps: 18883.03688
+  tps: 17422.54708
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 18831.46374
-  tps: 17360.75031
+  dps: 18884.60912
+  tps: 17422.33595
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 18844.47961
-  tps: 17372.46045
+  dps: 18898.19004
+  tps: 17434.71009
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 18274.55582
-  tps: 16896.32786
+  dps: 18160.81656
+  tps: 16782.50084
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 19091.14012
-  tps: 17657.92339
+  dps: 19028.50468
+  tps: 17597.51622
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 19219.40247
-  tps: 17770.21449
+  dps: 19317.21319
+  tps: 17872.05487
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 18836.87878
-  tps: 17365.10193
+  dps: 18890.78494
+  tps: 17427.5473
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 18836.87878
-  tps: 17365.10193
+  dps: 18890.78494
+  tps: 17427.5473
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 18109.81033
-  tps: 16725.01551
+  dps: 18055.37771
+  tps: 16669.88653
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 18199.18754
-  tps: 16818.19765
+  dps: 18198.59499
+  tps: 16811.99972
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FallofMortality-59500"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FallofMortality-65124"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 19388.10392
-  tps: 17908.75199
+  dps: 19516.5451
+  tps: 18039.3811
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 18267.0097
-  tps: 16890.34795
+  dps: 18267.34425
+  tps: 16889.6214
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 18132.16876
-  tps: 16764.84676
+  dps: 18109.0932
+  tps: 16738.17594
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 18797.58665
-  tps: 17329.91722
+  dps: 18821.6237
+  tps: 17359.76925
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FluidDeath-58181"
  value: {
-  dps: 19181.09455
-  tps: 17695.5053
+  dps: 19128.49479
+  tps: 17644.11085
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 18221.0262
-  tps: 16844.36445
+  dps: 18219.82851
+  tps: 16842.10566
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForgeEmber-37660"
  value: {
-  dps: 18124.17937
-  tps: 16747.56453
+  dps: 18102.71836
+  tps: 16720.91169
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 18836.87878
-  tps: 17365.10193
+  dps: 18890.78494
+  tps: 17427.5473
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 18842.18524
-  tps: 17370.40839
+  dps: 18896.09879
+  tps: 17432.86114
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 18841.12395
-  tps: 17369.34709
+  dps: 18895.03602
+  tps: 17431.79837
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 18438.88972
-  tps: 17055.34128
+  dps: 18376.34957
+  tps: 16991.3925
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 18444.61734
-  tps: 17049.65779
+  dps: 18443.26546
+  tps: 17047.22803
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FuturesightRune-38763"
  value: {
-  dps: 18210.78465
-  tps: 16834.1229
+  dps: 18209.46902
+  tps: 16831.74617
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GaleofShadows-56138"
  value: {
-  dps: 18417.47421
-  tps: 17036.17187
+  dps: 18444.16666
+  tps: 17065.92454
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GaleofShadows-56462"
  value: {
-  dps: 18338.81549
-  tps: 16962.86102
+  dps: 18429.8334
+  tps: 17054.77295
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GearDetector-61462"
  value: {
-  dps: 18548.07304
-  tps: 17153.54185
+  dps: 18512.85629
+  tps: 17120.49625
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 16912.67778
-  tps: 15577.87414
+  dps: 16949.87633
+  tps: 15623.52232
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 18237.53808
-  tps: 16860.87633
+  dps: 18236.53054
+  tps: 16858.80769
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 18242.76336
-  tps: 16866.10161
+  dps: 18241.816
+  tps: 16864.09314
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 18248.79051
-  tps: 16872.14967
+  dps: 18145.53906
+  tps: 16764.47256
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 18555.0917
-  tps: 17141.67753
+  dps: 18656.11014
+  tps: 17232.53395
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 18999.8203
-  tps: 17575.78152
+  dps: 18903.29929
+  tps: 17472.38311
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HarmlightToken-63839"
  value: {
-  dps: 18204.00569
-  tps: 16827.39885
+  dps: 18202.59099
+  tps: 16824.87289
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 18198.94515
-  tps: 16822.28341
+  dps: 18197.4803
+  tps: 16819.75745
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 18199.0905
-  tps: 16822.42876
+  dps: 18197.62565
+  tps: 16819.9028
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofRage-59224"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofRage-65072"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofSolace-55868"
  value: {
-  dps: 18413.89537
-  tps: 17032.59303
+  dps: 18440.58782
+  tps: 17062.3457
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofSolace-56393"
  value: {
-  dps: 18334.34845
-  tps: 16958.39398
+  dps: 18425.36635
+  tps: 17050.30591
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofThunder-55845"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofThunder-56370"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 18569.43952
-  tps: 17146.67166
+  dps: 18547.20562
+  tps: 17119.47405
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Heartpierce-49982"
  value: {
-  dps: 19331.05679
-  tps: 17845.98141
+  dps: 19410.17037
+  tps: 17934.25412
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Heartpierce-50641"
  value: {
-  dps: 19332.69878
-  tps: 17847.5001
+  dps: 19411.82
+  tps: 17935.78121
  }
 }
 dps_results: {
  key: "TestMM-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 18830.68865
-  tps: 17361.62157
+  dps: 18883.03688
+  tps: 17422.54708
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 18831.46374
-  tps: 17360.75031
+  dps: 18884.60912
+  tps: 17422.33595
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 18844.47961
-  tps: 17372.46045
+  dps: 18898.19004
+  tps: 17434.71009
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 18133.59884
-  tps: 16766.44702
+  dps: 18063.98486
+  tps: 16693.00839
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 18133.59884
-  tps: 16766.44702
+  dps: 18063.98486
+  tps: 16693.00839
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 18091.14417
-  tps: 16718.7425
+  dps: 18185.95432
+  tps: 16810.00527
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 18132.16876
-  tps: 16764.84676
+  dps: 18109.0932
+  tps: 16738.17594
  }
 }
 dps_results: {
  key: "TestMM-AllItems-IncisorFragment-37723"
  value: {
-  dps: 18540.1806
-  tps: 17154.70048
+  dps: 18537.83785
+  tps: 17151.28887
  }
 }
 dps_results: {
  key: "TestMM-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 18836.87878
-  tps: 17365.10193
+  dps: 18890.78494
+  tps: 17427.5473
  }
 }
 dps_results: {
  key: "TestMM-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 18237.51312
-  tps: 16864.39014
+  dps: 18167.74106
+  tps: 16783.66255
  }
 }
 dps_results: {
  key: "TestMM-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 18870.78932
-  tps: 17396.42419
-  hps: 58.03541
+  dps: 18924.80619
+  tps: 17458.9949
+  hps: 58.44556
  }
 }
 dps_results: {
  key: "TestMM-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 18795.56538
-  tps: 17384.78261
+  dps: 18891.68342
+  tps: 17476.31882
  }
 }
 dps_results: {
  key: "TestMM-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 19065.22626
-  tps: 17606.10841
+  dps: 19032.42765
+  tps: 17580.94445
  }
 }
 dps_results: {
  key: "TestMM-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 18234.09103
-  tps: 16864.64137
+  dps: 18118.32895
+  tps: 16744.92021
  }
 }
 dps_results: {
  key: "TestMM-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 18234.09103
-  tps: 16864.64137
+  dps: 18118.32895
+  tps: 16744.92021
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 18170.42487
-  tps: 16801.2209
+  dps: 18206.62708
+  tps: 16841.59912
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LastWord-50179"
  value: {
-  dps: 19254.7044
-  tps: 17775.36196
+  dps: 19333.46281
+  tps: 17863.24458
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LastWord-50708"
  value: {
-  dps: 19254.7044
-  tps: 17775.36196
+  dps: 19333.46281
+  tps: 17863.24458
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LeadenDespair-55816"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LeadenDespair-56347"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 18701.25527
-  tps: 17269.898
+  dps: 18793.9106
+  tps: 17361.54944
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 18853.60068
-  tps: 17423.49107
+  dps: 18925.52323
+  tps: 17482.5027
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 18283.89803
-  tps: 16878.32232
+  dps: 18218.86908
+  tps: 16817.25421
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Lightning-ChargedBattlegear"
  value: {
-  dps: 18938.65082
-  tps: 17521.5726
+  dps: 18916.29642
+  tps: 17510.2296
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 18130.38242
-  tps: 16756.43343
+  dps: 18161.96239
+  tps: 16791.05617
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 18252.56129
-  tps: 16882.40194
+  dps: 18259.24289
+  tps: 16895.39028
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 18337.02093
-  tps: 16962.59533
+  dps: 18442.23034
+  tps: 17064.53656
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 18371.79985
-  tps: 16972.70037
+  dps: 18303.95283
+  tps: 16907.83376
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 18283.89803
-  tps: 16878.32232
+  dps: 18218.86908
+  tps: 16817.25421
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 18133.59884
-  tps: 16766.44702
+  dps: 18063.98486
+  tps: 16693.00839
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 18133.59884
-  tps: 16766.44702
+  dps: 18063.98486
+  tps: 16693.00839
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 18124.8364
-  tps: 16757.12503
+  dps: 18205.77751
+  tps: 16836.01152
  }
 }
 dps_results: {
  key: "TestMM-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 18347.87203
-  tps: 16970.62894
+  dps: 18352.43962
+  tps: 16968.75332
  }
 }
 dps_results: {
  key: "TestMM-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 18376.90783
-  tps: 16990.96031
+  dps: 18395.71121
+  tps: 17010.57775
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 18864.33017
-  tps: 17390.45805
+  dps: 18918.32595
+  tps: 17453.00488
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 18870.78932
-  tps: 17396.42419
+  dps: 18924.80619
+  tps: 17458.9949
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 18836.87878
-  tps: 17365.10193
+  dps: 18890.78494
+  tps: 17427.5473
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 18836.87878
-  tps: 17365.10193
+  dps: 18890.78494
+  tps: 17427.5473
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 18836.87878
-  tps: 17365.10193
+  dps: 18890.78494
+  tps: 17427.5473
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 19150.93673
-  tps: 17730.32649
+  dps: 19093.49911
+  tps: 17668.5742
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 18225.44621
-  tps: 16794.99485
+  dps: 18223.37701
+  tps: 16785.99866
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Rainsong-55854"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Rainsong-56377"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 18229.17763
-  tps: 16852.51589
+  dps: 18228.07382
+  tps: 16850.35096
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 18232.93983
-  tps: 16856.27809
+  dps: 18231.87934
+  tps: 16854.15649
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 19180.01018
-  tps: 17705.10358
+  dps: 19236.97838
+  tps: 17770.77018
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 19137.39558
-  tps: 17665.61872
+  dps: 19194.59162
+  tps: 17731.35397
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 19137.39558
-  tps: 17665.61872
+  dps: 19194.59162
+  tps: 17731.35397
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 18836.87878
-  tps: 17365.10193
+  dps: 18890.78494
+  tps: 17427.5473
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 18289.82744
-  tps: 16883.35707
+  dps: 18215.39125
+  tps: 16813.29499
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 18283.89803
-  tps: 16878.32232
+  dps: 18218.86908
+  tps: 16817.25421
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 18589.82858
-  tps: 17170.11329
+  dps: 18578.26662
+  tps: 17152.84563
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ScourgestalkerBattlegear"
  value: {
-  dps: 14467.08933
-  tps: 13285.75344
+  dps: 14514.70943
+  tps: 13332.60299
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SeaStar-55256"
  value: {
-  dps: 18234.9667
-  tps: 16858.30495
+  dps: 18234.46785
+  tps: 16856.74499
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SeaStar-56290"
  value: {
-  dps: 18267.0097
-  tps: 16890.34795
+  dps: 18267.34425
+  tps: 16889.6214
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Shadowmourne-49623"
  value: {
-  dps: 19662.37313
-  tps: 18176.09525
+  dps: 19689.00456
+  tps: 18215.71713
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 18715.80178
-  tps: 17292.26002
+  dps: 18778.69953
+  tps: 17353.98003
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 18816.53193
-  tps: 17392.2009
+  dps: 18846.38845
+  tps: 17421.27687
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 18230.84972
-  tps: 16854.18798
+  dps: 18229.76516
+  tps: 16852.04231
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 18235.02995
-  tps: 16858.3682
+  dps: 18233.99353
+  tps: 16856.27067
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Sorrowsong-55879"
  value: {
-  dps: 18091.14417
-  tps: 16718.7425
+  dps: 18185.95432
+  tps: 16810.00527
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Sorrowsong-56400"
  value: {
-  dps: 18132.16876
-  tps: 16764.84676
+  dps: 18109.0932
+  tps: 16738.17594
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 18289.82744
-  tps: 16883.35707
+  dps: 18215.39125
+  tps: 16813.29499
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SoulCasket-58183"
  value: {
-  dps: 18241.13268
-  tps: 16873.98086
+  dps: 18172.15711
+  tps: 16801.18065
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SoulPreserver-37111"
  value: {
-  dps: 18213.50179
-  tps: 16836.84005
+  dps: 18212.21746
+  tps: 16834.49461
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SouloftheDead-40382"
  value: {
-  dps: 18172.16881
-  tps: 16791.17893
+  dps: 18172.78201
+  tps: 16786.18674
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SparkofLife-37657"
  value: {
-  dps: 18055.72906
-  tps: 16690.3525
+  dps: 18109.68319
+  tps: 16732.00623
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 18275.91823
-  tps: 16880.84035
+  dps: 18235.88159
+  tps: 16847.44434
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 18213.75149
-  tps: 16837.08975
+  dps: 18212.28664
+  tps: 16834.56379
  }
 }
 dps_results: {
  key: "TestMM-AllItems-StumpofTime-62465"
  value: {
-  dps: 18296.19132
-  tps: 16890.61561
+  dps: 18231.16237
+  tps: 16829.5475
  }
 }
 dps_results: {
  key: "TestMM-AllItems-StumpofTime-62470"
  value: {
-  dps: 18309.88967
-  tps: 16904.31397
+  dps: 18244.86073
+  tps: 16843.24586
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 18870.78932
-  tps: 17396.42419
+  dps: 18924.80619
+  tps: 17458.9949
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 18864.33017
-  tps: 17390.45805
+  dps: 18918.32595
+  tps: 17453.00488
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 18853.02666
-  tps: 17380.01729
+  dps: 18906.98554
+  tps: 17442.52234
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 18081.22505
-  tps: 16702.83286
+  dps: 18162.65176
+  tps: 16786.49059
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TearofBlood-55819"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TearofBlood-56351"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 18196.49288
-  tps: 16817.83251
+  dps: 18167.54852
+  tps: 16782.42723
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 18135.84888
-  tps: 16768.52688
+  dps: 18112.77332
+  tps: 16741.85606
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 18230.69255
-  tps: 16852.3688
+  dps: 18247.14802
+  tps: 16873.32002
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 18982.41131
-  tps: 17515.37416
+  dps: 18886.51494
+  tps: 17421.38367
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 18905.26185
-  tps: 17470.29471
+  dps: 18928.43752
+  tps: 17497.85727
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 18150.23951
-  tps: 16760.3167
+  dps: 18068.62328
+  tps: 16688.24689
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 18150.23951
-  tps: 16760.3167
+  dps: 18068.62328
+  tps: 16688.24689
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 18842.18524
-  tps: 17370.40839
+  dps: 18896.09879
+  tps: 17432.86114
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 18841.12395
-  tps: 17369.34709
+  dps: 18895.03602
+  tps: 17431.79837
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 18163.07624
-  tps: 16782.97293
+  dps: 18178.30835
+  tps: 16797.61036
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 18841.12395
-  tps: 17369.34709
+  dps: 18895.03602
+  tps: 17431.79837
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 18842.18524
-  tps: 17370.40839
+  dps: 18896.09879
+  tps: 17432.86114
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 18239.58916
-  tps: 16864.38132
+  dps: 18183.64272
+  tps: 16806.28878
  }
 }
 dps_results: {
  key: "TestMM-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 14691.49398
-  tps: 13550.55906
+  dps: 14627.59465
+  tps: 13488.55738
  }
 }
 dps_results: {
  key: "TestMM-AllItems-UnheededWarning-59520"
  value: {
-  dps: 18850.21027
-  tps: 17412.56075
+  dps: 18907.93258
+  tps: 17465.3742
  }
 }
 dps_results: {
  key: "TestMM-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 19090.33606
-  tps: 17651.71264
+  dps: 19062.20136
+  tps: 17620.61729
  }
 }
 dps_results: {
  key: "TestMM-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 19090.33606
-  tps: 17651.71264
+  dps: 19062.20136
+  tps: 17620.61729
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 18283.39714
-  tps: 16895.61701
+  dps: 18319.4297
+  tps: 16921.35611
  }
 }
 dps_results: {
  key: "TestMM-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 19181.50543
-  tps: 17720.98686
+  dps: 19200.96687
+  tps: 17741.23931
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 18275.7487
-  tps: 16899.08695
+  dps: 18276.31055
+  tps: 16898.58769
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 18283.89803
-  tps: 16878.32232
+  dps: 18218.86908
+  tps: 16817.25421
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 18383.15432
-  tps: 17027.01329
+  dps: 18395.84584
+  tps: 17031.11149
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 18477.3578
-  tps: 17090.9378
+  dps: 18406.14106
+  tps: 17017.56315
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 18120.33738
-  tps: 16756.00498
+  dps: 18069.03633
+  tps: 16698.57499
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 18959.56845
-  tps: 17506.55095
+  dps: 18990.04435
+  tps: 17537.54478
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 18202.7621
-  tps: 16826.10035
+  dps: 18201.29725
+  tps: 16823.5744
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Windrunner'sPursuit"
  value: {
-  dps: 15166.04814
-  tps: 13947.17958
+  dps: 15051.07989
+  tps: 13836.24737
  }
 }
 dps_results: {
  key: "TestMM-AllItems-WingedTalisman-37844"
  value: {
-  dps: 18214.62425
-  tps: 16837.96251
+  dps: 18213.59631
+  tps: 16835.87345
  }
 }
 dps_results: {
  key: "TestMM-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 18197.82595
-  tps: 16821.16421
+  dps: 18196.3611
+  tps: 16818.63825
  }
 }
 dps_results: {
  key: "TestMM-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 18195.572
-  tps: 16816.91164
+  dps: 18167.81171
+  tps: 16782.69042
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 18239.22227
-  tps: 16863.68949
+  dps: 18178.02312
+  tps: 16808.26106
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 18239.22227
-  tps: 16863.68949
+  dps: 18178.02312
+  tps: 16808.26106
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Zod'sRepeatingLongbow-50034"
  value: {
-  dps: 17110.20286
-  tps: 15694.70849
+  dps: 17170.26862
+  tps: 15754.26483
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 17341.07384
-  tps: 15921.92147
+  dps: 17300.50224
+  tps: 15882.17932
  }
 }
 dps_results: {
  key: "TestMM-Average-Default"
  value: {
-  dps: 16041.45312
-  tps: 14614.49318
+  dps: 16043.31946
+  tps: 14616.53088
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20644.64038
-  tps: 19249.96292
+  dps: 20565.75697
+  tps: 19169.30854
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-FullBuffs-LongSingleTarget"
  value: {
-  dps: 19010.18079
-  tps: 17614.45969
+  dps: 19086.58388
+  tps: 17699.23468
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 23929.36984
-  tps: 22013.24843
+  dps: 23867.45631
+  tps: 21948.32553
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11544.46394
-  tps: 10588.01657
+  dps: 11566.13047
+  tps: 10608.75631
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-NoBuffs-LongSingleTarget"
  value: {
-  dps: 10751.0888
-  tps: 9795.63821
+  dps: 10775.48761
+  tps: 9819.44127
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 13469.36964
-  tps: 12316.91755
+  dps: 13379.82017
+  tps: 12226.89017
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm_advanced-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20644.64038
-  tps: 19249.96292
+  dps: 20565.75697
+  tps: 19169.30854
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm_advanced-FullBuffs-LongSingleTarget"
  value: {
-  dps: 19010.18079
-  tps: 17614.45969
+  dps: 19086.58388
+  tps: 17699.23468
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm_advanced-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 23929.36984
-  tps: 22013.24843
+  dps: 23867.45631
+  tps: 21948.32553
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm_advanced-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11544.46394
-  tps: 10588.01657
+  dps: 11566.13047
+  tps: 10608.75631
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm_advanced-NoBuffs-LongSingleTarget"
  value: {
-  dps: 10751.0888
-  tps: 9795.63821
+  dps: 10775.48761
+  tps: 9819.44127
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm_advanced-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 13469.36964
-  tps: 12316.91755
+  dps: 13379.82017
+  tps: 12226.89017
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20959.52229
-  tps: 19480.98408
+  dps: 20879.32088
+  tps: 19398.75378
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-FullBuffs-LongSingleTarget"
  value: {
-  dps: 19254.7044
-  tps: 17775.36196
+  dps: 19333.46281
+  tps: 17863.24458
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 24407.88328
-  tps: 22361.95838
+  dps: 24346.11368
+  tps: 22297.02866
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11743.99515
-  tps: 10728.50811
+  dps: 11764.6528
+  tps: 10748.23028
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-NoBuffs-LongSingleTarget"
  value: {
-  dps: 10906.64521
-  tps: 9892.35926
+  dps: 10931.71193
+  tps: 9916.82524
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 13722.72726
-  tps: 12487.55415
+  dps: 13633.04724
+  tps: 12397.30654
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm_advanced-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20959.52229
-  tps: 19480.98408
+  dps: 20879.32088
+  tps: 19398.75378
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm_advanced-FullBuffs-LongSingleTarget"
  value: {
-  dps: 19254.7044
-  tps: 17775.36196
+  dps: 19333.46281
+  tps: 17863.24458
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm_advanced-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 24407.88328
-  tps: 22361.95838
+  dps: 24346.11368
+  tps: 22297.02866
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm_advanced-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11743.99515
-  tps: 10728.50811
+  dps: 11764.6528
+  tps: 10748.23028
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm_advanced-NoBuffs-LongSingleTarget"
  value: {
-  dps: 10906.64521
-  tps: 9892.35926
+  dps: 10931.71193
+  tps: 9916.82524
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm_advanced-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 13722.72726
-  tps: 12487.55415
+  dps: 13633.04724
+  tps: 12397.30654
  }
 }
 dps_results: {
  key: "TestMM-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 19245.43267
-  tps: 17771.51939
+  dps: 19326.94225
+  tps: 17859.4257
  }
 }

--- a/sim/hunter/marksmanship/TestMM.results
+++ b/sim/hunter/marksmanship/TestMM.results
@@ -40,2076 +40,2076 @@ character_stats_results: {
 dps_results: {
  key: "TestMM-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 19333.46281
-  tps: 17863.24458
+  dps: 19398.70685
+  tps: 17952.37963
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
-  dps: 16570.58857
-  tps: 15316.90764
+  dps: 16008.81731
+  tps: 14754.50632
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 18234.20494
-  tps: 16856.48209
+  dps: 18107.02791
+  tps: 16754.55157
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 18238.85614
-  tps: 16861.13329
+  dps: 18111.38495
+  tps: 16758.90861
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 18215.39125
-  tps: 16813.29499
+  dps: 18513.34096
+  tps: 17129.10153
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 18218.86908
-  tps: 16817.25421
+  dps: 18626.14262
+  tps: 17236.85376
  }
 }
 dps_results: {
  key: "TestMM-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 18890.78494
-  tps: 17427.5473
+  dps: 19032.48466
+  tps: 17593.66567
  }
 }
 dps_results: {
  key: "TestMM-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 18890.78494
-  tps: 17427.5473
+  dps: 19032.48466
+  tps: 17593.66567
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 18333.67011
-  tps: 16943.36635
+  dps: 18353.15554
+  tps: 16989.99269
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 18196.14892
-  tps: 16818.63825
-  hps: 88.88772
+  dps: 18071.51672
+  tps: 16719.10105
+  hps: 89.23224
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 18196.14892
-  tps: 16818.63825
-  hps: 88.88772
+  dps: 18071.51672
+  tps: 16719.10105
+  hps: 89.23224
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 18884.60912
-  tps: 17422.33595
+  dps: 18985.40316
+  tps: 17547.05326
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 18416.64722
-  tps: 17031.69015
+  dps: 18096.92028
+  tps: 16731.16001
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 18386.50841
-  tps: 16992.54733
+  dps: 18210.71607
+  tps: 16846.56876
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BindingPromise-67037"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlackBruise-50035"
  value: {
-  dps: 18252.1199
-  tps: 16851.76368
+  dps: 18532.71757
+  tps: 17146.36612
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlackBruise-50692"
  value: {
-  dps: 18235.15625
-  tps: 16836.07038
+  dps: 18515.5268
+  tps: 17130.43257
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 15193.83151
-  tps: 14021.03503
+  dps: 15564.18683
+  tps: 14397.55799
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 14410.41802
-  tps: 13300.82885
+  dps: 14708.1008
+  tps: 13613.41738
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 18891.68342
-  tps: 17476.31882
+  dps: 18732.87203
+  tps: 17348.60447
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 18185.95432
-  tps: 16810.00527
+  dps: 18437.5677
+  tps: 17095.39355
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 18109.0932
-  tps: 16738.17594
+  dps: 18322.49445
+  tps: 16981.27386
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 19363.96984
-  tps: 17912.68303
+  dps: 19437.83132
+  tps: 18005.53739
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 18272.07646
-  tps: 16894.35361
+  dps: 18146.40349
+  tps: 16793.92715
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 18456.8645
-  tps: 17068.5996
+  dps: 18132.05427
+  tps: 16764.19523
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 18915.19247
-  tps: 17480.96311
+  dps: 19053.82672
+  tps: 17639.01531
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 18208.67857
-  tps: 16830.95572
+  dps: 18084.73017
+  tps: 16732.25383
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BottledLightning-66879"
  value: {
-  dps: 18356.67514
-  tps: 16979.38747
+  dps: 18105.44199
+  tps: 16760.94567
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 18896.09879
-  tps: 17084.20392
+  dps: 19037.57859
+  tps: 17246.78441
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 18890.78494
-  tps: 17078.99635
+  dps: 19032.48466
+  tps: 17241.79236
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 19333.46281
-  tps: 17863.24458
+  dps: 19398.70685
+  tps: 17952.37963
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 19333.46281
-  tps: 17863.24458
+  dps: 19398.70685
+  tps: 17952.37963
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 19194.59162
-  tps: 17731.35397
+  dps: 19383.63895
+  tps: 17944.81996
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 19187.63657
-  tps: 17727.14676
+  dps: 19404.49986
+  tps: 17964.87765
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 19188.25785
-  tps: 17725.98468
+  dps: 19334.58824
+  tps: 17896.23833
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
   hps: 64
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CrushingWeight-59506"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CrushingWeight-65118"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CryptstalkerBattlegear"
  value: {
-  dps: 14842.29509
-  tps: 13621.6991
+  dps: 15311.07036
+  tps: 14095.60617
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 18167.29462
-  tps: 16780.78077
+  dps: 18142.47327
+  tps: 16788.97896
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 18127.97168
-  tps: 16748.71553
+  dps: 18266.05486
+  tps: 16913.30685
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 18408.27942
-  tps: 17007.14819
+  dps: 18383.75438
+  tps: 17016.41448
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 18441.33065
-  tps: 17072.02956
+  dps: 18403.87537
+  tps: 17059.49343
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 19237.85839
-  tps: 17814.07755
+  dps: 19294.63374
+  tps: 17885.36244
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 18069.1485
-  tps: 16698.23906
+  dps: 18441.94276
+  tps: 17100.07636
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Death'sChoice-47464"
  value: {
-  dps: 18771.12974
-  tps: 17340.79813
+  dps: 18873.62118
+  tps: 17471.33308
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 18190.60501
-  tps: 16807.82247
+  dps: 18137.2282
+  tps: 16784.6019
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 18748.55358
-  tps: 17333.20259
+  dps: 18733.49933
+  tps: 17365.93208
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 18966.58262
-  tps: 17557.1604
+  dps: 18754.88243
+  tps: 17372.83929
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Defender'sCode-40257"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 18883.03688
-  tps: 17422.54708
+  dps: 19051.7172
+  tps: 17612.09499
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 18910.81179
-  tps: 17448.7685
+  dps: 18986.53823
+  tps: 17548.18832
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 18082.83009
-  tps: 16709.77855
+  dps: 18369.81819
+  tps: 17009.77674
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 18262.41179
-  tps: 16884.74419
+  dps: 18002.22023
+  tps: 16634.48705
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 18890.78494
-  tps: 17427.5473
+  dps: 19032.48466
+  tps: 17593.66567
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 18890.78494
-  tps: 17427.5473
+  dps: 19032.48466
+  tps: 17593.66567
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 18890.78494
-  tps: 17427.5473
+  dps: 19032.48466
+  tps: 17593.66567
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 18896.09879
-  tps: 17432.86114
+  dps: 19037.57859
+  tps: 17598.7596
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 18883.03688
-  tps: 17422.54708
+  dps: 19051.7172
+  tps: 17612.09499
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 18884.60912
-  tps: 17422.33595
+  dps: 18985.40316
+  tps: 17547.05326
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 18898.19004
-  tps: 17434.71009
+  dps: 18985.40316
+  tps: 17547.05326
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 18160.81656
-  tps: 16782.50084
+  dps: 18129.21016
+  tps: 16744.29726
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 19028.50468
-  tps: 17597.51622
+  dps: 19019.01526
+  tps: 17595.70704
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 19317.21319
-  tps: 17872.05487
+  dps: 18897.34115
+  tps: 17476.67373
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 18890.78494
-  tps: 17427.5473
+  dps: 19032.48466
+  tps: 17593.66567
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 18890.78494
-  tps: 17427.5473
+  dps: 19032.48466
+  tps: 17593.66567
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 18055.37771
-  tps: 16669.88653
+  dps: 18084.1173
+  tps: 16731.20408
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 18198.59499
-  tps: 16811.99972
+  dps: 18197.1488
+  tps: 16842.77265
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FallofMortality-59500"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FallofMortality-65124"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 19516.5451
-  tps: 18039.3811
+  dps: 19738.52443
+  tps: 18288.77114
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 18267.34425
-  tps: 16889.6214
+  dps: 18141.72686
+  tps: 16789.25052
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 18109.0932
-  tps: 16738.17594
+  dps: 18322.49445
+  tps: 16981.27386
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 18821.6237
-  tps: 17359.76925
+  dps: 18914.87186
+  tps: 17485.49102
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FluidDeath-58181"
  value: {
-  dps: 19128.49479
-  tps: 17644.11085
+  dps: 19291.05809
+  tps: 17837.26065
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 18219.82851
-  tps: 16842.10566
+  dps: 18093.56067
+  tps: 16741.08433
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForgeEmber-37660"
  value: {
-  dps: 18102.71836
-  tps: 16720.91169
+  dps: 18184.31032
+  tps: 16831.33852
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 18890.78494
-  tps: 17427.5473
+  dps: 19032.48466
+  tps: 17593.66567
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 18896.09879
-  tps: 17432.86114
+  dps: 19037.57859
+  tps: 17598.7596
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 18895.03602
-  tps: 17431.79837
+  dps: 19036.5598
+  tps: 17597.74082
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 18376.34957
-  tps: 16991.3925
+  dps: 18055.89484
+  tps: 16690.13458
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 18443.26546
-  tps: 17047.22803
+  dps: 18315.2935
+  tps: 16944.84894
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FuturesightRune-38763"
  value: {
-  dps: 18209.46902
-  tps: 16831.74617
+  dps: 18083.85634
+  tps: 16731.38
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GaleofShadows-56138"
  value: {
-  dps: 18444.16666
-  tps: 17065.92454
+  dps: 18451.18684
+  tps: 17071.5155
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GaleofShadows-56462"
  value: {
-  dps: 18429.8334
-  tps: 17054.77295
+  dps: 18544.11034
+  tps: 17163.39889
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GearDetector-61462"
  value: {
-  dps: 18512.85629
-  tps: 17120.49625
+  dps: 18775.31707
+  tps: 17390.35498
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 16949.87633
-  tps: 15623.52232
+  dps: 17146.54896
+  tps: 15826.93472
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 18236.53054
-  tps: 16858.80769
+  dps: 18109.20643
+  tps: 16756.73009
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 18241.816
-  tps: 16864.09314
+  dps: 18114.15762
+  tps: 16761.68128
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 18145.53906
-  tps: 16764.47256
+  dps: 18208.21986
+  tps: 16854.31586
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 18656.11014
-  tps: 17232.53395
+  dps: 18668.00575
+  tps: 17279.9421
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 18903.29929
-  tps: 17472.38311
+  dps: 18799.91038
+  tps: 17391.62056
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HarmlightToken-63839"
  value: {
-  dps: 18202.59099
-  tps: 16824.87289
+  dps: 18077.8156
+  tps: 16725.33569
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 18197.4803
-  tps: 16819.75745
+  dps: 18072.68305
+  tps: 16720.20671
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 18197.62565
-  tps: 16819.9028
+  dps: 18072.82664
+  tps: 16720.3503
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofRage-59224"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofRage-65072"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofSolace-55868"
  value: {
-  dps: 18440.58782
-  tps: 17062.3457
+  dps: 18447.57769
+  tps: 17067.90635
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofSolace-56393"
  value: {
-  dps: 18425.36635
-  tps: 17050.30591
+  dps: 18539.75648
+  tps: 17159.04504
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofThunder-55845"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofThunder-56370"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 18547.20562
-  tps: 17119.47405
+  dps: 18600.37925
+  tps: 17207.92786
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Heartpierce-49982"
  value: {
-  dps: 19410.17037
-  tps: 17934.25412
+  dps: 19475.4762
+  tps: 18023.5492
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Heartpierce-50641"
  value: {
-  dps: 19411.82
-  tps: 17935.78121
+  dps: 19477.12716
+  tps: 18025.07973
  }
 }
 dps_results: {
  key: "TestMM-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 18883.03688
-  tps: 17422.54708
+  dps: 19051.7172
+  tps: 17612.09499
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 18884.60912
-  tps: 17422.33595
+  dps: 18985.40316
+  tps: 17547.05326
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 18898.19004
-  tps: 17434.71009
+  dps: 18985.40316
+  tps: 17547.05326
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 18063.98486
-  tps: 16693.00839
+  dps: 18436.74163
+  tps: 17094.84569
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 18063.98486
-  tps: 16693.00839
+  dps: 18436.74163
+  tps: 17094.84569
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 18185.95432
-  tps: 16810.00527
+  dps: 18437.5677
+  tps: 17095.39355
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 18109.0932
-  tps: 16738.17594
+  dps: 18322.49445
+  tps: 16981.27386
  }
 }
 dps_results: {
  key: "TestMM-AllItems-IncisorFragment-37723"
  value: {
-  dps: 18537.83785
-  tps: 17151.28887
+  dps: 18420.92816
+  tps: 17059.7867
  }
 }
 dps_results: {
  key: "TestMM-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 18890.78494
-  tps: 17427.5473
+  dps: 19032.48466
+  tps: 17593.66567
  }
 }
 dps_results: {
  key: "TestMM-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 18167.74106
-  tps: 16783.66255
+  dps: 18338.47201
+  tps: 16998.90162
  }
 }
 dps_results: {
  key: "TestMM-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 18924.80619
-  tps: 17458.9949
-  hps: 58.44556
+  dps: 19066.70449
+  tps: 17625.35694
+  hps: 60.90642
  }
 }
 dps_results: {
  key: "TestMM-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 18891.68342
-  tps: 17476.31882
+  dps: 18732.87203
+  tps: 17348.60447
  }
 }
 dps_results: {
  key: "TestMM-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 19032.42765
-  tps: 17580.94445
+  dps: 19213.29829
+  tps: 17768.94899
  }
 }
 dps_results: {
  key: "TestMM-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 18118.32895
-  tps: 16744.92021
+  dps: 18341.0304
+  tps: 16982.0446
  }
 }
 dps_results: {
  key: "TestMM-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 18118.32895
-  tps: 16744.92021
+  dps: 18341.0304
+  tps: 16982.0446
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 18206.62708
-  tps: 16841.59912
+  dps: 18375.17268
+  tps: 16992.23115
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LastWord-50179"
  value: {
-  dps: 19333.46281
-  tps: 17863.24458
+  dps: 19398.70685
+  tps: 17952.37963
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LastWord-50708"
  value: {
-  dps: 19333.46281
-  tps: 17863.24458
+  dps: 19398.70685
+  tps: 17952.37963
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LeadenDespair-55816"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LeadenDespair-56347"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 18793.9106
-  tps: 17361.54944
+  dps: 18799.16557
+  tps: 17388.10312
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 18925.52323
-  tps: 17482.5027
+  dps: 18942.28088
+  tps: 17523.95391
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 18218.86908
-  tps: 16817.25421
+  dps: 18626.14262
+  tps: 17236.85376
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Lightning-ChargedBattlegear"
  value: {
-  dps: 18916.29642
-  tps: 17510.2296
+  dps: 18840.13641
+  tps: 17428.15713
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 18161.96239
-  tps: 16791.05617
+  dps: 18366.64134
+  tps: 17001.92099
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 18259.24289
-  tps: 16895.39028
+  dps: 18458.17393
+  tps: 17103.05555
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 18442.23034
-  tps: 17064.53656
+  dps: 18217.9726
+  tps: 16830.71278
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 18303.95283
-  tps: 16907.83376
+  dps: 18127.32722
+  tps: 16753.89153
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 18218.86908
-  tps: 16817.25421
+  dps: 18626.14262
+  tps: 17236.85376
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 18063.98486
-  tps: 16693.00839
+  dps: 18436.74163
+  tps: 17094.84569
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 18063.98486
-  tps: 16693.00839
+  dps: 18436.74163
+  tps: 17094.84569
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 18205.77751
-  tps: 16836.01152
+  dps: 18484.49612
+  tps: 17125.21198
  }
 }
 dps_results: {
  key: "TestMM-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 18352.43962
-  tps: 16968.75332
+  dps: 18371.2427
+  tps: 17019.68016
  }
 }
 dps_results: {
  key: "TestMM-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 18395.71121
-  tps: 17010.57775
+  dps: 18135.12124
+  tps: 16790.43987
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 18918.32595
-  tps: 17453.00488
+  dps: 19060.18642
+  tps: 17619.32051
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 18924.80619
-  tps: 17458.9949
+  dps: 19066.70449
+  tps: 17625.35694
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 18890.78494
-  tps: 17427.5473
+  dps: 19032.48466
+  tps: 17593.66567
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 18890.78494
-  tps: 17427.5473
+  dps: 19032.48466
+  tps: 17593.66567
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 18890.78494
-  tps: 17427.5473
+  dps: 19032.48466
+  tps: 17593.66567
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 19093.49911
-  tps: 17668.5742
+  dps: 18894.48391
+  tps: 17464.93792
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 18223.37701
-  tps: 16785.99866
+  dps: 18288.1219
+  tps: 16856.47432
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Rainsong-55854"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Rainsong-56377"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 18228.07382
-  tps: 16850.35096
+  dps: 18101.28453
+  tps: 16748.80819
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 18231.87934
-  tps: 16854.15649
+  dps: 18104.84938
+  tps: 16752.37304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 19236.97838
-  tps: 17770.77018
+  dps: 19406.10646
+  tps: 17962.94072
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 19194.59162
-  tps: 17731.35397
+  dps: 19383.63895
+  tps: 17944.81996
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 19194.59162
-  tps: 17731.35397
+  dps: 19383.63895
+  tps: 17944.81996
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 18890.78494
-  tps: 17427.5473
+  dps: 19032.48466
+  tps: 17593.66567
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 18215.39125
-  tps: 16813.29499
+  dps: 18513.34096
+  tps: 17129.10153
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 18218.86908
-  tps: 16817.25421
+  dps: 18626.14262
+  tps: 17236.85376
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 18578.26662
-  tps: 17152.84563
+  dps: 18536.93477
+  tps: 17143.84114
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ScourgestalkerBattlegear"
  value: {
-  dps: 14514.70943
-  tps: 13332.60299
+  dps: 15466.21375
+  tps: 14270.6992
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SeaStar-55256"
  value: {
-  dps: 18234.46785
-  tps: 16856.74499
+  dps: 18109.23658
+  tps: 16756.76024
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SeaStar-56290"
  value: {
-  dps: 18267.34425
-  tps: 16889.6214
+  dps: 18141.72686
+  tps: 16789.25052
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Shadowmourne-49623"
  value: {
-  dps: 19689.00456
-  tps: 18215.71713
+  dps: 19692.12155
+  tps: 18244.40217
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 18778.69953
-  tps: 17353.98003
+  dps: 18656.49298
+  tps: 17270.27168
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 18846.38845
-  tps: 17421.27687
+  dps: 18971.00599
+  tps: 17566.96093
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 18229.76516
-  tps: 16852.04231
+  dps: 18102.86891
+  tps: 16750.39257
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 18233.99353
-  tps: 16856.27067
+  dps: 18106.82986
+  tps: 16754.35352
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Sorrowsong-55879"
  value: {
-  dps: 18185.95432
-  tps: 16810.00527
+  dps: 18437.5677
+  tps: 17095.39355
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Sorrowsong-56400"
  value: {
-  dps: 18109.0932
-  tps: 16738.17594
+  dps: 18322.49445
+  tps: 16981.27386
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 18215.39125
-  tps: 16813.29499
+  dps: 18513.34096
+  tps: 17129.10153
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SoulCasket-58183"
  value: {
-  dps: 18172.15711
-  tps: 16801.18065
+  dps: 18537.03399
+  tps: 17195.13805
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SoulPreserver-37111"
  value: {
-  dps: 18212.21746
-  tps: 16834.49461
+  dps: 18086.43096
+  tps: 16733.95462
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SouloftheDead-40382"
  value: {
-  dps: 18172.78201
-  tps: 16786.18674
+  dps: 18171.5168
+  tps: 16817.14065
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SparkofLife-37657"
  value: {
-  dps: 18109.68319
-  tps: 16732.00623
+  dps: 18472.56839
+  tps: 17110.26792
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 18235.88159
-  tps: 16847.44434
+  dps: 18184.60911
+  tps: 16810.01885
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 18212.28664
-  tps: 16834.56379
+  dps: 18086.30544
+  tps: 16733.8291
  }
 }
 dps_results: {
  key: "TestMM-AllItems-StumpofTime-62465"
  value: {
-  dps: 18231.16237
-  tps: 16829.5475
+  dps: 18639.14397
+  tps: 17249.8551
  }
 }
 dps_results: {
  key: "TestMM-AllItems-StumpofTime-62470"
  value: {
-  dps: 18244.86073
-  tps: 16843.24586
+  dps: 18653.19083
+  tps: 17263.90197
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 18924.80619
-  tps: 17458.9949
+  dps: 19066.70449
+  tps: 17625.35694
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 18918.32595
-  tps: 17453.00488
+  dps: 19060.18642
+  tps: 17619.32051
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 18906.98554
-  tps: 17442.52234
+  dps: 19048.77981
+  tps: 17608.75675
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 18162.65176
-  tps: 16786.49059
+  dps: 18153.98696
+  tps: 16799.59213
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TearofBlood-55819"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TearofBlood-56351"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 18167.54852
-  tps: 16782.42723
+  dps: 18270.71585
+  tps: 16931.00696
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 18112.77332
-  tps: 16741.85606
+  dps: 18326.17457
+  tps: 16984.95398
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 18247.14802
-  tps: 16873.32002
+  dps: 18109.49191
+  tps: 16757.48999
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 18886.51494
-  tps: 17421.38367
+  dps: 19120.68983
+  tps: 17674.47836
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 18928.43752
-  tps: 17497.85727
+  dps: 19067.36661
+  tps: 17657.27414
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 18068.62328
-  tps: 16688.24689
+  dps: 18248.32983
+  tps: 16882.91787
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 18068.62328
-  tps: 16688.24689
+  dps: 18248.32983
+  tps: 16882.91787
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 18896.09879
-  tps: 17432.86114
+  dps: 19037.57859
+  tps: 17598.7596
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 18895.03602
-  tps: 17431.79837
+  dps: 19036.5598
+  tps: 17597.74082
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 18178.30835
-  tps: 16797.61036
+  dps: 18183.30942
+  tps: 16815.41725
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 18895.03602
-  tps: 17431.79837
+  dps: 19036.5598
+  tps: 17597.74082
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 18896.09879
-  tps: 17432.86114
+  dps: 19037.57859
+  tps: 17598.7596
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 18183.64272
-  tps: 16806.28878
+  dps: 18047.42431
+  tps: 16695.06771
  }
 }
 dps_results: {
  key: "TestMM-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 14627.59465
-  tps: 13488.55738
+  dps: 15009.91926
+  tps: 13885.79901
  }
 }
 dps_results: {
  key: "TestMM-AllItems-UnheededWarning-59520"
  value: {
-  dps: 18907.93258
-  tps: 17465.3742
+  dps: 18830.82908
+  tps: 17426.42392
  }
 }
 dps_results: {
  key: "TestMM-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 19062.20136
-  tps: 17620.61729
+  dps: 19506.084
+  tps: 18081.33008
  }
 }
 dps_results: {
  key: "TestMM-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 19062.20136
-  tps: 17620.61729
+  dps: 19506.084
+  tps: 18081.33008
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 18319.4297
-  tps: 16921.35611
+  dps: 18781.19568
+  tps: 17393.03655
  }
 }
 dps_results: {
  key: "TestMM-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 19200.96687
-  tps: 17741.23931
+  dps: 18933.24904
+  tps: 17514.40107
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 18276.31055
-  tps: 16898.58769
+  dps: 18150.58784
+  tps: 16798.1115
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 18218.86908
-  tps: 16817.25421
+  dps: 18626.14262
+  tps: 17236.85376
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 18395.84584
-  tps: 17031.11149
+  dps: 18529.50909
+  tps: 17151.46672
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 18406.14106
-  tps: 17017.56315
+  dps: 18047.23794
+  tps: 16684.16813
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 18069.03633
-  tps: 16698.57499
+  dps: 18433.76766
+  tps: 17090.8197
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 18990.04435
-  tps: 17537.54478
+  dps: 18965.81877
+  tps: 17546.77365
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 18201.29725
-  tps: 16823.5744
+  dps: 18076.86234
+  tps: 16724.386
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Windrunner'sPursuit"
  value: {
-  dps: 15051.07989
-  tps: 13836.24737
+  dps: 14644.5833
+  tps: 13439.11969
  }
 }
 dps_results: {
  key: "TestMM-AllItems-WingedTalisman-37844"
  value: {
-  dps: 18213.59631
-  tps: 16835.87345
+  dps: 18088.61017
+  tps: 16736.13383
  }
 }
 dps_results: {
  key: "TestMM-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 18196.3611
-  tps: 16818.63825
+  dps: 18071.57739
+  tps: 16719.10105
  }
 }
 dps_results: {
  key: "TestMM-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 18167.81171
-  tps: 16782.69042
+  dps: 18269.79498
+  tps: 16930.08609
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 18178.02312
-  tps: 16808.26106
+  dps: 18390.02287
+  tps: 17025.26702
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 18178.02312
-  tps: 16808.26106
+  dps: 18390.02287
+  tps: 17025.26702
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Zod'sRepeatingLongbow-50034"
  value: {
-  dps: 17170.26862
-  tps: 15754.26483
+  dps: 17141.62723
+  tps: 15752.09565
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 17300.50224
-  tps: 15882.17932
+  dps: 17127.60174
+  tps: 15722.15694
  }
 }
 dps_results: {
  key: "TestMM-Average-Default"
  value: {
-  dps: 16043.31946
-  tps: 14616.53088
+  dps: 15981.78708
+  tps: 14553.73741
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20565.75697
-  tps: 19169.30854
+  dps: 20153.53937
+  tps: 18789.25274
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-FullBuffs-LongSingleTarget"
  value: {
-  dps: 19086.58388
-  tps: 17699.23468
+  dps: 19144.60734
+  tps: 17780.30899
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 23867.45631
-  tps: 21948.32553
+  dps: 23887.02068
+  tps: 21968.29791
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11566.13047
-  tps: 10608.75631
+  dps: 11519.29311
+  tps: 10562.93996
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-NoBuffs-LongSingleTarget"
  value: {
-  dps: 10775.48761
-  tps: 9819.44127
+  dps: 10803.76216
+  tps: 9837.33937
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 13379.82017
-  tps: 12226.89017
+  dps: 13458.90988
+  tps: 12291.77259
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm_advanced-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20565.75697
-  tps: 19169.30854
+  dps: 20153.53937
+  tps: 18789.25274
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm_advanced-FullBuffs-LongSingleTarget"
  value: {
-  dps: 19086.58388
-  tps: 17699.23468
+  dps: 19144.60734
+  tps: 17780.30899
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm_advanced-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 23867.45631
-  tps: 21948.32553
+  dps: 23887.02068
+  tps: 21968.29791
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm_advanced-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11566.13047
-  tps: 10608.75631
+  dps: 11519.29311
+  tps: 10562.93996
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm_advanced-NoBuffs-LongSingleTarget"
  value: {
-  dps: 10775.48761
-  tps: 9819.44127
+  dps: 10803.76216
+  tps: 9837.33937
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm_advanced-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 13379.82017
-  tps: 12226.89017
+  dps: 13458.90988
+  tps: 12291.77259
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20879.32088
-  tps: 19398.75378
+  dps: 20456.03469
+  tps: 19009.71398
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-FullBuffs-LongSingleTarget"
  value: {
-  dps: 19333.46281
-  tps: 17863.24458
+  dps: 19398.70685
+  tps: 17952.37963
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 24346.11368
-  tps: 22297.02866
+  dps: 24365.66391
+  tps: 22317.00735
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11764.6528
-  tps: 10748.23028
+  dps: 11718.04183
+  tps: 10702.64192
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-NoBuffs-LongSingleTarget"
  value: {
-  dps: 10931.71193
-  tps: 9916.82524
+  dps: 10960.81993
+  tps: 9934.89515
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 13633.04724
-  tps: 12397.30654
+  dps: 13712.93476
+  tps: 12462.4094
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm_advanced-FullBuffs-LongMultiTarget"
  value: {
-  dps: 20879.32088
-  tps: 19398.75378
+  dps: 20456.03469
+  tps: 19009.71398
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm_advanced-FullBuffs-LongSingleTarget"
  value: {
-  dps: 19333.46281
-  tps: 17863.24458
+  dps: 19398.70685
+  tps: 17952.37963
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm_advanced-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 24346.11368
-  tps: 22297.02866
+  dps: 24365.66391
+  tps: 22317.00735
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm_advanced-NoBuffs-LongMultiTarget"
  value: {
-  dps: 11764.6528
-  tps: 10748.23028
+  dps: 11718.04183
+  tps: 10702.64192
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm_advanced-NoBuffs-LongSingleTarget"
  value: {
-  dps: 10931.71193
-  tps: 9916.82524
+  dps: 10960.81993
+  tps: 9934.89515
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm_advanced-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 13633.04724
-  tps: 12397.30654
+  dps: 13712.93476
+  tps: 12462.4094
  }
 }
 dps_results: {
  key: "TestMM-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 19326.94225
-  tps: 17859.4257
+  dps: 19394.29285
+  tps: 17948.57661
  }
 }

--- a/sim/hunter/marksmanship/marksmanship_test.go
+++ b/sim/hunter/marksmanship/marksmanship_test.go
@@ -55,14 +55,15 @@ func BenchmarkSimulate(b *testing.B) {
 	rsr := &proto.RaidSimRequest{
 		Raid: core.SinglePlayerRaidProto(
 			&proto.Player{
-				Race:          proto.Race_RaceOrc,
-				Class:         proto.Class_ClassHunter,
-				Equipment:     core.GetGearSet("../../../ui/hunter/marksmanship/gear_sets", "preraid_mm").GearSet,
-				Consumes:      FullConsumes,
-				Spec:          PlayerOptionsBasic,
-				Glyphs:        MMGlyphs,
-				TalentsString: MMTalents,
-				Buffs:         core.FullIndividualBuffs,
+				Race:           proto.Race_RaceOrc,
+				Class:          proto.Class_ClassHunter,
+				Equipment:      core.GetGearSet("../../../ui/hunter/marksmanship/gear_sets", "preraid_mm").GearSet,
+				Consumes:       FullConsumes,
+				Spec:           PlayerOptionsBasic,
+				Glyphs:         MMGlyphs,
+				TalentsString:  MMTalents,
+				Buffs:          core.FullIndividualBuffs,
+				ReactionTimeMs: 100,
 			},
 			core.FullPartyBuffs,
 			core.FullRaidBuffs,

--- a/sim/hunter/survival/TestSV.results
+++ b/sim/hunter/survival/TestSV.results
@@ -40,2160 +40,2160 @@ character_stats_results: {
 dps_results: {
  key: "TestSV-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 26594.71009
-  tps: 25167.0252
+  dps: 26603.74102
+  tps: 25173.1618
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
-  dps: 22835.07956
-  tps: 21612.69012
+  dps: 22855.50254
+  tps: 21626.61594
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 25293.07331
-  tps: 23954.44987
+  dps: 25275.56766
+  tps: 23928.37408
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 25265.28118
-  tps: 23922.44707
+  dps: 25277.69013
+  tps: 23931.1912
  }
 }
 dps_results: {
  key: "TestSV-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 25969.41178
-  tps: 24550.55169
+  dps: 25962.54829
+  tps: 24549.26077
  }
 }
 dps_results: {
  key: "TestSV-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 25969.41178
-  tps: 24550.55169
+  dps: 25962.54829
+  tps: 24549.26077
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 24845.30823
-  tps: 23515.54819
+  dps: 24777.10424
+  tps: 23450.90047
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 24586.20062
-  tps: 23266.36102
-  hps: 88.21406
+  dps: 24518.78547
+  tps: 23202.62839
+  hps: 88.54119
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 24586.20062
-  tps: 23266.36102
-  hps: 88.21406
+  dps: 24518.78547
+  tps: 23202.62839
+  hps: 88.54119
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 26000.61779
-  tps: 24579.35827
+  dps: 26005.6074
+  tps: 24587.28612
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 24946.26852
-  tps: 23626.02675
+  dps: 24846.22417
+  tps: 23532.35297
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 25012.61205
-  tps: 23689.33609
+  dps: 24910.91661
+  tps: 23597.94408
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BindingPromise-67037"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlackBruise-50035"
  value: {
-  dps: 24791.75218
-  tps: 23444.76821
+  dps: 24766.46218
+  tps: 23421.38548
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlackBruise-50692"
  value: {
-  dps: 24769.6631
-  tps: 23423.82199
+  dps: 24744.40178
+  tps: 23400.46628
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 20276.0361
-  tps: 19169.76239
+  dps: 20333.49725
+  tps: 19226.39628
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 19137.48065
-  tps: 18099.13476
+  dps: 19198.33356
+  tps: 18160.46489
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 25592.73607
-  tps: 24237.38227
+  dps: 25638.82219
+  tps: 24287.22228
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 24819.225
-  tps: 23499.74184
+  dps: 24751.08513
+  tps: 23435.19408
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 24849.60353
-  tps: 23530.12037
+  dps: 24781.38554
+  tps: 23465.49449
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 26090.45515
-  tps: 24683.29993
+  dps: 26005.33395
+  tps: 24604.18966
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 24930.54806
-  tps: 23610.30629
+  dps: 24831.05963
+  tps: 23517.22716
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 25708.83152
-  tps: 24319.22419
+  dps: 25678.21547
+  tps: 24292.04378
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BottledLightning-66879"
  value: {
-  dps: 24775.60955
-  tps: 23455.02336
+  dps: 24731.44395
+  tps: 23421.24925
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 25969.41178
-  tps: 24059.54066
+  dps: 25962.54829
+  tps: 24058.27556
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 25969.41178
-  tps: 24059.54066
+  dps: 25962.54829
+  tps: 24058.27556
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 26594.71009
-  tps: 25167.0252
+  dps: 26603.74102
+  tps: 25173.1618
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 26594.71009
-  tps: 25167.0252
+  dps: 26603.74102
+  tps: 25173.1618
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 26392.10937
-  tps: 24973.24928
+  dps: 26384.46802
+  tps: 24971.1805
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 26471.98865
-  tps: 25053.3495
+  dps: 26478.98358
+  tps: 25056.286
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 26425.0744
-  tps: 25003.81489
+  dps: 26429.48689
+  tps: 25011.16561
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
   hps: 64
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CrushingWeight-59506"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CrushingWeight-65118"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CryptstalkerBattlegear"
  value: {
-  dps: 19823.60833
-  tps: 18672.76507
+  dps: 19881.38706
+  tps: 18736.84287
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 24681.62437
-  tps: 23357.87117
+  dps: 24644.31869
+  tps: 23325.46579
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 24710.76144
-  tps: 23386.09793
+  dps: 24682.5602
+  tps: 23361.97243
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 24974.15865
-  tps: 23634.30213
+  dps: 24938.38896
+  tps: 23607.77467
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 25012.55893
-  tps: 23693.15275
+  dps: 24944.02902
+  tps: 23628.20383
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 26113.25377
-  tps: 24737.53225
+  dps: 26004.94239
+  tps: 24633.59274
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 24889.01966
-  tps: 23569.58446
+  dps: 24820.06999
+  tps: 23504.06586
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Death'sChoice-47464"
  value: {
-  dps: 25538.30597
-  tps: 24162.46001
+  dps: 25446.20503
+  tps: 24080.85831
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 24674.00719
-  tps: 23362.38564
+  dps: 24566.54441
+  tps: 23250.16356
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 25155.73878
-  tps: 23816.54821
+  dps: 25071.6888
+  tps: 23742.20661
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 25220.97601
-  tps: 23880.60473
+  dps: 25119.26144
+  tps: 23779.56494
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Defender'sCode-40257"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 26044.75097
-  tps: 24626.11181
+  dps: 26052.70854
+  tps: 24630.01096
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 26007.55043
-  tps: 24586.29091
+  dps: 25996.46607
+  tps: 24577.67737
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 24745.96636
-  tps: 23432.51926
+  dps: 24766.79896
+  tps: 23457.23068
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 24780.941
-  tps: 23454.37877
+  dps: 24732.33653
+  tps: 23408.7705
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 25969.41178
-  tps: 24550.55169
+  dps: 25962.54829
+  tps: 24549.26077
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 25969.41178
-  tps: 24550.55169
+  dps: 25962.54829
+  tps: 24549.26077
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 25969.41178
-  tps: 24550.55169
+  dps: 25962.54829
+  tps: 24549.26077
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 25969.41178
-  tps: 24550.55169
+  dps: 25962.54829
+  tps: 24549.26077
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 26044.75097
-  tps: 24626.11181
+  dps: 26052.70854
+  tps: 24630.01096
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 26000.61779
-  tps: 24579.35827
+  dps: 26005.6074
+  tps: 24587.28612
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 25998.29842
-  tps: 24577.0389
+  dps: 26001.69815
+  tps: 24583.37688
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 24626.00595
-  tps: 23304.18057
+  dps: 24686.49169
+  tps: 23358.98421
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 26070.55547
-  tps: 24686.46632
+  dps: 25970.13118
+  tps: 24590.82635
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 26303.89656
-  tps: 24904.8107
+  dps: 26176.5768
+  tps: 24776.35664
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 25969.41178
-  tps: 24550.55169
+  dps: 25962.54829
+  tps: 24549.26077
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 25969.41178
-  tps: 24550.55169
+  dps: 25962.54829
+  tps: 24549.26077
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 24728.9253
-  tps: 23403.7225
+  dps: 24699.82838
+  tps: 23379.38736
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 24654.25072
-  tps: 23329.75693
+  dps: 24626.80331
+  tps: 23306.28198
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FallofMortality-59500"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FallofMortality-65124"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 26784.95241
-  tps: 25356.90573
+  dps: 26786.62788
+  tps: 25349.72929
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 24849.60353
-  tps: 23530.12037
+  dps: 24781.38554
+  tps: 23465.49449
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 26022.05349
-  tps: 24603.1934
+  dps: 26015.17254
+  tps: 24601.88502
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FluidDeath-58181"
  value: {
-  dps: 26576.37957
-  tps: 25157.199
+  dps: 26599.68828
+  tps: 25180.3751
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ForgeEmber-37660"
  value: {
-  dps: 24632.37808
-  tps: 23308.21573
+  dps: 24603.65046
+  tps: 23283.46056
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 25969.41178
-  tps: 24550.55169
+  dps: 25962.54829
+  tps: 24549.26077
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 25969.41178
-  tps: 24550.55169
+  dps: 25962.54829
+  tps: 24549.26077
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 25969.41178
-  tps: 24550.55169
+  dps: 25962.54829
+  tps: 24549.26077
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 24946.26852
-  tps: 23626.02675
+  dps: 24846.22417
+  tps: 23532.35297
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 24905.99911
-  tps: 23570.37224
+  dps: 24837.38587
+  tps: 23505.38748
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FuturesightRune-38763"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GaleofShadows-56138"
  value: {
-  dps: 24736.63211
-  tps: 23425.75065
+  dps: 24750.43609
+  tps: 23432.1519
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GaleofShadows-56462"
  value: {
-  dps: 24922.87535
-  tps: 23608.06989
+  dps: 24827.73315
+  tps: 23502.15677
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GearDetector-61462"
  value: {
-  dps: 25276.19919
-  tps: 23930.84126
+  dps: 25299.61527
+  tps: 23949.9715
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 23172.60579
-  tps: 21898.45847
+  dps: 23163.13454
+  tps: 21886.94241
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 24682.58876
-  tps: 23358.24158
+  dps: 24652.92436
+  tps: 23332.4088
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 25365.22435
-  tps: 24002.68179
+  dps: 25336.60913
+  tps: 23982.5344
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 25750.70317
-  tps: 24374.81607
+  dps: 25678.22987
+  tps: 24301.69884
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HarmlightToken-63839"
  value: {
-  dps: 24594.49646
-  tps: 23275.13221
+  dps: 24526.87483
+  tps: 23211.06059
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofRage-59224"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofRage-65072"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofSolace-55868"
  value: {
-  dps: 24736.63211
-  tps: 23425.75065
+  dps: 24750.43609
+  tps: 23432.1519
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofSolace-56393"
  value: {
-  dps: 24922.87535
-  tps: 23608.06989
+  dps: 24827.73315
+  tps: 23502.15677
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofThunder-55845"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofThunder-56370"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 25466.96352
-  tps: 24107.29609
+  dps: 25478.49601
+  tps: 24126.17601
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Heartpierce-49982"
  value: {
-  dps: 26695.52612
-  tps: 25262.68122
+  dps: 26704.56674
+  tps: 25268.81645
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Heartpierce-50641"
  value: {
-  dps: 26697.69421
-  tps: 25264.73834
+  dps: 26706.73503
+  tps: 25270.87354
  }
 }
 dps_results: {
  key: "TestSV-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 26044.75097
-  tps: 24626.11181
+  dps: 26052.70854
+  tps: 24630.01096
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 26000.61779
-  tps: 24579.35827
+  dps: 26005.6074
+  tps: 24587.28612
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 25998.29842
-  tps: 24577.0389
+  dps: 26001.69815
+  tps: 24583.37688
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 24882.74374
-  tps: 23563.26058
+  dps: 24814.44053
+  tps: 23498.54948
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 24882.74374
-  tps: 23563.26058
+  dps: 24814.44053
+  tps: 23498.54948
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 24819.225
-  tps: 23499.74184
+  dps: 24751.08513
+  tps: 23435.19408
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 24849.60353
-  tps: 23530.12037
+  dps: 24781.38554
+  tps: 23465.49449
  }
 }
 dps_results: {
  key: "TestSV-AllItems-IncisorFragment-37723"
  value: {
-  dps: 24807.2107
-  tps: 23479.81661
+  dps: 24740.69762
+  tps: 23416.91348
  }
 }
 dps_results: {
  key: "TestSV-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 25969.41178
-  tps: 24550.55169
+  dps: 25962.54829
+  tps: 24549.26077
  }
 }
 dps_results: {
  key: "TestSV-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 24765.83244
-  tps: 23446.34929
+  dps: 24697.82987
+  tps: 23381.93882
  }
 }
 dps_results: {
  key: "TestSV-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 26014.11444
-  tps: 24592.92684
+  dps: 26007.21745
+  tps: 24591.6107
   hps: 65.53792
  }
 }
 dps_results: {
  key: "TestSV-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 25592.73607
-  tps: 24237.38227
+  dps: 25638.82219
+  tps: 24287.22228
  }
 }
 dps_results: {
  key: "TestSV-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 26139.21931
-  tps: 24740.10319
+  dps: 26194.41606
+  tps: 24791.78776
  }
 }
 dps_results: {
  key: "TestSV-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 24705.75565
-  tps: 23377.93831
+  dps: 24660.29162
+  tps: 23343.54139
  }
 }
 dps_results: {
  key: "TestSV-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 24705.75565
-  tps: 23377.93831
+  dps: 24660.29162
+  tps: 23343.54139
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 24760.62722
-  tps: 23441.77653
+  dps: 24662.9899
+  tps: 23341.45077
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LastWord-50179"
  value: {
-  dps: 26594.71009
-  tps: 25167.0252
+  dps: 26603.74102
+  tps: 25173.1618
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LastWord-50708"
  value: {
-  dps: 26594.71009
-  tps: 25167.0252
+  dps: 26603.74102
+  tps: 25173.1618
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LeadenDespair-55816"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LeadenDespair-56347"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 25695.60655
-  tps: 24310.25198
+  dps: 25541.99884
+  tps: 24175.70618
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 25812.44562
-  tps: 24419.79556
+  dps: 25712.06778
+  tps: 24332.21214
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 25265.28118
-  tps: 23922.44707
+  dps: 25277.69013
+  tps: 23931.1912
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Lightning-ChargedBattlegear"
  value: {
-  dps: 26083.34238
-  tps: 24734.67242
+  dps: 25979.25078
+  tps: 24628.52958
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 24845.55509
-  tps: 23526.07193
+  dps: 24775.81893
+  tps: 23459.92788
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 24879.3816
-  tps: 23559.89845
+  dps: 24809.35829
+  tps: 23493.46724
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 24760.77353
-  tps: 23435.83083
+  dps: 24704.44687
+  tps: 23381.6524
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 25113.76506
-  tps: 23791.72812
+  dps: 25065.88745
+  tps: 23739.93326
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 25265.28118
-  tps: 23922.44707
+  dps: 25277.69013
+  tps: 23931.1912
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 24882.74374
-  tps: 23563.26058
+  dps: 24814.44053
+  tps: 23498.54948
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 24882.74374
-  tps: 23563.26058
+  dps: 24814.44053
+  tps: 23498.54948
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 24963.21358
-  tps: 23643.73042
+  dps: 24889.66288
+  tps: 23573.77182
  }
 }
 dps_results: {
  key: "TestSV-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 24746.19199
-  tps: 23434.72931
+  dps: 24711.41769
+  tps: 23396.26472
  }
 }
 dps_results: {
  key: "TestSV-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 24855.89592
-  tps: 23533.11361
+  dps: 24825.24364
+  tps: 23514.18306
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 26005.59965
-  tps: 24584.85538
+  dps: 25998.70904
+  tps: 24583.54404
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 26014.11444
-  tps: 24592.92684
+  dps: 26007.21745
+  tps: 24591.6107
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 25969.41178
-  tps: 24550.55169
+  dps: 25962.54829
+  tps: 24549.26077
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 25969.41178
-  tps: 24550.55169
+  dps: 25962.54829
+  tps: 24549.26077
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 25969.41178
-  tps: 24550.55169
+  dps: 25962.54829
+  tps: 24549.26077
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 25981.98866
-  tps: 24594.58426
+  dps: 26015.01178
+  tps: 24616.04892
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 26083.73631
-  tps: 24686.07663
+  dps: 26176.07899
+  tps: 24789.08968
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Rainsong-55854"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Rainsong-56377"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 26480.95227
-  tps: 25054.97135
+  dps: 26481.86009
+  tps: 25059.32843
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 26392.10937
-  tps: 24973.24928
+  dps: 26384.46802
+  tps: 24971.1805
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 26392.10937
-  tps: 24973.24928
+  dps: 26384.46802
+  tps: 24971.1805
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 25969.41178
-  tps: 24550.55169
+  dps: 25962.54829
+  tps: 24549.26077
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 25293.07331
-  tps: 23954.44987
+  dps: 25275.56766
+  tps: 23928.37408
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 25265.28118
-  tps: 23922.44707
+  dps: 25277.69013
+  tps: 23931.1912
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 25350.31624
-  tps: 23988.23236
+  dps: 25271.48881
+  tps: 23910.31349
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ScourgestalkerBattlegear"
  value: {
-  dps: 20436.04785
-  tps: 19316.06597
+  dps: 20348.72909
+  tps: 19230.3773
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SeaStar-55256"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SeaStar-56290"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Shadowmourne-49623"
  value: {
-  dps: 26854.25864
-  tps: 25414.3377
+  dps: 26794.61164
+  tps: 25361.77949
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 25699.54453
-  tps: 24326.46725
+  dps: 25618.19053
+  tps: 24251.33989
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 25869.63753
-  tps: 24499.68219
+  dps: 25838.55256
+  tps: 24470.85855
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Sorrowsong-55879"
  value: {
-  dps: 24819.225
-  tps: 23499.74184
+  dps: 24751.08513
+  tps: 23435.19408
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Sorrowsong-56400"
  value: {
-  dps: 24849.60353
-  tps: 23530.12037
+  dps: 24781.38554
+  tps: 23465.49449
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 25293.07331
-  tps: 23954.44987
+  dps: 25275.56766
+  tps: 23928.37408
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SoulCasket-58183"
  value: {
-  dps: 24882.74374
-  tps: 23563.26058
+  dps: 24814.44053
+  tps: 23498.54948
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SoulPreserver-37111"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SouloftheDead-40382"
  value: {
-  dps: 24656.49743
-  tps: 23331.2687
+  dps: 24627.39395
+  tps: 23306.87262
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SparkofLife-37657"
  value: {
-  dps: 24711.14244
-  tps: 23379.86057
+  dps: 24723.41345
+  tps: 23414.34808
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 24826.9329
-  tps: 23502.90879
+  dps: 24844.59119
+  tps: 23510.61349
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 24589.70787
-  tps: 23270.22471
+  dps: 24522.16451
+  tps: 23206.27346
  }
 }
 dps_results: {
  key: "TestSV-AllItems-StumpofTime-62465"
  value: {
-  dps: 25265.28118
-  tps: 23922.44707
+  dps: 25277.69013
+  tps: 23931.1912
  }
 }
 dps_results: {
  key: "TestSV-AllItems-StumpofTime-62470"
  value: {
-  dps: 25265.28118
-  tps: 23922.44707
+  dps: 25277.69013
+  tps: 23931.1912
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 26014.11444
-  tps: 24592.92684
+  dps: 26007.21745
+  tps: 24591.6107
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 26005.59965
-  tps: 24584.85538
+  dps: 25998.70904
+  tps: 24583.54404
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 25990.69876
-  tps: 24570.73033
+  dps: 25983.81932
+  tps: 24569.4274
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 24648.86735
-  tps: 23329.38419
+  dps: 24581.27294
+  tps: 23265.38189
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TearofBlood-55819"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TearofBlood-56351"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 24785.16423
-  tps: 23465.68107
+  dps: 24717.11195
+  tps: 23401.22089
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 24849.60353
-  tps: 23530.12037
+  dps: 24781.38554
+  tps: 23465.49449
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 24621.49688
-  tps: 23302.01372
+  dps: 24553.90175
+  tps: 23238.0107
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 25913.51099
-  tps: 24503.77019
+  dps: 25917.26515
+  tps: 24512.1596
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 25780.29844
-  tps: 24411.73962
+  dps: 25785.97034
+  tps: 24409.1368
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 24857.44104
-  tps: 23537.95573
+  dps: 24889.10255
+  tps: 23570.90984
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 24857.44104
-  tps: 23537.95573
+  dps: 24889.10255
+  tps: 23570.90984
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 25969.41178
-  tps: 24550.55169
+  dps: 25962.54829
+  tps: 24549.26077
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 25969.41178
-  tps: 24550.55169
+  dps: 25962.54829
+  tps: 24549.26077
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 24589.11941
-  tps: 23283.87195
+  dps: 24609.52036
+  tps: 23302.87656
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 25969.41178
-  tps: 24550.55169
+  dps: 25962.54829
+  tps: 24549.26077
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 25969.41178
-  tps: 24550.55169
+  dps: 25962.54829
+  tps: 24549.26077
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 19688.05842
-  tps: 18629.35387
+  dps: 19715.60037
+  tps: 18664.93729
  }
 }
 dps_results: {
  key: "TestSV-AllItems-UnheededWarning-59520"
  value: {
-  dps: 25686.35465
-  tps: 24310.27299
+  dps: 25576.56684
+  tps: 24204.83124
  }
 }
 dps_results: {
  key: "TestSV-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 26210.69137
-  tps: 24804.51801
+  dps: 26194.97999
+  tps: 24800.85402
  }
 }
 dps_results: {
  key: "TestSV-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 26210.69137
-  tps: 24804.51801
+  dps: 26194.97999
+  tps: 24800.85402
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 24687.09006
-  tps: 23348.62704
+  dps: 24761.47837
+  tps: 23420.15938
  }
 }
 dps_results: {
  key: "TestSV-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 25898.77096
-  tps: 24492.59759
+  dps: 25884.13367
+  tps: 24490.00771
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 25265.28118
-  tps: 23922.44707
+  dps: 25277.69013
+  tps: 23931.1912
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 24860.41642
-  tps: 23535.98062
+  dps: 24831.07714
+  tps: 23513.26851
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 24960.82361
-  tps: 23638.03966
+  dps: 24868.13364
+  tps: 23550.55602
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 24900.2344
-  tps: 23580.75124
+  dps: 24831.88622
+  tps: 23515.99517
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 25743.19392
-  tps: 24346.87078
+  dps: 25746.8417
+  tps: 24358.59086
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Windrunner'sPursuit"
  value: {
-  dps: 20410.0743
-  tps: 19241.9681
+  dps: 20377.58944
+  tps: 19211.82291
  }
 }
 dps_results: {
  key: "TestSV-AllItems-WingedTalisman-37844"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 24587.24354
-  tps: 23267.76039
+  dps: 24519.70019
+  tps: 23203.80914
  }
 }
 dps_results: {
  key: "TestSV-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 24788.84648
-  tps: 23469.36332
+  dps: 24720.78472
+  tps: 23404.89367
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 24811.72858
-  tps: 23492.24542
+  dps: 24742.27957
+  tps: 23426.38852
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 24811.72858
-  tps: 23492.24542
+  dps: 24742.27957
+  tps: 23426.38852
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Zod'sRepeatingLongbow-50034"
  value: {
-  dps: 23596.95535
-  tps: 22230.26888
+  dps: 23603.52594
+  tps: 22240.21786
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 23899.39152
-  tps: 22534.1535
+  dps: 23900.41203
+  tps: 22534.56076
  }
 }
 dps_results: {
  key: "TestSV-Average-Default"
  value: {
-  dps: 26539.04219
-  tps: 25115.67444
+  dps: 26530.9959
+  tps: 25107.46335
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-FullBuffs-LongMultiTarget"
  value: {
-  dps: 62902.55427
-  tps: 61758.881
+  dps: 62915.64416
+  tps: 61768.3219
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-FullBuffs-LongSingleTarget"
  value: {
-  dps: 20050.83465
-  tps: 18913.23403
+  dps: 20033.33079
+  tps: 18894.58304
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 24024.25535
-  tps: 22426.7766
+  dps: 24065.80665
+  tps: 22471.6685
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-NoBuffs-LongMultiTarget"
  value: {
-  dps: 39481.09249
-  tps: 38742.75045
+  dps: 39487.49255
+  tps: 38747.92478
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-NoBuffs-LongSingleTarget"
  value: {
-  dps: 12025.53393
-  tps: 11288.70058
+  dps: 12014.97415
+  tps: 11277.08617
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 12817.13012
-  tps: 11964.81215
+  dps: 12816.25404
+  tps: 11965.51795
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-FullBuffs-LongMultiTarget"
  value: {
-  dps: 28822.44119
-  tps: 27482.06863
+  dps: 28838.97887
+  tps: 27499.87955
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-FullBuffs-LongSingleTarget"
  value: {
-  dps: 26303.82753
-  tps: 24957.23134
+  dps: 26314.32385
+  tps: 24965.13962
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 32388.03054
-  tps: 30486.14535
+  dps: 32403.73446
+  tps: 30500.89412
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-NoBuffs-LongMultiTarget"
  value: {
-  dps: 17641.53793
-  tps: 16792.67925
+  dps: 17646.41898
+  tps: 16797.96287
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-NoBuffs-LongSingleTarget"
  value: {
-  dps: 16301.34112
-  tps: 15455.55373
+  dps: 16320.15425
+  tps: 15475.92134
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 17758.0868
-  tps: 16754.15462
+  dps: 17762.59472
+  tps: 16756.43155
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv_advanced-FullBuffs-LongMultiTarget"
  value: {
-  dps: 28822.44119
-  tps: 27482.06863
+  dps: 28838.97887
+  tps: 27499.87955
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv_advanced-FullBuffs-LongSingleTarget"
  value: {
-  dps: 26303.82753
-  tps: 24957.23134
+  dps: 26314.32385
+  tps: 24965.13962
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv_advanced-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 32388.03054
-  tps: 30486.14535
+  dps: 32403.73446
+  tps: 30500.89412
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv_advanced-NoBuffs-LongMultiTarget"
  value: {
-  dps: 17641.53793
-  tps: 16792.67925
+  dps: 17646.41898
+  tps: 16797.96287
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv_advanced-NoBuffs-LongSingleTarget"
  value: {
-  dps: 16301.34112
-  tps: 15455.55373
+  dps: 16320.15425
+  tps: 15475.92134
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv_advanced-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 17758.0868
-  tps: 16754.15462
+  dps: 17762.59472
+  tps: 16756.43155
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-FullBuffs-LongMultiTarget"
  value: {
-  dps: 63575.09359
-  tps: 62361.27595
+  dps: 63587.12376
+  tps: 62369.46041
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-FullBuffs-LongSingleTarget"
  value: {
-  dps: 20307.03682
-  tps: 19100.15288
+  dps: 20289.30756
+  tps: 19081.21917
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 24529.95914
-  tps: 22821.94613
+  dps: 24571.34935
+  tps: 22866.84429
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-NoBuffs-LongMultiTarget"
  value: {
-  dps: 39942.69843
-  tps: 39158.99731
+  dps: 39949.43559
+  tps: 39164.44667
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-NoBuffs-LongSingleTarget"
  value: {
-  dps: 12198.34924
-  tps: 11416.20413
+  dps: 12187.58758
+  tps: 11404.35295
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 13122.61848
-  tps: 12209.23543
+  dps: 13121.65154
+  tps: 12209.94131
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-FullBuffs-LongMultiTarget"
  value: {
-  dps: 29216.22041
-  tps: 27795.84189
+  dps: 29233.23009
+  tps: 27814.02481
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-FullBuffs-LongSingleTarget"
  value: {
-  dps: 26594.71009
-  tps: 25167.0252
+  dps: 26603.74102
+  tps: 25173.1618
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 32958.2765
-  tps: 30926.81116
+  dps: 32974.0297
+  tps: 30941.56133
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-NoBuffs-LongMultiTarget"
  value: {
-  dps: 17913.47065
-  tps: 17013.21561
+  dps: 17918.25716
+  tps: 17018.45465
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-NoBuffs-LongSingleTarget"
  value: {
-  dps: 16497.5049
-  tps: 15600.57116
+  dps: 16516.33353
+  tps: 15620.96882
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 18107.41976
-  tps: 17033.4341
+  dps: 18111.70182
+  tps: 17035.30799
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv_advanced-FullBuffs-LongMultiTarget"
  value: {
-  dps: 29216.22041
-  tps: 27795.84189
+  dps: 29233.23009
+  tps: 27814.02481
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv_advanced-FullBuffs-LongSingleTarget"
  value: {
-  dps: 26594.71009
-  tps: 25167.0252
+  dps: 26603.74102
+  tps: 25173.1618
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv_advanced-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 32958.2765
-  tps: 30926.81116
+  dps: 32974.0297
+  tps: 30941.56133
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv_advanced-NoBuffs-LongMultiTarget"
  value: {
-  dps: 17913.47065
-  tps: 17013.21561
+  dps: 17918.25716
+  tps: 17018.45465
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv_advanced-NoBuffs-LongSingleTarget"
  value: {
-  dps: 16497.5049
-  tps: 15600.57116
+  dps: 16516.33353
+  tps: 15620.96882
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv_advanced-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 18107.41976
-  tps: 17033.4341
+  dps: 18111.70182
+  tps: 17035.30799
  }
 }
 dps_results: {
  key: "TestSV-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 26585.00656
-  tps: 25161.5172
+  dps: 26590.62824
+  tps: 25167.6538
  }
 }

--- a/sim/hunter/survival/TestSV.results
+++ b/sim/hunter/survival/TestSV.results
@@ -40,2160 +40,2160 @@ character_stats_results: {
 dps_results: {
  key: "TestSV-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 26603.74102
-  tps: 25173.1618
+  dps: 26660.37266
+  tps: 25218.79149
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
-  dps: 22855.50254
-  tps: 21626.61594
+  dps: 22851.11332
+  tps: 21621.43627
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 25275.56766
-  tps: 23928.37408
+  dps: 25309.90967
+  tps: 23955.68518
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 25277.69013
-  tps: 23931.1912
+  dps: 25287.61416
+  tps: 23930.80975
  }
 }
 dps_results: {
  key: "TestSV-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 25962.54829
-  tps: 24549.26077
+  dps: 26053.63211
+  tps: 24631.43832
  }
 }
 dps_results: {
  key: "TestSV-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 25962.54829
-  tps: 24549.26077
+  dps: 26053.63211
+  tps: 24631.43832
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 24777.10424
-  tps: 23450.90047
+  dps: 24873.80409
+  tps: 23553.43217
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 24518.78547
-  tps: 23202.62839
-  hps: 88.54119
+  dps: 24615.0666
+  tps: 23304.72576
+  hps: 88.83564
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 24518.78547
-  tps: 23202.62839
-  hps: 88.54119
+  dps: 24615.0666
+  tps: 23304.72576
+  hps: 88.83564
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 26005.6074
-  tps: 24587.28612
+  dps: 26077.23714
+  tps: 24648.34306
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 24846.22417
-  tps: 23532.35297
+  dps: 24893.38502
+  tps: 23577.19028
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 24910.91661
-  tps: 23597.94408
+  dps: 24903.86603
+  tps: 23583.01659
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BindingPromise-67037"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlackBruise-50035"
  value: {
-  dps: 24766.46218
-  tps: 23421.38548
+  dps: 24801.74624
+  tps: 23445.74158
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlackBruise-50692"
  value: {
-  dps: 24744.40178
-  tps: 23400.46628
+  dps: 24779.66239
+  tps: 23424.80875
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 20333.49725
-  tps: 19226.39628
+  dps: 20332.61242
+  tps: 19224.53586
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 19198.33356
-  tps: 18160.46489
+  dps: 19083.16648
+  tps: 18048.90287
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 25638.82219
-  tps: 24287.22228
+  dps: 25659.34252
+  tps: 24308.20918
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 24751.08513
-  tps: 23435.19408
+  dps: 24847.55887
+  tps: 23537.22614
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 24781.38554
-  tps: 23465.49449
+  dps: 24878.00336
+  tps: 23567.67063
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 26005.33395
-  tps: 24604.18966
+  dps: 25992.9466
+  tps: 24591.37781
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 24831.05963
-  tps: 23517.22716
+  dps: 24859.07471
+  tps: 23543.20012
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 25678.21547
-  tps: 24292.04378
+  dps: 25669.66007
+  tps: 24296.14474
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BottledLightning-66879"
  value: {
-  dps: 24731.44395
-  tps: 23421.24925
+  dps: 24705.76632
+  tps: 23388.61688
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 25962.54829
-  tps: 24058.27556
+  dps: 26053.63211
+  tps: 24138.80956
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 25962.54829
-  tps: 24058.27556
+  dps: 26053.63211
+  tps: 24138.80956
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 26603.74102
-  tps: 25173.1618
+  dps: 26660.37266
+  tps: 25218.79149
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 26603.74102
-  tps: 25173.1618
+  dps: 26660.37266
+  tps: 25218.79149
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 26384.46802
-  tps: 24971.1805
+  dps: 26479.09537
+  tps: 25056.90159
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 26478.98358
-  tps: 25056.286
+  dps: 26559.06742
+  tps: 25131.01874
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 26429.48689
-  tps: 25011.16561
+  dps: 26502.92391
+  tps: 25074.02983
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
   hps: 64
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CrushingWeight-59506"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CrushingWeight-65118"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CryptstalkerBattlegear"
  value: {
-  dps: 19881.38706
-  tps: 18736.84287
+  dps: 19870.20663
+  tps: 18731.86728
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 24644.31869
-  tps: 23325.46579
+  dps: 24619.93606
+  tps: 23301.33598
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 24682.5602
-  tps: 23361.97243
+  dps: 24721.94068
+  tps: 23409.08772
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 24938.38896
-  tps: 23607.77467
+  dps: 25013.71747
+  tps: 23682.25276
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 24944.02902
-  tps: 23628.20383
+  dps: 25043.65851
+  tps: 23733.36516
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 26004.94239
-  tps: 24633.59274
+  dps: 26084.73837
+  tps: 24716.14293
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 24820.06999
-  tps: 23504.06586
+  dps: 24917.13283
+  tps: 23606.57484
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Death'sChoice-47464"
  value: {
-  dps: 25446.20503
-  tps: 24080.85831
+  dps: 25564.98213
+  tps: 24203.63691
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 24566.54441
-  tps: 23250.16356
+  dps: 24645.07156
+  tps: 23323.2127
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 25071.6888
-  tps: 23742.20661
+  dps: 25176.49255
+  tps: 23836.52731
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 25119.26144
-  tps: 23779.56494
+  dps: 25271.46105
+  tps: 23940.61586
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Defender'sCode-40257"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 26052.70854
-  tps: 24630.01096
+  dps: 26130.00801
+  tps: 24701.95933
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 25996.46607
-  tps: 24577.67737
+  dps: 26084.91753
+  tps: 24655.70026
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 24766.79896
-  tps: 23457.23068
+  dps: 24814.02248
+  tps: 23483.95506
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 24732.33653
-  tps: 23408.7705
+  dps: 24604.28913
+  tps: 23277.67368
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 25962.54829
-  tps: 24549.26077
+  dps: 26053.63211
+  tps: 24631.43832
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 25962.54829
-  tps: 24549.26077
+  dps: 26053.63211
+  tps: 24631.43832
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 25962.54829
-  tps: 24549.26077
+  dps: 26053.63211
+  tps: 24631.43832
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 25962.54829
-  tps: 24549.26077
+  dps: 26053.63211
+  tps: 24631.43832
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 26052.70854
-  tps: 24630.01096
+  dps: 26130.00801
+  tps: 24701.95933
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 26005.6074
-  tps: 24587.28612
+  dps: 26077.23714
+  tps: 24648.34306
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 26001.69815
-  tps: 24583.37688
+  dps: 26071.83688
+  tps: 24642.9428
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 24686.49169
-  tps: 23358.98421
+  dps: 24688.00707
+  tps: 23371.97817
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 25970.13118
-  tps: 24590.82635
+  dps: 25975.78723
+  tps: 24598.66056
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 26176.5768
-  tps: 24776.35664
+  dps: 26157.34255
+  tps: 24755.36119
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 25962.54829
-  tps: 24549.26077
+  dps: 26053.63211
+  tps: 24631.43832
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 25962.54829
-  tps: 24549.26077
+  dps: 26053.63211
+  tps: 24631.43832
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 24699.82838
-  tps: 23379.38736
+  dps: 24725.77715
+  tps: 23412.33617
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 24626.80331
-  tps: 23306.28198
+  dps: 24654.35325
+  tps: 23340.83079
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FallofMortality-59500"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FallofMortality-65124"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 26786.62788
-  tps: 25349.72929
+  dps: 26795.51666
+  tps: 25351.82834
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 24781.38554
-  tps: 23465.49449
+  dps: 24878.00336
+  tps: 23567.67063
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 26015.17254
-  tps: 24601.88502
+  dps: 26106.40708
+  tps: 24684.2133
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FluidDeath-58181"
  value: {
-  dps: 26599.68828
-  tps: 25180.3751
+  dps: 26605.56186
+  tps: 25181.69305
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ForgeEmber-37660"
  value: {
-  dps: 24603.65046
-  tps: 23283.46056
+  dps: 24655.60753
+  tps: 23343.89225
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 25962.54829
-  tps: 24549.26077
+  dps: 26053.63211
+  tps: 24631.43832
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 25962.54829
-  tps: 24549.26077
+  dps: 26053.63211
+  tps: 24631.43832
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 25962.54829
-  tps: 24549.26077
+  dps: 26053.63211
+  tps: 24631.43832
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 24846.22417
-  tps: 23532.35297
+  dps: 24893.38502
+  tps: 23577.19028
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 24837.38587
-  tps: 23505.38748
+  dps: 24934.26569
+  tps: 23607.91039
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FuturesightRune-38763"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GaleofShadows-56138"
  value: {
-  dps: 24750.43609
-  tps: 23432.1519
+  dps: 24840.65289
+  tps: 23514.46616
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GaleofShadows-56462"
  value: {
-  dps: 24827.73315
-  tps: 23502.15677
+  dps: 24870.55505
+  tps: 23555.69614
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GearDetector-61462"
  value: {
-  dps: 25299.61527
-  tps: 23949.9715
+  dps: 25360.85267
+  tps: 24003.19593
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 23163.13454
-  tps: 21886.94241
+  dps: 23102.05319
+  tps: 21819.98012
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 24652.92436
-  tps: 23332.4088
+  dps: 24692.99989
+  tps: 23380.05699
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 25336.60913
-  tps: 23982.5344
+  dps: 25301.43638
+  tps: 23943.66358
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 25678.22987
-  tps: 24301.69884
+  dps: 25647.00549
+  tps: 24266.39095
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HarmlightToken-63839"
  value: {
-  dps: 24526.87483
-  tps: 23211.06059
+  dps: 24622.28981
+  tps: 23311.97871
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofRage-59224"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofRage-65072"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofSolace-55868"
  value: {
-  dps: 24750.43609
-  tps: 23432.1519
+  dps: 24840.65289
+  tps: 23514.46616
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofSolace-56393"
  value: {
-  dps: 24827.73315
-  tps: 23502.15677
+  dps: 24870.55505
+  tps: 23555.69614
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofThunder-55845"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofThunder-56370"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 25478.49601
-  tps: 24126.17601
+  dps: 25426.00656
+  tps: 24059.93956
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Heartpierce-49982"
  value: {
-  dps: 26704.56674
-  tps: 25268.81645
+  dps: 26761.33438
+  tps: 25314.53955
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Heartpierce-50641"
  value: {
-  dps: 26706.73503
-  tps: 25270.87354
+  dps: 26763.5056
+  tps: 25316.59865
  }
 }
 dps_results: {
  key: "TestSV-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 26052.70854
-  tps: 24630.01096
+  dps: 26130.00801
+  tps: 24701.95933
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 26005.6074
-  tps: 24587.28612
+  dps: 26077.23714
+  tps: 24648.34306
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 26001.69815
-  tps: 24583.37688
+  dps: 26071.83688
+  tps: 24642.9428
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 24814.44053
-  tps: 23498.54948
+  dps: 24911.21553
+  tps: 23600.8828
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 24814.44053
-  tps: 23498.54948
+  dps: 24911.21553
+  tps: 23600.8828
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 24751.08513
-  tps: 23435.19408
+  dps: 24847.55887
+  tps: 23537.22614
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 24781.38554
-  tps: 23465.49449
+  dps: 24878.00336
+  tps: 23567.67063
  }
 }
 dps_results: {
  key: "TestSV-AllItems-IncisorFragment-37723"
  value: {
-  dps: 24740.69762
-  tps: 23416.91348
+  dps: 24835.5606
+  tps: 23517.37211
  }
 }
 dps_results: {
  key: "TestSV-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 25962.54829
-  tps: 24549.26077
+  dps: 26053.63211
+  tps: 24631.43832
  }
 }
 dps_results: {
  key: "TestSV-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 24697.82987
-  tps: 23381.93882
+  dps: 24794.05037
+  tps: 23483.71764
  }
 }
 dps_results: {
  key: "TestSV-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 26007.21745
-  tps: 24591.6107
+  dps: 26098.43167
+  tps: 24673.9026
   hps: 65.53792
  }
 }
 dps_results: {
  key: "TestSV-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 25638.82219
-  tps: 24287.22228
+  dps: 25659.34252
+  tps: 24308.20918
  }
 }
 dps_results: {
  key: "TestSV-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 26194.41606
-  tps: 24791.78776
+  dps: 26071.39427
+  tps: 24666.07176
  }
 }
 dps_results: {
  key: "TestSV-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 24660.29162
-  tps: 23343.54139
+  dps: 24572.13712
+  tps: 23240.89225
  }
 }
 dps_results: {
  key: "TestSV-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 24660.29162
-  tps: 23343.54139
+  dps: 24572.13712
+  tps: 23240.89225
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 24662.9899
-  tps: 23341.45077
+  dps: 24619.25455
+  tps: 23302.68612
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LastWord-50179"
  value: {
-  dps: 26603.74102
-  tps: 25173.1618
+  dps: 26660.37266
+  tps: 25218.79149
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LastWord-50708"
  value: {
-  dps: 26603.74102
-  tps: 25173.1618
+  dps: 26660.37266
+  tps: 25218.79149
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LeadenDespair-55816"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LeadenDespair-56347"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 25541.99884
-  tps: 24175.70618
+  dps: 25593.84024
+  tps: 24218.53857
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 25712.06778
-  tps: 24332.21214
+  dps: 25820.93481
+  tps: 24443.30721
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 25277.69013
-  tps: 23931.1912
+  dps: 25287.61416
+  tps: 23930.80975
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Lightning-ChargedBattlegear"
  value: {
-  dps: 25979.25078
-  tps: 24628.52958
+  dps: 26016.97412
+  tps: 24675.82837
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 24775.81893
-  tps: 23459.92788
+  dps: 24869.10752
+  tps: 23558.77479
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 24809.35829
-  tps: 23493.46724
+  dps: 24902.37385
+  tps: 23592.04113
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 24704.44687
-  tps: 23381.6524
+  dps: 24656.41063
+  tps: 23321.28751
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 25065.88745
-  tps: 23739.93326
+  dps: 25100.85318
+  tps: 23765.24344
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 25277.69013
-  tps: 23931.1912
+  dps: 25287.61416
+  tps: 23930.80975
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 24814.44053
-  tps: 23498.54948
+  dps: 24911.21553
+  tps: 23600.8828
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 24814.44053
-  tps: 23498.54948
+  dps: 24911.21553
+  tps: 23600.8828
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 24889.66288
-  tps: 23573.77182
+  dps: 24983.67304
+  tps: 23673.34031
  }
 }
 dps_results: {
  key: "TestSV-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 24711.41769
-  tps: 23396.26472
+  dps: 24646.23562
+  tps: 23329.83875
  }
 }
 dps_results: {
  key: "TestSV-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 24825.24364
-  tps: 23514.18306
+  dps: 24725.06717
+  tps: 23408.83099
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 25998.70904
-  tps: 24583.54404
+  dps: 26089.89842
+  tps: 24665.81417
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 26007.21745
-  tps: 24591.6107
+  dps: 26098.43167
+  tps: 24673.9026
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 25962.54829
-  tps: 24549.26077
+  dps: 26053.63211
+  tps: 24631.43832
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 25962.54829
-  tps: 24549.26077
+  dps: 26053.63211
+  tps: 24631.43832
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 25962.54829
-  tps: 24549.26077
+  dps: 26053.63211
+  tps: 24631.43832
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 26015.01178
-  tps: 24616.04892
+  dps: 26062.57166
+  tps: 24670.7343
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 26176.07899
-  tps: 24789.08968
+  dps: 26067.18359
+  tps: 24664.90476
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Rainsong-55854"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Rainsong-56377"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 26481.86009
-  tps: 25059.32843
+  dps: 26553.66965
+  tps: 25120.28229
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 26384.46802
-  tps: 24971.1805
+  dps: 26479.09537
+  tps: 25056.90159
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 26384.46802
-  tps: 24971.1805
+  dps: 26479.09537
+  tps: 25056.90159
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 25962.54829
-  tps: 24549.26077
+  dps: 26053.63211
+  tps: 24631.43832
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 25275.56766
-  tps: 23928.37408
+  dps: 25309.90967
+  tps: 23955.68518
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 25277.69013
-  tps: 23931.1912
+  dps: 25287.61416
+  tps: 23930.80975
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 25271.48881
-  tps: 23910.31349
+  dps: 25390.22829
+  tps: 24034.6913
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ScourgestalkerBattlegear"
  value: {
-  dps: 20348.72909
-  tps: 19230.3773
+  dps: 20388.45973
+  tps: 19258.06272
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SeaStar-55256"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SeaStar-56290"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Shadowmourne-49623"
  value: {
-  dps: 26794.61164
-  tps: 25361.77949
+  dps: 26884.50333
+  tps: 25441.53482
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 25618.19053
-  tps: 24251.33989
+  dps: 25749.75165
+  tps: 24392.11874
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 25838.55256
-  tps: 24470.85855
+  dps: 25864.49064
+  tps: 24501.65451
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Sorrowsong-55879"
  value: {
-  dps: 24751.08513
-  tps: 23435.19408
+  dps: 24847.55887
+  tps: 23537.22614
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Sorrowsong-56400"
  value: {
-  dps: 24781.38554
-  tps: 23465.49449
+  dps: 24878.00336
+  tps: 23567.67063
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 25275.56766
-  tps: 23928.37408
+  dps: 25309.90967
+  tps: 23955.68518
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SoulCasket-58183"
  value: {
-  dps: 24814.44053
-  tps: 23498.54948
+  dps: 24911.21553
+  tps: 23600.8828
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SoulPreserver-37111"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SouloftheDead-40382"
  value: {
-  dps: 24627.39395
-  tps: 23306.87262
+  dps: 24654.35325
+  tps: 23340.83079
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SparkofLife-37657"
  value: {
-  dps: 24723.41345
-  tps: 23414.34808
+  dps: 24581.50571
+  tps: 23259.95117
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 24844.59119
-  tps: 23510.61349
+  dps: 24826.54906
+  tps: 23483.40074
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 24522.16451
-  tps: 23206.27346
+  dps: 24621.72277
+  tps: 23311.03476
  }
 }
 dps_results: {
  key: "TestSV-AllItems-StumpofTime-62465"
  value: {
-  dps: 25277.69013
-  tps: 23931.1912
+  dps: 25287.61416
+  tps: 23930.80975
  }
 }
 dps_results: {
  key: "TestSV-AllItems-StumpofTime-62470"
  value: {
-  dps: 25277.69013
-  tps: 23931.1912
+  dps: 25287.61416
+  tps: 23930.80975
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 26007.21745
-  tps: 24591.6107
+  dps: 26098.43167
+  tps: 24673.9026
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 25998.70904
-  tps: 24583.54404
+  dps: 26089.89842
+  tps: 24665.81417
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 25983.81932
-  tps: 24569.4274
+  dps: 26074.96523
+  tps: 24651.65941
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 24581.27294
-  tps: 23265.38189
+  dps: 24676.53265
+  tps: 23366.19992
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TearofBlood-55819"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TearofBlood-56351"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 24717.11195
-  tps: 23401.22089
+  dps: 24813.42413
+  tps: 23503.09141
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 24781.38554
-  tps: 23465.49449
+  dps: 24878.00336
+  tps: 23567.67063
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 24553.90175
-  tps: 23238.0107
+  dps: 24649.36196
+  tps: 23339.02924
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 25917.26515
-  tps: 24512.1596
+  dps: 25972.23856
+  tps: 24561.77088
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 25785.97034
-  tps: 24409.1368
+  dps: 25795.7465
+  tps: 24428.41518
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 24889.10255
-  tps: 23570.90984
+  dps: 24849.7248
+  tps: 23530.37886
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 24889.10255
-  tps: 23570.90984
+  dps: 24849.7248
+  tps: 23530.37886
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 25962.54829
-  tps: 24549.26077
+  dps: 26053.63211
+  tps: 24631.43832
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 25962.54829
-  tps: 24549.26077
+  dps: 26053.63211
+  tps: 24631.43832
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 24609.52036
-  tps: 23302.87656
+  dps: 24625.88733
+  tps: 23291.08113
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 25962.54829
-  tps: 24549.26077
+  dps: 26053.63211
+  tps: 24631.43832
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 25962.54829
-  tps: 24549.26077
+  dps: 26053.63211
+  tps: 24631.43832
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 19715.60037
-  tps: 18664.93729
+  dps: 19667.58567
+  tps: 18612.8018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-UnheededWarning-59520"
  value: {
-  dps: 25576.56684
-  tps: 24204.83124
+  dps: 25658.66526
+  tps: 24290.08092
  }
 }
 dps_results: {
  key: "TestSV-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 26194.97999
-  tps: 24800.85402
+  dps: 26060.88198
+  tps: 24661.91621
  }
 }
 dps_results: {
  key: "TestSV-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 26194.97999
-  tps: 24800.85402
+  dps: 26060.88198
+  tps: 24661.91621
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 24761.47837
-  tps: 23420.15938
+  dps: 24773.37485
+  tps: 23438.79834
  }
 }
 dps_results: {
  key: "TestSV-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 25884.13367
-  tps: 24490.00771
+  dps: 25752.48077
+  tps: 24353.515
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 25277.69013
-  tps: 23931.1912
+  dps: 25287.61416
+  tps: 23930.80975
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 24831.07714
-  tps: 23513.26851
+  dps: 24873.78896
+  tps: 23543.05962
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 24868.13364
-  tps: 23550.55602
+  dps: 24850.35609
+  tps: 23533.09468
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 24831.88622
-  tps: 23515.99517
+  dps: 24928.74418
+  tps: 23618.41145
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 25746.8417
-  tps: 24358.59086
+  dps: 25746.01517
+  tps: 24361.1115
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Windrunner'sPursuit"
  value: {
-  dps: 20377.58944
-  tps: 19211.82291
+  dps: 20346.634
+  tps: 19171.03674
  }
 }
 dps_results: {
  key: "TestSV-AllItems-WingedTalisman-37844"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 24519.70019
-  tps: 23203.80914
+  dps: 24615.07366
+  tps: 23304.74094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 24720.78472
-  tps: 23404.89367
+  dps: 24817.11438
+  tps: 23506.78165
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 24742.27957
-  tps: 23426.38852
+  dps: 24835.84118
+  tps: 23525.50845
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 24742.27957
-  tps: 23426.38852
+  dps: 24835.84118
+  tps: 23525.50845
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Zod'sRepeatingLongbow-50034"
  value: {
-  dps: 23603.52594
-  tps: 22240.21786
+  dps: 23696.42583
+  tps: 22336.45862
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 23900.41203
-  tps: 22534.56076
+  dps: 23906.09319
+  tps: 22528.15231
  }
 }
 dps_results: {
  key: "TestSV-Average-Default"
  value: {
-  dps: 26530.9959
-  tps: 25107.46335
+  dps: 26553.8304
+  tps: 25128.5234
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-FullBuffs-LongMultiTarget"
  value: {
-  dps: 62915.64416
-  tps: 61768.3219
+  dps: 62957.06693
+  tps: 61812.66354
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-FullBuffs-LongSingleTarget"
  value: {
-  dps: 20033.33079
-  tps: 18894.58304
+  dps: 20071.98276
+  tps: 18936.41836
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 24065.80665
-  tps: 22471.6685
+  dps: 24022.88801
+  tps: 22425.61542
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-NoBuffs-LongMultiTarget"
  value: {
-  dps: 39487.49255
-  tps: 38747.92478
+  dps: 39493.51658
+  tps: 38753.6786
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-NoBuffs-LongSingleTarget"
  value: {
-  dps: 12014.97415
-  tps: 11277.08617
+  dps: 12027.63307
+  tps: 11289.08158
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 12816.25404
-  tps: 11965.51795
+  dps: 12840.24349
+  tps: 11984.24333
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-FullBuffs-LongMultiTarget"
  value: {
-  dps: 28838.97887
-  tps: 27499.87955
+  dps: 28846.8254
+  tps: 27507.97289
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-FullBuffs-LongSingleTarget"
  value: {
-  dps: 26314.32385
-  tps: 24965.13962
+  dps: 26368.08737
+  tps: 25008.54717
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 32403.73446
-  tps: 30500.89412
+  dps: 32488.35625
+  tps: 30562.37014
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-NoBuffs-LongMultiTarget"
  value: {
-  dps: 17646.41898
-  tps: 16797.96287
+  dps: 17621.8564
+  tps: 16772.29278
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-NoBuffs-LongSingleTarget"
  value: {
-  dps: 16320.15425
-  tps: 15475.92134
+  dps: 16435.617
+  tps: 15586.52222
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 17762.59472
-  tps: 16756.43155
+  dps: 17787.37737
+  tps: 16778.32628
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv_advanced-FullBuffs-LongMultiTarget"
  value: {
-  dps: 28838.97887
-  tps: 27499.87955
+  dps: 28846.8254
+  tps: 27507.97289
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv_advanced-FullBuffs-LongSingleTarget"
  value: {
-  dps: 26314.32385
-  tps: 24965.13962
+  dps: 26368.08737
+  tps: 25008.54717
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv_advanced-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 32403.73446
-  tps: 30500.89412
+  dps: 32488.35625
+  tps: 30562.37014
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv_advanced-NoBuffs-LongMultiTarget"
  value: {
-  dps: 17646.41898
-  tps: 16797.96287
+  dps: 17621.8564
+  tps: 16772.29278
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv_advanced-NoBuffs-LongSingleTarget"
  value: {
-  dps: 16320.15425
-  tps: 15475.92134
+  dps: 16435.617
+  tps: 15586.52222
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv_advanced-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 17762.59472
-  tps: 16756.43155
+  dps: 17787.37737
+  tps: 16778.32628
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-FullBuffs-LongMultiTarget"
  value: {
-  dps: 63587.12376
-  tps: 62369.46041
+  dps: 63632.40849
+  tps: 62417.85233
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-FullBuffs-LongSingleTarget"
  value: {
-  dps: 20289.30756
-  tps: 19081.21917
+  dps: 20328.39314
+  tps: 19123.57843
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 24571.34935
-  tps: 22866.84429
+  dps: 24528.62878
+  tps: 22820.78544
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-NoBuffs-LongMultiTarget"
  value: {
-  dps: 39949.43559
-  tps: 39164.44667
+  dps: 39955.55682
+  tps: 39170.28415
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-NoBuffs-LongSingleTarget"
  value: {
-  dps: 12187.58758
-  tps: 11404.35295
+  dps: 12200.47578
+  tps: 11416.5444
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 13121.65154
-  tps: 12209.94131
+  dps: 13146.51513
+  tps: 12229.27695
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-FullBuffs-LongMultiTarget"
  value: {
-  dps: 29233.23009
-  tps: 27814.02481
+  dps: 29243.25625
+  tps: 27824.17154
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-FullBuffs-LongSingleTarget"
  value: {
-  dps: 26603.74102
-  tps: 25173.1618
+  dps: 26660.37266
+  tps: 25218.79149
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 32974.0297
-  tps: 30941.56133
+  dps: 33059.83732
+  tps: 31003.06921
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-NoBuffs-LongMultiTarget"
  value: {
-  dps: 17918.25716
-  tps: 17018.45465
+  dps: 17892.47106
+  tps: 16991.58231
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-NoBuffs-LongSingleTarget"
  value: {
-  dps: 16516.33353
-  tps: 15620.96882
+  dps: 16623.53369
+  tps: 15724.4229
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 18111.70182
-  tps: 17035.30799
+  dps: 18137.17922
+  tps: 17057.97442
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv_advanced-FullBuffs-LongMultiTarget"
  value: {
-  dps: 29233.23009
-  tps: 27814.02481
+  dps: 29243.25625
+  tps: 27824.17154
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv_advanced-FullBuffs-LongSingleTarget"
  value: {
-  dps: 26603.74102
-  tps: 25173.1618
+  dps: 26660.37266
+  tps: 25218.79149
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv_advanced-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 32974.0297
-  tps: 30941.56133
+  dps: 33059.83732
+  tps: 31003.06921
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv_advanced-NoBuffs-LongMultiTarget"
  value: {
-  dps: 17918.25716
-  tps: 17018.45465
+  dps: 17892.47106
+  tps: 16991.58231
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv_advanced-NoBuffs-LongSingleTarget"
  value: {
-  dps: 16516.33353
-  tps: 15620.96882
+  dps: 16623.53369
+  tps: 15724.4229
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv_advanced-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 18111.70182
-  tps: 17035.30799
+  dps: 18137.17922
+  tps: 17057.97442
  }
 }
 dps_results: {
  key: "TestSV-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 26590.62824
-  tps: 25167.6538
+  dps: 26648.14909
+  tps: 25213.36449
  }
 }

--- a/sim/hunter/survival/survival_test.go
+++ b/sim/hunter/survival/survival_test.go
@@ -56,14 +56,15 @@ func BenchmarkSimulate(b *testing.B) {
 	rsr := &proto.RaidSimRequest{
 		Raid: core.SinglePlayerRaidProto(
 			&proto.Player{
-				Race:          proto.Race_RaceOrc,
-				Class:         proto.Class_ClassHunter,
-				Equipment:     core.GetGearSet("../../ui/hunter/survival/gear_sets", "preraid_sv").GearSet,
-				Consumes:      FullConsumes,
-				Spec:          PlayerOptionsBasic,
-				Glyphs:        SVGlyphs,
-				TalentsString: SVTalents,
-				Buffs:         core.FullIndividualBuffs,
+				Race:           proto.Race_RaceOrc,
+				Class:          proto.Class_ClassHunter,
+				Equipment:      core.GetGearSet("../../ui/hunter/survival/gear_sets", "preraid_sv").GearSet,
+				Consumes:       FullConsumes,
+				Spec:           PlayerOptionsBasic,
+				Glyphs:         SVGlyphs,
+				TalentsString:  SVTalents,
+				Buffs:          core.FullIndividualBuffs,
+				ReactionTimeMs: 100,
 			},
 			core.FullPartyBuffs,
 			core.FullRaidBuffs,

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -40,8 +40,8 @@ character_stats_results: {
 dps_results: {
  key: "TestShadow-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 27217.05189
-  tps: 25987.75274
+  dps: 27212.41047
+  tps: 25984.16579
  }
 }
 dps_results: {
@@ -75,15 +75,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 26751.47937
-  tps: 25530.34138
+  dps: 26747.33785
+  tps: 25527.15808
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 26751.47937
-  tps: 25530.34138
+  dps: 26747.33785
+  tps: 25527.15808
  }
 }
 dps_results: {
@@ -140,22 +140,22 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-BindingPromise-67037"
  value: {
-  dps: 25716.94137
-  tps: 24536.52586
+  dps: 25717.42807
+  tps: 24537.01255
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 17401.93772
-  tps: 16745.19055
+  dps: 17430.17415
+  tps: 16781.22003
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 26108.51101
-  tps: 24858.69268
+  dps: 26107.9314
+  tps: 24858.11307
  }
 }
 dps_results: {
@@ -175,22 +175,22 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 25767.74351
-  tps: 24517.92518
+  dps: 25767.1639
+  tps: 24517.34557
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 26585.65801
-  tps: 25330.9009
+  dps: 26585.27262
+  tps: 25330.37532
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 25716.94137
-  tps: 24536.52586
+  dps: 25717.42807
+  tps: 24537.01255
  }
 }
 dps_results: {
@@ -203,15 +203,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 25743.93115
-  tps: 24560.44806
+  dps: 25744.41785
+  tps: 24560.93476
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 25716.94137
-  tps: 24536.52586
+  dps: 25717.42807
+  tps: 24537.01255
  }
 }
 dps_results: {
@@ -238,43 +238,43 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-BottledLightning-66879"
  value: {
-  dps: 26475.84822
-  tps: 25308.65284
+  dps: 26476.13123
+  tps: 25308.89617
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 26814.87502
-  tps: 25086.60605
+  dps: 26810.72803
+  tps: 25083.48434
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 26948.5323
-  tps: 25183.68698
+  dps: 26947.16042
+  tps: 25182.34254
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 27419.56486
-  tps: 26151.86509
+  dps: 27418.07014
+  tps: 26150.37037
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 27359.6952
-  tps: 26073.08302
+  dps: 27355.72966
+  tps: 26069.06406
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 27256.81671
-  tps: 25985.14051
+  dps: 27251.49399
+  tps: 25980.84209
  }
 }
 dps_results: {
@@ -301,23 +301,23 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 25716.94137
-  tps: 24536.52586
+  dps: 25717.42807
+  tps: 24537.01255
   hps: 64
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CrimsonAcolyte'sRaiment"
  value: {
-  dps: 19068.45157
-  tps: 18237.03043
+  dps: 19013.94219
+  tps: 18212.58272
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CrimsonAcolyte'sRegalia"
  value: {
-  dps: 20082.88132
-  tps: 19132.88987
+  dps: 20092.48972
+  tps: 19141.19915
  }
 }
 dps_results: {
@@ -351,15 +351,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 25716.94137
-  tps: 24536.52586
+  dps: 25717.42807
+  tps: 24537.01255
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 26441.7354
-  tps: 25267.48352
+  dps: 26440.59845
+  tps: 25266.34657
  }
 }
 dps_results: {
@@ -421,50 +421,50 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-Defender'sCode-40257"
  value: {
-  dps: 25716.94137
-  tps: 24536.52586
+  dps: 25717.42807
+  tps: 24537.01255
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 26888.50594
-  tps: 25610.73662
+  dps: 26884.96155
+  tps: 25607.13403
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 26791.79398
-  tps: 25528.76055
+  dps: 26786.9319
+  tps: 25524.82653
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 26587.44085
-  tps: 25361.59929
+  dps: 26592.92572
+  tps: 25368.18871
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 26560.28329
-  tps: 25324.86145
+  dps: 26562.47311
+  tps: 25327.05126
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 26751.47937
-  tps: 25530.34138
+  dps: 26747.33785
+  tps: 25527.15808
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 26751.47937
-  tps: 25530.34138
+  dps: 26747.33785
+  tps: 25527.15808
  }
 }
 dps_results: {
@@ -491,29 +491,29 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 26888.50594
-  tps: 25610.73662
+  dps: 26884.96155
+  tps: 25607.13403
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 26791.79398
-  tps: 25528.76055
+  dps: 26786.9319
+  tps: 25524.82653
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 26788.64378
-  tps: 25525.61035
+  dps: 26783.78171
+  tps: 25521.67633
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 26018.30311
-  tps: 24747.84725
+  dps: 26015.22548
+  tps: 24744.75847
  }
 }
 dps_results: {
@@ -540,15 +540,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 26751.47937
-  tps: 25530.34138
+  dps: 26747.33785
+  tps: 25527.15808
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 26751.47937
-  tps: 25530.34138
+  dps: 26747.33785
+  tps: 25527.15808
  }
 }
 dps_results: {
@@ -575,15 +575,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-FallofMortality-65124"
  value: {
-  dps: 26902.59495
-  tps: 25729.67765
+  dps: 26926.39128
+  tps: 25753.42026
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 25794.67987
-  tps: 24539.83633
+  dps: 25794.10026
+  tps: 24539.25672
  }
 }
 dps_results: {
@@ -596,8 +596,8 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 25716.94137
-  tps: 24536.52586
+  dps: 25717.42807
+  tps: 24537.01255
  }
 }
 dps_results: {
@@ -610,8 +610,8 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 26161.77184
-  tps: 24981.35633
+  dps: 26162.26716
+  tps: 24981.85165
  }
 }
 dps_results: {
@@ -624,8 +624,8 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 26839.02442
-  tps: 25617.88643
+  dps: 26834.91959
+  tps: 25614.73982
  }
 }
 dps_results: {
@@ -645,29 +645,29 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-ForgeEmber-37660"
  value: {
-  dps: 25926.74056
-  tps: 24736.50721
+  dps: 25926.54944
+  tps: 24736.31608
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 26948.5323
-  tps: 25688.93963
+  dps: 26947.16042
+  tps: 25687.56776
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 26814.87502
-  tps: 25589.97927
+  dps: 26810.72803
+  tps: 25586.793
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 26802.19589
-  tps: 25578.05169
+  dps: 26798.05
+  tps: 25574.86602
  }
 }
 dps_results: {
@@ -687,29 +687,29 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-FuturesightRune-38763"
  value: {
-  dps: 25887.22428
-  tps: 24694.33729
+  dps: 25887.71441
+  tps: 24694.82741
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GaleofShadows-56138"
  value: {
-  dps: 26871.39973
-  tps: 25600.27041
+  dps: 26884.2116
+  tps: 25617.51106
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GaleofShadows-56462"
  value: {
-  dps: 27028.72176
-  tps: 25697.05239
+  dps: 27029.04218
+  tps: 25697.37281
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GarbofFaith"
  value: {
-  dps: 16699.41602
-  tps: 16044.90885
+  dps: 16728.29767
+  tps: 16020.79059
  }
 }
 dps_results: {
@@ -722,36 +722,36 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-Gladiator'sInvestiture"
  value: {
-  dps: 20968.88107
-  tps: 20054.55213
+  dps: 20997.44108
+  tps: 20086.12333
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Gladiator'sRaiment"
  value: {
-  dps: 25424.2336
-  tps: 24344.59852
+  dps: 25424.4431
+  tps: 24344.82142
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 26195.49135
-  tps: 24986.2841
+  dps: 26195.98856
+  tps: 24986.78131
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 26258.45845
-  tps: 25045.46282
+  dps: 26258.95704
+  tps: 25045.96141
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 25831.68227
-  tps: 24629.77396
+  dps: 25831.10267
+  tps: 24629.19435
  }
 }
 dps_results: {
@@ -771,8 +771,8 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-HarmlightToken-63839"
  value: {
-  dps: 26700.46053
-  tps: 25466.98368
+  dps: 26700.58221
+  tps: 25467.10535
  }
 }
 dps_results: {
@@ -785,8 +785,8 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 27055.372
-  tps: 25772.90223
+  dps: 27056.66999
+  tps: 25774.20022
  }
 }
 dps_results: {
@@ -806,15 +806,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-HeartofSolace-55868"
  value: {
-  dps: 26146.45471
-  tps: 24916.61199
+  dps: 26158.90189
+  tps: 24933.35698
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-HeartofSolace-56393"
  value: {
-  dps: 26206.28007
-  tps: 24922.19015
+  dps: 26206.59754
+  tps: 24922.50762
  }
 }
 dps_results: {
@@ -841,15 +841,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-Heartpierce-49982"
  value: {
-  dps: 27419.56486
-  tps: 26151.86509
+  dps: 27418.07014
+  tps: 26150.37037
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Heartpierce-50641"
  value: {
-  dps: 27419.56486
-  tps: 26151.86509
+  dps: 27418.07014
+  tps: 26150.37037
  }
 }
 dps_results: {
@@ -862,64 +862,64 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 26888.50594
-  tps: 25610.73662
+  dps: 26884.96155
+  tps: 25607.13403
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 26791.79398
-  tps: 25528.76055
+  dps: 26786.9319
+  tps: 25524.82653
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 26788.64378
-  tps: 25525.61035
+  dps: 26783.78171
+  tps: 25521.67633
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 26217.96095
-  tps: 25037.54544
+  dps: 26218.45737
+  tps: 25038.04185
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 26217.96095
-  tps: 25037.54544
+  dps: 26218.45737
+  tps: 25038.04185
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 26141.21089
-  tps: 24896.6983
+  dps: 26140.63128
+  tps: 24896.1187
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 26192.47308
-  tps: 24947.96049
+  dps: 26191.89347
+  tps: 24947.38089
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-IncisorFragment-37723"
  value: {
-  dps: 25716.94137
-  tps: 24536.52586
+  dps: 25717.42807
+  tps: 24537.01255
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 26908.92803
-  tps: 25648.69858
+  dps: 26910.88598
+  tps: 25650.65653
  }
 }
 dps_results: {
@@ -932,36 +932,36 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 26609.3442
-  tps: 25301.72332
+  dps: 26608.7646
+  tps: 25301.14371
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 26751.47937
-  tps: 25530.34138
+  dps: 26747.33785
+  tps: 25527.15808
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 25859.16375
-  tps: 24717.93345
+  dps: 25857.82829
+  tps: 24716.59799
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 25868.20571
-  tps: 24727.34675
+  dps: 25868.77655
+  tps: 24726.79292
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 26108.51101
-  tps: 24858.69268
+  dps: 26107.9314
+  tps: 24858.11307
  }
 }
 dps_results: {
@@ -995,29 +995,29 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 26002.37607
-  tps: 24821.07289
+  dps: 26007.2068
+  tps: 24825.90362
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-LastWord-50179"
  value: {
-  dps: 27419.56486
-  tps: 26151.86509
+  dps: 27418.07014
+  tps: 26150.37037
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-LastWord-50708"
  value: {
-  dps: 27419.56486
-  tps: 26151.86509
+  dps: 27418.07014
+  tps: 26150.37037
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 25716.94137
-  tps: 24536.52586
+  dps: 25717.42807
+  tps: 24537.01255
  }
 }
 dps_results: {
@@ -1058,15 +1058,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 25767.74351
-  tps: 24517.92518
+  dps: 25767.1639
+  tps: 24517.34557
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 25767.74351
-  tps: 24517.92518
+  dps: 25767.1639
+  tps: 24517.34557
  }
 }
 dps_results: {
@@ -1093,22 +1093,22 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 26185.87249
-  tps: 24936.05416
+  dps: 26185.29289
+  tps: 24935.47456
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 26240.62748
-  tps: 24990.80915
+  dps: 26240.04787
+  tps: 24990.22954
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MercurialRegalia"
  value: {
-  dps: 24541.00386
-  tps: 23351.41217
+  dps: 24536.98033
+  tps: 23348.44568
  }
 }
 dps_results: {
@@ -1121,36 +1121,36 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 25794.67987
-  tps: 24539.83633
+  dps: 25794.10026
+  tps: 24539.25672
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 25794.67987
-  tps: 24539.83633
+  dps: 25794.10026
+  tps: 24539.25672
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 26248.39547
-  tps: 25003.88288
+  dps: 26247.81586
+  tps: 25003.30327
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 26248.39547
-  tps: 25003.88288
+  dps: 26247.81586
+  tps: 25003.30327
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 27490.75979
-  tps: 26320.31234
+  dps: 27486.88524
+  tps: 26315.32996
  }
 }
 dps_results: {
@@ -1170,22 +1170,22 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 25956.67437
-  tps: 24790.51252
+  dps: 25956.48324
+  tps: 24790.32139
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 26751.47937
-  tps: 25530.34138
+  dps: 26747.33785
+  tps: 25527.15808
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 26751.47937
-  tps: 25530.34138
+  dps: 26747.33785
+  tps: 25527.15808
  }
 }
 dps_results: {
@@ -1226,22 +1226,22 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 26751.47937
-  tps: 25530.34138
+  dps: 26747.33785
+  tps: 25527.15808
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 26751.47937
-  tps: 25530.34138
+  dps: 26747.33785
+  tps: 25527.15808
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 26751.47937
-  tps: 25530.34138
+  dps: 26747.33785
+  tps: 25527.15808
  }
 }
 dps_results: {
@@ -1282,8 +1282,8 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-RegaliaofFaith"
  value: {
-  dps: 16480.58205
-  tps: 15870.73581
+  dps: 16452.75
+  tps: 15839.80112
  }
 }
 dps_results: {
@@ -1303,29 +1303,29 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 27217.05189
-  tps: 25987.75274
+  dps: 27212.41047
+  tps: 25984.16579
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 27217.05189
-  tps: 25987.75274
+  dps: 27212.41047
+  tps: 25984.16579
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 27198.52931
-  tps: 26007.98657
+  dps: 27193.88789
+  tps: 26004.39961
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 26705.16831
-  tps: 25488.45911
+  dps: 26691.05345
+  tps: 25472.53247
  }
 }
 dps_results: {
@@ -1345,22 +1345,22 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 25716.94137
-  tps: 24536.52586
+  dps: 25717.42807
+  tps: 24537.01255
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SanctificationGarb"
  value: {
-  dps: 17204.6299
-  tps: 16506.6613
+  dps: 17251.22097
+  tps: 16551.84783
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SanctificationRegalia"
  value: {
-  dps: 17068.31969
-  tps: 16439.09515
+  dps: 17060.04395
+  tps: 16422.95081
  }
 }
 dps_results: {
@@ -1373,22 +1373,22 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-SeaStar-55256"
  value: {
-  dps: 26181.14039
-  tps: 24960.23776
+  dps: 26181.18817
+  tps: 24960.21499
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SeaStar-56290"
  value: {
-  dps: 26558.47826
-  tps: 25305.15437
+  dps: 26558.14738
+  tps: 25304.69206
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 25716.94137
-  tps: 24536.52586
+  dps: 25717.42807
+  tps: 24537.01255
  }
 }
 dps_results: {
@@ -1408,22 +1408,22 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 25749.75417
-  tps: 24505.24158
+  dps: 25749.17456
+  tps: 24504.66197
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 26149.65219
-  tps: 24969.23668
+  dps: 26149.04471
+  tps: 24968.6292
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 26206.31671
-  tps: 25025.90119
+  dps: 26205.56594
+  tps: 25025.15043
  }
 }
 dps_results: {
@@ -1436,8 +1436,8 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 26270.77485
-  tps: 25043.51656
+  dps: 26272.05101
+  tps: 25044.97281
  }
 }
 dps_results: {
@@ -1457,15 +1457,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 25794.67987
-  tps: 24539.83633
+  dps: 25794.10026
+  tps: 24539.25672
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SoulCasket-58183"
  value: {
-  dps: 27338.43416
-  tps: 26063.77738
+  dps: 27337.77257
+  tps: 26062.93814
  }
 }
 dps_results: {
@@ -1478,8 +1478,8 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-SouloftheDead-40382"
  value: {
-  dps: 25920.5213
-  tps: 24740.4649
+  dps: 25921.02722
+  tps: 24740.97082
  }
 }
 dps_results: {
@@ -1492,8 +1492,8 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 25743.93115
-  tps: 24560.44806
+  dps: 25744.41785
+  tps: 24560.93476
  }
 }
 dps_results: {
@@ -1520,22 +1520,22 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 26751.47937
-  tps: 25530.34138
+  dps: 26747.33785
+  tps: 25527.15808
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 26751.47937
-  tps: 25530.34138
+  dps: 26747.33785
+  tps: 25527.15808
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 26751.47937
-  tps: 25530.34138
+  dps: 26747.33785
+  tps: 25527.15808
  }
 }
 dps_results: {
@@ -1562,8 +1562,8 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 25743.93115
-  tps: 24560.44806
+  dps: 25744.41785
+  tps: 24560.93476
  }
 }
 dps_results: {
@@ -1576,8 +1576,8 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-TearofBlood-55819"
  value: {
-  dps: 26487.90991
-  tps: 25307.03833
+  dps: 26488.12266
+  tps: 25307.25107
  }
 }
 dps_results: {
@@ -1590,8 +1590,8 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 26092.59894
-  tps: 24943.81536
+  dps: 26089.22859
+  tps: 24940.44501
  }
 }
 dps_results: {
@@ -1639,8 +1639,8 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 26751.47937
-  tps: 25530.34138
+  dps: 26747.33785
+  tps: 25527.15808
  }
 }
 dps_results: {
@@ -1674,36 +1674,36 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 26814.87502
-  tps: 25589.97927
+  dps: 26810.72803
+  tps: 25586.793
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 26802.19589
-  tps: 25578.05169
+  dps: 26798.05
+  tps: 25574.86602
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 26029.64982
-  tps: 24759.75297
+  dps: 26028.68651
+  tps: 24758.78967
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 26802.19589
-  tps: 25578.05169
+  dps: 26798.05
+  tps: 25574.86602
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 26814.87502
-  tps: 25589.97927
+  dps: 26810.72803
+  tps: 25586.793
  }
 }
 dps_results: {
@@ -1723,85 +1723,85 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 25743.93115
-  tps: 24560.44806
+  dps: 25744.41785
+  tps: 24560.93476
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 26217.96095
-  tps: 25037.54544
+  dps: 26218.45737
+  tps: 25038.04185
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 26217.96095
-  tps: 25037.54544
+  dps: 26218.45737
+  tps: 25038.04185
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 22633.29872
-  tps: 21627.89268
+  dps: 22639.2216
+  tps: 21632.85785
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-VestmentsofAbsolution"
  value: {
-  dps: 10680.10114
-  tps: 10086.28822
+  dps: 10700.88407
+  tps: 10102.75845
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 25716.94137
-  tps: 24536.52586
+  dps: 25717.42807
+  tps: 24537.01255
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 25716.94137
-  tps: 24536.52586
+  dps: 25717.42807
+  tps: 24537.01255
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 25716.94137
-  tps: 24536.52586
+  dps: 25717.42807
+  tps: 24537.01255
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 26634.24649
-  tps: 25375.32319
+  dps: 26633.81233
+  tps: 25374.741
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 25716.94137
-  tps: 24536.52586
+  dps: 25717.42807
+  tps: 24537.01255
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 25743.93115
-  tps: 24560.44806
+  dps: 25744.41785
+  tps: 24560.93476
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 26322.49653
-  tps: 25070.83775
+  dps: 26317.99703
+  tps: 25066.33824
  }
 }
 dps_results: {
@@ -1814,22 +1814,22 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 25716.94137
-  tps: 24536.52586
+  dps: 25717.42807
+  tps: 24537.01255
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 26247.61631
-  tps: 25067.2008
+  dps: 26248.11331
+  tps: 25067.69779
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 25716.94137
-  tps: 24536.52586
+  dps: 25717.42807
+  tps: 24537.01255
  }
 }
 dps_results: {
@@ -1856,78 +1856,78 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-WingedTalisman-37844"
  value: {
-  dps: 25914.61994
-  tps: 24717.3507
+  dps: 25914.90813
+  tps: 24717.60697
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 26774.22181
-  tps: 25520.68069
+  dps: 26773.73157
+  tps: 25520.19046
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 27341.55398
-  tps: 26126.42112
+  dps: 27338.98048
+  tps: 26123.84762
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 26058.75847
-  tps: 24878.34295
+  dps: 26059.25179
+  tps: 24878.83628
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 26131.11751
-  tps: 24881.29918
+  dps: 26130.5379
+  tps: 24880.71957
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 26131.11751
-  tps: 24881.29918
+  dps: 26130.5379
+  tps: 24880.71957
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Zabra'sRaiment"
  value: {
-  dps: 17879.035
-  tps: 17184.61436
+  dps: 17867.54217
+  tps: 17177.20728
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Zabra'sRegalia"
  value: {
-  dps: 17518.72266
-  tps: 16648.06022
+  dps: 17517.53287
+  tps: 16646.53059
  }
 }
 dps_results: {
  key: "TestShadow-Average-Default"
  value: {
-  dps: 27303.61018
-  tps: 26186.45719
+  dps: 27302.26806
+  tps: 26186.33317
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Basic-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 27016.04916
-  tps: 33473.17524
+  dps: 27016.79471
+  tps: 33473.92078
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Basic-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 27016.04916
-  tps: 25750.73317
+  dps: 27016.79471
+  tps: 25751.47872
  }
 }
 dps_results: {
@@ -1940,15 +1940,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Basic-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13858.8666
-  tps: 19428.59566
+  dps: 13859.38122
+  tps: 19440.49517
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Basic-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 13858.8666
-  tps: 13403.6494
+  dps: 13859.38122
+  tps: 13404.37413
  }
 }
 dps_results: {
@@ -1961,15 +1961,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Basic-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 27040.53563
-  tps: 33491.24158
+  dps: 27041.28118
+  tps: 33491.98713
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Basic-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 27040.53563
-  tps: 25770.33916
+  dps: 27041.28118
+  tps: 25771.08471
  }
 }
 dps_results: {
@@ -1982,15 +1982,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Basic-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 13876.09578
-  tps: 19408.44579
+  dps: 13876.6104
+  tps: 19420.3453
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Basic-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 13876.09578
-  tps: 13402.92641
+  dps: 13876.6104
+  tps: 13403.65114
  }
 }
 dps_results: {
@@ -2003,15 +2003,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-Troll-p1-Basic-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 27419.56486
-  tps: 34251.70047
+  dps: 27418.07014
+  tps: 34250.20575
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Troll-p1-Basic-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 27419.56486
-  tps: 26151.86509
+  dps: 27418.07014
+  tps: 26150.37037
  }
 }
 dps_results: {
@@ -2024,15 +2024,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-Troll-p1-Basic-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14017.77384
-  tps: 19542.98987
+  dps: 13998.29391
+  tps: 19624.98607
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Troll-p1-Basic-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 14017.77384
-  tps: 13489.44378
+  dps: 13998.29391
+  tps: 13501.47171
  }
 }
 dps_results: {
@@ -2045,7 +2045,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 27409.32936
-  tps: 26151.86509
+  dps: 27407.83464
+  tps: 26150.37037
  }
 }

--- a/sim/rogue/assassination/TestAssassination.results
+++ b/sim/rogue/assassination/TestAssassination.results
@@ -40,2209 +40,2209 @@ character_stats_results: {
 dps_results: {
  key: "TestAssassination-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 11185.62976
-  tps: 7941.79713
+  dps: 11184.73996
+  tps: 7941.16537
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 10851.17333
-  tps: 7704.33307
+  dps: 10850.28086
+  tps: 7703.69941
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 10899.10349
-  tps: 7738.36348
+  dps: 10898.53879
+  tps: 7737.96254
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 10616.82546
-  tps: 7537.94607
+  dps: 10615.96654
+  tps: 7537.33624
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 10965.31612
-  tps: 7785.37444
+  dps: 10964.4193
+  tps: 7784.7377
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 10965.31612
-  tps: 7785.37444
+  dps: 10964.4193
+  tps: 7784.7377
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 10803.30682
-  tps: 7670.34785
+  dps: 10802.88345
+  tps: 7670.04725
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
   hps: 81.71278
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
   hps: 81.71278
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 10987.19485
-  tps: 7800.90834
+  dps: 10986.3329
+  tps: 7800.29636
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 10744.12997
-  tps: 7628.33228
+  dps: 10743.27808
+  tps: 7627.72743
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 10752.16844
-  tps: 7634.03959
+  dps: 10751.18292
+  tps: 7633.33987
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BindingPromise-67037"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BlackBruise-50035"
  value: {
-  dps: 10346.98273
-  tps: 7346.35774
+  dps: 10346.65854
+  tps: 7346.12756
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BlackBruise-50692"
  value: {
-  dps: 10411.50022
-  tps: 7392.16516
+  dps: 10411.17681
+  tps: 7391.93553
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 9077.21712
-  tps: 6444.82415
+  dps: 9076.63541
+  tps: 6444.41114
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 11392.7483
-  tps: 8088.85129
+  dps: 11391.89353
+  tps: 8088.2444
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 10806.85224
-  tps: 7672.86509
+  dps: 10806.07643
+  tps: 7672.31426
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 10834.00252
-  tps: 7692.14179
+  dps: 10833.22534
+  tps: 7691.58999
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 11706.84852
-  tps: 8311.86245
+  dps: 11706.37205
+  tps: 8311.52415
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 10965.74141
-  tps: 7785.6764
+  dps: 10965.17994
+  tps: 7785.27776
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 10724.0875
-  tps: 7614.10213
+  dps: 10723.2356
+  tps: 7613.49728
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 11447.79487
-  tps: 8127.93436
+  dps: 11447.08858
+  tps: 8127.43289
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 10949.6673
-  tps: 7774.26379
+  dps: 10948.92618
+  tps: 7773.73759
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BonescytheBattlegear"
  value: {
-  dps: 10491.04975
-  tps: 7448.64533
+  dps: 10491.06802
+  tps: 7448.6583
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BottledLightning-66879"
  value: {
-  dps: 10691.2744
-  tps: 7590.80482
+  dps: 10690.44221
+  tps: 7590.21397
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 10965.31612
-  tps: 7629.66695
+  dps: 10964.4193
+  tps: 7629.04295
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 10965.31612
-  tps: 7629.66695
+  dps: 10964.4193
+  tps: 7629.04295
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 11044.11439
-  tps: 7841.32122
+  dps: 11043.1973
+  tps: 7840.67008
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 11099.18516
-  tps: 7880.42146
+  dps: 11098.34712
+  tps: 7879.82646
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 11066.64481
-  tps: 7857.31782
+  dps: 11065.76258
+  tps: 7856.69143
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
   hps: 64
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CrushingWeight-59506"
  value: {
-  dps: 11173.30036
-  tps: 7933.04325
+  dps: 11172.96445
+  tps: 7932.80476
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CrushingWeight-65118"
  value: {
-  dps: 11267.93549
-  tps: 8000.2342
+  dps: 11267.94692
+  tps: 8000.24232
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 10678.68136
-  tps: 7581.86377
+  dps: 10677.82244
+  tps: 7581.25394
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 10698.53472
-  tps: 7595.95965
+  dps: 10698.17633
+  tps: 7595.70519
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 10891.45283
-  tps: 7732.93151
+  dps: 10890.5454
+  tps: 7732.28724
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 11310.52406
-  tps: 8030.47208
+  dps: 11309.59027
+  tps: 8029.80909
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 11762.17401
-  tps: 8351.14355
+  dps: 11760.93559
+  tps: 8350.26427
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 10910.58852
-  tps: 7746.51785
+  dps: 10909.80986
+  tps: 7745.965
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Death'sChoice-47464"
  value: {
-  dps: 11378.04349
-  tps: 8078.41088
+  dps: 11377.32572
+  tps: 8077.90126
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 10635.89958
-  tps: 7551.4887
+  dps: 10635.04768
+  tps: 7550.88386
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 11022.6915
-  tps: 7826.11096
+  dps: 11021.71407
+  tps: 7825.41699
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 11112.43284
-  tps: 7889.82731
+  dps: 11111.94807
+  tps: 7889.48313
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Defender'sCode-40257"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 11018.5595
-  tps: 7823.17724
+  dps: 11017.74174
+  tps: 7822.59664
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 10988.19731
-  tps: 7801.62009
+  dps: 10987.33536
+  tps: 7801.0081
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 10665.9317
-  tps: 7572.81151
+  dps: 10665.49262
+  tps: 7572.49976
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 10649.66294
-  tps: 7561.26069
+  dps: 10641.88867
+  tps: 7555.74095
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 10965.31612
-  tps: 7785.37444
+  dps: 10964.4193
+  tps: 7784.7377
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 10965.31612
-  tps: 7785.37444
+  dps: 10964.4193
+  tps: 7784.7377
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 10965.31612
-  tps: 7785.37444
+  dps: 10964.4193
+  tps: 7784.7377
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 10965.31612
-  tps: 7785.37444
+  dps: 10964.4193
+  tps: 7784.7377
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 11018.5595
-  tps: 7823.17724
+  dps: 11017.74174
+  tps: 7822.59664
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 10987.19485
-  tps: 7800.90834
+  dps: 10986.3329
+  tps: 7800.29636
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 10986.24506
-  tps: 7800.23399
+  dps: 10985.38311
+  tps: 7799.62201
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 10695.11201
-  tps: 7593.52952
+  dps: 10695.21992
+  tps: 7593.60614
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 11595.25779
-  tps: 8232.63303
+  dps: 11594.37577
+  tps: 8232.0068
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 11686.63677
-  tps: 8297.51211
+  dps: 11685.69198
+  tps: 8296.8413
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 10965.31612
-  tps: 7785.37444
+  dps: 10964.4193
+  tps: 7784.7377
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 10965.31612
-  tps: 7785.37444
+  dps: 10964.4193
+  tps: 7784.7377
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 10694.44114
-  tps: 7593.05321
+  dps: 10693.94301
+  tps: 7592.69953
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 10669.63752
-  tps: 7575.44264
+  dps: 10668.7786
+  tps: 7574.83281
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FallofMortality-59500"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FallofMortality-65124"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 11933.80256
-  tps: 8472.99982
+  dps: 11933.75123
+  tps: 8472.96338
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 11184.67608
-  tps: 7941.12002
+  dps: 11184.09686
+  tps: 7940.70877
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 11011.31357
-  tps: 7818.03264
+  dps: 11010.41358
+  tps: 7817.39364
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FluidDeath-58181"
  value: {
-  dps: 11902.21544
-  tps: 8450.57296
+  dps: 11901.5735
+  tps: 8450.11718
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForgeEmber-37660"
  value: {
-  dps: 10659.02032
-  tps: 7567.90442
+  dps: 10658.22821
+  tps: 7567.34203
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 10965.31612
-  tps: 7785.37444
+  dps: 10964.4193
+  tps: 7784.7377
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 10965.31612
-  tps: 7785.37444
+  dps: 10964.4193
+  tps: 7784.7377
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 10965.31612
-  tps: 7785.37444
+  dps: 10964.4193
+  tps: 7784.7377
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 12026.55231
-  tps: 8538.85214
+  dps: 12025.42533
+  tps: 8538.05198
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 10910.80614
-  tps: 7746.67236
+  dps: 10910.02506
+  tps: 7746.11779
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuturesightRune-38763"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GaleofShadows-56138"
  value: {
-  dps: 10681.99137
-  tps: 7584.21387
+  dps: 10681.76933
+  tps: 7584.05622
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GaleofShadows-56462"
  value: {
-  dps: 10682.3194
-  tps: 7584.44677
+  dps: 10682.16951
+  tps: 7584.34035
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GearDetector-61462"
  value: {
-  dps: 11098.76399
-  tps: 7880.12243
+  dps: 11098.89848
+  tps: 7880.21792
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Gladiator'sVestments"
  value: {
-  dps: 12531.35392
-  tps: 8897.26129
+  dps: 12530.90292
+  tps: 8896.94107
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 10693.37589
-  tps: 7592.29688
+  dps: 10692.61222
+  tps: 7591.75467
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 11152.67445
-  tps: 7918.39886
+  dps: 11151.65983
+  tps: 7917.67848
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 11371.11623
-  tps: 8073.49252
+  dps: 11370.08123
+  tps: 8072.75768
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HarmlightToken-63839"
  value: {
-  dps: 10718.05587
-  tps: 7609.81967
+  dps: 10717.99757
+  tps: 7609.77827
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 11034.93106
-  tps: 7834.80105
+  dps: 11034.32418
+  tps: 7834.37017
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 10780.79666
-  tps: 7654.36563
+  dps: 10780.72193
+  tps: 7654.31257
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 10802.17153
-  tps: 7669.54179
+  dps: 10801.63943
+  tps: 7669.164
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofRage-59224"
  value: {
-  dps: 11173.0616
-  tps: 7932.87374
+  dps: 11172.30674
+  tps: 7932.33779
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofRage-65072"
  value: {
-  dps: 11285.0866
-  tps: 8012.41148
+  dps: 11284.62345
+  tps: 8012.08265
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofSolace-55868"
  value: {
-  dps: 10681.99137
-  tps: 7584.21387
+  dps: 10681.76933
+  tps: 7584.05622
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofSolace-56393"
  value: {
-  dps: 11097.10982
-  tps: 7878.94797
+  dps: 11096.624
+  tps: 7878.60304
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofThunder-55845"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofThunder-56370"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 11240.86801
-  tps: 7981.01629
+  dps: 11239.91526
+  tps: 7980.33983
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Heartpierce-49982"
  value: {
-  dps: 11106.55201
-  tps: 7885.65193
+  dps: 11105.66684
+  tps: 7885.02346
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Heartpierce-50641"
  value: {
-  dps: 11106.55201
-  tps: 7885.65193
+  dps: 11105.66684
+  tps: 7885.02346
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 11018.5595
-  tps: 7823.17724
+  dps: 11017.74174
+  tps: 7822.59664
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 10987.19485
-  tps: 7800.90834
+  dps: 10986.3329
+  tps: 7800.29636
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 10986.24506
-  tps: 7800.23399
+  dps: 10985.38311
+  tps: 7799.62201
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 11259.63497
-  tps: 7994.34083
+  dps: 11259.08023
+  tps: 7993.94696
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 11259.63497
-  tps: 7994.34083
+  dps: 11259.08023
+  tps: 7993.94696
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 10806.85224
-  tps: 7672.86509
+  dps: 10806.07643
+  tps: 7672.31426
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 10834.00252
-  tps: 7692.14179
+  dps: 10833.22534
+  tps: 7691.58999
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IncisorFragment-37723"
  value: {
-  dps: 10801.83287
-  tps: 7669.30134
+  dps: 10801.05808
+  tps: 7668.75124
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 10965.31612
-  tps: 7785.37444
+  dps: 10964.4193
+  tps: 7784.7377
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 10759.13356
-  tps: 7638.98483
+  dps: 10758.36015
+  tps: 7638.43571
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 11007.24185
-  tps: 7815.14171
+  dps: 11006.34244
+  tps: 7814.50313
   hps: 27.73483
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 11392.7483
-  tps: 8088.85129
+  dps: 11391.89353
+  tps: 8088.2444
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 11541.19209
-  tps: 8194.24638
+  dps: 11540.24617
+  tps: 8193.57478
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 11838.25266
-  tps: 8405.15939
+  dps: 11837.63452
+  tps: 8404.72051
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 10862.59083
-  tps: 7712.43949
+  dps: 10861.9634
+  tps: 7711.99402
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 10862.59083
-  tps: 7712.43949
+  dps: 10861.9634
+  tps: 7711.99402
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 10668.90495
-  tps: 7574.92252
+  dps: 10684.22853
+  tps: 7585.80226
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-LeadenDespair-55816"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-LeadenDespair-56347"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 11387.54152
-  tps: 8085.15448
+  dps: 11387.20846
+  tps: 8084.91801
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 11546.04202
-  tps: 8197.68983
+  dps: 11544.89641
+  tps: 8196.87645
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 11359.77495
-  tps: 8065.44021
+  dps: 11359.17919
+  tps: 8065.01723
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 10918.14553
-  tps: 7751.88332
+  dps: 10917.65127
+  tps: 7751.5324
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 11042.79399
-  tps: 7840.38373
+  dps: 11042.19624
+  tps: 7839.95933
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 11102.11997
-  tps: 7882.50518
+  dps: 11101.28458
+  tps: 7881.91205
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 11168.74969
-  tps: 7929.81228
+  dps: 11167.90499
+  tps: 7929.21254
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 10611.5717
-  tps: 7534.21591
+  dps: 10611.48043
+  tps: 7534.15111
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 11012.4926
-  tps: 7818.86974
+  dps: 11011.53594
+  tps: 7818.19052
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 11227.12295
-  tps: 7971.25729
+  dps: 11226.63822
+  tps: 7970.91314
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 10863.62101
-  tps: 7713.17091
+  dps: 10862.84234
+  tps: 7712.61806
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 10863.62101
-  tps: 7713.17091
+  dps: 10862.84234
+  tps: 7712.61806
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 10940.30301
-  tps: 7767.61513
+  dps: 10939.8957
+  tps: 7767.32595
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 10644.10062
-  tps: 7557.31144
+  dps: 10643.33523
+  tps: 7556.76802
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 10928.87926
-  tps: 7759.50427
+  dps: 10928.10627
+  tps: 7758.95545
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 10998.89127
-  tps: 7809.2128
+  dps: 10997.99235
+  tps: 7808.57457
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 11006.79131
-  tps: 7814.82183
+  dps: 11005.8919
+  tps: 7814.18325
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 10788.18963
-  tps: 7659.61464
+  dps: 10787.38628
+  tps: 7659.04426
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 10949.83231
-  tps: 7774.38094
+  dps: 10948.90254
+  tps: 7773.7208
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 10965.31612
-  tps: 7785.37444
+  dps: 10964.4193
+  tps: 7784.7377
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 10965.31612
-  tps: 7785.37444
+  dps: 10964.4193
+  tps: 7784.7377
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 10965.31612
-  tps: 7785.37444
+  dps: 10964.4193
+  tps: 7784.7377
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 11659.18828
-  tps: 8278.02368
+  dps: 11658.81083
+  tps: 8277.75569
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 11807.15418
-  tps: 8383.07947
+  dps: 11806.43538
+  tps: 8382.56912
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Rainsong-55854"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Rainsong-56377"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 10684.43898
-  tps: 7585.95167
+  dps: 10684.15273
+  tps: 7585.74844
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 10698.77765
-  tps: 7596.13213
+  dps: 10698.49141
+  tps: 7595.9289
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 11106.55201
-  tps: 7885.65193
+  dps: 11105.66684
+  tps: 7885.02346
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 11100.50374
-  tps: 7881.35766
+  dps: 11099.58304
+  tps: 7880.70396
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 11044.11439
-  tps: 7841.32122
+  dps: 11043.1973
+  tps: 7840.67008
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 10965.31612
-  tps: 7785.37444
+  dps: 10964.4193
+  tps: 7784.7377
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 11163.05005
-  tps: 7925.76553
+  dps: 11162.13636
+  tps: 7925.11682
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 11258.84744
-  tps: 7993.78168
+  dps: 11258.30674
+  tps: 7993.39778
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 11389.4545
-  tps: 8086.5127
+  dps: 11388.74664
+  tps: 8086.01011
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SeaStar-55256"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SeaStar-56290"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 12064.21287
-  tps: 8565.59114
+  dps: 12063.61519
+  tps: 8565.16678
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 10996.70092
-  tps: 7807.65765
+  dps: 10996.42189
+  tps: 7807.45954
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 11484.87623
-  tps: 8154.26212
+  dps: 11484.23748
+  tps: 8153.80861
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 11599.43152
-  tps: 8235.59638
+  dps: 11598.82583
+  tps: 8235.16634
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Slayer'sArmor"
  value: {
-  dps: 8972.69421
-  tps: 6370.61289
+  dps: 8972.157
+  tps: 6370.23147
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Sorrowsong-55879"
  value: {
-  dps: 10806.85224
-  tps: 7672.86509
+  dps: 10806.07643
+  tps: 7672.31426
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Sorrowsong-56400"
  value: {
-  dps: 10834.00252
-  tps: 7692.14179
+  dps: 10833.22534
+  tps: 7691.58999
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 11025.70077
-  tps: 7828.24755
+  dps: 11024.85123
+  tps: 7827.64437
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SoulCasket-58183"
  value: {
-  dps: 10863.62101
-  tps: 7713.17091
+  dps: 10862.84234
+  tps: 7712.61806
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SoulPreserver-37111"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SouloftheDead-40382"
  value: {
-  dps: 10675.90424
-  tps: 7579.89201
+  dps: 10675.04533
+  tps: 7579.28218
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SparkofLife-37657"
  value: {
-  dps: 10581.73147
-  tps: 7513.02935
+  dps: 10581.55506
+  tps: 7512.90409
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 10830.98639
-  tps: 7690.00034
+  dps: 10830.30661
+  tps: 7689.51769
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 10708.01063
-  tps: 7602.68755
+  dps: 10707.25059
+  tps: 7602.14792
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-StumpofTime-62465"
  value: {
-  dps: 10954.87013
-  tps: 7777.9578
+  dps: 10954.29208
+  tps: 7777.54738
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-StumpofTime-62470"
  value: {
-  dps: 10954.87013
-  tps: 7777.9578
+  dps: 10954.29208
+  tps: 7777.54738
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 11006.79131
-  tps: 7814.82183
+  dps: 11005.8919
+  tps: 7814.18325
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 10998.89127
-  tps: 7809.2128
+  dps: 10997.99235
+  tps: 7808.57457
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 10985.06621
-  tps: 7799.39701
+  dps: 10984.16815
+  tps: 7798.75939
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 10734.4042
-  tps: 7621.42698
+  dps: 10733.63882
+  tps: 7620.88356
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 11002.8229
-  tps: 7812.00426
+  dps: 11001.84842
+  tps: 7811.31238
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TearofBlood-55819"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TearofBlood-56351"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 10776.41101
-  tps: 7651.25182
+  dps: 10775.63673
+  tps: 7650.70208
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 10834.00252
-  tps: 7692.14179
+  dps: 10833.22534
+  tps: 7691.58999
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 10686.2476
-  tps: 7587.23579
+  dps: 10685.65138
+  tps: 7586.81248
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 10856.65331
-  tps: 7708.22385
+  dps: 10856.19907
+  tps: 7707.90134
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 10910.2306
-  tps: 7746.26373
+  dps: 10909.2541
+  tps: 7745.57041
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 10937.41136
-  tps: 7765.56206
+  dps: 10936.65633
+  tps: 7765.026
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 11546.09949
-  tps: 8197.73064
+  dps: 11545.16735
+  tps: 8197.06882
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 11667.01877
-  tps: 8283.58333
+  dps: 11666.10707
+  tps: 8282.93602
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 10914.42577
-  tps: 7749.2423
+  dps: 10908.06551
+  tps: 7744.72651
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 10988.08093
-  tps: 7801.53746
+  dps: 10987.86978
+  tps: 7801.38754
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 10965.31612
-  tps: 7785.37444
+  dps: 10964.4193
+  tps: 7784.7377
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 10965.31612
-  tps: 7785.37444
+  dps: 10964.4193
+  tps: 7784.7377
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 10580.08889
-  tps: 7511.86311
+  dps: 10588.02475
+  tps: 7517.49757
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 10965.31612
-  tps: 7785.37444
+  dps: 10964.4193
+  tps: 7784.7377
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 10965.31612
-  tps: 7785.37444
+  dps: 10964.4193
+  tps: 7784.7377
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 10632.77965
-  tps: 7549.27355
+  dps: 10632.01597
+  tps: 7548.73134
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 9550.79687
-  tps: 6781.06578
+  dps: 9550.31773
+  tps: 6780.72559
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-UnheededWarning-59520"
  value: {
-  dps: 11778.17368
-  tps: 8362.50331
+  dps: 11777.52778
+  tps: 8362.04473
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 11821.03299
-  tps: 8392.93342
+  dps: 11820.43555
+  tps: 8392.50924
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 11821.03299
-  tps: 8392.93342
+  dps: 11820.43555
+  tps: 8392.50924
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 10669.6692
-  tps: 7575.46513
+  dps: 10668.99835
+  tps: 7574.98883
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 11536.28304
-  tps: 8190.76096
+  dps: 11535.69145
+  tps: 8190.34093
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 10986.22074
-  tps: 7800.21672
+  dps: 10985.67067
+  tps: 7799.82618
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 10997.15597
-  tps: 7807.98074
+  dps: 10996.56455
+  tps: 7807.56083
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 10760.07855
-  tps: 7639.65577
+  dps: 10759.96074
+  tps: 7639.57212
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 10743.61881
-  tps: 7627.96936
+  dps: 10742.6333
+  tps: 7627.26964
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 10753.55679
-  tps: 7635.02532
+  dps: 10753.06693
+  tps: 7634.67752
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 10879.25299
-  tps: 7724.26962
+  dps: 10878.47354
+  tps: 7723.71621
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 11499.96022
-  tps: 8164.97175
+  dps: 11499.26757
+  tps: 8164.47998
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 10977.54003
-  tps: 7794.05342
+  dps: 10976.71628
+  tps: 7793.46856
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WindDancer'sRegalia"
  value: {
-  dps: 14552.84595
-  tps: 10332.52063
+  dps: 14553.02734
+  tps: 10332.64941
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WingedTalisman-37844"
  value: {
-  dps: 10599.52281
-  tps: 7525.66119
+  dps: 10598.75742
+  tps: 7525.11777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 10647.1537
-  tps: 7559.47913
+  dps: 10646.93328
+  tps: 7559.32263
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 10714.88498
-  tps: 7607.56834
+  dps: 10714.1196
+  tps: 7607.02491
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 10779.70195
-  tps: 7653.58839
+  dps: 10778.92751
+  tps: 7653.03853
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 10804.22455
-  tps: 7670.99943
+  dps: 10803.41388
+  tps: 7670.42385
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 10804.22455
-  tps: 7670.99943
+  dps: 10803.41388
+  tps: 7670.42385
  }
 }
 dps_results: {
  key: "TestAssassination-Average-Default"
  value: {
-  dps: 11078.68109
-  tps: 7865.86358
+  dps: 11078.0991
+  tps: 7865.45036
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-Assassination-mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11106.55201
-  tps: 7885.65193
+  dps: 11105.66684
+  tps: 7885.02346
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-Assassination-mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11106.55201
-  tps: 7885.65193
+  dps: 11105.66684
+  tps: 7885.02346
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-Assassination-mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 15374.22004
-  tps: 10915.69623
+  dps: 15370.24165
+  tps: 10912.87157
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-Assassination-mutilate-NoBuffs-LongMultiTarget"
  value: {
-  dps: 5624.54889
-  tps: 3993.42971
+  dps: 5624.28242
+  tps: 3993.24052
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-Assassination-mutilate-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5624.54889
-  tps: 3993.42971
+  dps: 5624.28242
+  tps: 3993.24052
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-Assassination-mutilate-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6267.94122
-  tps: 4450.23827
+  dps: 6266.78013
+  tps: 4449.4139
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8205.78976
-  tps: 5826.11073
+  dps: 8204.7878
+  tps: 5825.39934
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8205.78976
-  tps: 5826.11073
+  dps: 8204.7878
+  tps: 5825.39934
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11573.8136
-  tps: 8217.40765
+  dps: 11568.6552
+  tps: 8213.74519
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4248.80235
-  tps: 3016.64967
+  dps: 4248.83499
+  tps: 3016.67284
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4248.80235
-  tps: 3016.64967
+  dps: 4248.83499
+  tps: 3016.67284
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4781.78872
-  tps: 3395.06999
+  dps: 4781.83203
+  tps: 3395.10074
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Deadly-mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 10614.38896
-  tps: 7536.21616
+  dps: 10614.33099
+  tps: 7536.175
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Deadly-mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10614.38896
-  tps: 7536.21616
+  dps: 10614.33099
+  tps: 7536.175
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Deadly-mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14655.67981
-  tps: 10405.53266
+  dps: 14655.35217
+  tps: 10405.30004
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Deadly-mutilate-NoBuffs-LongMultiTarget"
  value: {
-  dps: 5365.42827
-  tps: 3809.45407
+  dps: 5365.41991
+  tps: 3809.44813
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Deadly-mutilate-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5365.42827
-  tps: 3809.45407
+  dps: 5365.41991
+  tps: 3809.44813
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Deadly-mutilate-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5909.7015
-  tps: 4195.88806
+  dps: 5909.564
+  tps: 4195.79044
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Instant-mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6687.63229
-  tps: 4748.21893
+  dps: 6687.38418
+  tps: 4748.04277
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Instant-mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6687.63229
-  tps: 4748.21893
+  dps: 6687.38418
+  tps: 4748.04277
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Instant-mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 8784.92863
-  tps: 6237.29933
+  dps: 8784.15513
+  tps: 6236.75014
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Instant-mutilate-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3537.90717
-  tps: 2511.91409
+  dps: 3537.89691
+  tps: 2511.9068
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Instant-mutilate-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3537.90717
-  tps: 2511.91409
+  dps: 3537.89691
+  tps: 2511.9068
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Instant-mutilate-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3986.89502
-  tps: 2830.69546
+  dps: 3986.75752
+  tps: 2830.59784
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-Assassination-mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11303.15618
-  tps: 8025.24089
+  dps: 11302.23315
+  tps: 8024.58554
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-Assassination-mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11303.15618
-  tps: 8025.24089
+  dps: 11302.23315
+  tps: 8024.58554
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-Assassination-mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 15822.10164
-  tps: 11233.69217
+  dps: 15817.93398
+  tps: 11230.73312
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-Assassination-mutilate-NoBuffs-LongMultiTarget"
  value: {
-  dps: 5741.68319
-  tps: 4076.59506
+  dps: 5741.459
+  tps: 4076.43589
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-Assassination-mutilate-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5741.68319
-  tps: 4076.59506
+  dps: 5741.459
+  tps: 4076.43589
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-Assassination-mutilate-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6493.53022
-  tps: 4610.40645
+  dps: 6492.24502
+  tps: 4609.49397
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8356.08736
-  tps: 5932.82202
+  dps: 8355.03197
+  tps: 5932.0727
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8356.08736
-  tps: 5932.82202
+  dps: 8355.03197
+  tps: 5932.0727
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11933.51837
-  tps: 8472.79804
+  dps: 11928.09283
+  tps: 8468.94591
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4337.62549
-  tps: 3079.7141
+  dps: 4337.59969
+  tps: 3079.69578
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4337.62549
-  tps: 3079.7141
+  dps: 4337.59969
+  tps: 3079.69578
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4971.38503
-  tps: 3529.68337
+  dps: 4971.41576
+  tps: 3529.70519
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Deadly-mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 10803.85136
-  tps: 7670.73447
+  dps: 10803.70848
+  tps: 7670.63302
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Deadly-mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10803.85136
-  tps: 7670.73447
+  dps: 10803.70848
+  tps: 7670.63302
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Deadly-mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 15081.95045
-  tps: 10708.18482
+  dps: 15081.58873
+  tps: 10707.928
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Deadly-mutilate-NoBuffs-LongMultiTarget"
  value: {
-  dps: 5474.69806
-  tps: 3887.03562
+  dps: 5474.68718
+  tps: 3887.0279
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Deadly-mutilate-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5474.69806
-  tps: 3887.03562
+  dps: 5474.68718
+  tps: 3887.0279
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Deadly-mutilate-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6123.58496
-  tps: 4347.74532
+  dps: 6123.43487
+  tps: 4347.63876
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Instant-mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6807.83739
-  tps: 4833.56454
+  dps: 6807.5685
+  tps: 4833.37363
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Instant-mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6807.83739
-  tps: 4833.56454
+  dps: 6807.5685
+  tps: 4833.37363
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Instant-mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 9036.3313
-  tps: 6415.79522
+  dps: 9035.48196
+  tps: 6415.19219
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Instant-mutilate-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3615.6716
-  tps: 2567.12683
+  dps: 3615.65882
+  tps: 2567.11776
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Instant-mutilate-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3615.6716
-  tps: 2567.12683
+  dps: 3615.65882
+  tps: 2567.11776
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Instant-mutilate-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4139.63383
-  tps: 2939.14002
+  dps: 4139.48375
+  tps: 2939.03346
  }
 }
 dps_results: {
  key: "TestAssassination-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 9947.62278
-  tps: 7062.81217
+  dps: 9942.84189
+  tps: 7059.41774
  }
 }

--- a/sim/rogue/assassination/TestAssassination.results
+++ b/sim/rogue/assassination/TestAssassination.results
@@ -40,2007 +40,2007 @@ character_stats_results: {
 dps_results: {
  key: "TestAssassination-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 11138.04671
-  tps: 7908.01317
+  dps: 11185.62976
+  tps: 7941.79713
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 10873.60874
-  tps: 7720.26221
+  dps: 10851.17333
+  tps: 7704.33307
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 10895.15589
-  tps: 7735.56068
+  dps: 10899.10349
+  tps: 7738.36348
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 10558.52429
-  tps: 7496.55225
+  dps: 10616.82546
+  tps: 7537.94607
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 10919.04032
-  tps: 7752.51863
+  dps: 10965.31612
+  tps: 7785.37444
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 10919.04032
-  tps: 7752.51863
+  dps: 10965.31612
+  tps: 7785.37444
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 10803.41814
-  tps: 7670.42688
+  dps: 10803.30682
+  tps: 7670.34785
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
   hps: 81.71278
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
   hps: 81.71278
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 10940.20759
-  tps: 7767.54739
+  dps: 10987.19485
+  tps: 7800.90834
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 10747.9718
-  tps: 7631.05998
+  dps: 10744.12997
+  tps: 7628.33228
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 10766.41211
-  tps: 7644.1526
+  dps: 10752.16844
+  tps: 7634.03959
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BindingPromise-67037"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BlackBruise-50035"
  value: {
-  dps: 10359.27645
-  tps: 7355.08628
+  dps: 10346.98273
+  tps: 7346.35774
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BlackBruise-50692"
  value: {
-  dps: 10426.03148
-  tps: 7402.48235
+  dps: 10411.50022
+  tps: 7392.16516
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 9086.19519
-  tps: 6451.19859
+  dps: 9077.21712
+  tps: 6444.82415
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 11338.85247
-  tps: 8050.58525
+  dps: 11392.7483
+  tps: 8088.85129
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 10746.3645
-  tps: 7629.9188
+  dps: 10806.85224
+  tps: 7672.86509
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 10773.42706
-  tps: 7649.13321
+  dps: 10834.00252
+  tps: 7692.14179
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 11652.27256
-  tps: 8273.11352
+  dps: 11706.84852
+  tps: 8311.86245
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 10911.20724
-  tps: 7746.95714
+  dps: 10965.74141
+  tps: 7785.6764
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 10741.80531
-  tps: 7626.68177
+  dps: 10724.0875
+  tps: 7614.10213
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 11382.13838
-  tps: 8081.31825
+  dps: 11447.79487
+  tps: 8127.93436
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 10888.92945
-  tps: 7731.13991
+  dps: 10949.6673
+  tps: 7774.26379
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BonescytheBattlegear"
  value: {
-  dps: 10489.37023
-  tps: 7447.45286
+  dps: 10491.04975
+  tps: 7448.64533
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BottledLightning-66879"
  value: {
-  dps: 10632.45202
-  tps: 7549.04094
+  dps: 10691.2744
+  tps: 7590.80482
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 10919.04032
-  tps: 7597.46825
+  dps: 10965.31612
+  tps: 7629.66695
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 10919.04032
-  tps: 7597.46825
+  dps: 10965.31612
+  tps: 7629.66695
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 10996.86895
-  tps: 7807.77695
+  dps: 11044.11439
+  tps: 7841.32122
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 11033.00008
-  tps: 7833.43006
+  dps: 11099.18516
+  tps: 7880.42146
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 11018.89655
-  tps: 7823.41655
+  dps: 11066.64481
+  tps: 7857.31782
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
   hps: 64
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CrushingWeight-59506"
  value: {
-  dps: 11163.72638
-  tps: 7926.24573
+  dps: 11173.30036
+  tps: 7933.04325
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CrushingWeight-65118"
  value: {
-  dps: 11313.79541
-  tps: 8032.79474
+  dps: 11267.93549
+  tps: 8000.2342
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 10581.2107
-  tps: 7512.6596
+  dps: 10678.68136
+  tps: 7581.86377
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 10679.03488
-  tps: 7582.11476
+  dps: 10698.53472
+  tps: 7595.95965
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 10833.81728
-  tps: 7692.01027
+  dps: 10891.45283
+  tps: 7732.93151
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 11286.53882
-  tps: 8013.44256
+  dps: 11310.52406
+  tps: 8030.47208
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 11728.49531
-  tps: 8327.23167
+  dps: 11762.17401
+  tps: 8351.14355
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 10845.23326
-  tps: 7700.11561
+  dps: 10910.58852
+  tps: 7746.51785
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Death'sChoice-47464"
  value: {
-  dps: 11359.26027
-  tps: 8065.07479
+  dps: 11378.04349
+  tps: 8078.41088
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 10561.04896
-  tps: 7498.34476
+  dps: 10635.89958
+  tps: 7551.4887
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 11024.98811
-  tps: 7827.74156
+  dps: 11022.6915
+  tps: 7826.11096
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 11095.24925
-  tps: 7877.62697
+  dps: 11112.43284
+  tps: 7889.82731
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Defender'sCode-40257"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 10953.43713
-  tps: 7776.94036
+  dps: 11018.5595
+  tps: 7823.17724
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 10941.14956
-  tps: 7768.21619
+  dps: 10988.19731
+  tps: 7801.62009
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 10656.26617
-  tps: 7565.94898
+  dps: 10665.9317
+  tps: 7572.81151
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 10635.92376
-  tps: 7551.50587
+  dps: 10649.66294
+  tps: 7561.26069
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 10919.04032
-  tps: 7752.51863
+  dps: 10965.31612
+  tps: 7785.37444
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EffulgentSkyflareDiamond"
  value: {
-  dps: 10919.04032
-  tps: 7752.51863
+  dps: 10965.31612
+  tps: 7785.37444
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 10919.04032
-  tps: 7752.51863
+  dps: 10965.31612
+  tps: 7785.37444
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 10919.04032
-  tps: 7752.51863
+  dps: 10965.31612
+  tps: 7785.37444
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 10953.43713
-  tps: 7776.94036
+  dps: 11018.5595
+  tps: 7823.17724
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 10940.20759
-  tps: 7767.54739
+  dps: 10987.19485
+  tps: 7800.90834
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 10938.63616
-  tps: 7766.43167
+  dps: 10986.24506
+  tps: 7800.23399
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 10610.49144
-  tps: 7533.44892
+  dps: 10695.11201
+  tps: 7593.52952
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 11533.72633
-  tps: 8188.9457
+  dps: 11595.25779
+  tps: 8232.63303
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 11612.53959
-  tps: 8244.90311
+  dps: 11686.63677
+  tps: 8297.51211
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 10919.04032
-  tps: 7752.51863
+  dps: 10965.31612
+  tps: 7785.37444
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 10919.04032
-  tps: 7752.51863
+  dps: 10965.31612
+  tps: 7785.37444
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 10715.36743
-  tps: 7607.91088
+  dps: 10694.44114
+  tps: 7593.05321
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 10580.01753
-  tps: 7511.81245
+  dps: 10669.63752
+  tps: 7575.44264
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FallofMortality-59500"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FallofMortality-65124"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 11976.07135
-  tps: 8503.01066
+  dps: 11933.80256
+  tps: 8472.99982
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 11129.16816
-  tps: 7901.7094
+  dps: 11184.67608
+  tps: 7941.12002
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 10964.90763
-  tps: 7785.08442
+  dps: 11011.31357
+  tps: 7818.03264
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FluidDeath-58181"
  value: {
-  dps: 11902.44723
-  tps: 8450.73754
+  dps: 11902.21544
+  tps: 8450.57296
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForgeEmber-37660"
  value: {
-  dps: 10579.13701
-  tps: 7511.18728
+  dps: 10659.02032
+  tps: 7567.90442
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 10919.04032
-  tps: 7752.51863
+  dps: 10965.31612
+  tps: 7785.37444
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 10919.04032
-  tps: 7752.51863
+  dps: 10965.31612
+  tps: 7785.37444
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 10919.04032
-  tps: 7752.51863
+  dps: 10965.31612
+  tps: 7785.37444
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 12027.08709
-  tps: 8539.23183
+  dps: 12026.55231
+  tps: 8538.85214
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 10849.31138
-  tps: 7703.01108
+  dps: 10910.80614
+  tps: 7746.67236
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuturesightRune-38763"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GaleofShadows-56138"
  value: {
-  dps: 10662.35317
-  tps: 7570.27075
+  dps: 10681.99137
+  tps: 7584.21387
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GaleofShadows-56462"
  value: {
-  dps: 10680.98042
-  tps: 7583.4961
+  dps: 10682.3194
+  tps: 7584.44677
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GearDetector-61462"
  value: {
-  dps: 11106.80351
-  tps: 7885.83049
+  dps: 11098.76399
+  tps: 7880.12243
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Gladiator'sVestments"
  value: {
-  dps: 12513.51372
-  tps: 8884.59474
+  dps: 12531.35392
+  tps: 8897.26129
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 10695.74119
-  tps: 7593.97624
+  dps: 10693.37589
+  tps: 7592.29688
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 11076.15415
-  tps: 7864.06945
+  dps: 11152.67445
+  tps: 7918.39886
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 11319.90666
-  tps: 8037.13373
+  dps: 11371.11623
+  tps: 8073.49252
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HarmlightToken-63839"
  value: {
-  dps: 10657.66788
-  tps: 7566.9442
+  dps: 10718.05587
+  tps: 7609.81967
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 10973.32354
-  tps: 7791.05971
+  dps: 11034.93106
+  tps: 7834.80105
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 10763.35706
-  tps: 7641.98351
+  dps: 10780.79666
+  tps: 7654.36563
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 10801.9728
-  tps: 7669.40069
+  dps: 10802.17153
+  tps: 7669.54179
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofRage-59224"
  value: {
-  dps: 11184.38172
-  tps: 7940.91102
+  dps: 11173.0616
+  tps: 7932.87374
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofRage-65072"
  value: {
-  dps: 11249.95621
-  tps: 7987.46891
+  dps: 11285.0866
+  tps: 8012.41148
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofSolace-55868"
  value: {
-  dps: 10662.35317
-  tps: 7570.27075
+  dps: 10681.99137
+  tps: 7584.21387
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofSolace-56393"
  value: {
-  dps: 11089.57849
-  tps: 7873.60073
+  dps: 11097.10982
+  tps: 7878.94797
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofThunder-55845"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofThunder-56370"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 11120.39564
-  tps: 7895.48091
+  dps: 11240.86801
+  tps: 7981.01629
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Heartpierce-49982"
  value: {
-  dps: 11054.62292
-  tps: 7848.78227
+  dps: 11106.55201
+  tps: 7885.65193
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Heartpierce-50641"
  value: {
-  dps: 11054.62292
-  tps: 7848.78227
+  dps: 11106.55201
+  tps: 7885.65193
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 10953.43713
-  tps: 7776.94036
+  dps: 11018.5595
+  tps: 7823.17724
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 10940.20759
-  tps: 7767.54739
+  dps: 10987.19485
+  tps: 7800.90834
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 10938.63616
-  tps: 7766.43167
+  dps: 10986.24506
+  tps: 7800.23399
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 11204.68769
-  tps: 7955.32826
+  dps: 11259.63497
+  tps: 7994.34083
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 11204.68769
-  tps: 7955.32826
+  dps: 11259.63497
+  tps: 7994.34083
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 10746.3645
-  tps: 7629.9188
+  dps: 10806.85224
+  tps: 7672.86509
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 10773.42706
-  tps: 7649.13321
+  dps: 10834.00252
+  tps: 7692.14179
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IncisorFragment-37723"
  value: {
-  dps: 10742.07114
-  tps: 7626.87051
+  dps: 10801.83287
+  tps: 7669.30134
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 10919.04032
-  tps: 7752.51863
+  dps: 10965.31612
+  tps: 7785.37444
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 10698.80002
-  tps: 7596.14802
+  dps: 10759.13356
+  tps: 7638.98483
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 10960.46919
-  tps: 7781.93312
-  hps: 27.19941
+  dps: 11007.24185
+  tps: 7815.14171
+  hps: 27.73483
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 11338.85247
-  tps: 8050.58525
+  dps: 11392.7483
+  tps: 8088.85129
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 11509.64763
-  tps: 8171.84982
+  dps: 11541.19209
+  tps: 8194.24638
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 11862.69668
-  tps: 8422.51464
+  dps: 11838.25266
+  tps: 8405.15939
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 10818.22999
-  tps: 7680.94329
+  dps: 10862.59083
+  tps: 7712.43949
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 10818.22999
-  tps: 7680.94329
+  dps: 10862.59083
+  tps: 7712.43949
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 10707.61789
-  tps: 7602.4087
+  dps: 10668.90495
+  tps: 7574.92252
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-LeadenDespair-55816"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-LeadenDespair-56347"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 11467.96748
-  tps: 8142.25691
+  dps: 11387.54152
+  tps: 8085.15448
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 11596.89287
-  tps: 8233.79394
+  dps: 11546.04202
+  tps: 8197.68983
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 11377.18415
-  tps: 8077.80074
+  dps: 11359.77495
+  tps: 8065.44021
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 10916.75498
-  tps: 7750.89604
+  dps: 10918.14553
+  tps: 7751.88332
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 11022.48063
-  tps: 7825.96125
+  dps: 11042.79399
+  tps: 7840.38373
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 11038.05546
-  tps: 7837.01938
+  dps: 11102.11997
+  tps: 7882.50518
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 11104.11954
-  tps: 7883.92488
+  dps: 11168.74969
+  tps: 7929.81228
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 10619.69066
-  tps: 7539.98037
+  dps: 10611.5717
+  tps: 7534.21591
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 10989.82211
-  tps: 7802.7737
+  dps: 11012.4926
+  tps: 7818.86974
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 11225.21291
-  tps: 7969.90116
+  dps: 11227.12295
+  tps: 7971.25729
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 10802.94984
-  tps: 7670.09438
+  dps: 10863.62101
+  tps: 7713.17091
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 10802.94984
-  tps: 7670.09438
+  dps: 10863.62101
+  tps: 7713.17091
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 10884.36689
-  tps: 7727.90049
+  dps: 10940.30301
+  tps: 7767.61513
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 10587.42851
-  tps: 7517.07425
+  dps: 10644.10062
+  tps: 7557.31144
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 10883.76288
-  tps: 7727.47164
+  dps: 10928.87926
+  tps: 7759.50427
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 10952.47515
-  tps: 7776.25736
+  dps: 10998.89127
+  tps: 7809.2128
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 10960.34217
-  tps: 7781.84294
+  dps: 11006.79131
+  tps: 7814.82183
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 10728.64455
-  tps: 7617.33763
+  dps: 10788.18963
+  tps: 7659.61464
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 10889.56754
-  tps: 7731.59295
+  dps: 10949.83231
+  tps: 7774.38094
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 10919.04032
-  tps: 7752.51863
+  dps: 10965.31612
+  tps: 7785.37444
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 10919.04032
-  tps: 7752.51863
+  dps: 10965.31612
+  tps: 7785.37444
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 10919.04032
-  tps: 7752.51863
+  dps: 10965.31612
+  tps: 7785.37444
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 11632.54679
-  tps: 8259.10822
+  dps: 11659.18828
+  tps: 8278.02368
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 11740.3106
-  tps: 8335.62053
+  dps: 11807.15418
+  tps: 8383.07947
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Rainsong-55854"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Rainsong-56377"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 10661.08179
-  tps: 7569.36807
+  dps: 10684.43898
+  tps: 7585.95167
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 10674.89953
-  tps: 7579.17866
+  dps: 10698.77765
+  tps: 7596.13213
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 11054.62292
-  tps: 7848.78227
+  dps: 11106.55201
+  tps: 7885.65193
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 11053.01882
-  tps: 7847.64336
+  dps: 11100.50374
+  tps: 7881.35766
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 10996.86895
-  tps: 7807.77695
+  dps: 11044.11439
+  tps: 7841.32122
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 10919.04032
-  tps: 7752.51863
+  dps: 10965.31612
+  tps: 7785.37444
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 11189.21747
-  tps: 7944.3444
+  dps: 11163.05005
+  tps: 7925.76553
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 11253.27611
-  tps: 7989.82604
+  dps: 11258.84744
+  tps: 7993.78168
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 11309.99171
-  tps: 8030.09412
+  dps: 11389.4545
+  tps: 8086.5127
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SeaStar-55256"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SeaStar-56290"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 12098.64438
-  tps: 8590.03751
+  dps: 12064.21287
+  tps: 8565.59114
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 11047.52557
-  tps: 7843.74315
+  dps: 10996.70092
+  tps: 7807.65765
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 11433.3508
-  tps: 8117.67906
+  dps: 11484.87623
+  tps: 8154.26212
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 11548.93901
-  tps: 8199.7467
+  dps: 11599.43152
+  tps: 8235.59638
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Slayer'sArmor"
  value: {
-  dps: 8945.95058
-  tps: 6351.62491
+  dps: 8972.69421
+  tps: 6370.61289
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Sorrowsong-55879"
  value: {
-  dps: 10746.3645
-  tps: 7629.9188
+  dps: 10806.85224
+  tps: 7672.86509
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Sorrowsong-56400"
  value: {
-  dps: 10773.42706
-  tps: 7649.13321
+  dps: 10834.00252
+  tps: 7692.14179
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 11048.56979
-  tps: 7844.48455
+  dps: 11025.70077
+  tps: 7828.24755
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SoulCasket-58183"
  value: {
-  dps: 10802.94984
-  tps: 7670.09438
+  dps: 10863.62101
+  tps: 7713.17091
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SoulPreserver-37111"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SouloftheDead-40382"
  value: {
-  dps: 10579.11543
-  tps: 7511.17196
+  dps: 10675.90424
+  tps: 7579.89201
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SparkofLife-37657"
  value: {
-  dps: 10581.5008
-  tps: 7512.86557
+  dps: 10581.73147
+  tps: 7513.02935
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 10807.03858
-  tps: 7672.99739
+  dps: 10830.98639
+  tps: 7690.00034
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 10614.72336
-  tps: 7536.45359
+  dps: 10708.01063
+  tps: 7602.68755
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-StumpofTime-62465"
  value: {
-  dps: 10971.44984
-  tps: 7789.72939
+  dps: 10954.87013
+  tps: 7777.9578
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-StumpofTime-62470"
  value: {
-  dps: 10971.44984
-  tps: 7789.72939
+  dps: 10954.87013
+  tps: 7777.9578
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 10960.34217
-  tps: 7781.84294
+  dps: 11006.79131
+  tps: 7814.82183
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 10952.47515
-  tps: 7776.25736
+  dps: 10998.89127
+  tps: 7809.2128
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 10938.70787
-  tps: 7766.48259
+  dps: 10985.06621
+  tps: 7799.39701
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 10672.13785
-  tps: 7577.21787
+  dps: 10734.4042
+  tps: 7621.42698
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 10950.91847
-  tps: 7775.15211
+  dps: 11002.8229
+  tps: 7812.00426
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TearofBlood-55819"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TearofBlood-56351"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 10716.02165
-  tps: 7608.37537
+  dps: 10776.41101
+  tps: 7651.25182
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 10773.42706
-  tps: 7649.13321
+  dps: 10834.00252
+  tps: 7692.14179
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 10643.08745
-  tps: 7556.59209
+  dps: 10686.2476
+  tps: 7587.23579
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 10795.79764
-  tps: 7665.01633
+  dps: 10856.65331
+  tps: 7708.22385
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 10851.01909
-  tps: 7704.22355
+  dps: 10910.2306
+  tps: 7746.26373
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 10980.44993
-  tps: 7796.11945
+  dps: 10937.41136
+  tps: 7765.56206
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 11490.64401
-  tps: 8158.35725
+  dps: 11546.09949
+  tps: 8197.73064
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 11631.82822
-  tps: 8258.59804
+  dps: 11667.01877
+  tps: 8283.58333
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 10929.36304
-  tps: 7759.84776
+  dps: 10914.42577
+  tps: 7749.2423
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 11014.48585
-  tps: 7820.28495
+  dps: 10988.08093
+  tps: 7801.53746
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 10919.04032
-  tps: 7752.51863
+  dps: 10965.31612
+  tps: 7785.37444
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 10919.04032
-  tps: 7752.51863
+  dps: 10965.31612
+  tps: 7785.37444
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 10564.12094
-  tps: 7500.52587
+  dps: 10580.08889
+  tps: 7511.86311
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 10919.04032
-  tps: 7752.51863
+  dps: 10965.31612
+  tps: 7785.37444
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 10919.04032
-  tps: 7752.51863
+  dps: 10965.31612
+  tps: 7785.37444
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 10617.15881
-  tps: 7538.18275
+  dps: 10632.77965
+  tps: 7549.27355
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 9574.87958
-  tps: 6798.1645
+  dps: 9550.79687
+  tps: 6781.06578
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-UnheededWarning-59520"
  value: {
-  dps: 11736.25728
-  tps: 8332.74267
+  dps: 11778.17368
+  tps: 8362.50331
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 11785.95239
-  tps: 8368.02619
+  dps: 11821.03299
+  tps: 8392.93342
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 11785.95239
-  tps: 8368.02619
+  dps: 11821.03299
+  tps: 8392.93342
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 10679.09801
-  tps: 7582.15959
+  dps: 10669.6692
+  tps: 7575.46513
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 11501.01762
-  tps: 8165.72251
+  dps: 11536.28304
+  tps: 8190.76096
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 10931.98204
-  tps: 7761.70725
+  dps: 10986.22074
+  tps: 7800.21672
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 11018.12194
-  tps: 7822.86658
+  dps: 10997.15597
+  tps: 7807.98074
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 10703.94333
-  tps: 7599.79976
+  dps: 10760.07855
+  tps: 7639.65577
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 10757.60644
-  tps: 7637.90057
+  dps: 10743.61881
+  tps: 7627.96936
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 10751.39032
-  tps: 7633.48713
+  dps: 10753.55679
+  tps: 7635.02532
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 10818.53131
-  tps: 7681.15723
+  dps: 10879.25299
+  tps: 7724.26962
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 11462.84678
-  tps: 8138.62122
+  dps: 11499.96022
+  tps: 8164.97175
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 10917.85518
-  tps: 7751.67718
+  dps: 10977.54003
+  tps: 7794.05342
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WindDancer'sRegalia"
  value: {
-  dps: 14555.60078
-  tps: 10334.47655
+  dps: 14552.84595
+  tps: 10332.52063
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WingedTalisman-37844"
  value: {
-  dps: 10539.70503
-  tps: 7483.19057
+  dps: 10599.52281
+  tps: 7525.66119
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 10674.59202
-  tps: 7578.96033
+  dps: 10647.1537
+  tps: 7559.47913
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 10684.68245
-  tps: 7586.12454
+  dps: 10714.88498
+  tps: 7607.56834
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 10719.30195
-  tps: 7610.70439
+  dps: 10779.70195
+  tps: 7653.58839
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 10741.97708
-  tps: 7626.80373
+  dps: 10804.22455
+  tps: 7670.99943
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 10741.97708
-  tps: 7626.80373
+  dps: 10804.22455
+  tps: 7670.99943
  }
 }
 dps_results: {
  key: "TestAssassination-Average-Default"
  value: {
-  dps: 11072.16868
-  tps: 7861.23977
+  dps: 11078.68109
+  tps: 7865.86358
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-Assassination-mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11054.62292
-  tps: 7848.78227
+  dps: 11106.55201
+  tps: 7885.65193
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-Assassination-mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11054.62292
-  tps: 7848.78227
+  dps: 11106.55201
+  tps: 7885.65193
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-Assassination-mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 15337.09823
-  tps: 10889.33974
+  dps: 15374.22004
+  tps: 10915.69623
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-Assassination-mutilate-NoBuffs-LongMultiTarget"
  value: {
-  dps: 5618.40712
-  tps: 3989.06906
+  dps: 5624.54889
+  tps: 3993.42971
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-Assassination-mutilate-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5618.40712
-  tps: 3989.06906
+  dps: 5624.54889
+  tps: 3993.42971
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-Assassination-mutilate-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6261.90918
-  tps: 4445.95552
+  dps: 6267.94122
+  tps: 4450.23827
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8140.24154
-  tps: 5779.57149
+  dps: 8205.78976
+  tps: 5826.11073
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8140.24154
-  tps: 5779.57149
+  dps: 8205.78976
+  tps: 5826.11073
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11533.21961
-  tps: 8188.58592
+  dps: 11573.8136
+  tps: 8217.40765
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4220.53148
-  tps: 2996.57735
+  dps: 4248.80235
+  tps: 3016.64967
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4220.53148
-  tps: 2996.57735
+  dps: 4248.80235
+  tps: 3016.64967
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4749.72981
-  tps: 3372.30817
+  dps: 4781.78872
+  tps: 3395.06999
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Deadly-mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 10588.83182
-  tps: 7518.07059
+  dps: 10614.38896
+  tps: 7536.21616
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Deadly-mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10588.83182
-  tps: 7518.07059
+  dps: 10614.38896
+  tps: 7536.21616
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Deadly-mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 14652.72734
-  tps: 10403.43641
+  dps: 14655.67981
+  tps: 10405.53266
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Deadly-mutilate-NoBuffs-LongMultiTarget"
  value: {
-  dps: 5370.26148
-  tps: 3812.88565
+  dps: 5365.42827
+  tps: 3809.45407
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Deadly-mutilate-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5370.26148
-  tps: 3812.88565
+  dps: 5365.42827
+  tps: 3809.45407
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Deadly-mutilate-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 5907.5853
-  tps: 4194.38557
+  dps: 5909.7015
+  tps: 4195.88806
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Instant-mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6688.43848
-  tps: 4748.79132
+  dps: 6687.63229
+  tps: 4748.21893
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Instant-mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6688.43848
-  tps: 4748.79132
+  dps: 6687.63229
+  tps: 4748.21893
  }
 }
 dps_results: {
@@ -2053,162 +2053,162 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Instant-mutilate-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3536.65477
-  tps: 2511.02489
+  dps: 3537.90717
+  tps: 2511.91409
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Instant-mutilate-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3536.65477
-  tps: 2511.02489
+  dps: 3537.90717
+  tps: 2511.91409
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Instant-mutilate-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 3986.1919
-  tps: 2830.19625
+  dps: 3986.89502
+  tps: 2830.69546
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-Assassination-mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 11253.61164
-  tps: 7990.06427
+  dps: 11303.15618
+  tps: 8025.24089
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-Assassination-mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 11253.61164
-  tps: 7990.06427
+  dps: 11303.15618
+  tps: 8025.24089
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-Assassination-mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 15784.86362
-  tps: 11207.25317
+  dps: 15822.10164
+  tps: 11233.69217
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-Assassination-mutilate-NoBuffs-LongMultiTarget"
  value: {
-  dps: 5733.52319
-  tps: 4070.80146
+  dps: 5741.68319
+  tps: 4076.59506
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-Assassination-mutilate-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5733.52319
-  tps: 4070.80146
+  dps: 5741.68319
+  tps: 4076.59506
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-Assassination-mutilate-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6487.49847
-  tps: 4606.12391
+  dps: 6493.53022
+  tps: 4610.40645
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 8290.13316
-  tps: 5885.99454
+  dps: 8356.08736
+  tps: 5932.82202
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 8290.13316
-  tps: 5885.99454
+  dps: 8356.08736
+  tps: 5932.82202
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 11892.41647
-  tps: 8443.6157
+  dps: 11933.51837
+  tps: 8472.79804
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-LongMultiTarget"
  value: {
-  dps: 4310.12149
-  tps: 3060.18626
+  dps: 4337.62549
+  tps: 3079.7141
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-LongSingleTarget"
  value: {
-  dps: 4310.12149
-  tps: 3060.18626
+  dps: 4337.62549
+  tps: 3079.7141
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4939.35301
-  tps: 3506.94064
+  dps: 4971.38503
+  tps: 3529.68337
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Deadly-mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 10778.15592
-  tps: 7652.4907
+  dps: 10803.85136
+  tps: 7670.73447
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Deadly-mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 10778.15592
-  tps: 7652.4907
+  dps: 10803.85136
+  tps: 7670.73447
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Deadly-mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 15078.99757
-  tps: 10706.08828
+  dps: 15081.95045
+  tps: 10708.18482
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Deadly-mutilate-NoBuffs-LongMultiTarget"
  value: {
-  dps: 5479.94815
-  tps: 3890.76319
+  dps: 5474.69806
+  tps: 3887.03562
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Deadly-mutilate-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5479.94815
-  tps: 3890.76319
+  dps: 5474.69806
+  tps: 3887.03562
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Deadly-mutilate-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6121.5024
-  tps: 4346.26671
+  dps: 6123.58496
+  tps: 4347.74532
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Instant-mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 6808.64333
-  tps: 4834.13676
+  dps: 6807.83739
+  tps: 4833.56454
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Instant-mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 6808.64333
-  tps: 4834.13676
+  dps: 6807.83739
+  tps: 4833.56454
  }
 }
 dps_results: {
@@ -2221,28 +2221,28 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Instant-mutilate-NoBuffs-LongMultiTarget"
  value: {
-  dps: 3614.51204
-  tps: 2566.30355
+  dps: 3615.6716
+  tps: 2567.12683
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Instant-mutilate-NoBuffs-LongSingleTarget"
  value: {
-  dps: 3614.51204
-  tps: 2566.30355
+  dps: 3615.6716
+  tps: 2567.12683
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Instant-mutilate-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 4138.94744
-  tps: 2938.65268
+  dps: 4139.63383
+  tps: 2939.14002
  }
 }
 dps_results: {
  key: "TestAssassination-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 9928.62492
-  tps: 7049.32369
+  dps: 9947.62278
+  tps: 7062.81217
  }
 }

--- a/sim/warrior/warrior.go
+++ b/sim/warrior/warrior.go
@@ -128,7 +128,6 @@ func (warrior *Warrior) Initialize() {
 	warrior.registerStances()
 	warrior.EnrageEffectMultiplier = 1.0
 	warrior.hsCleaveCD = warrior.NewTimer()
-	warrior.ReactionTime = time.Millisecond * 500
 
 	warrior.RegisterBerserkerRageSpell()
 	warrior.RegisterColossusSmash()

--- a/ui/core/components/other_inputs.ts
+++ b/ui/core/components/other_inputs.ts
@@ -79,10 +79,10 @@ export function makePhaseSelector(parent: HTMLElement, sim: Sim): EnumPicker<Sim
 	});
 }
 
-export const ReactionTime = {
+export const InputDelay = {
 	type: 'number' as const,
-	label: 'Reaction Time',
-	labelTooltip: 'Reaction time of the player, in milliseconds. Used with certain APL values (such as \'Aura Is Active With Reaction Time\').',
+	label: 'Input Delay',
+	labelTooltip: 'Player input delay, in milliseconds. Specifies the maximum delay on actions that cannot be spell queued, such as spell casts that are waiting on resource gains or waiting for a cooldown to expire. Also used with certain APL values (such as \'Aura Is Active With Reaction Time\'). Roughly models the sum of reaction time + server latency.',
 	changedEvent: (player: Player<any>) => player.miscOptionsChangeEmitter,
 	getValue: (player: Player<any>) => player.getReactionTime(),
 	setValue: (eventID: EventID, player: Player<any>, newValue: number) => {

--- a/ui/core/player.ts
+++ b/ui/core/player.ts
@@ -1499,7 +1499,7 @@ export class Player<SpecType extends Spec> {
 		TypedEvent.freezeAllAndDo(() => {
 			this.setEnableItemSwap(eventID, false);
 			this.setItemSwapGear(eventID, new ItemSwapGear({}));
-			this.setReactionTime(eventID, 200);
+			this.setReactionTime(eventID, 100);
 			this.setInFrontOfTarget(eventID, this.playerSpec.isTankSpec);
 			this.setHealingModel(
 				eventID,

--- a/ui/death_knight/blood/sim.ts
+++ b/ui/death_knight/blood/sim.ts
@@ -141,6 +141,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecBloodDeathKnight, {
 	// Inputs to include in the 'Other' section on the settings tab.
 	otherInputs: {
 		inputs: [
+			OtherInputs.InputDelay,
 			OtherInputs.TankAssignment,
 			OtherInputs.HpPercentForDefensives,
 			OtherInputs.IncomingHps,

--- a/ui/death_knight/frost/sim.ts
+++ b/ui/death_knight/frost/sim.ts
@@ -130,6 +130,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFrostDeathKnight, {
 			// FrostInputs.AvgAMSHitInput,
 			// OtherInputs.TankAssignment,
 			// OtherInputs.InFrontOfTarget,
+			OtherInputs.InputDelay,
 			OtherInputs.DarkIntentUptime
 		],
 	},

--- a/ui/death_knight/unholy/sim.ts
+++ b/ui/death_knight/unholy/sim.ts
@@ -143,6 +143,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecUnholyDeathKnight, {
 			// UnholyInputs.AvgAMSHitInput,
 			// OtherInputs.TankAssignment,
 			// OtherInputs.InFrontOfTarget,
+			OtherInputs.InputDelay,
 			OtherInputs.DarkIntentUptime
 		],
 	},

--- a/ui/druid/_feral_tank/sim.ts
+++ b/ui/druid/_feral_tank/sim.ts
@@ -161,6 +161,7 @@
 // 	// Inputs to include in the 'Other' section on the settings tab.
 // 	otherInputs: {
 // 		inputs: [
+// 			OtherInputs.InputDelay,
 // 			OtherInputs.TankAssignment,
 // 			OtherInputs.IncomingHps,
 // 			OtherInputs.HealingCadence,

--- a/ui/druid/balance/sim.ts
+++ b/ui/druid/balance/sim.ts
@@ -72,7 +72,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecBalanceDruid, {
 	excludeBuffDebuffInputs: [],
 	// Inputs to include in the 'Other' section on the settings tab.
 	otherInputs: {
-		inputs: [BalanceInputs.OkfUptime, OtherInputs.TankAssignment, OtherInputs.ReactionTime, OtherInputs.DistanceFromTarget, OtherInputs.DarkIntentUptime],
+		inputs: [BalanceInputs.OkfUptime, OtherInputs.TankAssignment, OtherInputs.InputDelay, OtherInputs.DistanceFromTarget, OtherInputs.DarkIntentUptime],
 	},
 	encounterPicker: {
 		// Whether to include 'Execute Duration (%)' in the 'Encounter' section of the settings tab.

--- a/ui/druid/feral/inputs.ts
+++ b/ui/druid/feral/inputs.ts
@@ -8,12 +8,6 @@ import { TypedEvent } from '../../core/typed_event.js';
 // Configuration for spec-specific UI elements on the settings tab.
 // These don't need to be in a separate file but it keeps things cleaner.
 
-export const LatencyMs = InputHelpers.makeSpecOptionsNumberInput<Spec.SpecFeralDruid>({
-	fieldName: 'latencyMs',
-	label: 'Latency',
-	labelTooltip: 'Player latency, in milliseconds. Adds a delay to actions that cannot be spell queued.',
-});
-
 export const AssumeBleedActive = InputHelpers.makeSpecOptionsBooleanInput<Spec.SpecFeralDruid>({
 	fieldName: 'assumeBleedActive',
 	label: 'Assume Bleed Always Active',

--- a/ui/druid/feral/presets.ts
+++ b/ui/druid/feral/presets.ts
@@ -74,7 +74,6 @@ export const StandardTalents = {
 };
 
 export const DefaultOptions = FeralDruidOptions.create({
-	latencyMs: 100,
 	assumeBleedActive: true,
 });
 

--- a/ui/druid/feral/sim.ts
+++ b/ui/druid/feral/sim.ts
@@ -102,7 +102,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFeralDruid, {
 	excludeBuffDebuffInputs: [],
 	// Inputs to include in the 'Other' section on the settings tab.
 	otherInputs: {
-		inputs: [FeralInputs.LatencyMs, FeralInputs.AssumeBleedActive, OtherInputs.InputDelay, OtherInputs.TankAssignment, OtherInputs.InFrontOfTarget, OtherInputs.DarkIntentUptime],
+		inputs: [FeralInputs.AssumeBleedActive, OtherInputs.InputDelay, OtherInputs.TankAssignment, OtherInputs.InFrontOfTarget, OtherInputs.DarkIntentUptime],
 	},
 	encounterPicker: {
 		// Whether to include 'Execute Duration (%)' in the 'Encounter' section of the settings tab.

--- a/ui/druid/feral/sim.ts
+++ b/ui/druid/feral/sim.ts
@@ -102,7 +102,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFeralDruid, {
 	excludeBuffDebuffInputs: [],
 	// Inputs to include in the 'Other' section on the settings tab.
 	otherInputs: {
-		inputs: [FeralInputs.LatencyMs, FeralInputs.AssumeBleedActive, OtherInputs.TankAssignment, OtherInputs.InFrontOfTarget, OtherInputs.DarkIntentUptime],
+		inputs: [FeralInputs.LatencyMs, FeralInputs.AssumeBleedActive, OtherInputs.InputDelay, OtherInputs.TankAssignment, OtherInputs.InFrontOfTarget, OtherInputs.DarkIntentUptime],
 	},
 	encounterPicker: {
 		// Whether to include 'Execute Duration (%)' in the 'Encounter' section of the settings tab.

--- a/ui/druid/restoration/sim.ts
+++ b/ui/druid/restoration/sim.ts
@@ -69,7 +69,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecRestorationDruid, {
 	excludeBuffDebuffInputs: [],
 	// Inputs to include in the 'Other' section on the settings tab.
 	otherInputs: {
-		inputs: [OtherInputs.TankAssignment],
+		inputs: [OtherInputs.InputDelay, OtherInputs.TankAssignment],
 	},
 	encounterPicker: {
 		// Whether to include 'Execute Duration (%)' in the 'Encounter' section of the settings tab.

--- a/ui/hunter/beast_mastery/sim.ts
+++ b/ui/hunter/beast_mastery/sim.ts
@@ -113,6 +113,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecBeastMasteryHunter, {
 		inputs: [
 			HunterInputs.PetUptime(),
 			HunterInputs.TimeToTrapWeaveMs(),
+			OtherInputs.InputDelay,
 			OtherInputs.TankAssignment,
 			OtherInputs.InFrontOfTarget,
 			OtherInputs.DarkIntentUptime,

--- a/ui/hunter/marksmanship/sim.ts
+++ b/ui/hunter/marksmanship/sim.ts
@@ -147,6 +147,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecMarksmanshipHunter, {
 		inputs: [
 			HunterInputs.PetUptime(),
 			HunterInputs.TimeToTrapWeaveMs(),
+			OtherInputs.InputDelay,
 			OtherInputs.TankAssignment,
 			OtherInputs.InFrontOfTarget,
 			OtherInputs.DarkIntentUptime,

--- a/ui/hunter/survival/sim.ts
+++ b/ui/hunter/survival/sim.ts
@@ -139,6 +139,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecSurvivalHunter, {
 			HunterInputs.PetUptime(),
 			HunterInputs.TimeToTrapWeaveMs(),
 			SVInputs.SniperTrainingUptime,
+			OtherInputs.InputDelay,
 			OtherInputs.TankAssignment,
 			OtherInputs.InFrontOfTarget,
 			OtherInputs.DarkIntentUptime

--- a/ui/mage/arcane/sim.ts
+++ b/ui/mage/arcane/sim.ts
@@ -111,7 +111,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecArcaneMage, {
 	excludeBuffDebuffInputs: [],
 	// Inputs to include in the 'Other' section on the settings tab.
 	otherInputs: {
-		inputs: [ArcaneInputs.FocusMagicUptime, OtherInputs.ReactionTime, OtherInputs.DistanceFromTarget, OtherInputs.TankAssignment],
+		inputs: [ArcaneInputs.FocusMagicUptime, OtherInputs.InputDelay, OtherInputs.DistanceFromTarget, OtherInputs.TankAssignment],
 	},
 	encounterPicker: {
 		// Whether to include 'Execute Duration (%)' in the 'Encounter' section of the settings tab.

--- a/ui/mage/fire/sim.ts
+++ b/ui/mage/fire/sim.ts
@@ -110,7 +110,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFireMage, {
 	excludeBuffDebuffInputs: [],
 	// Inputs to include in the 'Other' section on the settings tab.
 	otherInputs: {
-		inputs: [OtherInputs.ReactionTime, OtherInputs.DistanceFromTarget, OtherInputs.TankAssignment, OtherInputs.DarkIntentUptime,],
+		inputs: [OtherInputs.InputDelay, OtherInputs.DistanceFromTarget, OtherInputs.TankAssignment, OtherInputs.DarkIntentUptime,],
 	},
 	encounterPicker: {
 		// Whether to include 'Execute Duration (%)' in the 'Encounter' section of the settings tab.

--- a/ui/mage/frost/sim.ts
+++ b/ui/mage/frost/sim.ts
@@ -112,7 +112,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFrostMage, {
 	otherInputs: {
 		inputs: [
 			//FrostInputs.WaterElementalDisobeyChance,
-			OtherInputs.ReactionTime,
+			OtherInputs.InputDelay,
 			OtherInputs.DistanceFromTarget,
 			OtherInputs.TankAssignment,
 		],

--- a/ui/paladin/holy/sim.ts
+++ b/ui/paladin/holy/sim.ts
@@ -85,7 +85,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecHolyPaladin, {
 	excludeBuffDebuffInputs: [],
 	// Inputs to include in the 'Other' section on the settings tab.
 	otherInputs: {
-		inputs: [OtherInputs.TankAssignment, OtherInputs.InspirationUptime],
+		inputs: [OtherInputs.InputDelay, OtherInputs.TankAssignment, OtherInputs.InspirationUptime],
 	},
 	encounterPicker: {
 		// Whether to include 'Execute Duration (%)' in the 'Encounter' section of the settings tab.

--- a/ui/paladin/protection/sim.ts
+++ b/ui/paladin/protection/sim.ts
@@ -170,6 +170,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecProtectionPaladin, {
 	// Inputs to include in the 'Other' section on the settings tab.
 	otherInputs: {
 		inputs: [
+			OtherInputs.InputDelay,
 			OtherInputs.TankAssignment,
 			OtherInputs.IncomingHps,
 			OtherInputs.HealingCadence,

--- a/ui/paladin/retribution/sim.ts
+++ b/ui/paladin/retribution/sim.ts
@@ -143,7 +143,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecRetributionPaladin, {
 	excludeBuffDebuffInputs: [],
 	// Inputs to include in the 'Other' section on the settings tab.
 	otherInputs: {
-		inputs: [OtherInputs.TankAssignment, OtherInputs.InFrontOfTarget],
+		inputs: [OtherInputs.InputDelay, OtherInputs.TankAssignment, OtherInputs.InFrontOfTarget],
 	},
 	encounterPicker: {
 		// Whether to include 'Execute Duration (%)' in the 'Encounter' section of the settings tab.

--- a/ui/priest/discipline/sim.ts
+++ b/ui/priest/discipline/sim.ts
@@ -87,7 +87,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecDisciplinePriest, {
 	excludeBuffDebuffInputs: [],
 	// Inputs to include in the 'Other' section on the settings tab.
 	otherInputs: {
-		inputs: [OtherInputs.TankAssignment, OtherInputs.ChannelClipDelay],
+		inputs: [OtherInputs.InputDelay, OtherInputs.TankAssignment, OtherInputs.ChannelClipDelay],
 	},
 	encounterPicker: {
 		// Whether to include 'Execute Duration (%)' in the 'Encounter' section of the settings tab.

--- a/ui/priest/holy/sim.ts
+++ b/ui/priest/holy/sim.ts
@@ -87,7 +87,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecHolyPriest, {
 	excludeBuffDebuffInputs: [],
 	// Inputs to include in the 'Other' section on the settings tab.
 	otherInputs: {
-		inputs: [OtherInputs.TankAssignment, OtherInputs.ChannelClipDelay],
+		inputs: [OtherInputs.InputDelay, OtherInputs.TankAssignment, OtherInputs.ChannelClipDelay],
 	},
 	encounterPicker: {
 		// Whether to include 'Execute Duration (%)' in the 'Encounter' section of the settings tab.

--- a/ui/priest/shadow/sim.ts
+++ b/ui/priest/shadow/sim.ts
@@ -88,7 +88,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecShadowPriest, {
 	excludeBuffDebuffInputs: [],
 	// Inputs to include in the 'Other' section on the settings tab.
 	otherInputs: {
-		inputs: [OtherInputs.TankAssignment, OtherInputs.ChannelClipDelay, OtherInputs.DistanceFromTarget, OtherInputs.DarkIntentUptime,],
+		inputs: [OtherInputs.InputDelay, OtherInputs.TankAssignment, OtherInputs.ChannelClipDelay, OtherInputs.DistanceFromTarget, OtherInputs.DarkIntentUptime,],
 	},
 	encounterPicker: {
 		// Whether to include 'Execute Duration (%)' in the 'Encounter' section of the settings tab.

--- a/ui/rogue/assassination/sim.ts
+++ b/ui/rogue/assassination/sim.ts
@@ -261,6 +261,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecAssassinationRogue, {
 			// RogueInputs.AssumeBleedActive(),
 			// OtherInputs.TankAssignment,
 			// OtherInputs.InFrontOfTarget,
+			OtherInputs.InputDelay,
 		],
 	},
 	encounterPicker: {

--- a/ui/rogue/assassination/sim.ts
+++ b/ui/rogue/assassination/sim.ts
@@ -1,4 +1,5 @@
 import * as BuffDebuffInputs from '../../core/components/inputs/buffs_debuffs';
+import * as OtherInputs from '../../core/components/other_inputs.js';
 import { IndividualSimUI, registerSpecConfig } from '../../core/individual_sim_ui';
 import { Player } from '../../core/player';
 import { PlayerClasses } from '../../core/player_classes';

--- a/ui/rogue/combat/sim.ts
+++ b/ui/rogue/combat/sim.ts
@@ -263,6 +263,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecCombatRogue, {
 			// RogueInputs.AssumeBleedActive(),
 			// OtherInputs.TankAssignment,
 			// OtherInputs.InFrontOfTarget,
+			OtherInputs.InputDelay,
 		],
 	},
 	encounterPicker: {

--- a/ui/rogue/subtlety/sim.ts
+++ b/ui/rogue/subtlety/sim.ts
@@ -264,6 +264,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecSubtletyRogue, {
 			// SubInputs.HonorAmongThievesCritRate,
 			// OtherInputs.TankAssignment,
 			// OtherInputs.InFrontOfTarget,
+			OtherInputs.InputDelay,
 		],
 	},
 	encounterPicker: {

--- a/ui/shaman/elemental/sim.ts
+++ b/ui/shaman/elemental/sim.ts
@@ -118,7 +118,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecElementalShaman, {
 	excludeBuffDebuffInputs: [],
 	// Inputs to include in the 'Other' section on the settings tab.
 	otherInputs: {
-		inputs: [ElementalInputs.InThunderstormRange, OtherInputs.TankAssignment],
+		inputs: [ElementalInputs.InThunderstormRange, OtherInputs.InputDelay, OtherInputs.TankAssignment],
 	},
 	customSections: [ShamanInputs.TotemsSection],
 	encounterPicker: {

--- a/ui/shaman/enhancement/sim.ts
+++ b/ui/shaman/enhancement/sim.ts
@@ -128,7 +128,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecEnhancementShaman, {
 	excludeBuffDebuffInputs: [BuffDebuffInputs.BleedDebuff],
 	// Inputs to include in the 'Other' section on the settings tab.
 	otherInputs: {
-		inputs: [EnhancementInputs.SyncTypeInput, OtherInputs.TankAssignment, OtherInputs.InFrontOfTarget],
+		inputs: [EnhancementInputs.SyncTypeInput, OtherInputs.InputDelay, OtherInputs.TankAssignment, OtherInputs.InFrontOfTarget],
 	},
 	itemSwapSlots: [ItemSlot.ItemSlotMainHand, ItemSlot.ItemSlotOffHand],
 	customSections: [ShamanInputs.TotemsSection, FireElementalSection],

--- a/ui/shaman/restoration/sim.ts
+++ b/ui/shaman/restoration/sim.ts
@@ -96,6 +96,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecRestorationShaman, {
 		inputs: [
 			// RestorationInputs.TriggerEarthShield,
 			// OtherInputs.TankAssignment
+			OtherInputs.InputDelay,
 		],
 	},
 	customSections: [ShamanInputs.TotemsSection],

--- a/ui/warlock/affliction/sim.ts
+++ b/ui/warlock/affliction/sim.ts
@@ -89,7 +89,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecAfflictionWarlock, {
 	petConsumeInputs: [],
 	// Inputs to include in the 'Other' section on the settings tab.
 	otherInputs: {
-		inputs: [WarlockInputs.DetonateSeed(), OtherInputs.DistanceFromTarget, OtherInputs.TankAssignment, OtherInputs.ChannelClipDelay],
+		inputs: [WarlockInputs.DetonateSeed(), OtherInputs.InputDelay, OtherInputs.DistanceFromTarget, OtherInputs.TankAssignment, OtherInputs.ChannelClipDelay],
 	},
 	itemSwapSlots: [ItemSlot.ItemSlotMainHand, ItemSlot.ItemSlotOffHand, ItemSlot.ItemSlotRanged],
 	encounterPicker: {

--- a/ui/warlock/demonology/sim.ts
+++ b/ui/warlock/demonology/sim.ts
@@ -89,7 +89,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecDemonologyWarlock, {
 	petConsumeInputs: [],
 	// Inputs to include in the 'Other' section on the settings tab.
 	otherInputs: {
-		inputs: [WarlockInputs.DetonateSeed(), OtherInputs.DistanceFromTarget, OtherInputs.TankAssignment, OtherInputs.ChannelClipDelay],
+		inputs: [WarlockInputs.DetonateSeed(), OtherInputs.InputDelay, OtherInputs.DistanceFromTarget, OtherInputs.TankAssignment, OtherInputs.ChannelClipDelay],
 	},
 	itemSwapSlots: [ItemSlot.ItemSlotMainHand, ItemSlot.ItemSlotOffHand, ItemSlot.ItemSlotRanged],
 	encounterPicker: {

--- a/ui/warlock/destruction/sim.ts
+++ b/ui/warlock/destruction/sim.ts
@@ -89,7 +89,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecDestructionWarlock, {
 	petConsumeInputs: [],
 	// Inputs to include in the 'Other' section on the settings tab.
 	otherInputs: {
-		inputs: [WarlockInputs.DetonateSeed(), OtherInputs.DistanceFromTarget, OtherInputs.TankAssignment, OtherInputs.ChannelClipDelay],
+		inputs: [WarlockInputs.DetonateSeed(), OtherInputs.InputDelay, OtherInputs.DistanceFromTarget, OtherInputs.TankAssignment, OtherInputs.ChannelClipDelay],
 	},
 	itemSwapSlots: [ItemSlot.ItemSlotMainHand, ItemSlot.ItemSlotOffHand, ItemSlot.ItemSlotRanged],
 	encounterPicker: {

--- a/ui/warrior/arms/sim.ts
+++ b/ui/warrior/arms/sim.ts
@@ -126,6 +126,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecArmsWarrior, {
 			WarriorInputs.StartingRage(),
 			WarriorInputs.StanceSnapshot(),
 			WarriorInputs.DisableExpertiseGemming(),
+			OtherInputs.InputDelay,
 			OtherInputs.TankAssignment,
 			OtherInputs.InFrontOfTarget,
 		],

--- a/ui/warrior/fury/sim.ts
+++ b/ui/warrior/fury/sim.ts
@@ -126,6 +126,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFuryWarrior, {
 			WarriorInputs.StartingRage(),
 			WarriorInputs.StanceSnapshot(),
 			WarriorInputs.DisableExpertiseGemming(),
+			OtherInputs.InputDelay,
 			OtherInputs.TankAssignment,
 			OtherInputs.InFrontOfTarget,
 		],

--- a/ui/warrior/protection/sim.ts
+++ b/ui/warrior/protection/sim.ts
@@ -139,6 +139,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecProtectionWarrior, {
 	// Inputs to include in the 'Other' section on the settings tab.
 	otherInputs: {
 		inputs: [
+			OtherInputs.InputDelay,
 			OtherInputs.TankAssignment,
 			OtherInputs.IncomingHps,
 			OtherInputs.HealingCadence,


### PR DESCRIPTION
- Reaction time is now used self-consistently for _all_ actions that cannot be spell queued, not just aura checks.
- The "Input Delay" parameter, now exposed to all sims in the UI, controls the maximum delay on all such actions. This includes spell casts that are waiting on a cooldown to expire, as well as spell casts that are waiting on Energy or Focus regen.
- As a result of this unified behavior, APL no longer needs to be explicitly called on Energy or Focus gains, and all the associated bookkeeping code for this has been removed. Hunter, Rogue, and Feral sims now run more than 2x faster than they did before as a result of this change.
- Focus has also been fixed to apply the same partial tick refunds that Energy does upon dynamic changes to Haste.
- Small DPS changes for all specs are expected from this refactor, and are reflected in the test results.