### PR TITLE
Feral Rotation Optimizations

### DIFF
--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -1836,8 +1836,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 22891.00586
-  tps: 16253.89567
+  dps: 22890.86838
+  tps: 16253.79806
  }
 }
 dps_results: {

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -40,1894 +40,1894 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 22728.23298
-  tps: 16138.242
+  dps: 22718.95854
+  tps: 16131.65715
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 21449.4868
-  tps: 15230.407
+  dps: 21428.24527
+  tps: 15215.32551
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 21449.4868
-  tps: 15230.407
+  dps: 21428.24527
+  tps: 15215.32551
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 22182.21434
-  tps: 15750.56877
+  dps: 22172.97357
+  tps: 15744.00782
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 22182.21434
-  tps: 15750.56877
+  dps: 22172.97357
+  tps: 15744.00782
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 21584.05671
-  tps: 15325.95164
+  dps: 21573.02143
+  tps: 15318.11659
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
   hps: 84.91645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
   hps: 84.91645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 22200.43295
-  tps: 15763.50398
+  dps: 22191.41258
+  tps: 15757.09952
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 21597.99314
-  tps: 15335.77172
+  dps: 21591.72786
+  tps: 15331.32337
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 21631.66433
-  tps: 15359.67826
+  dps: 21640.58694
+  tps: 15366.01331
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BindingPromise-67037"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 16516.91828
-  tps: 11728.20857
+  dps: 16515.52644
+  tps: 11727.22036
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 22357.23537
-  tps: 15874.8337
+  dps: 22339.68097
+  tps: 15862.37008
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 21571.34426
-  tps: 15316.85101
+  dps: 21559.51219
+  tps: 15308.45024
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 21605.76295
-  tps: 15341.28828
+  dps: 21593.84162
+  tps: 15332.82414
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 22809.76532
-  tps: 16196.12996
+  dps: 22780.30657
+  tps: 16175.21425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 21750.19047
-  tps: 15443.83182
+  dps: 21739.23785
+  tps: 15436.05546
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 21585.06181
-  tps: 15326.59047
+  dps: 21576.97767
+  tps: 15320.85073
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 22393.08469
-  tps: 15900.28672
+  dps: 22388.78765
+  tps: 15897.23582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 21720.343
-  tps: 15422.64012
+  dps: 21711.28721
+  tps: 15416.21051
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledLightning-66879"
  value: {
-  dps: 21436.78661
-  tps: 15221.31508
+  dps: 21435.92431
+  tps: 15220.70285
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 22182.21434
-  tps: 15435.55739
+  dps: 22172.97357
+  tps: 15429.12767
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 22182.21434
-  tps: 15435.55739
+  dps: 22172.97357
+  tps: 15429.12767
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 22549.44651
-  tps: 16011.30361
+  dps: 22540.46035
+  tps: 16004.92343
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 22595.8277
-  tps: 16044.23426
+  dps: 22584.33604
+  tps: 16036.07517
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 22568.76001
-  tps: 16025.01619
+  dps: 22560.00746
+  tps: 16018.80188
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
   hps: 64
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-59506"
  value: {
-  dps: 22105.88743
-  tps: 15696.37666
+  dps: 22134.04648
+  tps: 15716.36959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-65118"
  value: {
-  dps: 22167.8952
-  tps: 15740.40218
+  dps: 22201.70119
+  tps: 15764.40443
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 21408.51382
-  tps: 15201.2414
+  dps: 21398.8986
+  tps: 15194.41459
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 21435.64562
-  tps: 15220.65455
+  dps: 21425.6681
+  tps: 15213.57051
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 21673.06789
-  tps: 15389.07479
+  dps: 21665.84584
+  tps: 15383.94713
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 21949.38746
-  tps: 15585.26168
+  dps: 21936.83418
+  tps: 15576.34885
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 22364.63127
-  tps: 15880.08479
+  dps: 22357.15314
+  tps: 15874.77532
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 21644.20122
-  tps: 15370.88933
+  dps: 21632.18252
+  tps: 15362.35606
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Death'sChoice-47464"
  value: {
-  dps: 22270.56495
-  tps: 15813.2977
+  dps: 22252.69264
+  tps: 15800.60836
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 21391.61298
-  tps: 15189.2418
+  dps: 21378.09268
+  tps: 15179.64239
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 21904.74807
-  tps: 15553.56772
+  dps: 21889.52701
+  tps: 15542.76077
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 21930.39624
-  tps: 15571.77792
+  dps: 21944.18762
+  tps: 15581.5698
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Defender'sCode-40257"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 22226.01363
-  tps: 15781.66626
+  dps: 22214.41442
+  tps: 15773.43082
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 22206.66457
-  tps: 15767.92843
+  dps: 22197.06698
+  tps: 15761.11414
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 21409.68727
-  tps: 15202.07455
+  dps: 21449.11024
+  tps: 15230.06486
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 21375.23302
-  tps: 15177.61203
+  dps: 21380.09452
+  tps: 15181.0637
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 22182.21434
-  tps: 15750.56877
+  dps: 22172.97357
+  tps: 15744.00782
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 21308.51063
-  tps: 15167.3811
+  dps: 21297.36016
+  tps: 15159.3462
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 22182.21434
-  tps: 15750.56877
+  dps: 22172.97357
+  tps: 15744.00782
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 22182.21434
-  tps: 15750.56877
+  dps: 22172.97357
+  tps: 15744.00782
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 22226.01363
-  tps: 15781.66626
+  dps: 22214.41442
+  tps: 15773.43082
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 22200.43295
-  tps: 15763.50398
+  dps: 22191.41258
+  tps: 15757.09952
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 22196.28044
-  tps: 15760.5557
+  dps: 22187.22702
+  tps: 15754.12777
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 21409.3391
-  tps: 15201.82735
+  dps: 21418.80085
+  tps: 15208.54519
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 22777.88128
-  tps: 16173.49229
+  dps: 22746.13285
+  tps: 16150.95091
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 23000.49603
-  tps: 16331.54877
+  dps: 22968.72809
+  tps: 16308.99353
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 22182.21434
-  tps: 15750.56877
+  dps: 22172.97357
+  tps: 15744.00782
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 22182.21434
-  tps: 15750.56877
+  dps: 22172.97357
+  tps: 15744.00782
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 21435.02924
-  tps: 15220.06735
+  dps: 21425.31087
+  tps: 15213.1673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 21391.2101
-  tps: 15188.95576
+  dps: 21381.23258
+  tps: 15181.87172
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-59500"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-65124"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 22822.24017
-  tps: 16205.0619
+  dps: 22794.10168
+  tps: 16185.08357
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 22025.77513
-  tps: 15639.49693
+  dps: 22013.96864
+  tps: 15631.11432
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 22240.09139
-  tps: 15791.66148
+  dps: 22230.71283
+  tps: 15785.00269
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FluidDeath-58181"
  value: {
-  dps: 22671.52523
-  tps: 16098.12908
+  dps: 22681.3189
+  tps: 16105.08258
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForgeEmber-37660"
  value: {
-  dps: 21368.25253
-  tps: 15172.65588
+  dps: 21357.74048
+  tps: 15165.19232
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 22182.21434
-  tps: 15750.56877
+  dps: 22172.97357
+  tps: 15744.00782
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 22182.21434
-  tps: 15750.56877
+  dps: 22172.97357
+  tps: 15744.00782
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 22182.21434
-  tps: 15750.56877
+  dps: 22172.97357
+  tps: 15744.00782
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 23141.5144
-  tps: 16431.67181
+  dps: 23147.54619
+  tps: 16435.95438
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 21687.64841
-  tps: 15399.42696
+  dps: 21676.59096
+  tps: 15391.57617
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuturesightRune-38763"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56138"
  value: {
-  dps: 21436.56021
-  tps: 15221.15434
+  dps: 21528.06581
+  tps: 15286.12331
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56462"
  value: {
-  dps: 21554.36633
-  tps: 15304.79668
+  dps: 21543.5508
+  tps: 15297.11766
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GearDetector-61462"
  value: {
-  dps: 22073.25642
-  tps: 15673.20865
+  dps: 22027.13591
+  tps: 15640.46308
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 21416.25368
-  tps: 15206.88628
+  dps: 21406.50656
+  tps: 15199.96582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 22056.99177
-  tps: 15661.66074
+  dps: 22048.66226
+  tps: 15655.74679
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 22391.34204
-  tps: 15899.04943
+  dps: 22371.41615
+  tps: 15884.90206
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HarmlightToken-63839"
  value: {
-  dps: 21315.80934
-  tps: 15135.42122
+  dps: 21304.65887
+  tps: 15127.50438
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 21824.86182
-  tps: 15496.84848
+  dps: 21813.84382
+  tps: 15489.0257
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-59224"
  value: {
-  dps: 22035.32663
-  tps: 15646.27849
+  dps: 22070.69241
+  tps: 15671.3882
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-65072"
  value: {
-  dps: 22186.67111
-  tps: 15753.73307
+  dps: 22197.3684
+  tps: 15761.32815
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-55868"
  value: {
-  dps: 21436.56021
-  tps: 15221.15434
+  dps: 21528.06581
+  tps: 15286.12331
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-56393"
  value: {
-  dps: 22025.20881
-  tps: 15639.09484
+  dps: 22015.91348
+  tps: 15632.49516
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-55845"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-56370"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 22168.54633
-  tps: 15740.86448
+  dps: 22157.76349
+  tps: 15733.20867
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-49982"
  value: {
-  dps: 23068.36334
-  tps: 16379.73456
+  dps: 23043.93029
+  tps: 16362.38709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-50641"
  value: {
-  dps: 23127.87202
-  tps: 16421.98572
+  dps: 23196.03725
+  tps: 16470.38303
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 22226.01363
-  tps: 15781.66626
+  dps: 22214.41442
+  tps: 15773.43082
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 22200.43295
-  tps: 15763.50398
+  dps: 22191.41258
+  tps: 15757.09952
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 22196.28044
-  tps: 15760.5557
+  dps: 22187.22702
+  tps: 15754.12777
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 22117.22167
-  tps: 15704.42397
+  dps: 22105.32227
+  tps: 15695.9754
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 22117.22167
-  tps: 15704.42397
+  dps: 22105.32227
+  tps: 15695.9754
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 21571.34426
-  tps: 15316.85101
+  dps: 21559.51219
+  tps: 15308.45024
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 21605.76295
-  tps: 15341.28828
+  dps: 21593.84162
+  tps: 15332.82414
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IncisorFragment-37723"
  value: {
-  dps: 21674.57083
-  tps: 15390.14187
+  dps: 21665.3247
+  tps: 15383.57712
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 22182.21434
-  tps: 15750.56877
+  dps: 22172.97357
+  tps: 15744.00782
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 21510.8508
-  tps: 15273.90066
+  dps: 21499.17561
+  tps: 15265.61127
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 22188.03218
-  tps: 15754.69943
+  dps: 22188.79344
+  tps: 15755.23993
   hps: 61.37058
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 22357.23537
-  tps: 15874.8337
+  dps: 22339.68097
+  tps: 15862.37008
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 22346.13898
-  tps: 15867.03005
+  dps: 22332.13376
+  tps: 15857.08634
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 22658.71198
-  tps: 16088.95688
+  dps: 22637.58733
+  tps: 16073.95837
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 21665.28667
-  tps: 15383.55012
+  dps: 21605.87278
+  tps: 15341.36626
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 21665.28667
-  tps: 15383.55012
+  dps: 21605.87278
+  tps: 15341.36626
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 21427.92412
-  tps: 15215.02271
+  dps: 21414.90131
+  tps: 15205.77652
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50179"
  value: {
-  dps: 22857.76224
-  tps: 16230.20777
+  dps: 22848.56698
+  tps: 16223.67914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50708"
  value: {
-  dps: 22876.9645
-  tps: 16243.84138
+  dps: 22867.73491
+  tps: 16237.28837
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-55816"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-56347"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 22536.65184
-  tps: 16002.21939
+  dps: 22557.76661
+  tps: 16017.21088
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 22663.49249
-  tps: 16092.27625
+  dps: 22642.83346
+  tps: 16077.60834
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 21930.18655
-  tps: 15571.77861
+  dps: 21908.5942
+  tps: 15556.44804
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 21775.04652
-  tps: 15461.47961
+  dps: 21748.42332
+  tps: 15442.57715
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 21981.39878
-  tps: 15607.98972
+  dps: 21956.47768
+  tps: 15590.29574
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 21964.03217
-  tps: 15595.65943
+  dps: 21949.96234
+  tps: 15585.66985
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 22050.60965
-  tps: 15657.12944
+  dps: 22036.15146
+  tps: 15646.86412
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 21470.21121
-  tps: 15245.04655
+  dps: 21486.63991
+  tps: 15256.71092
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 21691.00442
-  tps: 15401.88451
+  dps: 21644.75066
+  tps: 15369.04434
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 21879.01289
-  tps: 15535.37053
+  dps: 21857.79994
+  tps: 15520.30933
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 21643.31061
-  tps: 15367.94712
+  dps: 21631.29191
+  tps: 15359.41384
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 21643.31061
-  tps: 15367.94712
+  dps: 21631.29191
+  tps: 15359.41384
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 21722.61069
-  tps: 15424.25018
+  dps: 21708.37379
+  tps: 15414.14198
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 21465.66558
-  tps: 15241.81915
+  dps: 21448.53955
+  tps: 15229.65967
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 21791.70225
-  tps: 15473.30518
+  dps: 21787.32027
+  tps: 15470.19398
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 22196.28044
-  tps: 15760.5557
+  dps: 22187.22702
+  tps: 15754.12777
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 22200.43295
-  tps: 15763.50398
+  dps: 22191.41258
+  tps: 15757.09952
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 21518.04859
-  tps: 15279.01108
+  dps: 21504.09695
+  tps: 15269.10542
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 21697.14642
-  tps: 15406.17054
+  dps: 21683.75665
+  tps: 15396.66381
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 22182.21434
-  tps: 15750.56877
+  dps: 22172.97357
+  tps: 15744.00782
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 22182.21434
-  tps: 15750.56877
+  dps: 22172.97357
+  tps: 15744.00782
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 22182.21434
-  tps: 15750.56877
+  dps: 22172.97357
+  tps: 15744.00782
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 22685.32975
-  tps: 16107.78071
+  dps: 22703.36993
+  tps: 16120.58923
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 22870.61044
-  tps: 16239.33
+  dps: 22890.65711
+  tps: 16253.56314
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-55854"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-56377"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 22619.98022
-  tps: 16061.38255
+  dps: 22611.22889
+  tps: 16055.1691
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 22619.53551
-  tps: 16061.0668
+  dps: 22610.59331
+  tps: 16054.71784
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 22549.44651
-  tps: 16011.30361
+  dps: 22540.46035
+  tps: 16004.92343
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 22182.21434
-  tps: 15750.56877
+  dps: 22172.97357
+  tps: 15744.00782
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 21849.46412
-  tps: 15514.3909
+  dps: 21828.09753
+  tps: 15499.22062
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 21889.82524
-  tps: 15543.04729
+  dps: 21864.59155
+  tps: 15525.13137
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 22303.45172
-  tps: 15836.6473
+  dps: 22294.92511
+  tps: 15830.59341
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-55256"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-56290"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShieldedSkyflareDiamond"
  value: {
-  dps: 22182.21434
-  tps: 15750.56877
+  dps: 22172.97357
+  tps: 15744.00782
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 21852.0563
-  tps: 15516.15656
+  dps: 21866.70599
+  tps: 15526.55784
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 22458.37165
-  tps: 15946.64046
+  dps: 22447.76161
+  tps: 15939.10733
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 22610.04623
-  tps: 16054.32941
+  dps: 22599.1763
+  tps: 16046.61176
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-55879"
  value: {
-  dps: 21571.34426
-  tps: 15316.85101
+  dps: 21559.51219
+  tps: 15308.45024
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-56400"
  value: {
-  dps: 21605.76295
-  tps: 15341.28828
+  dps: 21593.84162
+  tps: 15332.82414
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 21680.07449
-  tps: 15394.12426
+  dps: 21658.8483
+  tps: 15379.05367
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulCasket-58183"
  value: {
-  dps: 21643.31061
-  tps: 15367.94712
+  dps: 21631.29191
+  tps: 15359.41384
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulPreserver-37111"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SouloftheDead-40382"
  value: {
-  dps: 21393.42309
-  tps: 15190.52698
+  dps: 21383.70472
+  tps: 15183.62694
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SparkofLife-37657"
  value: {
-  dps: 21366.14326
-  tps: 15171.1583
+  dps: 21421.59488
+  tps: 15210.52895
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 21574.36803
-  tps: 15319.07267
+  dps: 21549.66406
+  tps: 15301.53285
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 21319.25643
-  tps: 15137.86865
+  dps: 21308.10595
+  tps: 15129.95181
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62465"
  value: {
-  dps: 21449.53
-  tps: 15230.51246
+  dps: 21428.28847
+  tps: 15215.43097
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62470"
  value: {
-  dps: 21449.53
-  tps: 15230.51246
+  dps: 21428.28847
+  tps: 15215.43097
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 22200.43295
-  tps: 15763.50398
+  dps: 22191.41258
+  tps: 15757.09952
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 22196.28044
-  tps: 15760.5557
+  dps: 22187.22702
+  tps: 15754.12777
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 22191.58093
-  tps: 15757.21905
+  dps: 22182.52439
+  tps: 15750.78891
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 21318.60716
-  tps: 15137.40767
+  dps: 21307.45668
+  tps: 15129.49083
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 21892.86124
-  tps: 15545.12807
+  dps: 21888.47042
+  tps: 15542.01058
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-55819"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-56351"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 21532.75361
-  tps: 15289.45165
+  dps: 21521.02161
+  tps: 15281.12193
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 21605.76295
-  tps: 15341.28828
+  dps: 21593.84162
+  tps: 15332.82414
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 21332.25475
-  tps: 15147.09746
+  dps: 21321.00943
+  tps: 15139.11329
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 22222.69079
-  tps: 15779.30705
+  dps: 22209.22442
+  tps: 15769.74592
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 22562.24308
-  tps: 16020.38917
+  dps: 22553.61989
+  tps: 16014.26671
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 21454.18902
-  tps: 15233.74558
+  dps: 21473.3468
+  tps: 15247.3476
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 21530.78306
-  tps: 15288.12735
+  dps: 21532.32724
+  tps: 15289.22371
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 22182.21434
-  tps: 15750.56877
+  dps: 22172.97357
+  tps: 15744.00782
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 22182.21434
-  tps: 15750.56877
+  dps: 22172.97357
+  tps: 15744.00782
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 21323.74675
-  tps: 15141.05678
+  dps: 21354.64606
+  tps: 15162.99529
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 22182.21434
-  tps: 15750.56877
+  dps: 22172.97357
+  tps: 15744.00782
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 22182.21434
-  tps: 15750.56877
+  dps: 22172.97357
+  tps: 15744.00782
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 21380.56174
-  tps: 15181.54499
+  dps: 21370.1185
+  tps: 15174.13029
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 17480.89714
-  tps: 12412.63355
+  dps: 17475.98424
+  tps: 12409.14539
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 22919.95203
-  tps: 16274.36252
+  dps: 22914.87558
+  tps: 16270.75825
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 22919.95203
-  tps: 16274.36252
+  dps: 22914.87558
+  tps: 16270.75825
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 19327.43227
-  tps: 13723.6735
+  dps: 19313.65803
+  tps: 13713.89378
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 22565.96121
-  tps: 16023.02905
+  dps: 22561.86986
+  tps: 16020.12418
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 21774.88967
-  tps: 15461.36825
+  dps: 21763.94812
+  tps: 15453.59975
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 21449.53
-  tps: 15230.51246
+  dps: 21428.28847
+  tps: 15215.43097
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 21664.75083
-  tps: 15383.16968
+  dps: 21658.46035
+  tps: 15378.70344
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 21615.66101
-  tps: 15348.3159
+  dps: 21614.21792
+  tps: 15347.29131
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 21552.60129
-  tps: 15303.54351
+  dps: 21578.89136
+  tps: 15322.20945
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 21663.12743
-  tps: 15382.01706
+  dps: 21651.05734
+  tps: 15373.4473
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 22509.29577
-  tps: 15982.79658
+  dps: 22505.36508
+  tps: 15980.00579
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 21754.70915
-  tps: 15447.04009
+  dps: 21745.21078
+  tps: 15440.29624
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WingedTalisman-37844"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 21308.51063
-  tps: 15130.23914
+  dps: 21297.36016
+  tps: 15122.3223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 21536.92557
-  tps: 15292.41374
+  dps: 21525.18275
+  tps: 15284.07634
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 21595.94681
-  tps: 15334.31882
+  dps: 21582.15547
+  tps: 15324.52697
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 21595.94681
-  tps: 15334.31882
+  dps: 21582.15547
+  tps: 15324.52697
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 22871.65764
-  tps: 16240.15844
+  dps: 22868.99753
+  tps: 16238.26976
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 22724.57724
-  tps: 16135.64643
+  dps: 22718.95854
+  tps: 16131.65715
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 22724.57724
-  tps: 16135.64643
+  dps: 22718.95854
+  tps: 16131.65715
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 27632.31443
-  tps: 19624.92618
+  dps: 27655.87155
+  tps: 19641.65174
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14246.68106
-  tps: 10117.76109
+  dps: 14280.35142
+  tps: 10141.66704
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 14246.68106
-  tps: 10117.76109
+  dps: 14280.35142
+  tps: 10141.66704
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 15342.97053
-  tps: 10900.98775
+  dps: 15352.16715
+  tps: 10907.51734
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 22728.23298
-  tps: 16138.242
+  dps: 22718.95854
+  tps: 16131.65715
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 22728.23298
-  tps: 16138.242
+  dps: 22718.95854
+  tps: 16131.65715
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 27616.52216
-  tps: 19613.71366
+  dps: 27655.87155
+  tps: 19641.65174
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14246.68106
-  tps: 10117.76109
+  dps: 14280.35142
+  tps: 10141.66704
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 14246.68106
-  tps: 10117.76109
+  dps: 14280.35142
+  tps: 10141.66704
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 15342.97053
-  tps: 10900.98775
+  dps: 15352.16715
+  tps: 10907.51734
  }
 }
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 19786.50862
-  tps: 14049.61771
+  dps: 19808.67183
+  tps: 14065.35358
  }
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -40,22 +40,22 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 22718.95854
-  tps: 16131.65715
+  dps: 22721.26354
+  tps: 16133.2937
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
@@ -75,52 +75,52 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 22172.97357
-  tps: 15744.00782
+  dps: 22175.26412
+  tps: 15745.63411
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 22172.97357
-  tps: 15744.00782
+  dps: 22175.26412
+  tps: 15745.63411
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 21573.02143
-  tps: 15318.11659
+  dps: 21575.2585
+  tps: 15319.70491
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
   hps: 84.91645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
   hps: 84.91645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 22191.41258
-  tps: 15757.09952
+  dps: 22193.70313
+  tps: 15758.72581
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
@@ -140,57 +140,57 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-BindingPromise-67037"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 16515.52644
-  tps: 11727.22036
+  dps: 16523.38301
+  tps: 11732.79852
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 22339.68097
-  tps: 15862.37008
+  dps: 22346.39316
+  tps: 15867.13573
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 21559.51219
-  tps: 15308.45024
+  dps: 21561.7262
+  tps: 15310.02219
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 21593.84162
-  tps: 15332.82414
+  dps: 21596.05563
+  tps: 15334.39608
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 22780.30657
-  tps: 16175.21425
+  dps: 22782.52058
+  tps: 16176.7862
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 21739.23785
-  tps: 15436.05546
+  dps: 21741.45187
+  tps: 15437.62741
  }
 }
 dps_results: {
@@ -203,15 +203,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
@@ -224,93 +224,93 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 21711.28721
-  tps: 15416.21051
+  dps: 21713.50123
+  tps: 15417.78246
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledLightning-66879"
  value: {
-  dps: 21435.92431
-  tps: 15220.70285
+  dps: 21438.13832
+  tps: 15222.27479
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 22172.97357
-  tps: 15429.12767
+  dps: 22175.26412
+  tps: 15430.72143
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 22172.97357
-  tps: 15429.12767
+  dps: 22175.26412
+  tps: 15430.72143
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 22540.46035
-  tps: 16004.92343
+  dps: 22542.7509
+  tps: 16006.54972
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 22584.33604
-  tps: 16036.07517
+  dps: 22586.62659
+  tps: 16037.70146
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 22560.00746
-  tps: 16018.80188
+  dps: 22562.29801
+  tps: 16020.42817
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
   hps: 64
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-59506"
  value: {
-  dps: 22134.04648
-  tps: 15716.36959
+  dps: 22136.33663
+  tps: 15717.99559
  }
 }
 dps_results: {
@@ -323,169 +323,169 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 21398.8986
-  tps: 15194.41459
+  dps: 21401.11261
+  tps: 15195.98654
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 21425.6681
-  tps: 15213.57051
+  dps: 21427.88212
+  tps: 15215.14246
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 21665.84584
-  tps: 15383.94713
+  dps: 21668.05985
+  tps: 15385.51908
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 21936.83418
-  tps: 15576.34885
+  dps: 21938.98126
+  tps: 15577.87328
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 22357.15314
-  tps: 15874.77532
+  dps: 22359.45306
+  tps: 15876.40826
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 21632.18252
-  tps: 15362.35606
+  dps: 21634.39653
+  tps: 15363.928
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Death'sChoice-47464"
  value: {
-  dps: 22252.69264
-  tps: 15800.60836
+  dps: 22254.9416
+  tps: 15802.20513
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 21378.09268
-  tps: 15179.64239
+  dps: 21380.30669
+  tps: 15181.21434
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 21889.52701
-  tps: 15542.76077
+  dps: 21894.17754
+  tps: 15546.06264
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 21944.18762
-  tps: 15581.5698
+  dps: 21955.18988
+  tps: 15589.3814
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Defender'sCode-40257"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 22214.41442
-  tps: 15773.43082
+  dps: 22216.70497
+  tps: 15775.05711
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 22197.06698
-  tps: 15761.11414
+  dps: 22199.35753
+  tps: 15762.74043
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 21449.11024
-  tps: 15230.06486
+  dps: 21452.24416
+  tps: 15232.28994
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 21380.09452
-  tps: 15181.0637
+  dps: 21384.56061
+  tps: 15184.23462
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 22172.97357
-  tps: 15744.00782
+  dps: 22175.26412
+  tps: 15745.63411
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 21297.36016
-  tps: 15159.3462
+  dps: 21299.57417
+  tps: 15160.91815
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 22172.97357
-  tps: 15744.00782
+  dps: 22175.26412
+  tps: 15745.63411
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 22172.97357
-  tps: 15744.00782
+  dps: 22175.26412
+  tps: 15745.63411
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 22214.41442
-  tps: 15773.43082
+  dps: 22216.70497
+  tps: 15775.05711
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 22191.41258
-  tps: 15757.09952
+  dps: 22193.70313
+  tps: 15758.72581
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 22187.22702
-  tps: 15754.12777
+  dps: 22189.51757
+  tps: 15755.75406
  }
 }
 dps_results: {
@@ -498,64 +498,64 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 22746.13285
-  tps: 16150.95091
+  dps: 22748.43277
+  tps: 16152.58385
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 22968.72809
-  tps: 16308.99353
+  dps: 22971.03925
+  tps: 16310.63445
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 22172.97357
-  tps: 15744.00782
+  dps: 22175.26412
+  tps: 15745.63411
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 22172.97357
-  tps: 15744.00782
+  dps: 22175.26412
+  tps: 15745.63411
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 21425.31087
-  tps: 15213.1673
+  dps: 21427.52488
+  tps: 15214.73925
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 21381.23258
-  tps: 15181.87172
+  dps: 21383.44659
+  tps: 15183.44366
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-59500"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-65124"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
@@ -568,43 +568,43 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 22013.96864
-  tps: 15631.11432
+  dps: 22016.18265
+  tps: 15632.68627
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 22230.71283
-  tps: 15785.00269
+  dps: 22233.00338
+  tps: 15786.62898
  }
 }
 dps_results: {
@@ -617,36 +617,36 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForgeEmber-37660"
  value: {
-  dps: 21357.74048
-  tps: 15165.19232
+  dps: 21359.95449
+  tps: 15166.76427
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 22172.97357
-  tps: 15744.00782
+  dps: 22175.26412
+  tps: 15745.63411
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 22172.97357
-  tps: 15744.00782
+  dps: 22175.26412
+  tps: 15745.63411
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 22172.97357
-  tps: 15744.00782
+  dps: 22175.26412
+  tps: 15745.63411
  }
 }
 dps_results: {
@@ -659,29 +659,29 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 21676.59096
-  tps: 15391.57617
+  dps: 21678.84381
+  tps: 15393.17569
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuturesightRune-38763"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56138"
  value: {
-  dps: 21528.06581
-  tps: 15286.12331
+  dps: 21538.69704
+  tps: 15293.67148
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56462"
  value: {
-  dps: 21543.5508
-  tps: 15297.11766
+  dps: 21556.51134
+  tps: 15306.31964
  }
 }
 dps_results: {
@@ -694,317 +694,317 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 21406.50656
-  tps: 15199.96582
+  dps: 21408.72057
+  tps: 15201.53777
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 22048.66226
-  tps: 15655.74679
+  dps: 22050.92979
+  tps: 15657.35674
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 22371.41615
-  tps: 15884.90206
+  dps: 22378.47329
+  tps: 15889.91263
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HarmlightToken-63839"
  value: {
-  dps: 21304.65887
-  tps: 15127.50438
+  dps: 21306.87288
+  tps: 15129.07633
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 21813.84382
-  tps: 15489.0257
+  dps: 21816.08766
+  tps: 15490.61882
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-59224"
  value: {
-  dps: 22070.69241
-  tps: 15671.3882
+  dps: 22074.60254
+  tps: 15674.16439
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-65072"
  value: {
-  dps: 22197.3684
-  tps: 15761.32815
+  dps: 22202.02171
+  tps: 15764.632
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-55868"
  value: {
-  dps: 21528.06581
-  tps: 15286.12331
+  dps: 21538.69704
+  tps: 15293.67148
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-56393"
  value: {
-  dps: 22015.91348
-  tps: 15632.49516
+  dps: 22028.87402
+  tps: 15641.69714
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-55845"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-56370"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 22157.76349
-  tps: 15733.20867
+  dps: 22160.04013
+  tps: 15734.82508
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-49982"
  value: {
-  dps: 23043.93029
-  tps: 16362.38709
+  dps: 23046.31198
+  tps: 16364.07809
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-50641"
  value: {
-  dps: 23196.03725
-  tps: 16470.38303
+  dps: 23198.60624
+  tps: 16472.20702
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 22214.41442
-  tps: 15773.43082
+  dps: 22216.70497
+  tps: 15775.05711
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 22191.41258
-  tps: 15757.09952
+  dps: 22193.70313
+  tps: 15758.72581
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 22187.22702
-  tps: 15754.12777
+  dps: 22189.51757
+  tps: 15755.75406
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 22105.32227
-  tps: 15695.9754
+  dps: 22107.53628
+  tps: 15697.54734
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 22105.32227
-  tps: 15695.9754
+  dps: 22107.53628
+  tps: 15697.54734
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 21559.51219
-  tps: 15308.45024
+  dps: 21561.7262
+  tps: 15310.02219
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 21593.84162
-  tps: 15332.82414
+  dps: 21596.05563
+  tps: 15334.39608
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IncisorFragment-37723"
  value: {
-  dps: 21665.3247
-  tps: 15383.57712
+  dps: 21667.55668
+  tps: 15385.16183
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 22172.97357
-  tps: 15744.00782
+  dps: 22175.26412
+  tps: 15745.63411
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 21499.17561
-  tps: 15265.61127
+  dps: 21501.38962
+  tps: 15267.18322
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 22188.79344
-  tps: 15755.23993
+  dps: 22199.17922
+  tps: 15762.61383
   hps: 61.37058
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 22339.68097
-  tps: 15862.37008
+  dps: 22346.39316
+  tps: 15867.13573
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 22332.13376
-  tps: 15857.08634
+  dps: 22334.42403
+  tps: 15858.71244
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 22637.58733
-  tps: 16073.95837
+  dps: 22640.26745
+  tps: 16075.86127
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 21605.87278
-  tps: 15341.36626
+  dps: 21612.25943
+  tps: 15345.90078
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 21605.87278
-  tps: 15341.36626
+  dps: 21612.25943
+  tps: 15345.90078
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 21414.90131
-  tps: 15205.77652
+  dps: 21424.81103
+  tps: 15212.81242
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50179"
  value: {
-  dps: 22848.56698
-  tps: 16223.67914
+  dps: 22850.88472
+  tps: 16225.32474
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50708"
  value: {
-  dps: 22867.73491
-  tps: 16237.28837
+  dps: 22870.05457
+  tps: 16238.93533
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-55816"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-56347"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 22557.76661
-  tps: 16017.21088
+  dps: 22559.51326
+  tps: 16018.451
  }
 }
 dps_results: {
@@ -1024,8 +1024,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 21748.42332
-  tps: 15442.57715
+  dps: 21750.7136
+  tps: 15444.20324
  }
 }
 dps_results: {
@@ -1038,50 +1038,50 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 21949.96234
-  tps: 15585.66985
+  dps: 21952.20846
+  tps: 15587.2646
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 22036.15146
-  tps: 15646.86412
+  dps: 22038.40179
+  tps: 15648.46186
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 21486.63991
-  tps: 15256.71092
+  dps: 21491.48428
+  tps: 15260.15043
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 21644.75066
-  tps: 15369.04434
+  dps: 21655.18588
+  tps: 15376.45335
  }
 }
 dps_results: {
@@ -1094,113 +1094,113 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 21631.29191
-  tps: 15359.41384
+  dps: 21633.50592
+  tps: 15360.98579
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 21631.29191
-  tps: 15359.41384
+  dps: 21633.50592
+  tps: 15360.98579
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 21708.37379
-  tps: 15414.14198
+  dps: 21710.5878
+  tps: 15415.71393
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 21448.53955
-  tps: 15229.65967
+  dps: 21450.75357
+  tps: 15231.23162
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 21787.32027
-  tps: 15470.19398
+  dps: 21789.55901
+  tps: 15471.78348
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 22187.22702
-  tps: 15754.12777
+  dps: 22189.51757
+  tps: 15755.75406
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 22191.41258
-  tps: 15757.09952
+  dps: 22193.70313
+  tps: 15758.72581
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 21504.09695
-  tps: 15269.10542
+  dps: 21506.31096
+  tps: 15270.67737
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 21683.75665
-  tps: 15396.66381
+  dps: 21685.97066
+  tps: 15398.23575
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 22172.97357
-  tps: 15744.00782
+  dps: 22175.26412
+  tps: 15745.63411
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 22172.97357
-  tps: 15744.00782
+  dps: 22175.26412
+  tps: 15745.63411
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 22172.97357
-  tps: 15744.00782
+  dps: 22175.26412
+  tps: 15745.63411
  }
 }
 dps_results: {
@@ -1213,71 +1213,71 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 22890.65711
-  tps: 16253.56314
+  dps: 22894.78248
+  tps: 16256.49215
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-55854"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-56377"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 22611.22889
-  tps: 16055.1691
+  dps: 22613.52506
+  tps: 16056.79938
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 22610.59331
-  tps: 16054.71784
+  dps: 22612.89074
+  tps: 16056.34901
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 22540.46035
-  tps: 16004.92343
+  dps: 22542.7509
+  tps: 16006.54972
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 22172.97357
-  tps: 15744.00782
+  dps: 22175.26412
+  tps: 15745.63411
  }
 }
 dps_results: {
@@ -1297,106 +1297,106 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 22294.92511
-  tps: 15830.59341
+  dps: 22297.20174
+  tps: 15832.20982
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-55256"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-56290"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShieldedSkyflareDiamond"
  value: {
-  dps: 22172.97357
-  tps: 15744.00782
+  dps: 22175.26412
+  tps: 15745.63411
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 21866.70599
-  tps: 15526.55784
+  dps: 21870.53738
+  tps: 15529.27813
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 22447.76161
-  tps: 15939.10733
+  dps: 22450.04306
+  tps: 15940.72716
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 22599.1763
-  tps: 16046.61176
+  dps: 22601.46659
+  tps: 16048.23786
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-55879"
  value: {
-  dps: 21559.51219
-  tps: 15308.45024
+  dps: 21561.7262
+  tps: 15310.02219
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-56400"
  value: {
-  dps: 21593.84162
-  tps: 15332.82414
+  dps: 21596.05563
+  tps: 15334.39608
  }
 }
 dps_results: {
@@ -1409,29 +1409,29 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-SoulCasket-58183"
  value: {
-  dps: 21631.29191
-  tps: 15359.41384
+  dps: 21633.50592
+  tps: 15360.98579
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulPreserver-37111"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SouloftheDead-40382"
  value: {
-  dps: 21383.70472
-  tps: 15183.62694
+  dps: 21385.91873
+  tps: 15185.19888
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SparkofLife-37657"
  value: {
-  dps: 21421.59488
-  tps: 15210.52895
+  dps: 21426.31284
+  tps: 15213.87871
  }
 }
 dps_results: {
@@ -1444,8 +1444,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 21308.10595
-  tps: 15129.95181
+  dps: 21310.31997
+  tps: 15131.52376
  }
 }
 dps_results: {
@@ -1465,50 +1465,50 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 22191.41258
-  tps: 15757.09952
+  dps: 22193.70313
+  tps: 15758.72581
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 22187.22702
-  tps: 15754.12777
+  dps: 22189.51757
+  tps: 15755.75406
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 22182.52439
-  tps: 15750.78891
+  dps: 22184.81494
+  tps: 15752.4152
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 21307.45668
-  tps: 15129.49083
+  dps: 21309.67069
+  tps: 15131.06278
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
@@ -1521,85 +1521,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-55819"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-56351"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 21521.02161
-  tps: 15281.12193
+  dps: 21523.23562
+  tps: 15282.69388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 21593.84162
-  tps: 15332.82414
+  dps: 21596.05563
+  tps: 15334.39608
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 21321.00943
-  tps: 15139.11329
+  dps: 21323.22345
+  tps: 15140.68523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 22209.22442
-  tps: 15769.74592
+  dps: 22213.62377
+  tps: 15772.86946
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 22553.61989
-  tps: 16014.26671
+  dps: 22555.91419
+  tps: 16015.89566
  }
 }
 dps_results: {
@@ -1612,120 +1612,120 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 21532.32724
-  tps: 15289.22371
+  dps: 21535.81073
+  tps: 15291.69699
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 22172.97357
-  tps: 15744.00782
+  dps: 22175.26412
+  tps: 15745.63411
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 22172.97357
-  tps: 15744.00782
+  dps: 22175.26412
+  tps: 15745.63411
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 21354.64606
-  tps: 15162.99529
+  dps: 21363.63358
+  tps: 15169.37643
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 22172.97357
-  tps: 15744.00782
+  dps: 22175.26412
+  tps: 15745.63411
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 22172.97357
-  tps: 15744.00782
+  dps: 22175.26412
+  tps: 15745.63411
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 21370.1185
-  tps: 15174.13029
+  dps: 21372.33251
+  tps: 15175.70224
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 17475.98424
-  tps: 12409.14539
+  dps: 17477.7885
+  tps: 12410.42642
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 22914.87558
-  tps: 16270.75825
+  dps: 22917.08959
+  tps: 16272.3302
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 22914.87558
-  tps: 16270.75825
+  dps: 22917.08959
+  tps: 16272.3302
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 19313.65803
-  tps: 13713.89378
+  dps: 19317.92193
+  tps: 13716.92116
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 22561.86986
-  tps: 16020.12418
+  dps: 22564.08387
+  tps: 16021.69613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 21763.94812
-  tps: 15453.59975
+  dps: 21766.16213
+  tps: 15455.1717
  }
 }
 dps_results: {
@@ -1738,8 +1738,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 21658.46035
-  tps: 15378.70344
+  dps: 21662.43534
+  tps: 15381.52568
  }
 }
 dps_results: {
@@ -1752,113 +1752,113 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 21578.89136
-  tps: 15322.20945
+  dps: 21581.01901
+  tps: 15323.72008
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 21651.05734
-  tps: 15373.4473
+  dps: 21653.27135
+  tps: 15375.01925
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 22505.36508
-  tps: 15980.00579
+  dps: 22507.57909
+  tps: 15981.57774
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 21745.21078
-  tps: 15440.29624
+  dps: 21747.54751
+  tps: 15441.95532
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WingedTalisman-37844"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 21297.36016
-  tps: 15122.3223
+  dps: 21299.57417
+  tps: 15123.89425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 21525.18275
-  tps: 15284.07634
+  dps: 21527.39677
+  tps: 15285.64829
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 21582.15547
-  tps: 15324.52697
+  dps: 21584.36948
+  tps: 15326.09892
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 21582.15547
-  tps: 15324.52697
+  dps: 21584.36948
+  tps: 15326.09892
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 22868.99753
-  tps: 16238.26976
+  dps: 22872.11661
+  tps: 16240.4843
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 22718.95854
-  tps: 16131.65715
+  dps: 22721.26354
+  tps: 16133.2937
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 22718.95854
-  tps: 16131.65715
+  dps: 22721.26354
+  tps: 16133.2937
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 27655.87155
-  tps: 19641.65174
+  dps: 27697.90517
+  tps: 19671.49561
  }
 }
 dps_results: {
@@ -1878,29 +1878,29 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 15352.16715
-  tps: 10907.51734
+  dps: 15370.751
+  tps: 10920.71188
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 22718.95854
-  tps: 16131.65715
+  dps: 22721.26354
+  tps: 16133.2937
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 22718.95854
-  tps: 16131.65715
+  dps: 22721.26354
+  tps: 16133.2937
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 27655.87155
-  tps: 19641.65174
+  dps: 27697.90517
+  tps: 19671.49561
  }
 }
 dps_results: {
@@ -1920,14 +1920,14 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 15352.16715
-  tps: 10907.51734
+  dps: 15370.751
+  tps: 10920.71188
  }
 }
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 19808.67183
-  tps: 14065.35358
+  dps: 19812.34003
+  tps: 14067.958
  }
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -1864,15 +1864,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14222.2933
-  tps: 10100.44578
+  dps: 14246.68106
+  tps: 10117.76109
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 14222.2933
-  tps: 10100.44578
+  dps: 14246.68106
+  tps: 10117.76109
  }
 }
 dps_results: {
@@ -1906,15 +1906,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14222.2933
-  tps: 10100.44578
+  dps: 14246.68106
+  tps: 10117.76109
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 14222.2933
-  tps: 10100.44578
+  dps: 14246.68106
+  tps: 10117.76109
  }
 }
 dps_results: {

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -40,1894 +40,1894 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 22711.31854
-  tps: 16126.23275
+  dps: 22702.84314
+  tps: 16120.21522
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 21440.26385
-  tps: 15223.85871
+  dps: 21442.4235
+  tps: 15225.39206
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 21440.26385
-  tps: 15223.85871
+  dps: 21442.4235
+  tps: 15225.39206
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 22165.78196
-  tps: 15738.90178
+  dps: 22157.7145
+  tps: 15733.17388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 22165.78196
-  tps: 15738.90178
+  dps: 22157.7145
+  tps: 15733.17388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 21565.56911
-  tps: 15312.82544
+  dps: 21556.91636
+  tps: 15306.68199
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
   hps: 84.91645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
   hps: 84.91645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 22184.22096
-  tps: 15751.99347
+  dps: 22176.1535
+  tps: 15746.26557
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 21582.14019
-  tps: 15324.51612
+  dps: 21572.88819
+  tps: 15317.9472
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 21640.58694
-  tps: 15366.01331
+  dps: 21631.33493
+  tps: 15359.44439
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BindingPromise-67037"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 16523.38301
-  tps: 11732.79852
+  dps: 16507.90063
+  tps: 11721.80603
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 22346.39316
-  tps: 15867.13573
+  dps: 22332.8406
+  tps: 15857.51342
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 21552.17535
-  tps: 15303.24108
+  dps: 21543.62444
+  tps: 15297.16994
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 21586.5096
-  tps: 15327.6184
+  dps: 21577.95852
+  tps: 15321.54714
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 22782.52058
-  tps: 16176.7862
+  dps: 22770.37025
+  tps: 16168.15946
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 21731.86419
-  tps: 15430.82016
+  dps: 21723.3146
+  tps: 15424.74995
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 21567.39
-  tps: 15314.04349
+  dps: 21557.73166
+  tps: 15307.18606
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 22379.19998
-  tps: 15890.42857
+  dps: 22369.37276
+  tps: 15883.45125
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 21703.98975
-  tps: 15411.02931
+  dps: 21694.95899
+  tps: 15404.61747
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledLightning-66879"
  value: {
-  dps: 21428.55065
-  tps: 15215.46755
+  dps: 21420.91448
+  tps: 15210.04587
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 22165.78196
-  tps: 15424.12374
+  dps: 22157.7145
+  tps: 15418.5104
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 22165.78196
-  tps: 15424.12374
+  dps: 22157.7145
+  tps: 15418.5104
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 22532.86926
-  tps: 15999.53376
+  dps: 22524.45546
+  tps: 15993.55996
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 22576.74495
-  tps: 16030.6855
+  dps: 22568.33115
+  tps: 16024.7117
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 22552.41637
-  tps: 16013.41221
+  dps: 22544.00257
+  tps: 16007.43841
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
   hps: 64
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-59506"
  value: {
-  dps: 22136.33663
-  tps: 15717.99559
+  dps: 22135.29508
+  tps: 15717.25609
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-65118"
  value: {
-  dps: 22199.43008
-  tps: 15762.79195
+  dps: 22192.18876
+  tps: 15757.6506
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 21391.52494
-  tps: 15189.1793
+  dps: 21383.43884
+  tps: 15183.43816
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 21418.29444
-  tps: 15208.33522
+  dps: 21410.20834
+  tps: 15202.59408
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 21658.46146
-  tps: 15378.70422
+  dps: 21649.68083
+  tps: 15372.46998
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 21939.72913
-  tps: 15578.40427
+  dps: 21946.46033
+  tps: 15583.18342
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 22349.48645
-  tps: 15869.33197
+  dps: 22341.03554
+  tps: 15863.33182
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 21624.85576
-  tps: 15357.15406
+  dps: 21616.30449
+  tps: 15351.08266
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Death'sChoice-47464"
  value: {
-  dps: 22245.318
-  tps: 15795.37237
+  dps: 22234.43633
+  tps: 15787.64638
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 21370.71902
-  tps: 15174.40709
+  dps: 21362.63292
+  tps: 15168.66596
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 21884.58987
-  tps: 15539.2554
+  dps: 21881.71939
+  tps: 15537.21735
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 21945.60221
-  tps: 15582.57416
+  dps: 21937.16308
+  tps: 15576.58238
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Defender'sCode-40257"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 22207.2228
-  tps: 15768.32477
+  dps: 22199.15534
+  tps: 15762.59688
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 22189.87536
-  tps: 15756.00809
+  dps: 22181.8079
+  tps: 15750.2802
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 21453.16816
-  tps: 15232.94598
+  dps: 21452.9338
+  tps: 15232.77958
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 21393.66925
-  tps: 15190.70175
+  dps: 21403.51261
+  tps: 15197.69054
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 22165.78196
-  tps: 15738.90178
+  dps: 22157.7145
+  tps: 15733.17388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 21289.9865
-  tps: 15154.1109
+  dps: 21281.4369
+  tps: 15148.04069
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 22165.78196
-  tps: 15738.90178
+  dps: 22157.7145
+  tps: 15733.17388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 22165.78196
-  tps: 15738.90178
+  dps: 22157.7145
+  tps: 15733.17388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 22207.2228
-  tps: 15768.32477
+  dps: 22199.15534
+  tps: 15762.59688
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 22184.22096
-  tps: 15751.99347
+  dps: 22176.1535
+  tps: 15746.26557
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 22180.03541
-  tps: 15749.02173
+  dps: 22171.96795
+  tps: 15743.29383
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 21414.70598
-  tps: 15205.63783
+  dps: 21419.73608
+  tps: 15209.2092
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 22748.43277
-  tps: 16152.58385
+  dps: 22746.8473
+  tps: 16151.45817
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 22971.03925
-  tps: 16310.63445
+  dps: 22961.48054
+  tps: 16303.84777
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 22165.78196
-  tps: 15738.90178
+  dps: 22157.7145
+  tps: 15733.17388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 22165.78196
-  tps: 15738.90178
+  dps: 22157.7145
+  tps: 15733.17388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 21417.93721
-  tps: 15207.932
+  dps: 21409.8511
+  tps: 15202.19087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 21373.85892
-  tps: 15176.63642
+  dps: 21365.77281
+  tps: 15170.89528
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-59500"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-65124"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 22809.01466
-  tps: 16195.67178
+  dps: 22812.43053
+  tps: 16198.09705
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 22006.63662
-  tps: 15625.90859
+  dps: 21998.08554
+  tps: 15619.83732
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 22223.52903
-  tps: 15779.9022
+  dps: 22215.46147
+  tps: 15774.17423
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FluidDeath-58181"
  value: {
-  dps: 22681.3189
-  tps: 16105.08258
+  dps: 22686.06275
+  tps: 16108.45071
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForgeEmber-37660"
  value: {
-  dps: 21350.36682
-  tps: 15159.95703
+  dps: 21342.28071
+  tps: 15154.21589
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 22165.78196
-  tps: 15738.90178
+  dps: 22157.7145
+  tps: 15733.17388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 22165.78196
-  tps: 15738.90178
+  dps: 22157.7145
+  tps: 15733.17388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 22165.78196
-  tps: 15738.90178
+  dps: 22157.7145
+  tps: 15733.17388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 23136.40079
-  tps: 16428.04115
+  dps: 23124.10647
+  tps: 16419.31218
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 21669.08482
-  tps: 15386.24681
+  dps: 21660.3615
+  tps: 15380.05325
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuturesightRune-38763"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56138"
  value: {
-  dps: 21538.69704
-  tps: 15293.67148
+  dps: 21538.16277
+  tps: 15293.29215
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56462"
  value: {
-  dps: 21556.51134
-  tps: 15306.31964
+  dps: 21548.04587
+  tps: 15300.30916
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GearDetector-61462"
  value: {
-  dps: 22027.13591
-  tps: 15640.46308
+  dps: 22024.26573
+  tps: 15638.42525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 21398.83332
-  tps: 15194.51781
+  dps: 21390.74721
+  tps: 15188.77668
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 22041.10603
-  tps: 15650.38187
+  dps: 22032.79263
+  tps: 15644.47935
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 22378.47329
-  tps: 15889.91263
+  dps: 22374.18514
+  tps: 15886.86804
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HarmlightToken-63839"
  value: {
-  dps: 21297.28521
-  tps: 15122.26908
+  dps: 21288.73561
+  tps: 15116.19887
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 21806.36845
-  tps: 15483.71818
+  dps: 21797.68546
+  tps: 15477.55326
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-59224"
  value: {
-  dps: 22061.1149
-  tps: 15664.58816
+  dps: 22049.79278
+  tps: 15656.54946
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-65072"
  value: {
-  dps: 22207.18642
-  tps: 15768.29894
+  dps: 22204.97829
+  tps: 15766.73117
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-55868"
  value: {
-  dps: 21538.69704
-  tps: 15293.67148
+  dps: 21538.16277
+  tps: 15293.29215
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-56393"
  value: {
-  dps: 22028.87402
-  tps: 15641.69714
+  dps: 22020.40855
+  tps: 15635.68665
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-55845"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-56370"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 22150.17623
-  tps: 15727.82171
+  dps: 22141.82419
+  tps: 15721.89176
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-49982"
  value: {
-  dps: 23046.31198
-  tps: 16364.07809
+  dps: 23043.24549
+  tps: 16361.90088
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-50641"
  value: {
-  dps: 23198.60624
-  tps: 16472.20702
+  dps: 23197.24484
+  tps: 16471.24042
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 22207.2228
-  tps: 15768.32477
+  dps: 22199.15534
+  tps: 15762.59688
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 22184.22096
-  tps: 15751.99347
+  dps: 22176.1535
+  tps: 15746.26557
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 22180.03541
-  tps: 15749.02173
+  dps: 22171.96795
+  tps: 15743.29383
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 22097.99551
-  tps: 15690.7734
+  dps: 22089.44424
+  tps: 15684.702
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 22097.99551
-  tps: 15690.7734
+  dps: 22089.44424
+  tps: 15684.702
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 21552.17535
-  tps: 15303.24108
+  dps: 21543.62444
+  tps: 15297.16994
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 21586.5096
-  tps: 15327.6184
+  dps: 21577.95852
+  tps: 15321.54714
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IncisorFragment-37723"
  value: {
-  dps: 21657.88977
-  tps: 15378.29832
+  dps: 21649.25982
+  tps: 15372.17106
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 22165.78196
-  tps: 15738.90178
+  dps: 22157.7145
+  tps: 15733.17388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 21491.8303
-  tps: 15260.3961
+  dps: 21483.27969
+  tps: 15254.32516
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 22197.92869
-  tps: 15761.72596
+  dps: 22206.3288
+  tps: 15767.69003
   hps: 61.37058
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 22346.39316
-  tps: 15867.13573
+  dps: 22332.8406
+  tps: 15857.51342
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 22351.00314
-  tps: 15870.4836
+  dps: 22350.46776
+  tps: 15870.10348
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 22648.37953
-  tps: 16081.62084
+  dps: 22650.53918
+  tps: 16083.15419
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 21612.25943
-  tps: 15345.90078
+  dps: 21614.62149
+  tps: 15347.57785
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 21612.25943
-  tps: 15345.90078
+  dps: 21614.62149
+  tps: 15347.57785
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 21425.08115
-  tps: 15213.00421
+  dps: 21423.56745
+  tps: 15211.92947
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50179"
  value: {
-  dps: 22840.88384
-  tps: 16218.22411
+  dps: 22832.35413
+  tps: 16212.16802
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50708"
  value: {
-  dps: 22860.0453
-  tps: 16231.82875
+  dps: 22851.50744
+  tps: 16225.76687
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-55816"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-56347"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 22562.25303
-  tps: 16020.39623
+  dps: 22563.44756
+  tps: 16021.24436
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 22625.01184
-  tps: 16064.95499
+  dps: 22631.97579
+  tps: 16069.8994
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 21920.86121
-  tps: 15565.15762
+  dps: 21923.01535
+  tps: 15566.68706
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 21763.65183
-  tps: 15453.38938
+  dps: 21763.11148
+  tps: 15453.00573
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 21939.4304
-  tps: 15578.19217
+  dps: 21935.73254
+  tps: 15575.56669
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 21942.67809
-  tps: 15580.49803
+  dps: 21930.89966
+  tps: 15572.13535
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 22028.87935
-  tps: 15641.70093
+  dps: 22016.67127
+  tps: 15633.03319
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 21491.48428
-  tps: 15260.15043
+  dps: 21496.67132
+  tps: 15263.83322
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 21667.55324
-  tps: 15385.23417
+  dps: 21667.0402
+  tps: 15384.86992
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 21871.03758
-  tps: 15529.70806
+  dps: 21873.14434
+  tps: 15531.20386
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 21623.96515
-  tps: 15354.21185
+  dps: 21615.41388
+  tps: 15348.14044
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 21623.96515
-  tps: 15354.21185
+  dps: 21615.41388
+  tps: 15348.14044
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 21701.00013
-  tps: 15408.90668
+  dps: 21692.45054
+  tps: 15402.83647
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 21441.16589
-  tps: 15224.42437
+  dps: 21432.6163
+  tps: 15218.35416
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 21779.86228
-  tps: 15464.89881
+  dps: 21770.72079
+  tps: 15458.40835
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 22180.03541
-  tps: 15749.02173
+  dps: 22171.96795
+  tps: 15743.29383
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 22184.22096
-  tps: 15751.99347
+  dps: 22176.1535
+  tps: 15746.26557
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 21496.72329
-  tps: 15263.87012
+  dps: 21488.17369
+  tps: 15257.79991
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 21676.38299
-  tps: 15391.42851
+  dps: 21667.83339
+  tps: 15385.35829
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 22165.78196
-  tps: 15738.90178
+  dps: 22157.7145
+  tps: 15733.17388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 22165.78196
-  tps: 15738.90178
+  dps: 22157.7145
+  tps: 15733.17388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 22165.78196
-  tps: 15738.90178
+  dps: 22157.7145
+  tps: 15733.17388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 22702.8345
-  tps: 16120.20908
+  dps: 22685.04192
+  tps: 16107.57635
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 22894.78248
-  tps: 16256.49215
+  dps: 22886.15071
+  tps: 16250.36359
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-55854"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-56377"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 22603.61878
-  tps: 16049.76592
+  dps: 22595.18102
+  tps: 16043.77511
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 22602.97893
-  tps: 16049.31163
+  dps: 22594.5358
+  tps: 16043.317
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 22532.86926
-  tps: 15999.53376
+  dps: 22524.45546
+  tps: 15993.55996
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 22165.78196
-  tps: 15738.90178
+  dps: 22157.7145
+  tps: 15733.17388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 21837.86246
-  tps: 15506.15372
+  dps: 21840.06053
+  tps: 15507.71435
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 21876.89325
-  tps: 15533.86558
+  dps: 21878.92481
+  tps: 15535.30799
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 22287.33784
-  tps: 15825.20645
+  dps: 22278.9858
+  tps: 15819.27651
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-55256"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-56290"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShieldedSkyflareDiamond"
  value: {
-  dps: 22165.78196
-  tps: 15738.90178
+  dps: 22157.7145
+  tps: 15733.17388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 21870.53738
-  tps: 15529.27813
+  dps: 21875.72889
+  tps: 15532.9641
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 22440.15791
-  tps: 15933.70871
+  dps: 22431.78542
+  tps: 15927.76423
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 22591.54248
-  tps: 16041.19175
+  dps: 22583.13248
+  tps: 16035.22065
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-55879"
  value: {
-  dps: 21552.17535
-  tps: 15303.24108
+  dps: 21543.62444
+  tps: 15297.16994
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-56400"
  value: {
-  dps: 21586.5096
-  tps: 15327.6184
+  dps: 21577.95852
+  tps: 15321.54714
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 21671.52133
-  tps: 15388.05152
+  dps: 21673.65259
+  tps: 15389.56471
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulCasket-58183"
  value: {
-  dps: 21623.96515
-  tps: 15354.21185
+  dps: 21615.41388
+  tps: 15348.14044
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulPreserver-37111"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SouloftheDead-40382"
  value: {
-  dps: 21376.33106
-  tps: 15178.39164
+  dps: 21368.24495
+  tps: 15172.6505
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SparkofLife-37657"
  value: {
-  dps: 21426.31284
-  tps: 15213.87871
+  dps: 21420.80395
+  tps: 15209.96739
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 21547.33348
-  tps: 15299.87814
+  dps: 21540.9587
+  tps: 15295.35205
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 21300.73229
-  tps: 15124.71652
+  dps: 21292.1827
+  tps: 15118.6463
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62465"
  value: {
-  dps: 21440.30705
-  tps: 15223.96417
+  dps: 21442.4667
+  tps: 15225.49752
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62470"
  value: {
-  dps: 21440.30705
-  tps: 15223.96417
+  dps: 21442.4667
+  tps: 15225.49752
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 22184.22096
-  tps: 15751.99347
+  dps: 22176.1535
+  tps: 15746.26557
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 22180.03541
-  tps: 15749.02173
+  dps: 22171.96795
+  tps: 15743.29383
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 22175.33278
-  tps: 15745.68286
+  dps: 22167.26532
+  tps: 15739.95496
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 21300.08302
-  tps: 15124.25553
+  dps: 21291.53342
+  tps: 15118.18532
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 21887.16908
-  tps: 15541.08663
+  dps: 21895.35153
+  tps: 15546.89617
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-55819"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-56351"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 21513.67937
-  tps: 15275.90894
+  dps: 21505.12865
+  tps: 15269.83793
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 21586.5096
-  tps: 15327.6184
+  dps: 21577.95852
+  tps: 15321.54714
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 21313.63578
-  tps: 15133.87799
+  dps: 21305.08618
+  tps: 15127.80777
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 22213.79156
-  tps: 15772.9886
+  dps: 22223.26223
+  tps: 15779.71277
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 22546.01106
-  tps: 16008.86444
+  dps: 22537.5816
+  tps: 16002.87952
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 21473.3468
-  tps: 15247.3476
+  dps: 21470.1262
+  tps: 15245.06097
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 21550.49806
-  tps: 15302.125
+  dps: 21547.40089
+  tps: 15299.92601
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 22165.78196
-  tps: 15738.90178
+  dps: 22157.7145
+  tps: 15733.17388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 22165.78196
-  tps: 15738.90178
+  dps: 22157.7145
+  tps: 15733.17388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 21363.63358
-  tps: 15169.37643
+  dps: 21356.09188
+  tps: 15164.02182
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 22165.78196
-  tps: 15738.90178
+  dps: 22157.7145
+  tps: 15733.17388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 22165.78196
-  tps: 15738.90178
+  dps: 22157.7145
+  tps: 15733.17388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 21361.96616
-  tps: 15168.34213
+  dps: 21353.41656
+  tps: 15162.27192
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 17477.7885
-  tps: 12410.42642
+  dps: 17471.44052
+  tps: 12405.91935
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 22907.54882
-  tps: 16265.55625
+  dps: 22898.55913
+  tps: 16259.17357
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 22907.54882
-  tps: 16265.55625
+  dps: 22898.55913
+  tps: 16259.17357
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 19317.92193
-  tps: 13716.92116
+  dps: 19317.54074
+  tps: 13716.65051
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 22554.4962
-  tps: 16014.88889
+  dps: 22545.49265
+  tps: 16008.49637
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 21756.57446
-  tps: 15448.36445
+  dps: 21748.02486
+  tps: 15442.29424
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 21440.30705
-  tps: 15223.96417
+  dps: 21442.4667
+  tps: 15225.49752
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 21662.43534
-  tps: 15381.52568
+  dps: 21660.02094
+  tps: 15379.81145
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 21614.21792
-  tps: 15347.29131
+  dps: 21604.96592
+  tps: 15340.72239
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 21567.64976
-  tps: 15314.22792
+  dps: 21564.9198
+  tps: 15312.28965
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 21643.73336
-  tps: 15368.24727
+  dps: 21635.18199
+  tps: 15362.1758
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 22496.41418
-  tps: 15973.65065
+  dps: 22488.36767
+  tps: 15967.93763
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 21737.38088
-  tps: 15434.73701
+  dps: 21729.75472
+  tps: 15429.32244
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WingedTalisman-37844"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 21289.9865
-  tps: 15117.087
+  dps: 21281.4369
+  tps: 15111.01678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 21517.84109
-  tps: 15278.86376
+  dps: 21509.29036
+  tps: 15272.79274
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 21574.95216
-  tps: 15319.41262
+  dps: 21563.76146
+  tps: 15311.46722
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 21574.95216
-  tps: 15319.41262
+  dps: 21563.76146
+  tps: 15311.46722
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 22871.85675
-  tps: 16240.2998
+  dps: 22871.23537
+  tps: 16239.85862
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 22711.31854
-  tps: 16126.23275
+  dps: 22702.84314
+  tps: 16120.21522
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 22711.31854
-  tps: 16126.23275
+  dps: 22702.84314
+  tps: 16120.21522
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 27697.90517
-  tps: 19671.49561
+  dps: 27707.16369
+  tps: 19678.06915
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14279.85928
-  tps: 10141.31762
+  dps: 14274.19763
+  tps: 10137.29785
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 14279.85928
-  tps: 10141.31762
+  dps: 14274.19763
+  tps: 10137.29785
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 15372.05905
-  tps: 10921.64059
+  dps: 15404.62525
+  tps: 10944.76259
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 22711.31854
-  tps: 16126.23275
+  dps: 22702.84314
+  tps: 16120.21522
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 22711.31854
-  tps: 16126.23275
+  dps: 22702.84314
+  tps: 16120.21522
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 27697.90517
-  tps: 19671.49561
+  dps: 27707.16369
+  tps: 19678.06915
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14279.85928
-  tps: 10141.31762
+  dps: 14274.19763
+  tps: 10137.29785
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 14279.85928
-  tps: 10141.31762
+  dps: 14274.19763
+  tps: 10137.29785
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 15372.05905
-  tps: 10921.64059
+  dps: 15404.62525
+  tps: 10944.76259
  }
 }
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 19810.07941
-  tps: 14066.35297
+  dps: 19806.87376
+  tps: 14064.07696
  }
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -40,1839 +40,1839 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 22702.84314
-  tps: 16120.21522
+  dps: 22720.71054
+  tps: 16132.90107
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 21442.4235
-  tps: 15225.39206
+  dps: 21431.62901
+  tps: 15217.72797
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 21442.4235
-  tps: 15225.39206
+  dps: 21431.62901
+  tps: 15217.72797
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 22157.7145
-  tps: 15733.17388
+  dps: 22174.63425
+  tps: 15745.18691
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 22157.7145
-  tps: 15733.17388
+  dps: 22174.63425
+  tps: 15745.18691
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 21556.91636
-  tps: 15306.68199
+  dps: 21574.50903
+  tps: 15319.17278
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
   hps: 84.91645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
   hps: 84.91645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 22176.1535
-  tps: 15746.26557
+  dps: 22192.93526
+  tps: 15758.18062
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 21572.88819
-  tps: 15317.9472
+  dps: 21576.0977
+  tps: 15320.22595
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 21631.33493
-  tps: 15359.44439
+  dps: 21622.55444
+  tps: 15353.21024
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BindingPromise-67037"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 16507.90063
-  tps: 11721.80603
+  dps: 16526.00804
+  tps: 11734.66229
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 22332.8406
-  tps: 15857.51342
+  dps: 22337.68944
+  tps: 15860.95609
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 21543.62444
-  tps: 15297.16994
+  dps: 21561.37322
+  tps: 15309.77157
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 21577.95852
-  tps: 15321.54714
+  dps: 21595.7571
+  tps: 15334.18412
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 22770.37025
-  tps: 16168.15946
+  dps: 22752.78893
+  tps: 16155.67673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 21723.3146
-  tps: 15424.74995
+  dps: 21739.7837
+  tps: 15436.44301
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 21557.73166
-  tps: 15307.18606
+  dps: 21562.32648
+  tps: 15310.44838
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 22369.37276
-  tps: 15883.45125
+  dps: 22376.5786
+  tps: 15888.5674
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 21694.95899
-  tps: 15404.61747
+  dps: 21713.36585
+  tps: 15417.68634
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledLightning-66879"
  value: {
-  dps: 21420.91448
-  tps: 15210.04587
+  dps: 21430.1544
+  tps: 15216.60621
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 22157.7145
-  tps: 15418.5104
+  dps: 22174.63425
+  tps: 15430.28317
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 22157.7145
-  tps: 15418.5104
+  dps: 22174.63425
+  tps: 15430.28317
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 22524.45546
-  tps: 15993.55996
+  dps: 22541.71796
+  tps: 16005.81634
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 22568.33115
-  tps: 16024.7117
+  dps: 22586.03682
+  tps: 16037.28273
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 22544.00257
-  tps: 16007.43841
+  dps: 22561.1188
+  tps: 16019.59094
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
   hps: 64
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-59506"
  value: {
-  dps: 22135.29508
-  tps: 15717.25609
+  dps: 22094.03004
+  tps: 15687.95792
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-65118"
  value: {
-  dps: 22192.18876
-  tps: 15757.6506
+  dps: 22221.80936
+  tps: 15778.68123
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 21383.43884
-  tps: 15183.43816
+  dps: 21403.14787
+  tps: 15197.43157
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 21410.20834
-  tps: 15202.59408
+  dps: 21433.32878
+  tps: 15219.00959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 21649.68083
-  tps: 15372.46998
+  dps: 21666.58457
+  tps: 15384.47163
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 21946.46033
-  tps: 15583.18342
+  dps: 21956.79234
+  tps: 15590.51915
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 22341.03554
-  tps: 15863.33182
+  dps: 22357.99671
+  tps: 15875.37425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 21616.30449
-  tps: 15351.08266
+  dps: 21634.15739
+  tps: 15363.75821
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Death'sChoice-47464"
  value: {
-  dps: 22234.43633
-  tps: 15787.64638
+  dps: 22255.14777
+  tps: 15802.3515
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 21362.63292
-  tps: 15168.66596
+  dps: 21376.69205
+  tps: 15178.64795
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 21881.71939
-  tps: 15537.21735
+  dps: 21872.99467
+  tps: 15531.0228
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 21937.16308
-  tps: 15576.58238
+  dps: 21958.21496
+  tps: 15591.52921
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Defender'sCode-40257"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 22199.15534
-  tps: 15762.59688
+  dps: 22216.49334
+  tps: 15774.90686
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 22181.8079
-  tps: 15750.2802
+  dps: 22199.17868
+  tps: 15762.61345
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 21452.9338
-  tps: 15232.77958
+  dps: 21421.43539
+  tps: 15210.41571
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 21403.51261
-  tps: 15197.69054
+  dps: 21408.94756
+  tps: 15201.54935
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 22157.7145
-  tps: 15733.17388
+  dps: 22174.63425
+  tps: 15745.18691
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 21281.4369
-  tps: 15148.04069
+  dps: 21298.80545
+  tps: 15160.26587
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 22157.7145
-  tps: 15733.17388
+  dps: 22174.63425
+  tps: 15745.18691
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 22157.7145
-  tps: 15733.17388
+  dps: 22174.63425
+  tps: 15745.18691
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 22199.15534
-  tps: 15762.59688
+  dps: 22216.49334
+  tps: 15774.90686
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 22176.1535
-  tps: 15746.26557
+  dps: 22192.93526
+  tps: 15758.18062
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 22171.96795
-  tps: 15743.29383
+  dps: 22188.74971
+  tps: 15755.20888
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 21419.73608
-  tps: 15209.2092
+  dps: 21412.02256
+  tps: 15203.7326
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 22746.8473
-  tps: 16151.45817
+  dps: 22764.56536
+  tps: 16164.038
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 22961.48054
-  tps: 16303.84777
+  dps: 22992.10468
+  tps: 16325.59091
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 22157.7145
-  tps: 15733.17388
+  dps: 22174.63425
+  tps: 15745.18691
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 22157.7145
-  tps: 15733.17388
+  dps: 22174.63425
+  tps: 15745.18691
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 21409.8511
-  tps: 15202.19087
+  dps: 21429.56013
+  tps: 15216.18428
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 21365.77281
-  tps: 15170.89528
+  dps: 21388.89325
+  tps: 15187.3108
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-59500"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-65124"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 22812.43053
-  tps: 16198.09705
+  dps: 22818.85196
+  tps: 16202.65627
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 21998.08554
-  tps: 15619.83732
+  dps: 22015.0167
+  tps: 15631.85845
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 22215.46147
-  tps: 15774.17423
+  dps: 22232.42694
+  tps: 15786.21972
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FluidDeath-58181"
  value: {
-  dps: 22686.06275
-  tps: 16108.45071
+  dps: 22672.5951
+  tps: 16098.88868
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForgeEmber-37660"
  value: {
-  dps: 21342.28071
-  tps: 15154.21589
+  dps: 21361.63766
+  tps: 15167.95933
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 22157.7145
-  tps: 15733.17388
+  dps: 22174.63425
+  tps: 15745.18691
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 22157.7145
-  tps: 15733.17388
+  dps: 22174.63425
+  tps: 15745.18691
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 22157.7145
-  tps: 15733.17388
+  dps: 22174.63425
+  tps: 15745.18691
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 23124.10647
-  tps: 16419.31218
+  dps: 23124.71163
+  tps: 16419.74185
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 21660.3615
-  tps: 15380.05325
+  dps: 21678.1075
+  tps: 15392.65291
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuturesightRune-38763"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56138"
  value: {
-  dps: 21538.16277
-  tps: 15293.29215
+  dps: 21505.12087
+  tps: 15269.8324
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56462"
  value: {
-  dps: 21548.04587
-  tps: 15300.30916
+  dps: 21584.86417
+  tps: 15326.45015
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GearDetector-61462"
  value: {
-  dps: 22024.26573
-  tps: 15638.42525
+  dps: 21999.2964
+  tps: 15620.69703
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 21390.74721
-  tps: 15188.77668
+  dps: 21413.86765
+  tps: 15205.19219
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 22032.79263
-  tps: 15644.47935
+  dps: 22055.94244
+  tps: 15660.91572
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 22374.18514
-  tps: 15886.86804
+  dps: 22398.77666
+  tps: 15904.32802
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HarmlightToken-63839"
  value: {
-  dps: 21288.73561
-  tps: 15116.19887
+  dps: 21306.10417
+  tps: 15128.53054
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 21797.68546
-  tps: 15477.55326
+  dps: 21816.31345
+  tps: 15490.77914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-59224"
  value: {
-  dps: 22049.79278
-  tps: 15656.54946
+  dps: 22081.87429
+  tps: 15679.32733
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-65072"
  value: {
-  dps: 22204.97829
-  tps: 15766.73117
+  dps: 22198.83394
+  tps: 15762.36868
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-55868"
  value: {
-  dps: 21538.16277
-  tps: 15293.29215
+  dps: 21505.12087
+  tps: 15269.8324
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-56393"
  value: {
-  dps: 22020.40855
-  tps: 15635.68665
+  dps: 22060.91566
+  tps: 15664.44671
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-55845"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-56370"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 22141.82419
-  tps: 15721.89176
+  dps: 22161.93953
+  tps: 15736.17365
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-49982"
  value: {
-  dps: 23043.24549
-  tps: 16361.90088
+  dps: 23040.39812
+  tps: 16359.87925
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-50641"
  value: {
-  dps: 23197.24484
-  tps: 16471.24042
+  dps: 23147.25164
+  tps: 16435.74525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 22199.15534
-  tps: 15762.59688
+  dps: 22216.49334
+  tps: 15774.90686
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 22176.1535
-  tps: 15746.26557
+  dps: 22192.93526
+  tps: 15758.18062
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 22171.96795
-  tps: 15743.29383
+  dps: 22188.74971
+  tps: 15755.20888
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 22089.44424
-  tps: 15684.702
+  dps: 22106.31671
+  tps: 15696.68145
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 22089.44424
-  tps: 15684.702
+  dps: 22106.31671
+  tps: 15696.68145
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 21543.62444
-  tps: 15297.16994
+  dps: 21561.37322
+  tps: 15309.77157
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 21577.95852
-  tps: 15321.54714
+  dps: 21595.7571
+  tps: 15334.18412
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IncisorFragment-37723"
  value: {
-  dps: 21649.25982
-  tps: 15372.17106
+  dps: 21666.78359
+  tps: 15384.61294
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 22157.7145
-  tps: 15733.17388
+  dps: 22174.63425
+  tps: 15745.18691
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 21483.27969
-  tps: 15254.32516
+  dps: 21500.94096
+  tps: 15266.86467
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 22206.3288
-  tps: 15767.69003
+  dps: 22196.51271
+  tps: 15760.72061
   hps: 61.37058
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 22332.8406
-  tps: 15857.51342
+  dps: 22337.68944
+  tps: 15860.95609
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 22350.46776
-  tps: 15870.10348
+  dps: 22337.41487
+  tps: 15860.83593
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 22650.53918
-  tps: 16083.15419
+  dps: 22637.50689
+  tps: 16073.90126
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 21614.62149
-  tps: 15347.57785
+  dps: 21629.21526
+  tps: 15357.93942
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 21614.62149
-  tps: 15347.57785
+  dps: 21629.21526
+  tps: 15357.93942
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 21423.56745
-  tps: 15211.92947
+  dps: 21414.54411
+  tps: 15205.52291
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50179"
  value: {
-  dps: 22832.35413
-  tps: 16212.16802
+  dps: 22850.33352
+  tps: 16224.93338
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50708"
  value: {
-  dps: 22851.50744
-  tps: 16225.76687
+  dps: 22869.51515
+  tps: 16238.55234
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-55816"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-56347"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 22563.44756
-  tps: 16021.24436
+  dps: 22545.60528
+  tps: 16008.57634
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 22631.97579
-  tps: 16069.8994
+  dps: 22662.05836
+  tps: 16091.25802
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 21923.01535
-  tps: 15566.68706
+  dps: 21912.32485
+  tps: 15559.0968
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 21763.11148
-  tps: 15453.00573
+  dps: 21752.86166
+  tps: 15445.72836
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 21935.73254
-  tps: 15575.56669
+  dps: 21956.56301
+  tps: 15590.35632
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 21930.89966
-  tps: 15572.13535
+  dps: 21948.96832
+  tps: 15584.9641
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 22016.67127
-  tps: 15633.03319
+  dps: 22034.83322
+  tps: 15645.92818
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 21496.67132
-  tps: 15263.83322
+  dps: 21451.68218
+  tps: 15231.89093
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 21667.0402
-  tps: 15384.86992
+  dps: 21628.1918
+  tps: 15357.28755
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 21873.14434
-  tps: 15531.20386
+  dps: 21863.07186
+  tps: 15524.0524
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 21615.41388
-  tps: 15348.14044
+  dps: 21633.26678
+  tps: 15360.816
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 21615.41388
-  tps: 15348.14044
+  dps: 21633.26678
+  tps: 15360.816
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 21692.45054
-  tps: 15402.83647
+  dps: 21710.14455
+  tps: 15415.39922
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 21432.6163
-  tps: 15218.35416
+  dps: 21444.90152
+  tps: 15227.07666
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 21770.72079
-  tps: 15458.40835
+  dps: 21779.86954
+  tps: 15464.90396
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 22171.96795
-  tps: 15743.29383
+  dps: 22188.74971
+  tps: 15755.20888
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 22176.1535
-  tps: 15746.26557
+  dps: 22192.93526
+  tps: 15758.18062
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 21488.17369
-  tps: 15257.79991
+  dps: 21509.51137
+  tps: 15272.94966
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 21667.83339
-  tps: 15385.35829
+  dps: 21687.11668
+  tps: 15399.04943
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 22157.7145
-  tps: 15733.17388
+  dps: 22174.63425
+  tps: 15745.18691
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 22157.7145
-  tps: 15733.17388
+  dps: 22174.63425
+  tps: 15745.18691
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 22157.7145
-  tps: 15733.17388
+  dps: 22174.63425
+  tps: 15745.18691
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 22685.04192
-  tps: 16107.57635
+  dps: 22665.97249
+  tps: 16094.03705
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 22886.15071
-  tps: 16250.36359
+  dps: 22918.75231
+  tps: 16273.51073
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-55854"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-56377"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 22595.18102
-  tps: 16043.77511
+  dps: 22612.34562
+  tps: 16055.96198
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 22594.5358
-  tps: 16043.317
+  dps: 22611.85793
+  tps: 16055.61572
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 22524.45546
-  tps: 15993.55996
+  dps: 22541.71796
+  tps: 16005.81634
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 22157.7145
-  tps: 15733.17388
+  dps: 22174.63425
+  tps: 15745.18691
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 21840.06053
-  tps: 15507.71435
+  dps: 21829.28885
+  tps: 15500.06646
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 21878.92481
-  tps: 15535.30799
+  dps: 21867.70459
+  tps: 15527.34163
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 22278.9858
-  tps: 15819.27651
+  dps: 22299.46179
+  tps: 15833.81445
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-55256"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-56290"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShieldedSkyflareDiamond"
  value: {
-  dps: 22157.7145
-  tps: 15733.17388
+  dps: 22174.63425
+  tps: 15745.18691
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 21875.72889
-  tps: 15532.9641
+  dps: 21903.11911
+  tps: 15552.41115
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 22431.78542
-  tps: 15927.76423
+  dps: 22450.87394
+  tps: 15941.31709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 22583.13248
-  tps: 16035.22065
+  dps: 22598.95282
+  tps: 16046.45309
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-55879"
  value: {
-  dps: 21543.62444
-  tps: 15297.16994
+  dps: 21561.37322
+  tps: 15309.77157
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-56400"
  value: {
-  dps: 21577.95852
-  tps: 15321.54714
+  dps: 21595.7571
+  tps: 15334.18412
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 21673.65259
-  tps: 15389.56471
+  dps: 21663.2457
+  tps: 15382.17582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulCasket-58183"
  value: {
-  dps: 21615.41388
-  tps: 15348.14044
+  dps: 21633.26678
+  tps: 15360.816
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulPreserver-37111"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SouloftheDead-40382"
  value: {
-  dps: 21368.24495
-  tps: 15172.6505
+  dps: 21387.95398
+  tps: 15186.64391
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SparkofLife-37657"
  value: {
-  dps: 21420.80395
-  tps: 15209.96739
+  dps: 21417.93769
+  tps: 15207.93235
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 21540.9587
-  tps: 15295.35205
+  dps: 21564.95936
+  tps: 15312.39252
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 21292.1827
-  tps: 15118.6463
+  dps: 21309.55125
+  tps: 15130.97798
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62465"
  value: {
-  dps: 21442.4667
-  tps: 15225.49752
+  dps: 21431.67221
+  tps: 15217.83343
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62470"
  value: {
-  dps: 21442.4667
-  tps: 15225.49752
+  dps: 21431.67221
+  tps: 15217.83343
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 22176.1535
-  tps: 15746.26557
+  dps: 22192.93526
+  tps: 15758.18062
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 22171.96795
-  tps: 15743.29383
+  dps: 22188.74971
+  tps: 15755.20888
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 22167.26532
-  tps: 15739.95496
+  dps: 22184.04708
+  tps: 15751.87001
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 21291.53342
-  tps: 15118.18532
+  dps: 21308.90198
+  tps: 15130.51699
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 21895.35153
-  tps: 15546.89617
+  dps: 21850.90785
+  tps: 15515.34116
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-55819"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-56351"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 21505.12865
-  tps: 15269.83793
+  dps: 21522.82161
+  tps: 15282.39993
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 21577.95852
-  tps: 15321.54714
+  dps: 21595.7571
+  tps: 15334.18412
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 21305.08618
-  tps: 15127.80777
+  dps: 21322.45473
+  tps: 15140.13945
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 22223.26223
-  tps: 15779.71277
+  dps: 22215.91721
+  tps: 15774.49781
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 22537.5816
-  tps: 16002.87952
+  dps: 22554.70285
+  tps: 16015.03561
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 21470.1262
-  tps: 15245.06097
+  dps: 21480.01785
+  tps: 15252.08405
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 21547.40089
-  tps: 15299.92601
+  dps: 21563.01408
+  tps: 15311.01137
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 22157.7145
-  tps: 15733.17388
+  dps: 22174.63425
+  tps: 15745.18691
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 22157.7145
-  tps: 15733.17388
+  dps: 22174.63425
+  tps: 15745.18691
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 21356.09188
-  tps: 15164.02182
+  dps: 21374.22324
+  tps: 15176.89509
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 22157.7145
-  tps: 15733.17388
+  dps: 22174.63425
+  tps: 15745.18691
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 22157.7145
-  tps: 15733.17388
+  dps: 22174.63425
+  tps: 15745.18691
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 21353.41656
-  tps: 15162.27192
+  dps: 21370.78511
+  tps: 15174.60359
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 17471.44052
-  tps: 12405.91935
+  dps: 17478.61936
+  tps: 12411.01633
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 22898.55913
-  tps: 16259.17357
+  dps: 22904.89307
+  tps: 16263.67067
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 22898.55913
-  tps: 16259.17357
+  dps: 22904.89307
+  tps: 16263.67067
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 19317.54074
-  tps: 13716.65051
+  dps: 19303.06829
+  tps: 13706.37507
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 22545.49265
-  tps: 16008.49637
+  dps: 22551.45208
+  tps: 16012.72756
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 21748.02486
-  tps: 15442.29424
+  dps: 21764.44367
+  tps: 15453.95159
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 21442.4667
-  tps: 15225.49752
+  dps: 21431.67221
+  tps: 15217.83343
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 21660.02094
-  tps: 15379.81145
+  dps: 21630.33249
+  tps: 15358.73265
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 21604.96592
-  tps: 15340.72239
+  dps: 21595.60939
+  tps: 15334.07925
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 21564.9198
-  tps: 15312.28965
+  dps: 21562.11201
+  tps: 15310.29611
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 21635.18199
-  tps: 15362.1758
+  dps: 21653.06355
+  tps: 15374.87171
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 22488.36767
-  tps: 15967.93763
+  dps: 22497.6896
+  tps: 15974.5562
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 21729.75472
-  tps: 15429.32244
+  dps: 21749.53383
+  tps: 15443.36561
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WingedTalisman-37844"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 21281.4369
-  tps: 15111.01678
+  dps: 21298.80545
+  tps: 15123.34846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 21509.29036
-  tps: 15272.79274
+  dps: 21526.98935
+  tps: 15285.35902
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 21563.76146
-  tps: 15311.46722
+  dps: 21581.45776
+  tps: 15324.03159
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 21563.76146
-  tps: 15311.46722
+  dps: 21581.45776
+  tps: 15324.03159
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 22871.23537
-  tps: 16239.85862
+  dps: 22891.00586
+  tps: 16253.89567
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 22702.84314
-  tps: 16120.21522
+  dps: 22720.71054
+  tps: 16132.90107
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 22702.84314
-  tps: 16120.21522
+  dps: 22720.71054
+  tps: 16132.90107
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 27707.16369
-  tps: 19678.06915
+  dps: 27763.86284
+  tps: 19718.32555
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14274.19763
-  tps: 10137.29785
+  dps: 14282.31222
+  tps: 10143.05921
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 14274.19763
-  tps: 10137.29785
+  dps: 14282.31222
+  tps: 10143.05921
  }
 }
 dps_results: {
@@ -1885,36 +1885,36 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 22702.84314
-  tps: 16120.21522
+  dps: 22720.71054
+  tps: 16132.90107
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 22702.84314
-  tps: 16120.21522
+  dps: 22720.71054
+  tps: 16132.90107
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 27707.16369
-  tps: 19678.06915
+  dps: 27763.86284
+  tps: 19718.32555
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14274.19763
-  tps: 10137.29785
+  dps: 14282.31222
+  tps: 10143.05921
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 14274.19763
-  tps: 10137.29785
+  dps: 14282.31222
+  tps: 10143.05921
  }
 }
 dps_results: {
@@ -1927,7 +1927,7 @@ dps_results: {
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 19806.87376
-  tps: 14064.07696
+  dps: 19880.7253
+  tps: 14116.51155
  }
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -1878,8 +1878,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 15370.751
-  tps: 10920.71188
+  dps: 15372.05905
+  tps: 10921.64059
  }
 }
 dps_results: {
@@ -1920,8 +1920,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 15370.751
-  tps: 10920.71188
+  dps: 15372.05905
+  tps: 10921.64059
  }
 }
 dps_results: {

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -40,1894 +40,1894 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 22607.1308
-  tps: 16052.25945
+  dps: 22728.23298
+  tps: 16138.242
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 21333.29216
-  tps: 15147.9088
+  dps: 21449.4868
+  tps: 15230.407
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 21333.29216
-  tps: 15147.9088
+  dps: 21449.4868
+  tps: 15230.407
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 22064.45668
-  tps: 15666.96083
+  dps: 22182.21434
+  tps: 15750.56877
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 22064.45668
-  tps: 15666.96083
+  dps: 22182.21434
+  tps: 15750.56877
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 21472.74688
-  tps: 15246.92165
+  dps: 21584.05671
+  tps: 15325.95164
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
   hps: 84.91645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
   hps: 84.91645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 22082.68051
-  tps: 15679.89975
+  dps: 22200.43295
+  tps: 15763.50398
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 21477.95359
-  tps: 15250.54364
+  dps: 21597.99314
+  tps: 15335.77172
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 21526.05343
-  tps: 15284.69452
+  dps: 21631.66433
+  tps: 15359.67826
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BindingPromise-67037"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 16424.97739
-  tps: 11662.93053
+  dps: 16516.91828
+  tps: 11728.20857
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 22235.86197
-  tps: 15788.65858
+  dps: 22357.23537
+  tps: 15874.8337
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 21457.40524
-  tps: 15235.95431
+  dps: 21571.34426
+  tps: 15316.85101
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 21491.2766
-  tps: 15260.00298
+  dps: 21605.76295
+  tps: 15341.28828
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 22662.78462
-  tps: 16091.77367
+  dps: 22809.76532
+  tps: 16196.12996
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 21640.43102
-  tps: 15365.90261
+  dps: 21750.19047
+  tps: 15443.83182
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 21472.83534
-  tps: 15246.90968
+  dps: 21585.06181
+  tps: 15326.59047
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 22284.6517
-  tps: 15823.29929
+  dps: 22393.08469
+  tps: 15900.28672
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 21609.38593
-  tps: 15343.8606
+  dps: 21720.343
+  tps: 15422.64012
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledLightning-66879"
  value: {
-  dps: 21329.06206
-  tps: 15144.83065
+  dps: 21436.78661
+  tps: 15221.31508
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 22064.45668
-  tps: 15353.62161
+  dps: 22182.21434
+  tps: 15435.55739
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 22064.45668
-  tps: 15353.62161
+  dps: 22182.21434
+  tps: 15435.55739
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 22429.30881
-  tps: 15926.00584
+  dps: 22549.44651
+  tps: 16011.30361
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 22475.74944
-  tps: 15958.97869
+  dps: 22595.8277
+  tps: 16044.23426
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 22448.62783
-  tps: 15939.72235
+  dps: 22568.76001
+  tps: 16025.01619
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
   hps: 64
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-59506"
  value: {
-  dps: 22008.54132
-  tps: 15627.26093
+  dps: 22105.88743
+  tps: 15696.37666
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-65118"
  value: {
-  dps: 22057.87616
-  tps: 15662.28866
+  dps: 22167.8952
+  tps: 15740.40218
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 21297.96305
-  tps: 15122.75035
+  dps: 21408.51382
+  tps: 15201.2414
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 21325.07182
-  tps: 15142.14715
+  dps: 21435.64562
+  tps: 15220.65455
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 21557.05865
-  tps: 15306.70823
+  dps: 21673.06789
+  tps: 15389.07479
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 21851.51729
-  tps: 15515.77386
+  dps: 21949.38746
+  tps: 15585.26168
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 22248.7429
-  tps: 15797.80405
+  dps: 22364.63127
+  tps: 15880.08479
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 21529.11779
-  tps: 15289.1801
+  dps: 21644.20122
+  tps: 15370.88933
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Death'sChoice-47464"
  value: {
-  dps: 22147.19685
-  tps: 15725.70635
+  dps: 22270.56495
+  tps: 15813.2977
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 21283.32308
-  tps: 15112.35597
+  dps: 21391.61298
+  tps: 15189.2418
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 21792.45045
-  tps: 15473.83641
+  dps: 21904.74807
+  tps: 15553.56772
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 21813.64023
-  tps: 15488.88115
+  dps: 21930.39624
+  tps: 15571.77792
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Defender'sCode-40257"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 22108.31205
-  tps: 15698.09814
+  dps: 22226.01363
+  tps: 15781.66626
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 22088.91213
-  tps: 15684.3242
+  dps: 22206.66457
+  tps: 15767.92843
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 21319.84899
-  tps: 15138.28937
+  dps: 21409.68727
+  tps: 15202.07455
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 21291.3468
-  tps: 15118.05281
+  dps: 21375.23302
+  tps: 15177.61203
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 22064.45668
-  tps: 15666.96083
+  dps: 22182.21434
+  tps: 15750.56877
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 21198.75118
-  tps: 15089.45189
+  dps: 21308.51063
+  tps: 15167.3811
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 22064.45668
-  tps: 15666.96083
+  dps: 22182.21434
+  tps: 15750.56877
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 22064.45668
-  tps: 15666.96083
+  dps: 22182.21434
+  tps: 15750.56877
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 22108.31205
-  tps: 15698.09814
+  dps: 22226.01363
+  tps: 15781.66626
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 22082.68051
-  tps: 15679.89975
+  dps: 22200.43295
+  tps: 15763.50398
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 22078.52799
-  tps: 15676.95146
+  dps: 22196.28044
+  tps: 15760.5557
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 21316.05936
-  tps: 15135.59873
+  dps: 21409.3391
+  tps: 15201.82735
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 22650.97247
-  tps: 16083.38704
+  dps: 22777.88128
+  tps: 16173.49229
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 22902.12192
-  tps: 16261.70315
+  dps: 23000.49603
+  tps: 16331.54877
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 22064.45668
-  tps: 15666.96083
+  dps: 22182.21434
+  tps: 15750.56877
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 22064.45668
-  tps: 15666.96083
+  dps: 22182.21434
+  tps: 15750.56877
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 21324.28944
-  tps: 15141.44209
+  dps: 21435.02924
+  tps: 15220.06735
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 21280.63629
-  tps: 15110.44836
+  dps: 21391.2101
+  tps: 15188.95576
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-59500"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-65124"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 22685.17518
-  tps: 16107.74575
+  dps: 22822.24017
+  tps: 16205.0619
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 21911.28878
-  tps: 15558.21162
+  dps: 22025.77513
+  tps: 15639.49693
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 22121.42393
-  tps: 15707.40758
+  dps: 22240.09139
+  tps: 15791.66148
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FluidDeath-58181"
  value: {
-  dps: 22566.54666
-  tps: 16023.59429
+  dps: 22671.52523
+  tps: 16098.12908
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForgeEmber-37660"
  value: {
-  dps: 21259.38195
-  tps: 15095.35777
+  dps: 21368.25253
+  tps: 15172.65588
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 22064.45668
-  tps: 15666.96083
+  dps: 22182.21434
+  tps: 15750.56877
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 22064.45668
-  tps: 15666.96083
+  dps: 22182.21434
+  tps: 15750.56877
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 22064.45668
-  tps: 15666.96083
+  dps: 22182.21434
+  tps: 15750.56877
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 23008.79602
-  tps: 16337.44176
+  dps: 23141.5144
+  tps: 16431.67181
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 21575.27779
-  tps: 15319.64381
+  dps: 21687.64841
+  tps: 15399.42696
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuturesightRune-38763"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56138"
  value: {
-  dps: 21329.01845
-  tps: 15144.79969
+  dps: 21436.56021
+  tps: 15221.15434
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56462"
  value: {
-  dps: 21444.18307
-  tps: 15226.56656
+  dps: 21554.36633
+  tps: 15304.79668
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GearDetector-61462"
  value: {
-  dps: 21978.01059
-  tps: 15605.5841
+  dps: 22073.25642
+  tps: 15673.20865
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 21305.67988
-  tps: 15128.37888
+  dps: 21416.25368
+  tps: 15206.88628
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 21940.88242
-  tps: 15579.2231
+  dps: 22056.99177
+  tps: 15661.66074
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 22278.9189
-  tps: 15819.22901
+  dps: 22391.34204
+  tps: 15899.04943
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HarmlightToken-63839"
  value: {
-  dps: 21206.45155
-  tps: 15057.77719
+  dps: 21315.80934
+  tps: 15135.42122
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 21713.09747
-  tps: 15417.49579
+  dps: 21824.86182
+  tps: 15496.84848
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-59224"
  value: {
-  dps: 21932.46006
-  tps: 15573.24323
+  dps: 22035.32663
+  tps: 15646.27849
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-65072"
  value: {
-  dps: 22089.34607
-  tps: 15684.6323
+  dps: 22186.67111
+  tps: 15753.73307
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-55868"
  value: {
-  dps: 21329.01845
-  tps: 15144.79969
+  dps: 21436.56021
+  tps: 15221.15434
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-56393"
  value: {
-  dps: 21915.02555
-  tps: 15560.86473
+  dps: 22025.20881
+  tps: 15639.09484
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-55845"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-56370"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 22053.5286
-  tps: 15659.2019
+  dps: 22168.54633
+  tps: 15740.86448
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-49982"
  value: {
-  dps: 22949.0228
-  tps: 16295.00278
+  dps: 23068.36334
+  tps: 16379.73456
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-50641"
  value: {
-  dps: 22995.27587
-  tps: 16327.84245
+  dps: 23127.87202
+  tps: 16421.98572
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 22108.31205
-  tps: 15698.09814
+  dps: 22226.01363
+  tps: 15781.66626
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 22082.68051
-  tps: 15679.89975
+  dps: 22200.43295
+  tps: 15763.50398
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 22078.52799
-  tps: 15676.95146
+  dps: 22196.28044
+  tps: 15760.5557
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 22002.13825
-  tps: 15622.71474
+  dps: 22117.22167
+  tps: 15704.42397
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 22002.13825
-  tps: 15622.71474
+  dps: 22117.22167
+  tps: 15704.42397
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 21457.40524
-  tps: 15235.95431
+  dps: 21571.34426
+  tps: 15316.85101
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 21491.2766
-  tps: 15260.00298
+  dps: 21605.76295
+  tps: 15341.28828
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IncisorFragment-37723"
  value: {
-  dps: 21563.60371
-  tps: 15311.35522
+  dps: 21674.57083
+  tps: 15390.14187
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 22064.45668
-  tps: 15666.96083
+  dps: 22182.21434
+  tps: 15750.56877
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 21397.87375
-  tps: 15193.68695
+  dps: 21510.8508
+  tps: 15273.90066
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 22071.2517
-  tps: 15671.78529
+  dps: 22188.03218
+  tps: 15754.69943
   hps: 61.37058
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 22235.86197
-  tps: 15788.65858
+  dps: 22357.23537
+  tps: 15874.8337
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 22243.93106
-  tps: 15794.46242
+  dps: 22346.13898
+  tps: 15867.03005
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 22549.66116
-  tps: 16011.5308
+  dps: 22658.71198
+  tps: 16088.95688
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 21571.83959
-  tps: 15317.20269
+  dps: 21665.28667
+  tps: 15383.55012
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 21571.83959
-  tps: 15317.20269
+  dps: 21665.28667
+  tps: 15383.55012
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 21313.35688
-  tps: 15133.67997
+  dps: 21427.92412
+  tps: 15215.02271
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50179"
  value: {
-  dps: 22735.75713
-  tps: 16143.58415
+  dps: 22857.76224
+  tps: 16230.20777
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50708"
  value: {
-  dps: 22754.82396
-  tps: 16157.1216
+  dps: 22876.9645
+  tps: 16243.84138
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-55816"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-56347"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 22440.06665
-  tps: 15933.64391
+  dps: 22536.65184
+  tps: 16002.21939
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 22572.80172
-  tps: 16027.88581
+  dps: 22663.49249
+  tps: 16092.27625
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 21810.66386
-  tps: 15486.9175
+  dps: 21930.18655
+  tps: 15571.77861
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 21653.83173
-  tps: 15375.41711
+  dps: 21775.04652
+  tps: 15461.47961
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 21880.65762
-  tps: 15536.46349
+  dps: 21981.39878
+  tps: 15607.98972
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 21843.04689
-  tps: 15509.75988
+  dps: 21964.03217
+  tps: 15595.65943
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 21928.12942
-  tps: 15570.16848
+  dps: 22050.60965
+  tps: 15657.12944
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 21392.04582
-  tps: 15189.54912
+  dps: 21470.21121
+  tps: 15245.04655
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 21585.53489
-  tps: 15327.00114
+  dps: 21691.00442
+  tps: 15401.88451
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 21753.35696
-  tps: 15446.15482
+  dps: 21879.01289
+  tps: 15535.37053
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 21528.22718
-  tps: 15286.23789
+  dps: 21643.31061
+  tps: 15367.94712
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 21528.22718
-  tps: 15286.23789
+  dps: 21643.31061
+  tps: 15367.94712
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 21612.85124
-  tps: 15346.32097
+  dps: 21722.61069
+  tps: 15424.25018
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 21354.12229
-  tps: 15162.62341
+  dps: 21465.66558
+  tps: 15241.81915
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 21679.07311
-  tps: 15393.3385
+  dps: 21791.70225
+  tps: 15473.30518
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 22078.52799
-  tps: 15676.95146
+  dps: 22196.28044
+  tps: 15760.5557
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 22082.68051
-  tps: 15679.89975
+  dps: 22200.43295
+  tps: 15763.50398
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 21408.28914
-  tps: 15201.08187
+  dps: 21518.04859
+  tps: 15279.01108
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 21587.38697
-  tps: 15328.24133
+  dps: 21697.14642
+  tps: 15406.17054
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 22064.45668
-  tps: 15666.96083
+  dps: 22182.21434
+  tps: 15750.56877
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 22064.45668
-  tps: 15666.96083
+  dps: 22182.21434
+  tps: 15750.56877
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 22064.45668
-  tps: 15666.96083
+  dps: 22182.21434
+  tps: 15750.56877
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 22569.95975
-  tps: 16025.86801
+  dps: 22685.32975
+  tps: 16107.78071
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 22733.39039
-  tps: 16141.90376
+  dps: 22870.61044
+  tps: 16239.33
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-55854"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-56377"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 22499.44986
-  tps: 15975.80599
+  dps: 22619.98022
+  tps: 16061.38255
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 22498.91022
-  tps: 15975.42285
+  dps: 22619.53551
+  tps: 16061.0668
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 22429.30881
-  tps: 15926.00584
+  dps: 22549.44651
+  tps: 16011.30361
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 22064.45668
-  tps: 15666.96083
+  dps: 22182.21434
+  tps: 15750.56877
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 21733.11845
-  tps: 15431.78547
+  dps: 21849.46412
+  tps: 15514.3909
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 21772.44744
-  tps: 15459.70906
+  dps: 21889.82524
+  tps: 15543.04729
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 22190.46569
-  tps: 15756.42723
+  dps: 22303.45172
+  tps: 15836.6473
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-55256"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-56290"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShieldedSkyflareDiamond"
  value: {
-  dps: 22064.45668
-  tps: 15666.96083
+  dps: 22182.21434
+  tps: 15750.56877
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 21755.58155
-  tps: 15447.65949
+  dps: 21852.0563
+  tps: 15516.15656
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 22345.06062
-  tps: 15866.18962
+  dps: 22458.37165
+  tps: 15946.64046
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 22494.80954
-  tps: 15972.51136
+  dps: 22610.04623
+  tps: 16054.32941
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-55879"
  value: {
-  dps: 21457.40524
-  tps: 15235.95431
+  dps: 21571.34426
+  tps: 15316.85101
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-56400"
  value: {
-  dps: 21491.2766
-  tps: 15260.00298
+  dps: 21605.76295
+  tps: 15341.28828
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 21558.80063
-  tps: 15308.01982
+  dps: 21680.07449
+  tps: 15394.12426
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulCasket-58183"
  value: {
-  dps: 21528.22718
-  tps: 15286.23789
+  dps: 21643.31061
+  tps: 15367.94712
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulPreserver-37111"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SouloftheDead-40382"
  value: {
-  dps: 21282.84929
-  tps: 15112.01958
+  dps: 21393.42309
+  tps: 15190.52698
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SparkofLife-37657"
  value: {
-  dps: 21253.21097
-  tps: 15090.97637
+  dps: 21366.14326
+  tps: 15171.1583
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 21472.44266
-  tps: 15246.70566
+  dps: 21574.36803
+  tps: 15319.07267
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 21209.49698
-  tps: 15059.93944
+  dps: 21319.25643
+  tps: 15137.86865
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62465"
  value: {
-  dps: 21333.33536
-  tps: 15148.01426
+  dps: 21449.53
+  tps: 15230.51246
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62470"
  value: {
-  dps: 21333.33536
-  tps: 15148.01426
+  dps: 21449.53
+  tps: 15230.51246
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 22082.68051
-  tps: 15679.89975
+  dps: 22200.43295
+  tps: 15763.50398
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 22078.52799
-  tps: 15676.95146
+  dps: 22196.28044
+  tps: 15760.5557
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 22073.82849
-  tps: 15673.61481
+  dps: 22191.58093
+  tps: 15757.21905
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 21208.84771
-  tps: 15059.47846
+  dps: 21318.60716
+  tps: 15137.40767
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 21793.0918
-  tps: 15474.29177
+  dps: 21892.86124
+  tps: 15545.12807
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-55819"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-56351"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 21419.42826
-  tps: 15208.99065
+  dps: 21532.75361
+  tps: 15289.45165
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 21491.2766
-  tps: 15260.00298
+  dps: 21605.76295
+  tps: 15341.28828
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 21222.4953
-  tps: 15069.16825
+  dps: 21332.25475
+  tps: 15147.09746
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 22120.45568
-  tps: 15706.72012
+  dps: 22222.69079
+  tps: 15779.30705
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 22442.41196
-  tps: 15935.30908
+  dps: 22562.24308
+  tps: 16020.38917
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 21349.9863
-  tps: 15159.76165
+  dps: 21454.18902
+  tps: 15233.74558
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 21421.28513
-  tps: 15210.38382
+  dps: 21530.78306
+  tps: 15288.12735
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 22064.45668
-  tps: 15666.96083
+  dps: 22182.21434
+  tps: 15750.56877
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 22064.45668
-  tps: 15666.96083
+  dps: 22182.21434
+  tps: 15750.56877
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 21226.09159
-  tps: 15071.72161
+  dps: 21323.74675
+  tps: 15141.05678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 22064.45668
-  tps: 15666.96083
+  dps: 22182.21434
+  tps: 15750.56877
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 22064.45668
-  tps: 15666.96083
+  dps: 22182.21434
+  tps: 15750.56877
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 21270.78131
-  tps: 15103.60089
+  dps: 21380.56174
+  tps: 15181.54499
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 17380.366
-  tps: 12341.25645
+  dps: 17480.89714
+  tps: 12412.63355
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 22803.71318
-  tps: 16191.83295
+  dps: 22919.95203
+  tps: 16274.36252
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 22803.71318
-  tps: 16191.83295
+  dps: 22919.95203
+  tps: 16274.36252
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 19215.71143
-  tps: 13644.3517
+  dps: 19327.43227
+  tps: 13723.6735
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 22454.97867
-  tps: 15944.23144
+  dps: 22565.96121
+  tps: 16023.02905
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 21665.13022
-  tps: 15383.43905
+  dps: 21774.88967
+  tps: 15461.36825
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 21333.33536
-  tps: 15148.01426
+  dps: 21449.53
+  tps: 15230.51246
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 21557.09438
-  tps: 15306.7336
+  dps: 21664.75083
+  tps: 15383.16968
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 21495.62146
-  tps: 15263.08782
+  dps: 21615.66101
+  tps: 15348.3159
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 21461.74498
-  tps: 15239.03552
+  dps: 21552.60129
+  tps: 15303.54351
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 21547.72888
-  tps: 15300.08409
+  dps: 21663.12743
+  tps: 15382.01706
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 22399.02996
-  tps: 15904.50786
+  dps: 22509.29577
+  tps: 15982.79658
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 21644.90271
-  tps: 15369.07751
+  dps: 21754.70915
+  tps: 15447.04009
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WingedTalisman-37844"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 21198.75118
-  tps: 15052.30993
+  dps: 21308.51063
+  tps: 15130.23914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 21423.53387
-  tps: 15211.90564
+  dps: 21536.92557
+  tps: 15292.41374
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 21478.45405
-  tps: 15250.89896
+  dps: 21595.94681
+  tps: 15334.31882
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 21478.45405
-  tps: 15250.89896
+  dps: 21595.94681
+  tps: 15334.31882
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 22778.99676
-  tps: 16174.36921
+  dps: 22871.65764
+  tps: 16240.15844
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 22608.46918
-  tps: 16053.20971
+  dps: 22724.57724
+  tps: 16135.64643
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 22608.46918
-  tps: 16053.20971
+  dps: 22724.57724
+  tps: 16135.64643
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 26994.35027
-  tps: 19171.97162
+  dps: 27632.31443
+  tps: 19624.92618
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14162.74214
-  tps: 10058.16445
+  dps: 14222.2933
+  tps: 10100.44578
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 14162.74214
-  tps: 10058.16445
+  dps: 14222.2933
+  tps: 10100.44578
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 14846.889
-  tps: 10548.76986
+  dps: 15342.97053
+  tps: 10900.98775
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 22607.1308
-  tps: 16052.25945
+  dps: 22728.23298
+  tps: 16138.242
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 22607.1308
-  tps: 16052.25945
+  dps: 22728.23298
+  tps: 16138.242
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 27064.8474
-  tps: 19222.02459
+  dps: 27616.52216
+  tps: 19613.71366
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14162.74214
-  tps: 10058.16445
+  dps: 14222.2933
+  tps: 10100.44578
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 14162.74214
-  tps: 10058.16445
+  dps: 14222.2933
+  tps: 10100.44578
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 14882.7457
-  tps: 10574.22812
+  dps: 15342.97053
+  tps: 10900.98775
  }
 }
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 19669.21513
-  tps: 13966.33933
+  dps: 19786.50862
+  tps: 14049.61771
  }
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -40,94 +40,94 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 22721.26354
-  tps: 16133.2937
+  dps: 22711.31854
+  tps: 16126.23275
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 21428.24527
-  tps: 15215.32551
+  dps: 21440.26385
+  tps: 15223.85871
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 21428.24527
-  tps: 15215.32551
+  dps: 21440.26385
+  tps: 15223.85871
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 22175.26412
-  tps: 15745.63411
+  dps: 22165.78196
+  tps: 15738.90178
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 22175.26412
-  tps: 15745.63411
+  dps: 22165.78196
+  tps: 15738.90178
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 21575.2585
-  tps: 15319.70491
+  dps: 21565.56911
+  tps: 15312.82544
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
   hps: 84.91645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
   hps: 84.91645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 22193.70313
-  tps: 15758.72581
+  dps: 22184.22096
+  tps: 15751.99347
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 21591.72786
-  tps: 15331.32337
+  dps: 21582.14019
+  tps: 15324.51612
  }
 }
 dps_results: {
@@ -140,8 +140,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-BindingPromise-67037"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
@@ -161,15 +161,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 21561.7262
-  tps: 15310.02219
+  dps: 21552.17535
+  tps: 15303.24108
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 21596.05563
-  tps: 15334.39608
+  dps: 21586.5096
+  tps: 15327.6184
  }
 }
 dps_results: {
@@ -182,127 +182,127 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 21741.45187
-  tps: 15437.62741
+  dps: 21731.86419
+  tps: 15430.82016
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 21576.97767
-  tps: 15320.85073
+  dps: 21567.39
+  tps: 15314.04349
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 22388.78765
-  tps: 15897.23582
+  dps: 22379.19998
+  tps: 15890.42857
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 21713.50123
-  tps: 15417.78246
+  dps: 21703.98975
+  tps: 15411.02931
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledLightning-66879"
  value: {
-  dps: 21438.13832
-  tps: 15222.27479
+  dps: 21428.55065
+  tps: 15215.46755
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 22175.26412
-  tps: 15430.72143
+  dps: 22165.78196
+  tps: 15424.12374
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 22175.26412
-  tps: 15430.72143
+  dps: 22165.78196
+  tps: 15424.12374
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 22542.7509
-  tps: 16006.54972
+  dps: 22532.86926
+  tps: 15999.53376
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 22586.62659
-  tps: 16037.70146
+  dps: 22576.74495
+  tps: 16030.6855
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 22562.29801
-  tps: 16020.42817
+  dps: 22552.41637
+  tps: 16013.41221
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
   hps: 64
  }
 }
@@ -316,190 +316,190 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-65118"
  value: {
-  dps: 22201.70119
-  tps: 15764.40443
+  dps: 22199.43008
+  tps: 15762.79195
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 21401.11261
-  tps: 15195.98654
+  dps: 21391.52494
+  tps: 15189.1793
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 21427.88212
-  tps: 15215.14246
+  dps: 21418.29444
+  tps: 15208.33522
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 21668.05985
-  tps: 15385.51908
+  dps: 21658.46146
+  tps: 15378.70422
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 21938.98126
-  tps: 15577.87328
+  dps: 21939.72913
+  tps: 15578.40427
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 22359.45306
-  tps: 15876.40826
+  dps: 22349.48645
+  tps: 15869.33197
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 21634.39653
-  tps: 15363.928
+  dps: 21624.85576
+  tps: 15357.15406
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Death'sChoice-47464"
  value: {
-  dps: 22254.9416
-  tps: 15802.20513
+  dps: 22245.318
+  tps: 15795.37237
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 21380.30669
-  tps: 15181.21434
+  dps: 21370.71902
+  tps: 15174.40709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 21894.17754
-  tps: 15546.06264
+  dps: 21884.58987
+  tps: 15539.2554
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 21955.18988
-  tps: 15589.3814
+  dps: 21945.60221
+  tps: 15582.57416
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Defender'sCode-40257"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 22216.70497
-  tps: 15775.05711
+  dps: 22207.2228
+  tps: 15768.32477
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 22199.35753
-  tps: 15762.74043
+  dps: 22189.87536
+  tps: 15756.00809
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 21452.24416
-  tps: 15232.28994
+  dps: 21453.16816
+  tps: 15232.94598
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 21384.56061
-  tps: 15184.23462
+  dps: 21393.66925
+  tps: 15190.70175
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 22175.26412
-  tps: 15745.63411
+  dps: 22165.78196
+  tps: 15738.90178
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 21299.57417
-  tps: 15160.91815
+  dps: 21289.9865
+  tps: 15154.1109
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 22175.26412
-  tps: 15745.63411
+  dps: 22165.78196
+  tps: 15738.90178
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 22175.26412
-  tps: 15745.63411
+  dps: 22165.78196
+  tps: 15738.90178
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 22216.70497
-  tps: 15775.05711
+  dps: 22207.2228
+  tps: 15768.32477
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 22193.70313
-  tps: 15758.72581
+  dps: 22184.22096
+  tps: 15751.99347
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 22189.51757
-  tps: 15755.75406
+  dps: 22180.03541
+  tps: 15749.02173
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 21418.80085
-  tps: 15208.54519
+  dps: 21414.70598
+  tps: 15205.63783
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
@@ -519,92 +519,92 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 22175.26412
-  tps: 15745.63411
+  dps: 22165.78196
+  tps: 15738.90178
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 22175.26412
-  tps: 15745.63411
+  dps: 22165.78196
+  tps: 15738.90178
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 21427.52488
-  tps: 15214.73925
+  dps: 21417.93721
+  tps: 15207.932
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 21383.44659
-  tps: 15183.44366
+  dps: 21373.85892
+  tps: 15176.63642
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-59500"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-65124"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 22794.10168
-  tps: 16185.08357
+  dps: 22809.01466
+  tps: 16195.67178
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 22016.18265
-  tps: 15632.68627
+  dps: 22006.63662
+  tps: 15625.90859
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 22233.00338
-  tps: 15786.62898
+  dps: 22223.52903
+  tps: 15779.9022
  }
 }
 dps_results: {
@@ -617,57 +617,57 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForgeEmber-37660"
  value: {
-  dps: 21359.95449
-  tps: 15166.76427
+  dps: 21350.36682
+  tps: 15159.95703
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 22175.26412
-  tps: 15745.63411
+  dps: 22165.78196
+  tps: 15738.90178
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 22175.26412
-  tps: 15745.63411
+  dps: 22165.78196
+  tps: 15738.90178
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 22175.26412
-  tps: 15745.63411
+  dps: 22165.78196
+  tps: 15738.90178
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 23147.54619
-  tps: 16435.95438
+  dps: 23136.40079
+  tps: 16428.04115
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 21678.84381
-  tps: 15393.17569
+  dps: 21669.08482
+  tps: 15386.24681
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuturesightRune-38763"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
@@ -694,29 +694,29 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 21408.72057
-  tps: 15201.53777
+  dps: 21398.83332
+  tps: 15194.51781
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 22050.92979
-  tps: 15657.35674
+  dps: 22041.10603
+  tps: 15650.38187
  }
 }
 dps_results: {
@@ -729,43 +729,43 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-HarmlightToken-63839"
  value: {
-  dps: 21306.87288
-  tps: 15129.07633
+  dps: 21297.28521
+  tps: 15122.26908
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 21816.08766
-  tps: 15490.61882
+  dps: 21806.36845
+  tps: 15483.71818
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-59224"
  value: {
-  dps: 22074.60254
-  tps: 15674.16439
+  dps: 22061.1149
+  tps: 15664.58816
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-65072"
  value: {
-  dps: 22202.02171
-  tps: 15764.632
+  dps: 22207.18642
+  tps: 15768.29894
  }
 }
 dps_results: {
@@ -785,22 +785,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-55845"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-56370"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 22160.04013
-  tps: 15734.82508
+  dps: 22150.17623
+  tps: 15727.82171
  }
 }
 dps_results: {
@@ -820,107 +820,107 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 22216.70497
-  tps: 15775.05711
+  dps: 22207.2228
+  tps: 15768.32477
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 22193.70313
-  tps: 15758.72581
+  dps: 22184.22096
+  tps: 15751.99347
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 22189.51757
-  tps: 15755.75406
+  dps: 22180.03541
+  tps: 15749.02173
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 22107.53628
-  tps: 15697.54734
+  dps: 22097.99551
+  tps: 15690.7734
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 22107.53628
-  tps: 15697.54734
+  dps: 22097.99551
+  tps: 15690.7734
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 21561.7262
-  tps: 15310.02219
+  dps: 21552.17535
+  tps: 15303.24108
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 21596.05563
-  tps: 15334.39608
+  dps: 21586.5096
+  tps: 15327.6184
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IncisorFragment-37723"
  value: {
-  dps: 21667.55668
-  tps: 15385.16183
+  dps: 21657.88977
+  tps: 15378.29832
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 22175.26412
-  tps: 15745.63411
+  dps: 22165.78196
+  tps: 15738.90178
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 21501.38962
-  tps: 15267.18322
+  dps: 21491.8303
+  tps: 15260.3961
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 22199.17922
-  tps: 15762.61383
+  dps: 22197.92869
+  tps: 15761.72596
   hps: 61.37058
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
@@ -933,15 +933,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 22334.42403
-  tps: 15858.71244
+  dps: 22351.00314
+  tps: 15870.4836
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 22640.26745
-  tps: 16075.86127
+  dps: 22648.37953
+  tps: 16081.62084
  }
 }
 dps_results: {
@@ -961,113 +961,113 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 21424.81103
-  tps: 15212.81242
+  dps: 21425.08115
+  tps: 15213.00421
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50179"
  value: {
-  dps: 22850.88472
-  tps: 16225.32474
+  dps: 22840.88384
+  tps: 16218.22411
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50708"
  value: {
-  dps: 22870.05457
-  tps: 16238.93533
+  dps: 22860.0453
+  tps: 16231.82875
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-55816"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-56347"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 22559.51326
-  tps: 16018.451
+  dps: 22562.25303
+  tps: 16020.39623
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 22642.83346
-  tps: 16077.60834
+  dps: 22625.01184
+  tps: 16064.95499
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 21908.5942
-  tps: 15556.44804
+  dps: 21920.86121
+  tps: 15565.15762
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 21750.7136
-  tps: 15444.20324
+  dps: 21763.65183
+  tps: 15453.38938
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 21956.47768
-  tps: 15590.29574
+  dps: 21939.4304
+  tps: 15578.19217
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 21952.20846
-  tps: 15587.2646
+  dps: 21942.67809
+  tps: 15580.49803
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 22038.40179
-  tps: 15648.46186
+  dps: 22028.87935
+  tps: 15641.70093
  }
 }
 dps_results: {
@@ -1080,134 +1080,134 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 21655.18588
-  tps: 15376.45335
+  dps: 21667.55324
+  tps: 15385.23417
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 21857.79994
-  tps: 15520.30933
+  dps: 21871.03758
+  tps: 15529.70806
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 21633.50592
-  tps: 15360.98579
+  dps: 21623.96515
+  tps: 15354.21185
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 21633.50592
-  tps: 15360.98579
+  dps: 21623.96515
+  tps: 15354.21185
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 21710.5878
-  tps: 15415.71393
+  dps: 21701.00013
+  tps: 15408.90668
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 21450.75357
-  tps: 15231.23162
+  dps: 21441.16589
+  tps: 15224.42437
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 21789.55901
-  tps: 15471.78348
+  dps: 21779.86228
+  tps: 15464.89881
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 22189.51757
-  tps: 15755.75406
+  dps: 22180.03541
+  tps: 15749.02173
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 22193.70313
-  tps: 15758.72581
+  dps: 22184.22096
+  tps: 15751.99347
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 21506.31096
-  tps: 15270.67737
+  dps: 21496.72329
+  tps: 15263.87012
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 21685.97066
-  tps: 15398.23575
+  dps: 21676.38299
+  tps: 15391.42851
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 22175.26412
-  tps: 15745.63411
+  dps: 22165.78196
+  tps: 15738.90178
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 22175.26412
-  tps: 15745.63411
+  dps: 22165.78196
+  tps: 15738.90178
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 22175.26412
-  tps: 15745.63411
+  dps: 22165.78196
+  tps: 15738.90178
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 22703.36993
-  tps: 16120.58923
+  dps: 22702.8345
+  tps: 16120.20908
  }
 }
 dps_results: {
@@ -1220,127 +1220,127 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-55854"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-56377"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 22613.52506
-  tps: 16056.79938
+  dps: 22603.61878
+  tps: 16049.76592
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 22612.89074
-  tps: 16056.34901
+  dps: 22602.97893
+  tps: 16049.31163
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 22542.7509
-  tps: 16006.54972
+  dps: 22532.86926
+  tps: 15999.53376
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 22175.26412
-  tps: 15745.63411
+  dps: 22165.78196
+  tps: 15738.90178
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 21828.09753
-  tps: 15499.22062
+  dps: 21837.86246
+  tps: 15506.15372
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 21864.59155
-  tps: 15525.13137
+  dps: 21876.89325
+  tps: 15533.86558
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 22297.20174
-  tps: 15832.20982
+  dps: 22287.33784
+  tps: 15825.20645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-55256"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-56290"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShieldedSkyflareDiamond"
  value: {
-  dps: 22175.26412
-  tps: 15745.63411
+  dps: 22165.78196
+  tps: 15738.90178
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
@@ -1353,78 +1353,78 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 22450.04306
-  tps: 15940.72716
+  dps: 22440.15791
+  tps: 15933.70871
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 22601.46659
-  tps: 16048.23786
+  dps: 22591.54248
+  tps: 16041.19175
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-55879"
  value: {
-  dps: 21561.7262
-  tps: 15310.02219
+  dps: 21552.17535
+  tps: 15303.24108
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-56400"
  value: {
-  dps: 21596.05563
-  tps: 15334.39608
+  dps: 21586.5096
+  tps: 15327.6184
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 21658.8483
-  tps: 15379.05367
+  dps: 21671.52133
+  tps: 15388.05152
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulCasket-58183"
  value: {
-  dps: 21633.50592
-  tps: 15360.98579
+  dps: 21623.96515
+  tps: 15354.21185
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulPreserver-37111"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SouloftheDead-40382"
  value: {
-  dps: 21385.91873
-  tps: 15185.19888
+  dps: 21376.33106
+  tps: 15178.39164
  }
 }
 dps_results: {
@@ -1437,169 +1437,169 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 21549.66406
-  tps: 15301.53285
+  dps: 21547.33348
+  tps: 15299.87814
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 21310.31997
-  tps: 15131.52376
+  dps: 21300.73229
+  tps: 15124.71652
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62465"
  value: {
-  dps: 21428.28847
-  tps: 15215.43097
+  dps: 21440.30705
+  tps: 15223.96417
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62470"
  value: {
-  dps: 21428.28847
-  tps: 15215.43097
+  dps: 21440.30705
+  tps: 15223.96417
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 22193.70313
-  tps: 15758.72581
+  dps: 22184.22096
+  tps: 15751.99347
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 22189.51757
-  tps: 15755.75406
+  dps: 22180.03541
+  tps: 15749.02173
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 22184.81494
-  tps: 15752.4152
+  dps: 22175.33278
+  tps: 15745.68286
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 21309.67069
-  tps: 15131.06278
+  dps: 21300.08302
+  tps: 15124.25553
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 21888.47042
-  tps: 15542.01058
+  dps: 21887.16908
+  tps: 15541.08663
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-55819"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-56351"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 21523.23562
-  tps: 15282.69388
+  dps: 21513.67937
+  tps: 15275.90894
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 21596.05563
-  tps: 15334.39608
+  dps: 21586.5096
+  tps: 15327.6184
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 21323.22345
-  tps: 15140.68523
+  dps: 21313.63578
+  tps: 15133.87799
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 22213.62377
-  tps: 15772.86946
+  dps: 22213.79156
+  tps: 15772.9886
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 22555.91419
-  tps: 16015.89566
+  dps: 22546.01106
+  tps: 16008.86444
  }
 }
 dps_results: {
@@ -1612,22 +1612,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 21535.81073
-  tps: 15291.69699
+  dps: 21550.49806
+  tps: 15302.125
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 22175.26412
-  tps: 15745.63411
+  dps: 22165.78196
+  tps: 15738.90178
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 22175.26412
-  tps: 15745.63411
+  dps: 22165.78196
+  tps: 15738.90178
  }
 }
 dps_results: {
@@ -1640,22 +1640,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 22175.26412
-  tps: 15745.63411
+  dps: 22165.78196
+  tps: 15738.90178
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 22175.26412
-  tps: 15745.63411
+  dps: 22165.78196
+  tps: 15738.90178
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 21372.33251
-  tps: 15175.70224
+  dps: 21361.96616
+  tps: 15168.34213
  }
 }
 dps_results: {
@@ -1668,22 +1668,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 22917.08959
-  tps: 16272.3302
+  dps: 22907.54882
+  tps: 16265.55625
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 22917.08959
-  tps: 16272.3302
+  dps: 22907.54882
+  tps: 16265.55625
  }
 }
 dps_results: {
@@ -1696,43 +1696,43 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 22564.08387
-  tps: 16021.69613
+  dps: 22554.4962
+  tps: 16014.88889
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 21766.16213
-  tps: 15455.1717
+  dps: 21756.57446
+  tps: 15448.36445
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 21428.28847
-  tps: 15215.43097
+  dps: 21440.30705
+  tps: 15223.96417
  }
 }
 dps_results: {
@@ -1752,106 +1752,106 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 21581.01901
-  tps: 15323.72008
+  dps: 21567.64976
+  tps: 15314.22792
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 21653.27135
-  tps: 15375.01925
+  dps: 21643.73336
+  tps: 15368.24727
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 22507.57909
-  tps: 15981.57774
+  dps: 22496.41418
+  tps: 15973.65065
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 21747.54751
-  tps: 15441.95532
+  dps: 21737.38088
+  tps: 15434.73701
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WingedTalisman-37844"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 21299.57417
-  tps: 15123.89425
+  dps: 21289.9865
+  tps: 15117.087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 21527.39677
-  tps: 15285.64829
+  dps: 21517.84109
+  tps: 15278.86376
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 21584.36948
-  tps: 15326.09892
+  dps: 21574.95216
+  tps: 15319.41262
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 21584.36948
-  tps: 15326.09892
+  dps: 21574.95216
+  tps: 15319.41262
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 22872.11661
-  tps: 16240.4843
+  dps: 22871.85675
+  tps: 16240.2998
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 22721.26354
-  tps: 16133.2937
+  dps: 22711.31854
+  tps: 16126.23275
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 22721.26354
-  tps: 16133.2937
+  dps: 22711.31854
+  tps: 16126.23275
  }
 }
 dps_results: {
@@ -1864,15 +1864,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14280.35142
-  tps: 10141.66704
+  dps: 14279.85928
+  tps: 10141.31762
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 14280.35142
-  tps: 10141.66704
+  dps: 14279.85928
+  tps: 10141.31762
  }
 }
 dps_results: {
@@ -1885,15 +1885,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 22721.26354
-  tps: 16133.2937
+  dps: 22711.31854
+  tps: 16126.23275
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 22721.26354
-  tps: 16133.2937
+  dps: 22711.31854
+  tps: 16126.23275
  }
 }
 dps_results: {
@@ -1906,15 +1906,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14280.35142
-  tps: 10141.66704
+  dps: 14279.85928
+  tps: 10141.31762
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 14280.35142
-  tps: 10141.66704
+  dps: 14279.85928
+  tps: 10141.31762
  }
 }
 dps_results: {
@@ -1927,7 +1927,7 @@ dps_results: {
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 19812.34003
-  tps: 14067.958
+  dps: 19810.07941
+  tps: 14066.35297
  }
 }

--- a/sim/druid/feral/apl_values.go
+++ b/sim/druid/feral/apl_values.go
@@ -159,6 +159,7 @@ func (action *APLActionCatOptimalRotationAction) Execute(sim *core.Simulation) {
 
 func (action *APLActionCatOptimalRotationAction) Reset(*core.Simulation) {
 	action.cat.usingHardcodedAPL = true
+	action.cat.cachedRipEndThresh = time.Second * 10 // placeholder until first calc
 	action.lastAction = core.DurationFromSeconds(-100)
 }
 

--- a/sim/druid/feral/feral.go
+++ b/sim/druid/feral/feral.go
@@ -62,14 +62,15 @@ type FeralDruid struct {
 
 	Rotation FeralDruidRotation
 
-	readyToShift      bool
-	readyToGift       bool
-	waitingForTick    bool
-	maxRipTicks       int32
-	berserkUsed       bool
-	bleedAura         *core.Aura
-	lastShift         time.Duration
-	usingHardcodedAPL bool
+	readyToShift       bool
+	readyToGift        bool
+	waitingForTick     bool
+	maxRipTicks        int32
+	berserkUsed        bool
+	bleedAura          *core.Aura
+	lastShift          time.Duration
+	cachedRipEndThresh time.Duration
+	usingHardcodedAPL  bool
 
 	rotationAction *core.PendingAction
 }

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -300,8 +300,8 @@ func (cat *FeralDruid) doRotation(sim *core.Simulation) (bool, time.Duration) {
 	clipMangle := false
 
 	if mangleRefreshPending {
-		numManglesRemaining := int((time.Second + (simTimeRemain - cat.bleedAura.RemainingDuration(sim) - time.Second)).Minutes())
-		earliestMangle := (sim.GetRemainingDuration() + sim.CurrentTime) - time.Duration(numManglesRemaining)*time.Minute
+		numManglesRemaining := 1 + int32((sim.Duration - time.Second - cat.bleedAura.ExpiresAt()) / time.Minute)
+		earliestMangle := sim.Duration - time.Duration(numManglesRemaining) * time.Minute
 		clipMangle = sim.CurrentTime >= earliestMangle
 	}
 

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -352,6 +352,7 @@ func (cat *FeralDruid) doRotation(sim *core.Simulation) (bool, time.Duration) {
 	// Pooling calcs
 	ripRefreshPending := ripDot.IsActive() && (ripDot.RemainingDuration(sim) < simTimeRemain - endThresh) && (curCp >= core.TernaryInt32(isExecutePhase, 1, rotation.MinCombosForRip))
 	rakeRefreshPending := rakeDot.IsActive() && (rakeDot.RemainingDuration(sim) < simTimeRemain - rakeDot.TickLength)
+	roarRefreshPending := cat.SavageRoarAura.IsActive() && (cat.SavageRoarAura.RemainingDuration(sim) < simTimeRemain - cat.ReactionTime)
 	pendingPool := PoolingActions{}
 	pendingPool.create(4)
 
@@ -370,7 +371,7 @@ func (cat *FeralDruid) doRotation(sim *core.Simulation) (bool, time.Duration) {
 		mangleCost := core.Ternary(cat.berserkExpectedAt(sim, cat.bleedAura.ExpiresAt()), cat.MangleCat.DefaultCast.Cost*0.5, cat.MangleCat.DefaultCast.Cost)
 		pendingPool.addAction(cat.bleedAura.ExpiresAt(), mangleCost)
 	}
-	if cat.SavageRoarAura.IsActive() {
+	if roarRefreshPending {
 		roarCost := core.Ternary(cat.berserkExpectedAt(sim, cat.SavageRoarAura.ExpiresAt()), cat.SavageRoar.DefaultCast.Cost*0.5, cat.SavageRoar.DefaultCast.Cost)
 		pendingPool.addAction(cat.SavageRoarAura.ExpiresAt(), roarCost)
 	}

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -283,10 +283,11 @@ func (cat *FeralDruid) doRotation(sim *core.Simulation) (bool, time.Duration) {
 	regenRate := cat.EnergyRegenPerSecond()
 	isExecutePhase := rotation.BiteDuringExecute && sim.IsExecutePhase25()
 
-	// Prioritize using rake/rip with omen procs if bleed isnt active
-	// But less priority then mangle aura
+	// Prioritize using Rip with omen procs if bleed isnt active
 	ripCcCheck := core.Ternary(isBleedActive, !isClearcast, true)
-	rakeCcCheck := core.Ternary(isBleedActive, !isClearcast, cat.bleedAura.IsActive())
+
+	// Allow Clearcast Rakes if we will lose Rake uptime by Shredding first
+	rakeCcCheck := !isClearcast || !rakeDot.IsActive() || (rakeDot.RemainingDuration(sim) < time.Second)
 
 	endThresh := time.Second * 10
 

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -320,7 +320,7 @@ func (cat *FeralDruid) doRotation(sim *core.Simulation) (bool, time.Duration) {
 	emergencyBiteNow := isExecutePhase && ripDot.IsActive() && (ripDot.RemainingDuration(sim) < ripDot.TickLength) && (curCp >= 1)
 	biteNow = biteNow || emergencyBiteNow
 
-	rakeNow := rotation.UseRake && (!rakeDot.IsActive() || (rakeDot.RemainingDuration(sim) < rakeDot.TickLength)) && (simTimeRemain > rakeDot.Duration) && rakeCcCheck
+	rakeNow := rotation.UseRake && (!rakeDot.IsActive() || (rakeDot.RemainingDuration(sim) < rakeDot.TickLength)) && (simTimeRemain > rakeDot.TickLength) && rakeCcCheck
 
 	// Additionally, don't Rake if the current Shred DPE is higher due to
 	// trinket procs etc.
@@ -350,7 +350,7 @@ func (cat *FeralDruid) doRotation(sim *core.Simulation) (bool, time.Duration) {
 
 	// Pooling calcs
 	ripRefreshPending := ripDot.IsActive() && (ripDot.RemainingDuration(sim) < simTimeRemain - endThresh) && (curCp >= core.TernaryInt32(isExecutePhase, 1, rotation.MinCombosForRip))
-	rakeRefreshPending := rakeDot.IsActive() && (rakeDot.RemainingDuration(sim) < simTimeRemain - rakeDot.Duration)
+	rakeRefreshPending := rakeDot.IsActive() && (rakeDot.RemainingDuration(sim) < simTimeRemain - rakeDot.TickLength)
 	pendingPool := PoolingActions{}
 	pendingPool.create(4)
 

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -533,18 +533,18 @@ func (cat *FeralDruid) doRotation(sim *core.Simulation) (bool, time.Duration) {
 	} else if ffNow {
 		cat.FaerieFire.Cast(sim, cat.CurrentTarget)
 		return false, 0
-	} else if roarNow {
-		if cat.SavageRoar.CanCast(sim, cat.CurrentTarget) {
-			cat.SavageRoar.Cast(sim, nil)
-			return false, 0
-		}
-		timeToNextAction = core.DurationFromSeconds((cat.CurrentSavageRoarCost() - curEnergy) / regenRate)
 	} else if ripNow {
 		if cat.Rip.CanCast(sim, cat.CurrentTarget) {
 			cat.Rip.Cast(sim, cat.CurrentTarget)
 			return false, 0
 		}
 		timeToNextAction = core.DurationFromSeconds((cat.CurrentRipCost() - curEnergy) / regenRate)
+	} else if roarNow {
+		if cat.SavageRoar.CanCast(sim, cat.CurrentTarget) {
+			cat.SavageRoar.Cast(sim, nil)
+			return false, 0
+		}
+		timeToNextAction = core.DurationFromSeconds((cat.CurrentSavageRoarCost() - curEnergy) / regenRate)
 	} else if biteNow {
 		if cat.FerociousBite.CanCast(sim, cat.CurrentTarget) {
 			cat.FerociousBite.Cast(sim, cat.CurrentTarget)

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -339,7 +339,7 @@ func (cat *FeralDruid) doRotation(sim *core.Simulation) (bool, time.Duration) {
 	mangleNow := !ripNow && cat.MangleCat != nil && (mangleRefreshNow || clipMangle)
 
 	biteBeforeRip := (curCp >= rotation.MinCombosForBite) && ripDot.IsActive() && cat.SavageRoarAura.IsActive() && (rotation.UseBite || isExecutePhase) && cat.canBite(sim, isExecutePhase)
-	biteNow := (biteBeforeRip || biteAtEnd) && !isClearcast && curEnergy < 67
+	biteNow := (biteBeforeRip || biteAtEnd) && !isClearcast
 
 	// During Berserk, we additionally add an Energy constraint on Bite
 	// usage to maximize the total Energy expenditure we can get.

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -146,6 +146,11 @@ func (cat *FeralDruid) clipRoar(sim *core.Simulation, isExecutePhase bool) bool 
 		return true
 	}
 
+	// If waiting another GCD to build an additional CP would lower our total Roar casts for the fight, then force a wait.
+	if newRoarDur + time.Second + core.TernaryDuration(cat.ComboPoints() < 5, time.Second * 5, 0) >= simTimeRemaining {
+		return false
+	}
+
 	// Clip as soon as we have enough CPs for the new roar to expire well
 	// after the current rip
 	if !isExecutePhase {

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -357,7 +357,7 @@ func (cat *FeralDruid) doRotation(sim *core.Simulation) (bool, time.Duration) {
 	// Pooling calcs
 	ripRefreshPending := ripDot.IsActive() && (ripDot.RemainingDuration(sim) < simTimeRemain - endThresh) && (curCp >= core.TernaryInt32(isExecutePhase, 1, rotation.MinCombosForRip))
 	rakeRefreshPending := rakeDot.IsActive() && (rakeDot.RemainingDuration(sim) < simTimeRemain - rakeDot.TickLength)
-	roarRefreshPending := cat.SavageRoarAura.IsActive() && (cat.SavageRoarAura.RemainingDuration(sim) < simTimeRemain - cat.ReactionTime)
+	roarRefreshPending := cat.SavageRoarAura.IsActive() && (cat.SavageRoarAura.RemainingDuration(sim) < simTimeRemain - cat.ReactionTime) && (curCp >= 1)
 	pendingPool := PoolingActions{}
 	pendingPool.create(4)
 


### PR DESCRIPTION
- Changed end-of-fight threshold for Rake usage to only 1 tick required before it is worth casting over Shred.
- Fixed bug in Mangle clipping calculation.
- Prioritize Rake uptime over only spending Clearcasting on Shred.
- Added end-of-fight check to Roar pooling logic.
- Delay Roar clips when an additional CP would cover us to end of fight.
- Added CP check to Roar pooling logic.
- Replaced hardcoded 10s rule for end-of-fight Bite usage with a more accurate DPE-based calculation.
- Removed 67 Energy threshold for Bite usage that was left over from WotLK.
- Prioritize Rip over Savage Roar at 5 CP when both are down.