### PR TITLE
[Shaman] Enhancement Mastery & Flameshock Fix

### DIFF
--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -40,1932 +40,1932 @@ character_stats_results: {
 dps_results: {
  key: "TestElemental-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 20981.95495
+  dps: 22554.31287
   tps: 466.83145
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 20143.94602
+  dps: 21676.30936
   tps: 388.36419
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 20190.49797
+  dps: 21727.55034
   tps: 388.44218
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 20975.99685
+  dps: 22555.4856
   tps: 388.89237
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 21010.01791
+  dps: 22591.37633
   tps: 388.24827
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 20493.85251
+  dps: 22038.82842
   tps: 466.4415
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 20493.85251
+  dps: 22038.82842
   tps: 466.4415
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 20037.48282
+  dps: 21538.76619
   tps: 389.83759
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 20129.65416
+  dps: 21636.3691
   tps: 388.90263
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 20504.00047
+  dps: 22051.35973
   tps: 469.9238
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 20731.19573
+  dps: 22316.48504
   tps: 384.3181
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 20875.331
+  dps: 22468.241
   tps: 383.52976
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BindingPromise-67037"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlackBruise-50035"
  value: {
-  dps: 15618.39709
+  dps: 16724.66865
   tps: 453.93695
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlackBruise-50692"
  value: {
-  dps: 15618.39709
+  dps: 16724.66865
   tps: 453.93695
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 15033.95377
+  dps: 16153.46197
   tps: 373.99229
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 15058.22441
+  dps: 16172.83817
   tps: 376.31436
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 19970.08639
+  dps: 21474.3555
   tps: 394.43578
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 20064.05994
+  dps: 21576.13152
   tps: 395.45415
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 20157.41837
+  dps: 21663.72456
   tps: 395.31983
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 19921.42684
+  dps: 21446.9692
   tps: 384.58698
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 20451.65428
+  dps: 21984.35648
   tps: 388.71246
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 20316.25543
+  dps: 21862.31598
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BottledLightning-66879"
  value: {
-  dps: 20190.49797
+  dps: 21727.55034
   tps: 388.44218
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 20549.76973
+  dps: 22099.59445
   tps: 466.01131
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 20633.72676
+  dps: 22192.02554
   tps: 466.68205
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 21125.51015
+  dps: 22711.5649
   tps: 467.88713
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 21125.51015
+  dps: 22711.5649
   tps: 467.88713
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 21125.51015
+  dps: 22711.5649
   tps: 467.88713
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 21020.47057
+  dps: 22599.33324
   tps: 466.30274
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 20992.86103
+  dps: 22567.81681
   tps: 466.61277
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 20577.01663
+  dps: 22150.56972
   tps: 389.13231
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CrushingWeight-59506"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CrushingWeight-65118"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 19795.16443
+  dps: 21298.91783
   tps: 386.95081
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 19706.62663
+  dps: 21207.58167
   tps: 440.40827
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 20195.33799
+  dps: 21732.0461
   tps: 399.42115
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 20577.01663
+  dps: 22150.56972
   tps: 389.13231
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Death'sChoice-47464"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 19752.72108
+  dps: 21251.75119
   tps: 388.00233
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 19959.29189
+  dps: 21477.79102
   tps: 387.47075
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 19920.27136
+  dps: 21434.21334
   tps: 390.50128
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Defender'sCode-40257"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 20529.57893
+  dps: 22080.62638
   tps: 465.90168
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 20504.19492
+  dps: 22051.96729
   tps: 466.34624
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 20374.69854
+  dps: 21927.49417
   tps: 394.43981
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 20309.99223
+  dps: 21848.85278
   tps: 392.92593
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 20493.85251
+  dps: 22038.82842
   tps: 466.4415
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 20315.02042
+  dps: 21842.97732
   tps: 388.0847
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 20633.72676
+  dps: 22192.02554
   tps: 471.27095
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 20827.41827
+  dps: 22404.04458
   tps: 469.67954
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 20529.57893
+  dps: 22080.62638
   tps: 465.90168
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 20504.00047
+  dps: 22051.35973
   tps: 466.22282
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 20503.91821
+  dps: 22050.79904
   tps: 466.22282
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 20493.85251
+  dps: 22038.82842
   tps: 466.4415
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 20493.85251
+  dps: 22038.82842
   tps: 466.4415
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 19822.55017
+  dps: 21347.86683
   tps: 418.05728
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 20038.30984
+  dps: 21564.89997
   tps: 386.99767
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FallofMortality-59500"
  value: {
-  dps: 20577.01663
+  dps: 22150.56972
   tps: 389.13231
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FallofMortality-65124"
  value: {
-  dps: 20683.94201
+  dps: 22267.08832
   tps: 389.44412
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 20518.89115
+  dps: 22055.22212
   tps: 388.24827
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 20484.49154
+  dps: 22047.5322
   tps: 388.94977
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 20484.49154
+  dps: 22047.5322
   tps: 388.94977
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 20157.41837
+  dps: 21663.72456
   tps: 395.31983
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 19844.27802
+  dps: 21351.11466
   tps: 388.30119
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 20664.35388
+  dps: 22248.04333
   tps: 465.78373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FluidDeath-58181"
  value: {
-  dps: 20646.19128
+  dps: 22173.12557
   tps: 388.64426
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 19982.03007
+  dps: 21501.39938
   tps: 388.59587
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForgeEmber-37660"
  value: {
-  dps: 19945.51394
+  dps: 21463.69985
   tps: 387.40379
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 20633.72676
+  dps: 22192.02554
   tps: 467.49718
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 20549.76973
+  dps: 22099.59445
   tps: 466.82644
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 20537.13793
+  dps: 22086.11775
   tps: 466.85765
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 19937.55575
+  dps: 21463.62374
   tps: 384.3181
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FuturesightRune-38763"
  value: {
-  dps: 19871.22882
+  dps: 21381.10297
   tps: 388.39345
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GaleofShadows-56138"
  value: {
-  dps: 20542.37133
+  dps: 22102.46203
   tps: 398.62194
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GaleofShadows-56462"
  value: {
-  dps: 20625.90826
+  dps: 22198.63144
   tps: 397.77489
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GearDetector-61462"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 20168.49589
+  dps: 21703.61985
   tps: 388.40643
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 20221.46485
+  dps: 21761.08842
   tps: 388.50403
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 19780.64632
+  dps: 21281.87438
   tps: 387.40379
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HarmlightToken-63839"
  value: {
-  dps: 20467.58624
+  dps: 22010.85308
   tps: 544.70421
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 20454.33569
+  dps: 22016.81271
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 20547.56541
+  dps: 22118.65123
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofRage-59224"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofRage-65072"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofSolace-55868"
  value: {
-  dps: 20014.53681
+  dps: 21524.49189
   tps: 398.62194
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofSolace-56393"
  value: {
-  dps: 20030.06585
+  dps: 21546.12689
   tps: 397.77489
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofThunder-55845"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofThunder-56370"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Heartpierce-49982"
  value: {
-  dps: 21125.51015
+  dps: 22711.5649
   tps: 467.88713
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Heartpierce-50641"
  value: {
-  dps: 21125.51015
+  dps: 22711.5649
   tps: 467.88713
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 20108.4272
+  dps: 21639.0333
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 20529.57893
+  dps: 22080.62638
   tps: 465.90168
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 20504.00047
+  dps: 22051.35973
   tps: 466.22282
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 20503.91821
+  dps: 22050.79904
   tps: 466.22282
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 20185.16629
+  dps: 21693.94321
   tps: 394.52785
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 20185.16629
+  dps: 21693.94321
   tps: 394.52785
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 20064.05994
+  dps: 21576.13152
   tps: 395.45415
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 20157.41837
+  dps: 21663.72456
   tps: 395.31983
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-IncisorFragment-37723"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 20549.76973
+  dps: 22099.59445
   tps: 469.70676
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 20021.73857
+  dps: 21524.38694
   tps: 392.78127
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 20523.85515
+  dps: 22083.82646
   tps: 466.06801
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 19970.08639
+  dps: 21474.3555
   tps: 394.43578
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 20388.78982
+  dps: 21916.74672
   tps: 388.0847
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 20518.89115
+  dps: 22055.22212
   tps: 388.24827
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 19904.96092
+  dps: 21405.3115
   tps: 394.6885
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 19904.96092
+  dps: 21405.3115
   tps: 394.6885
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 20129.65416
+  dps: 21636.3691
   tps: 388.90263
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LastWord-50179"
  value: {
-  dps: 21125.51015
+  dps: 22711.5649
   tps: 467.88713
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LastWord-50708"
  value: {
-  dps: 21125.51015
+  dps: 22711.5649
   tps: 467.88713
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LeadenDespair-55816"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LeadenDespair-56347"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 20646.19128
+  dps: 22173.12557
   tps: 388.64426
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 20153.30637
+  dps: 21662.85551
   tps: 387.82756
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 20538.78866
+  dps: 22065.72295
   tps: 388.64426
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 20538.78866
+  dps: 22065.72295
   tps: 388.64426
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 19778.81611
+  dps: 21280.04417
   tps: 387.40379
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 20347.82121
+  dps: 21871.71107
   tps: 388.421
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 20518.89115
+  dps: 22055.22212
   tps: 388.24827
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 20185.16629
+  dps: 21693.94321
   tps: 394.52785
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 20185.16629
+  dps: 21693.94321
   tps: 394.52785
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 20625.44373
+  dps: 22203.07972
   tps: 389.2644
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 19982.03007
+  dps: 21501.39938
   tps: 388.59587
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 20503.91821
+  dps: 22050.79904
   tps: 466.22282
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 20504.00047
+  dps: 22051.35973
   tps: 466.22282
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 20493.85251
+  dps: 22038.82842
   tps: 466.4415
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 20493.85251
+  dps: 22038.82842
   tps: 466.4415
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 20493.85251
+  dps: 22038.82842
   tps: 466.4415
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Rainsong-55854"
  value: {
-  dps: 20315.02042
+  dps: 21842.97732
   tps: 388.0847
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Rainsong-56377"
  value: {
-  dps: 20445.12175
+  dps: 21981.45272
   tps: 388.24827
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 20146.28195
+  dps: 21693.93879
   tps: 559.71991
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 20185.90878
+  dps: 21735.31125
   tps: 581.28834
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 20981.95495
+  dps: 22554.31287
   tps: 466.83145
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 20981.95495
+  dps: 22554.31287
   tps: 466.83145
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 21196.98164
+  dps: 22792.1582
   tps: 468.23468
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 20567.77413
+  dps: 22122.71948
   tps: 468.45779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 20498.21534
+  dps: 22035.11783
   tps: 388.89237
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 20518.89115
+  dps: 22055.22212
   tps: 388.24827
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SeaStar-55256"
  value: {
-  dps: 20274.05181
+  dps: 21797.94166
   tps: 388.421
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SeaStar-56290"
  value: {
-  dps: 20445.12175
+  dps: 21981.45272
   tps: 388.24827
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Shadowmourne-49623"
  value: {
-  dps: 21125.51015
+  dps: 22711.5649
   tps: 467.88713
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ShieldedSkyflareDiamond"
  value: {
-  dps: 20493.85251
+  dps: 22038.82842
   tps: 466.4415
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 20237.49992
+  dps: 21757.07012
   tps: 389.33914
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 20095.38477
+  dps: 21623.89289
   tps: 388.41328
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 20141.50134
+  dps: 21673.65051
   tps: 388.35975
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Sorrowsong-55879"
  value: {
-  dps: 20363.15755
+  dps: 21908.67071
   tps: 395.45415
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Sorrowsong-56400"
  value: {
-  dps: 20515.35914
+  dps: 22052.27381
   tps: 395.31983
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 20498.21534
+  dps: 22035.11783
   tps: 388.89237
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SoulCasket-58183"
  value: {
-  dps: 20185.16629
+  dps: 21693.94321
   tps: 394.52785
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SoulPreserver-37111"
  value: {
-  dps: 19900.65872
+  dps: 21412.88714
   tps: 388.46338
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SouloftheDead-40382"
  value: {
-  dps: 19790.03026
+  dps: 21294.07812
   tps: 389.98353
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SparkofLife-37657"
  value: {
-  dps: 19850.89027
+  dps: 21327.11251
   tps: 389.29134
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 19807.24697
+  dps: 21314.05398
   tps: 390.3761
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 20393.80828
+  dps: 21951.91101
   tps: 386.68512
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-StumpofTime-62465"
  value: {
-  dps: 21202.19631
+  dps: 22769.92434
   tps: 388.64426
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-StumpofTime-62470"
  value: {
-  dps: 21235.58006
+  dps: 22808.14354
   tps: 388.64426
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 20504.00047
+  dps: 22051.35973
   tps: 466.22282
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 20503.91821
+  dps: 22050.79904
   tps: 466.22282
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 20502.15124
+  dps: 22048.51885
   tps: 466.22282
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 20646.00219
+  dps: 22181.23952
   tps: 396.38853
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 19911.22761
+  dps: 21420.67568
   tps: 391.65065
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TearofBlood-55819"
  value: {
-  dps: 20297.34843
+  dps: 21844.1705
   tps: 388.6702
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TearofBlood-56351"
  value: {
-  dps: 20484.49154
+  dps: 22047.5322
   tps: 388.94977
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 19952.02765
+  dps: 21469.0419
   tps: 388.57189
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 20408.5878
+  dps: 21945.52228
   tps: 394.33901
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 20774.9697
+  dps: 22338.11249
   tps: 395.31983
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 21469.15547
+  dps: 23056.67743
   tps: 399.08392
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 20493.85251
+  dps: 22038.82842
   tps: 466.4415
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 20064.05994
+  dps: 21576.13152
   tps: 395.45415
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 20157.41837
+  dps: 21663.72456
   tps: 395.31983
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 19924.18374
+  dps: 21428.92319
   tps: 391.62837
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 19924.18374
+  dps: 21428.92319
   tps: 391.62837
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 20549.76973
+  dps: 22099.59445
   tps: 466.82644
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 20537.13793
+  dps: 22086.11775
   tps: 466.85765
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 19883.43432
+  dps: 21394.3786
   tps: 388.42554
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 20537.13793
+  dps: 22086.11775
   tps: 466.85765
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 20549.76973
+  dps: 22099.59445
   tps: 466.82644
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 20577.01663
+  dps: 22150.56972
   tps: 389.13231
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 14496.89377
+  dps: 15592.55957
   tps: 362.44437
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-UnheededWarning-59520"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 20129.65416
+  dps: 21636.3691
   tps: 388.90263
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 20185.16629
+  dps: 21693.94321
   tps: 394.52785
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 20185.16629
+  dps: 21693.94321
   tps: 394.52785
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 17293.41133
+  dps: 18559.92841
   tps: 456.77712
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 20695.64164
+  dps: 22214.76582
   tps: 387.74409
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 20169.96598
+  dps: 21712.4478
   tps: 401.21174
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 19953.5592
+  dps: 21481.9403
   tps: 384.00754
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 20236.11388
+  dps: 21751.53638
   tps: 396.3408
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 20365.33483
+  dps: 21904.417
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WingedTalisman-37844"
  value: {
-  dps: 19911.22761
+  dps: 21420.67568
   tps: 391.65065
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 20361.06646
+  dps: 21913.2793
   tps: 396.22368
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 20661.9061
+  dps: 22240.28528
   tps: 404.71304
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 19970.08639
+  dps: 21474.3555
   tps: 394.43578
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 19736.46685
+  dps: 21232.6561
   tps: 388.10828
  }
 }
 dps_results: {
  key: "TestElemental-Average-Default"
  value: {
-  dps: 21459.95986
+  dps: 23073.15615
   tps: 459.0961
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-Standard-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 23723.84868
+  dps: 28342.28293
   tps: 7831.91773
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-Standard-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 21257.63958
+  dps: 22842.97715
   tps: 468.44099
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-Standard-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 25251.17474
+  dps: 26946.55577
   tps: 571.33538
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-Standard-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15842.74121
+  dps: 18949.32156
   tps: 5884.01675
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-Standard-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 16541.93943
+  dps: 17743.90566
   tps: 464.65738
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-Standard-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 18619.36523
+  dps: 19808.35338
   tps: 509.53338
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-Standard-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 23554.50404
+  dps: 28172.32003
   tps: 7831.02526
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-Standard-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 21125.51015
+  dps: 22711.5649
   tps: 467.88713
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-Standard-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 25050.16667
+  dps: 26745.32489
   tps: 570.20189
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-Standard-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15692.54705
+  dps: 18795.37182
   tps: 5936.6256
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-Standard-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 16452.62012
+  dps: 17656.2664
   tps: 464.45362
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-Standard-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 18470.79719
+  dps: 19659.60697
   tps: 508.4897
  }
 }
 dps_results: {
  key: "TestElemental-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 20946.32289
+  dps: 22532.37765
   tps: 467.88713
  }
 }

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -40,1975 +40,1975 @@ character_stats_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 28669.75474
-  tps: 18471.166
+  dps: 26359.47356
+  tps: 16986.45144
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 26855.63694
-  tps: 17385.31655
+  dps: 24671.20191
+  tps: 15979.02977
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 26857.94474
-  tps: 17386.38284
+  dps: 24673.5343
+  tps: 15979.88883
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 27180.57824
-  tps: 17466.90363
+  dps: 24959.04314
+  tps: 16065.70615
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 27105.8846
-  tps: 17467.9345
+  dps: 24897.21132
+  tps: 16062.03591
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 28053.30326
-  tps: 18058.93823
+  dps: 25792.33729
+  tps: 16604.40241
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 28053.30326
-  tps: 18058.93823
+  dps: 25792.33729
+  tps: 16604.40241
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 27172.12993
-  tps: 17499.65501
+  dps: 24959.33747
+  tps: 16087.64125
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 27027.33453
-  tps: 17368.23725
+  dps: 24825.20661
+  tps: 15964.89251
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 27027.33453
-  tps: 17368.23725
+  dps: 24825.20661
+  tps: 15964.89251
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 28068.12154
-  tps: 18069.91532
+  dps: 25806.52976
+  tps: 16615.01675
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 27044.00597
-  tps: 17523.57854
+  dps: 24841.23612
+  tps: 16110.01826
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 27057.34218
-  tps: 17558.40777
+  dps: 24863.21165
+  tps: 16146.54589
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BindingPromise-67037"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlackBruise-50035"
  value: {
-  dps: 26444.31616
-  tps: 16971.03384
+  dps: 24246.98825
+  tps: 15536.79927
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlackBruise-50692"
  value: {
-  dps: 26578.28948
-  tps: 17111.3092
+  dps: 24379.69875
+  tps: 15674.96401
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 20594.27201
-  tps: 13621.17523
+  dps: 18954.68141
+  tps: 12561.40141
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 20168.48721
-  tps: 13305.26227
+  dps: 18558.77613
+  tps: 12267.15552
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 27224.19317
-  tps: 17569.67133
+  dps: 24992.6182
+  tps: 16132.75707
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 27282.27219
-  tps: 17598.09707
+  dps: 25043.34752
+  tps: 16156.44518
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 27340.35178
-  tps: 17626.52337
+  dps: 25094.07732
+  tps: 16180.13377
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 27019.7429
-  tps: 17512.55871
+  dps: 24821.56579
+  tps: 16099.9337
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 27027.33453
-  tps: 17368.23725
+  dps: 24825.20661
+  tps: 15964.89251
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 28003.96262
-  tps: 18091.68219
+  dps: 25731.11275
+  tps: 16630.95848
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BottledLightning-66879"
  value: {
-  dps: 26857.94474
-  tps: 17386.38284
+  dps: 24673.5343
+  tps: 15979.88883
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 28055.02615
-  tps: 17704.27503
+  dps: 25793.94749
+  tps: 16278.76536
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 28059.08683
-  tps: 17705.80654
+  dps: 25797.528
+  tps: 16280.03823
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 28537.26588
-  tps: 18383.27949
+  dps: 26236.87934
+  tps: 16905.64734
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 28537.26588
-  tps: 18383.27949
+  dps: 26236.87934
+  tps: 16905.64734
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 28463.78063
-  tps: 18336.55557
+  dps: 26168.90446
+  tps: 16862.49564
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 28515.26123
-  tps: 18411.32226
+  dps: 26217.1583
+  tps: 16929.80175
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 28473.36336
-  tps: 18346.66475
+  dps: 26178.45127
+  tps: 16872.56891
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 26876.99364
-  tps: 17392.93576
+  dps: 24690.30732
+  tps: 15985.52904
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CrushingWeight-59506"
  value: {
-  dps: 27121.71401
-  tps: 17514.09059
+  dps: 24924.04985
+  tps: 16106.35503
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CrushingWeight-65118"
  value: {
-  dps: 27115.40032
-  tps: 17541.45353
+  dps: 24947.23326
+  tps: 16134.74562
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 26924.58217
-  tps: 17464.14595
+  dps: 24737.04235
+  tps: 16053.58939
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 26963.49044
-  tps: 17425.79817
+  dps: 24763.91499
+  tps: 16020.30202
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 27237.40561
-  tps: 17631.72936
+  dps: 25020.68599
+  tps: 16207.60991
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 27319.52709
-  tps: 17899.56836
+  dps: 25135.7321
+  tps: 16495.29228
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 28043.00571
-  tps: 18135.20715
+  dps: 25757.54212
+  tps: 16664.82686
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 26876.99364
-  tps: 17392.93576
+  dps: 24690.30732
+  tps: 15985.52904
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 27409.83258
-  tps: 17669.17767
+  dps: 25146.04932
+  tps: 16211.5778
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Death'sChoice-47464"
  value: {
-  dps: 27892.55895
-  tps: 18033.60103
+  dps: 25619.62671
+  tps: 16576.51057
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 26878.5372
-  tps: 17433.58689
+  dps: 24695.7308
+  tps: 16026.49445
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 27407.12995
-  tps: 17716.05197
+  dps: 25190.46543
+  tps: 16286.88148
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 27433.42817
-  tps: 17745.65557
+  dps: 25219.00055
+  tps: 16317.44709
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Defender'sCode-40257"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 28107.19905
-  tps: 18131.24822
+  dps: 25842.61714
+  tps: 16669.40819
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 28073.6903
-  tps: 18079.62629
+  dps: 25811.81
+  tps: 16623.83362
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 26930.8523
-  tps: 17432.27844
+  dps: 24739.70333
+  tps: 16028.74046
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 26861.79016
-  tps: 17348.37375
+  dps: 24675.29215
+  tps: 15949.84045
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 28053.30326
-  tps: 18058.93823
+  dps: 25792.33729
+  tps: 16604.40241
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 27027.33453
-  tps: 17368.23725
+  dps: 24825.20661
+  tps: 15964.89251
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 28059.08683
-  tps: 18060.34289
+  dps: 25797.528
+  tps: 16605.47726
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 28055.02615
-  tps: 18059.09357
+  dps: 25793.94749
+  tps: 16604.49187
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 28107.19905
-  tps: 18131.24822
+  dps: 25842.61714
+  tps: 16669.40819
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 28068.12154
-  tps: 18070.25914
+  dps: 25806.52976
+  tps: 16615.36056
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 28064.73023
-  tps: 18066.86782
+  dps: 25803.13845
+  tps: 16611.96925
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 28367.76548
-  tps: 18394.11382
+  dps: 26071.06988
+  tps: 16915.49987
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 28053.30326
-  tps: 18058.93823
+  dps: 25792.33729
+  tps: 16604.40241
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 28053.30326
-  tps: 18058.93823
+  dps: 25792.33729
+  tps: 16604.40241
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 26946.9286
-  tps: 17433.2585
+  dps: 24758.79971
+  tps: 16026.25819
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 26929.01699
-  tps: 17456.55721
+  dps: 24739.58706
+  tps: 16046.95311
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FallofMortality-59500"
  value: {
-  dps: 26876.99364
-  tps: 17392.93576
+  dps: 24690.30732
+  tps: 15985.52904
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FallofMortality-65124"
  value: {
-  dps: 26893.61084
-  tps: 17402.72444
+  dps: 24705.5965
+  tps: 15994.95829
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 27105.8846
-  tps: 17467.9345
+  dps: 24897.21132
+  tps: 16062.03591
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 26873.90185
-  tps: 17391.53383
+  dps: 24687.57172
+  tps: 15984.25776
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 26873.90185
-  tps: 17391.53383
+  dps: 24687.57172
+  tps: 15984.25776
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 27340.35178
-  tps: 17626.52337
+  dps: 25094.07732
+  tps: 16180.13377
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 26841.56588
-  tps: 17381.24642
+  dps: 24658.45841
+  tps: 15975.66784
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 28152.76339
-  tps: 18107.07384
+  dps: 25879.34046
+  tps: 16644.51542
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FluidDeath-58181"
  value: {
-  dps: 28745.15088
-  tps: 18479.47263
+  dps: 26406.28075
+  tps: 16993.67908
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 26848.49011
-  tps: 17383.00033
+  dps: 24664.63525
+  tps: 15977.14226
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForgeEmber-37660"
  value: {
-  dps: 26917.5809
-  tps: 17459.64681
+  dps: 24731.81862
+  tps: 16050.74565
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 28059.08683
-  tps: 18060.69797
+  dps: 25797.528
+  tps: 16605.83234
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 28055.02615
-  tps: 18059.12864
+  dps: 25793.94749
+  tps: 16604.52694
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 28054.83958
-  tps: 18058.98104
+  dps: 25793.79201
+  tps: 16604.41043
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 27044.00597
-  tps: 17523.57854
+  dps: 24841.23612
+  tps: 16110.01826
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 27285.55465
-  tps: 17645.19581
+  dps: 25065.90305
+  tps: 16216.49667
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuturesightRune-38763"
  value: {
-  dps: 26844.39948
-  tps: 17382.15825
+  dps: 24661.06647
+  tps: 15976.50724
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GaleofShadows-56138"
  value: {
-  dps: 27023.4958
-  tps: 17474.38687
+  dps: 24819.62939
+  tps: 16069.63213
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GaleofShadows-56462"
  value: {
-  dps: 27169.7749
-  tps: 17608.43694
+  dps: 24967.39117
+  tps: 16191.53682
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GearDetector-61462"
  value: {
-  dps: 27600.3547
-  tps: 17854.39513
+  dps: 25360.31653
+  tps: 16423.52362
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 26856.27251
-  tps: 17385.82624
+  dps: 24671.91089
+  tps: 15979.43893
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 26858.60733
-  tps: 17386.87459
+  dps: 24674.42571
+  tps: 15980.28006
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 26918.00867
-  tps: 17453.24755
+  dps: 24730.31692
+  tps: 16044.94694
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 27667.73665
-  tps: 17934.78355
+  dps: 25418.77967
+  tps: 16483.47123
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 28028.24818
-  tps: 18154.29599
+  dps: 25753.56497
+  tps: 16689.28748
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HarmlightToken-63839"
  value: {
-  dps: 27078.24664
-  tps: 17602.89502
+  dps: 24858.38567
+  tps: 16160.34395
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 27172.35691
-  tps: 17540.63891
+  dps: 24950.55535
+  tps: 16108.56339
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartofRage-59224"
  value: {
-  dps: 26843.49056
-  tps: 17366.39181
+  dps: 24658.15733
+  tps: 15963.05242
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartofRage-65072"
  value: {
-  dps: 26843.49056
-  tps: 17366.39181
+  dps: 24658.15733
+  tps: 15963.05242
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartofSolace-55868"
  value: {
-  dps: 27023.4958
-  tps: 17474.38687
+  dps: 24819.62939
+  tps: 16069.63213
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartofSolace-56393"
  value: {
-  dps: 27169.7749
-  tps: 17608.43694
+  dps: 24967.39117
+  tps: 16191.53682
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartofThunder-55845"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartofThunder-56370"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 27798.01451
-  tps: 18007.36012
+  dps: 25537.38007
+  tps: 16553.10531
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Heartpierce-49982"
  value: {
-  dps: 28537.26588
-  tps: 18383.27949
+  dps: 26236.87934
+  tps: 16905.64734
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Heartpierce-50641"
  value: {
-  dps: 28537.26588
-  tps: 18383.27949
+  dps: 26236.87934
+  tps: 16905.64734
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 28107.19905
-  tps: 18131.24822
+  dps: 25842.61714
+  tps: 16669.40819
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 28068.12154
-  tps: 18070.25914
+  dps: 25806.52976
+  tps: 16615.36056
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 28064.73023
-  tps: 18066.86782
+  dps: 25803.13845
+  tps: 16611.96925
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 27403.71198
-  tps: 17657.53453
+  dps: 25149.41945
+  tps: 16205.9764
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 27403.71198
-  tps: 17657.53453
+  dps: 25149.41945
+  tps: 16205.9764
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 27282.27219
-  tps: 17598.09707
+  dps: 25043.34752
+  tps: 16156.44518
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 27340.35178
-  tps: 17626.52337
+  dps: 25094.07732
+  tps: 16180.13377
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IncisorFragment-37723"
  value: {
-  dps: 27049.08294
-  tps: 17505.7054
+  dps: 24849.08082
+  tps: 16089.26473
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 28055.02615
-  tps: 18059.69277
+  dps: 25793.94749
+  tps: 16605.09107
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 27180.19429
-  tps: 17548.13706
+  dps: 24954.18721
+  tps: 16114.81185
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 28091.63387
-  tps: 18122.14827
+  dps: 25839.6421
+  tps: 16662.5533
   hps: 63.62803
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 27224.19317
-  tps: 17569.67133
+  dps: 24992.6182
+  tps: 16132.75707
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 28213.23705
-  tps: 18161.81497
+  dps: 25913.78364
+  tps: 16703.43296
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 28552.48991
-  tps: 18311.40155
+  dps: 26240.25857
+  tps: 16838.39969
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 26929.38785
-  tps: 17436.60356
+  dps: 24727.38762
+  tps: 16026.71533
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 26929.38785
-  tps: 17436.60356
+  dps: 24727.38762
+  tps: 16026.71533
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 27027.33453
-  tps: 17368.23725
+  dps: 24825.20661
+  tps: 15964.89251
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LastWord-50179"
  value: {
-  dps: 28537.26588
-  tps: 18383.27949
+  dps: 26236.87934
+  tps: 16905.64734
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LastWord-50708"
  value: {
-  dps: 28537.26588
-  tps: 18383.27949
+  dps: 26236.87934
+  tps: 16905.64734
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LeadenDespair-55816"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LeadenDespair-56347"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 28037.96162
-  tps: 18150.02241
+  dps: 25768.17703
+  tps: 16681.80595
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 28200.76417
-  tps: 18229.83125
+  dps: 25917.93184
+  tps: 16758.87431
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 27224.88148
-  tps: 17523.29372
+  dps: 24996.26511
+  tps: 16111.97388
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 26843.49056
-  tps: 17366.39181
+  dps: 24658.15733
+  tps: 15963.05242
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 26843.49056
-  tps: 17366.39181
+  dps: 24658.15733
+  tps: 15963.05242
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 27017.22551
-  tps: 17368.45706
+  dps: 24816.12604
+  tps: 15964.49939
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 27027.33453
-  tps: 17368.23725
+  dps: 24825.20661
+  tps: 15964.89251
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 27027.33453
-  tps: 17368.23725
+  dps: 24825.20661
+  tps: 15964.89251
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 26928.2755
-  tps: 17407.23505
+  dps: 24734.4837
+  tps: 16011.32838
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 27128.41847
-  tps: 17506.4602
+  dps: 24911.80061
+  tps: 16094.26242
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 27105.8846
-  tps: 17467.9345
+  dps: 24897.21132
+  tps: 16062.03591
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 27403.71198
-  tps: 17657.53453
+  dps: 25149.41945
+  tps: 16205.9764
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 27403.71198
-  tps: 17657.53453
+  dps: 25149.41945
+  tps: 16205.9764
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 26880.51561
-  tps: 17393.99847
+  dps: 24693.4088
+  tps: 15986.55154
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 26848.49011
-  tps: 17383.00033
+  dps: 24664.63525
+  tps: 15977.14226
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 28064.73023
-  tps: 18066.86782
+  dps: 25803.13845
+  tps: 16611.96925
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 28068.12154
-  tps: 18070.25914
+  dps: 25806.52976
+  tps: 16615.36056
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 27166.93441
-  tps: 17536.1824
+  dps: 24945.97498
+  tps: 16104.84963
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 27455.39644
-  tps: 17671.7579
+  dps: 25200.49787
+  tps: 16217.82921
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 28053.30326
-  tps: 18058.93823
+  dps: 25792.33729
+  tps: 16604.40241
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 28053.30326
-  tps: 18058.93823
+  dps: 25792.33729
+  tps: 16604.40241
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 28053.30326
-  tps: 18058.93823
+  dps: 25792.33729
+  tps: 16604.40241
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 28381.93613
-  tps: 18299.9835
+  dps: 26078.64696
+  tps: 16829.06079
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Rainsong-55854"
  value: {
-  dps: 27027.33453
-  tps: 17368.23725
+  dps: 24825.20661
+  tps: 15964.89251
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Rainsong-56377"
  value: {
-  dps: 27027.33453
-  tps: 17368.23725
+  dps: 24825.20661
+  tps: 15964.89251
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 27060.87463
-  tps: 17634.96755
+  dps: 24828.05608
+  tps: 16177.96258
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 27121.48899
-  tps: 17679.21154
+  dps: 24878.72045
+  tps: 16215.55539
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 28537.26588
-  tps: 18383.27949
+  dps: 26236.87934
+  tps: 16905.64734
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 28457.48577
-  tps: 18334.59928
+  dps: 26163.25581
+  tps: 16860.89885
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 28514.81315
-  tps: 18371.26904
+  dps: 26211.11367
+  tps: 16892.79188
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 28093.00526
-  tps: 18065.75701
+  dps: 25829.12808
+  tps: 16610.73758
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 27180.57824
-  tps: 17466.90363
+  dps: 24959.04314
+  tps: 16065.70615
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 27105.8846
-  tps: 17467.9345
+  dps: 24897.21132
+  tps: 16062.03591
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 28054.66219
-  tps: 18106.88713
+  dps: 25760.29428
+  tps: 16627.53089
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SeaStar-55256"
  value: {
-  dps: 27027.33453
-  tps: 17368.23725
+  dps: 24825.20661
+  tps: 15964.89251
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SeaStar-56290"
  value: {
-  dps: 27027.33453
-  tps: 17368.23725
+  dps: 24825.20661
+  tps: 15964.89251
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Shadowmourne-49623"
  value: {
-  dps: 28537.26588
-  tps: 18383.27949
+  dps: 26236.87934
+  tps: 16905.64734
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ShieldedSkyflareDiamond"
  value: {
-  dps: 28053.30326
-  tps: 18058.93823
+  dps: 25792.33729
+  tps: 16604.40241
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 27027.33453
-  tps: 17368.23725
+  dps: 24825.20661
+  tps: 15964.89251
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 27058.02889
-  tps: 17422.02454
+  dps: 24863.2366
+  tps: 16023.23535
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 27776.60534
-  tps: 17981.264
+  dps: 25517.33786
+  tps: 16526.021
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 27908.2107
-  tps: 18064.8911
+  dps: 25637.44939
+  tps: 16601.6657
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 26852.11021
-  tps: 17383.99928
+  dps: 24668.07107
+  tps: 15977.96008
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 26855.63694
-  tps: 17385.32589
+  dps: 24671.20191
+  tps: 15979.03911
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Sorrowsong-55879"
  value: {
-  dps: 27282.27219
-  tps: 17598.09707
+  dps: 25043.34752
+  tps: 16156.44518
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Sorrowsong-56400"
  value: {
-  dps: 27340.35178
-  tps: 17626.52337
+  dps: 25094.07732
+  tps: 16180.13377
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 27180.57824
-  tps: 17466.90363
+  dps: 24959.04314
+  tps: 16065.70615
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SoulCasket-58183"
  value: {
-  dps: 27403.71198
-  tps: 17657.53453
+  dps: 25149.41945
+  tps: 16205.9764
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SoulPreserver-37111"
  value: {
-  dps: 26844.61659
-  tps: 17382.26898
+  dps: 24661.24739
+  tps: 15976.58179
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SouloftheDead-40382"
  value: {
-  dps: 26931.74518
-  tps: 17458.72902
+  dps: 24742.12452
+  tps: 16049.15707
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SparkofLife-37657"
  value: {
-  dps: 26903.63426
-  tps: 17422.28451
+  dps: 24708.5216
+  tps: 16013.95987
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 26909.83815
-  tps: 17358.68572
+  dps: 24714.91534
+  tps: 15958.5038
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 26955.52169
-  tps: 17477.31448
+  dps: 24772.37559
+  tps: 16072.24462
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-StumpofTime-62465"
  value: {
-  dps: 27224.88148
-  tps: 17523.29372
+  dps: 24996.26511
+  tps: 16111.97388
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-StumpofTime-62470"
  value: {
-  dps: 27224.88148
-  tps: 17523.29372
+  dps: 24996.26511
+  tps: 16111.97388
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 28068.12154
-  tps: 18070.25914
+  dps: 25806.52976
+  tps: 16615.36056
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 28064.73023
-  tps: 18066.86782
+  dps: 25803.13845
+  tps: 16611.96925
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 28056.84827
-  tps: 18061.15565
+  dps: 25795.7696
+  tps: 16606.55395
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 27190.93666
-  tps: 17549.30512
+  dps: 24964.82661
+  tps: 16115.66265
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 26924.31943
-  tps: 17385.28269
+  dps: 24725.50752
+  tps: 15977.92966
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 26900.93492
-  tps: 17384.97637
+  dps: 24734.77042
+  tps: 15989.81882
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TearofBlood-55819"
  value: {
-  dps: 26861.71929
-  tps: 17388.17841
+  dps: 24677.16846
+  tps: 15981.31868
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TearofBlood-56351"
  value: {
-  dps: 26873.90185
-  tps: 17391.53383
+  dps: 24687.57172
+  tps: 15984.25776
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 26846.76838
-  tps: 17382.89881
+  dps: 24663.20047
+  tps: 15977.07491
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 27217.15333
-  tps: 17566.22583
+  dps: 24986.46922
+  tps: 16129.88582
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 27340.35178
-  tps: 17626.52337
+  dps: 25094.07732
+  tps: 16180.13377
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 27475.0793
-  tps: 17695.84819
+  dps: 25210.82108
+  tps: 16237.95606
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 27578.97012
-  tps: 17746.18128
+  dps: 25304.09423
+  tps: 16281.17232
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 28137.01712
-  tps: 18194.34515
+  dps: 25875.60665
+  tps: 16729.80463
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 28438.88528
-  tps: 18338.39031
+  dps: 26106.40197
+  tps: 16833.35086
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 28654.98902
-  tps: 18445.51835
+  dps: 26297.48412
+  tps: 16927.32073
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 27647.21465
-  tps: 17896.13965
+  dps: 25377.88001
+  tps: 16461.22927
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 27779.36479
-  tps: 18015.74201
+  dps: 25498.41707
+  tps: 16563.89413
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 28055.02615
-  tps: 18059.12864
+  dps: 25793.94749
+  tps: 16604.52694
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 28054.83958
-  tps: 18058.98104
+  dps: 25793.79201
+  tps: 16604.41043
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 26844.61659
-  tps: 17382.327
+  dps: 24661.24739
+  tps: 15976.63981
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 28054.83958
-  tps: 18058.98104
+  dps: 25793.79201
+  tps: 16604.41043
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 28055.02615
-  tps: 18059.12864
+  dps: 25793.94749
+  tps: 16604.52694
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 26876.99364
-  tps: 17392.93576
+  dps: 24690.30732
+  tps: 15985.52904
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 20511.33322
-  tps: 13577.54358
+  dps: 18885.14849
+  tps: 12516.3401
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-UnheededWarning-59520"
  value: {
-  dps: 28586.88731
-  tps: 18458.72455
+  dps: 26263.20317
+  tps: 16960.61017
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 27027.33453
-  tps: 17368.23725
+  dps: 24825.20661
+  tps: 15964.89251
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 27403.71198
-  tps: 17657.53453
+  dps: 25149.41945
+  tps: 16205.9764
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 27403.71198
-  tps: 17657.53453
+  dps: 25149.41945
+  tps: 16205.9764
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 25062.703
-  tps: 15690.06571
+  dps: 22911.25593
+  tps: 14287.654
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 27174.11926
-  tps: 17516.96705
+  dps: 24946.40817
+  tps: 16109.19305
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 26979.78061
-  tps: 17407.86121
+  dps: 24788.96473
+  tps: 16008.62258
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 27074.32368
-  tps: 17543.39256
+  dps: 24868.05673
+  tps: 16127.90706
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 26843.49056
-  tps: 17366.39181
+  dps: 24658.15733
+  tps: 15963.05242
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 27437.15236
-  tps: 17673.9018
+  dps: 25178.62803
+  tps: 16219.6158
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 28120.71502
-  tps: 18175.2966
+  dps: 25843.75036
+  tps: 16710.84731
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WingedTalisman-37844"
  value: {
-  dps: 26930.7729
-  tps: 17394.22307
+  dps: 24732.1302
+  tps: 15987.11948
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 26931.08547
-  tps: 17382.34279
+  dps: 24739.87446
+  tps: 15981.27529
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 27040.19583
-  tps: 17426.48842
+  dps: 24848.84958
+  tps: 16031.17578
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 27224.19317
-  tps: 17569.67133
+  dps: 24992.6182
+  tps: 16132.75707
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 26838.77403
-  tps: 17381.04219
+  dps: 24655.97195
+  tps: 15975.56612
  }
 }
 dps_results: {
  key: "TestEnhancement-Average-Default"
  value: {
-  dps: 28675.732
-  tps: 18527.93725
+  dps: 26364.6307
+  tps: 17045.24203
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-Standard-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 28393.70864
-  tps: 24203.5585
+  dps: 26100.23639
+  tps: 22718.57052
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-Standard-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 28537.26588
-  tps: 18383.27949
+  dps: 26236.87934
+  tps: 16905.64734
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-Standard-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 32627.78372
-  tps: 20899.06507
+  dps: 30296.93954
+  tps: 19316.76998
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-Standard-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 22112.22205
-  tps: 20717.32848
+  dps: 20298.57396
+  tps: 19555.47446
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-Standard-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 22061.6316
-  tps: 14508.96169
+  dps: 20263.2285
+  tps: 13362.43266
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-Standard-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 23871.98908
-  tps: 15517.76501
+  dps: 22067.54654
+  tps: 14333.37039
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Standard-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 28173.76802
-  tps: 24165.59282
+  dps: 25916.74882
+  tps: 22689.10661
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Standard-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 28258.53294
-  tps: 18290.99484
+  dps: 25994.37374
+  tps: 16822.41657
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Standard-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 32644.48189
-  tps: 20927.364
+  dps: 30316.48002
+  tps: 19339.17475
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Standard-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 21771.14859
-  tps: 20481.32097
+  dps: 19992.76385
+  tps: 19326.98729
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Standard-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 21940.16394
-  tps: 14430.33452
+  dps: 20167.64318
+  tps: 13291.3196
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Standard-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 23651.70952
-  tps: 15422.47809
+  dps: 21879.24568
+  tps: 14244.95478
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-Standard-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 28234.65027
-  tps: 24186.91803
+  dps: 25959.56087
+  tps: 22705.41326
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-Standard-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 28342.509
-  tps: 18350.77413
+  dps: 26071.25895
+  tps: 16879.91369
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-Standard-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 32588.07401
-  tps: 20931.71628
+  dps: 30258.7397
+  tps: 19337.58171
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-Standard-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 21732.45606
-  tps: 20484.67214
+  dps: 19956.00287
+  tps: 19323.0116
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-Standard-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 21924.61413
-  tps: 14431.14864
+  dps: 20152.20312
+  tps: 13291.02931
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-Standard-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 23636.47753
-  tps: 15428.54455
+  dps: 21863.47389
+  tps: 14249.78934
  }
 }
 dps_results: {
  key: "TestEnhancement-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 26784.34293
-  tps: 16986.89954
+  dps: 24634.29226
+  tps: 15606.18023
  }
 }

--- a/sim/shaman/shaman.go
+++ b/sim/shaman/shaman.go
@@ -40,11 +40,6 @@ func NewShaman(character *core.Character, talents string, totems *proto.ShamanTo
 		shaman.AddStat(stats.MeleeHit, core.MeleeHitRatingPerHitChance*6)
 		shaman.AddStatDependency(stats.AttackPower, stats.SpellPower, 0.55)
 		shaman.AddStatDependency(stats.Agility, stats.AttackPower, 2.4)
-
-		masteryBonusPoints := shaman.GetMasteryPoints()
-		shaman.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexFire] *= 1.2 + (masteryBonusPoints * 0.025)
-		shaman.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexFrost] *= 1.2 + (masteryBonusPoints * 0.025)
-		shaman.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexNature] *= 1.2 + (masteryBonusPoints * 0.025)
 		shaman.PseudoStats.CanParry = true
 	} else if shaman.Spec == proto.Spec_SpecElementalShaman {
 		shaman.AddStatDependency(stats.Agility, stats.AttackPower, 2.0)

--- a/sim/shaman/shocks.go
+++ b/sim/shaman/shocks.go
@@ -76,6 +76,7 @@ func (shaman *Shaman) registerFlameShockSpell(shockTimer *core.Timer) {
 		BonusCoefficient:    0.1,
 		OnSnapshot: func(sim *core.Simulation, target *core.Unit, dot *core.Dot, _ bool) {
 			dot.SnapshotBaseDamage = 856 / 6
+			dot.SnapshotBaseDamage += dot.BonusCoefficient * dot.Spell.BonusDamage()
 			dot.SnapshotCritChance = dot.Spell.SpellCritChance(target)
 			dot.Spell.DamageMultiplierAdditive += bonusPeriodicDamageMultiplier
 			dot.SnapshotAttackerMultiplier = dot.Spell.AttackerDamageMultiplier(dot.Spell.Unit.AttackTables[target.UnitIndex], true)


### PR DESCRIPTION
- Enhancement benefitting from double mastery fixed.
Mastery was being added as SchoolDamageDealtMultipliers in shaman.go, and also as DynamicMod in enhancement.go

- Dot portion of flame shock scales with spellpower