### PR TITLE
update hurricane procMask

### DIFF
--- a/sim/common/cata/damage_procs.go
+++ b/sim/common/cata/damage_procs.go
@@ -33,7 +33,7 @@ func init() {
 		Flags:   core.SpellFlagNoSpellMods | core.SpellFlagIgnoreModifiers | core.SpellFlagNoOnDamageDealt,
 		Trigger: core.ProcTrigger{
 			Name:     "Darkmoon Card: Hurricane",
-			ProcMask: core.ProcMaskProc,
+			ProcMask: core.ProcMaskMeleeOrRanged,
 			PPM:      1,
 			Outcome:  core.OutcomeLanded,
 			Callback: core.CallbackOnSpellHitDealt,

--- a/sim/death_knight/blood/TestBlood.results
+++ b/sim/death_knight/blood/TestBlood.results
@@ -432,9 +432,9 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 13444.05725
-  tps: 67859.48229
-  hps: 5148.86555
+  dps: 13651.44683
+  tps: 68820.04695
+  hps: 5103.08562
  }
 }
 dps_results: {

--- a/sim/death_knight/frost/TestFrost.results
+++ b/sim/death_knight/frost/TestFrost.results
@@ -386,8 +386,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 28038.67306
-  tps: 25968.59577
+  dps: 28766.50643
+  tps: 26627.91202
  }
 }
 dps_results: {

--- a/sim/death_knight/unholy/TestUnholy.results
+++ b/sim/death_knight/unholy/TestUnholy.results
@@ -386,8 +386,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 32173.13873
-  tps: 23062.57084
+  dps: 32442.07644
+  tps: 23321.53391
  }
 }
 dps_results: {

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -358,8 +358,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 22649.72178
-  tps: 16082.49905
+  dps: 22786.38021
+  tps: 16179.52654
  }
 }
 dps_results: {

--- a/sim/hunter/beast_mastery/TestBM.results
+++ b/sim/hunter/beast_mastery/TestBM.results
@@ -407,8 +407,8 @@ dps_results: {
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 19664.51613
-  tps: 16607.02659
+  dps: 20059.88403
+  tps: 17007.01185
  }
 }
 dps_results: {

--- a/sim/hunter/marksmanship/TestMM.results
+++ b/sim/hunter/marksmanship/TestMM.results
@@ -407,8 +407,8 @@ dps_results: {
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 20284.70248
-  tps: 18269.34154
+  dps: 21111.56549
+  tps: 19100.7441
  }
 }
 dps_results: {

--- a/sim/hunter/survival/TestSV.results
+++ b/sim/hunter/survival/TestSV.results
@@ -407,8 +407,8 @@ dps_results: {
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 23542.2196
-  tps: 21410.51874
+  dps: 23884.77729
+  tps: 21744.42092
  }
 }
 dps_results: {

--- a/sim/rogue/assassination/TestAssassination.results
+++ b/sim/rogue/assassination/TestAssassination.results
@@ -372,8 +372,8 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 27787.94565
-  tps: 19729.44141
+  dps: 28355.23635
+  tps: 20132.21781
  }
 }
 dps_results: {

--- a/sim/rogue/combat/TestCombat.results
+++ b/sim/rogue/combat/TestCombat.results
@@ -400,8 +400,8 @@ dps_results: {
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 28071.35601
-  tps: 19930.66277
+  dps: 28745.90092
+  tps: 20409.58965
  }
 }
 dps_results: {

--- a/sim/rogue/subtlety/TestSubtlety.results
+++ b/sim/rogue/subtlety/TestSubtlety.results
@@ -374,8 +374,8 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 23510.81877
-  tps: 16692.68132
+  dps: 23832.41089
+  tps: 16921.01173
  }
 }
 dps_results: {

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -393,8 +393,8 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 26876.46707
-  tps: 18544.02937
+  dps: 27266.07069
+  tps: 18944.65508
  }
 }
 dps_results: {


### PR DESCRIPTION
agility Darkmoon Card: Hurricane procMask is not set to the correct value making it not proc
Updated according to the implementation of the strength version of the trinket