### PR TITLE
Update other effects trinkets

### DIFF
--- a/sim/common/cata/other_effects.go
+++ b/sim/common/cata/other_effects.go
@@ -235,6 +235,10 @@ func init() {
 					Timer:    sharedCD,
 					Duration: time.Second * 20,
 				},
+				CD: core.Cooldown{
+					Timer:    character.NewTimer(),
+					Duration: time.Minute * 2,
+				},
 			},
 			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 				dummyAura.Deactivate(sim)
@@ -295,7 +299,7 @@ func init() {
 
 		sharedCD := character.GetOffensiveTrinketCD()
 		trinketSpell := character.RegisterSpell(core.SpellConfig{
-			ActionID:    core.ActionID{ItemID: 59461},
+			ActionID:    core.ActionID{ItemID: 59514},
 			SpellSchool: core.SpellSchoolPhysical,
 			ProcMask:    core.ProcMaskEmpty,
 			Flags:       core.SpellFlagNoOnCastComplete,

--- a/sim/death_knight/frost/TestFrost.results
+++ b/sim/death_knight/frost/TestFrost.results
@@ -680,8 +680,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 26889.70403
-  tps: 24926.18881
+  dps: 24476.61876
+  tps: 22662.38231
  }
 }
 dps_results: {

--- a/sim/death_knight/unholy/TestUnholy.results
+++ b/sim/death_knight/unholy/TestUnholy.results
@@ -680,8 +680,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 30122.95948
-  tps: 21511.06798
+  dps: 27621.50055
+  tps: 19689.0726
  }
 }
 dps_results: {

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -652,8 +652,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 23124.71163
-  tps: 16419.74185
+  dps: 22088.99498
+  tps: 15684.38302
  }
 }
 dps_results: {

--- a/sim/rogue/assassination/TestAssassination.results
+++ b/sim/rogue/assassination/TestAssassination.results
@@ -659,8 +659,8 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 24621.39661
-  tps: 17481.1916
+  dps: 23472.34969
+  tps: 16665.36828
  }
 }
 dps_results: {

--- a/sim/rogue/combat/TestCombat.results
+++ b/sim/rogue/combat/TestCombat.results
@@ -687,8 +687,8 @@ dps_results: {
 dps_results: {
  key: "TestCombat-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 25438.08657
-  tps: 18061.04146
+  dps: 24144.56085
+  tps: 17142.6382
  }
 }
 dps_results: {

--- a/sim/rogue/subtlety/TestSubtlety.results
+++ b/sim/rogue/subtlety/TestSubtlety.results
@@ -661,8 +661,8 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 16331.63019
-  tps: 11595.45743
+  dps: 15702.12443
+  tps: 11148.50835
  }
 }
 dps_results: {


### PR DESCRIPTION
Fury of Angerforge had his on-use cooldown set to 2 minutes.
Heart of Ignacious was using Fury of Angerforge itemID as his actionID showing the wrong icon on the ui timeline