### PR TITLE
Fix typo & add Mastery to Warrior display stats

### DIFF
--- a/ui/core/components/character_stats.tsx
+++ b/ui/core/components/character_stats.tsx
@@ -2,18 +2,18 @@ import { Popover, Tooltip } from 'bootstrap';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { element, fragment, ref } from 'tsx-vanilla';
 
-import { Player } from '..//player.js';
-import { Class, PseudoStat, Stat, TristateEffect } from '..//proto/common.js';
-import { getClassStatName, masterySpellIDs, masterySpellNames, statOrder } from '..//proto_utils/names.js';
-import { Stats } from '..//proto_utils/stats.js';
-import { EventID, TypedEvent } from '..//typed_event.js';
 import * as Mechanics from '../constants/mechanics.js';
+import { Player } from '../player.js';
+import { PseudoStat, Stat } from '../proto/common.js';
 import { ActionId } from '../proto_utils/action_id';
+import { getClassStatName, masterySpellIDs, masterySpellNames, statOrder } from '../proto_utils/names.js';
+import { Stats } from '../proto_utils/stats.js';
+import { EventID, TypedEvent } from '../typed_event.js';
 import { Component } from './component.js';
 import { NumberPicker } from './number_picker';
 
-export type StatMods = { base?:Stats, gear?:Stats, talents?: Stats, buffs?: Stats, consumes?: Stats, final?: Stats, stats?: Array<Stat> };
-export type StatWrites = { base:Stats, gear:Stats, talents: Stats, buffs: Stats, consumes: Stats, final: Stats, stats: Array<Stat> };
+export type StatMods = { base?: Stats; gear?: Stats; talents?: Stats; buffs?: Stats; consumes?: Stats; final?: Stats; stats?: Array<Stat> };
+export type StatWrites = { base: Stats; gear: Stats; talents: Stats; buffs: Stats; consumes: Stats; final: Stats; stats: Array<Stat> };
 
 export class CharacterStats extends Component {
 	readonly stats: Array<Stat>;
@@ -25,7 +25,13 @@ export class CharacterStats extends Component {
 	private readonly modifyDisplayStats?: (player: Player<any>) => StatMods;
 	private readonly overwriteDisplayStats?: (player: Player<any>) => StatWrites;
 
-	constructor(parent: HTMLElement, player: Player<any>, stats: Array<Stat>, modifyDisplayStats?: (player: Player<any>) => StatMods, overwriteDisplayStats?: (player: Player<any>) => StatWrites) {
+	constructor(
+		parent: HTMLElement,
+		player: Player<any>,
+		stats: Array<Stat>,
+		modifyDisplayStats?: (player: Player<any>) => StatMods,
+		overwriteDisplayStats?: (player: Player<any>) => StatWrites,
+	) {
 		super(parent, 'character-stats-root');
 		this.stats = statOrder.filter(stat => stats.includes(stat));
 		this.player = player;
@@ -89,10 +95,7 @@ export class CharacterStats extends Component {
 	private updateStats(player: Player<any>) {
 		const playerStats = player.getCurrentStats();
 
-		const statMods = this.modifyDisplayStats
-			? this.modifyDisplayStats(this.player)
-			: {
-			  };
+		const statMods = this.modifyDisplayStats ? this.modifyDisplayStats(this.player) : {};
 
 		const baseStats = Stats.fromProto(playerStats.baseStats);
 		const gearStats = Stats.fromProto(playerStats.gearStats);
@@ -103,7 +106,10 @@ export class CharacterStats extends Component {
 		const bonusStats = player.getBonusStats();
 
 		let baseDelta = baseStats.add(statMods.base || new Stats());
-		let gearDelta = gearStats.subtract(baseStats).subtract(bonusStats).add(statMods.gear || new Stats());
+		let gearDelta = gearStats
+			.subtract(baseStats)
+			.subtract(bonusStats)
+			.add(statMods.gear || new Stats());
 		let talentsDelta = talentsStats.subtract(gearStats).add(statMods.talents || new Stats());
 		let buffsDelta = buffsStats.subtract(talentsStats).add(statMods.buffs || new Stats());
 		let consumesDelta = consumesStats.subtract(buffsStats).add(statMods.consumes || new Stats());
@@ -121,13 +127,13 @@ export class CharacterStats extends Component {
 			const statOverwrites = this.overwriteDisplayStats(this.player);
 			if (statOverwrites.stats) {
 				statOverwrites.stats.forEach((stat, _) => {
-					baseDelta = baseDelta.withStat(stat, statOverwrites.base.getStat(stat))
-					gearDelta = gearDelta.withStat(stat, statOverwrites.gear.getStat(stat))
-					talentsDelta = talentsDelta.withStat(stat, statOverwrites.talents.getStat(stat))
-					buffsDelta = buffsDelta.withStat(stat, statOverwrites.buffs.getStat(stat))
-					consumesDelta = consumesDelta.withStat(stat, statOverwrites.consumes.getStat(stat))
-					finalStats = finalStats.withStat(stat, statOverwrites.final.getStat(stat))
-				})
+					baseDelta = baseDelta.withStat(stat, statOverwrites.base.getStat(stat));
+					gearDelta = gearDelta.withStat(stat, statOverwrites.gear.getStat(stat));
+					talentsDelta = talentsDelta.withStat(stat, statOverwrites.talents.getStat(stat));
+					buffsDelta = buffsDelta.withStat(stat, statOverwrites.buffs.getStat(stat));
+					consumesDelta = consumesDelta.withStat(stat, statOverwrites.consumes.getStat(stat));
+					finalStats = finalStats.withStat(stat, statOverwrites.final.getStat(stat));
+				});
 			}
 		}
 
@@ -136,26 +142,26 @@ export class CharacterStats extends Component {
 
 		this.stats.forEach((stat, idx) => {
 			const bonusStatValue = bonusStats.getStat(stat);
-			let contextualKlass: string;
+			let contextualClass: string;
 			if (bonusStatValue == 0) {
-				contextualKlass = 'text-white';
+				contextualClass = 'text-white';
 			} else if (bonusStatValue > 0) {
-				contextualKlass = 'text-success';
+				contextualClass = 'text-success';
 			} else {
-				contextualKlass = 'text-danger';
+				contextualClass = 'text-danger';
 			}
 
 			const statLinkElemRef = ref<HTMLAnchorElement>();
 
 			const valueElem = (
 				<div className="stat-value-link-container">
-					<a href="javascript:void(0)" className={`stat-value-link ${contextualKlass}`} attributes={{ role: 'button' }} ref={statLinkElemRef}>
+					<a href="javascript:void(0)" className={`stat-value-link ${contextualClass}`} attributes={{ role: 'button' }} ref={statLinkElemRef}>
 						{`${this.statDisplayString(finalStats, finalStats, stat, true)} `}
 					</a>
 					{stat == Stat.StatMastery && (
 						<a
 							href={ActionId.makeSpellUrl(masterySpellIDs.get(this.player.getSpec()) || 0)}
-							className={`stat-value-link-mastery ${contextualKlass}`}
+							className={`stat-value-link-mastery ${contextualClass}`}
 							attributes={{ role: 'button' }}>
 							{`${(masteryPoints * this.player.getMasteryPerPointModifier()).toFixed(2)}%`}
 						</a>

--- a/ui/core/individual_sim_ui.ts
+++ b/ui/core/individual_sim_ui.ts
@@ -14,7 +14,6 @@ import * as InputHelpers from './components/input_helpers';
 import { addRaidSimAction, RaidSimResultsManager } from './components/raid_sim_action';
 import { SavedDataConfig } from './components/saved_data_manager';
 import { addStatWeightsAction } from './components/stat_weights_action';
-import * as Mechanics from './constants/mechanics';
 import * as Tooltips from './constants/tooltips';
 import { simLaunchStatuses } from './launched_sims';
 import { Player, PlayerConfig, registerSpecConfig as registerPlayerConfig } from './player';
@@ -117,8 +116,8 @@ export interface IndividualSimUIConfig<SpecType extends Spec> extends PlayerConf
 
 		debuffs: Debuffs;
 
-		rotationType?: APLRotationType,
-		simpleRotation?: SpecRotation<SpecType>,
+		rotationType?: APLRotationType;
+		simpleRotation?: SpecRotation<SpecType>;
 
 		other?: OtherDefaults;
 	};
@@ -403,9 +402,12 @@ export abstract class IndividualSimUI<SpecType extends Spec> extends SimUI {
 	applyDefaultRotation(eventID: EventID) {
 		TypedEvent.freezeAllAndDo(() => {
 			const defaultRotationType = this.individualConfig.defaults.rotationType || APLRotationType.TypeAuto;
-			this.player.setAplRotation(eventID, APLRotation.create({
-				type: defaultRotationType,
-			}))
+			this.player.setAplRotation(
+				eventID,
+				APLRotation.create({
+					type: defaultRotationType,
+				}),
+			);
 
 			if (!this.individualConfig.defaults.simpleRotation) {
 				return;

--- a/ui/warrior/arms/sim.ts
+++ b/ui/warrior/arms/sim.ts
@@ -1,11 +1,10 @@
 import * as BuffDebuffInputs from '../../core/components/inputs/buffs_debuffs';
 import * as OtherInputs from '../../core/components/other_inputs';
-import * as Mechanics from '../../core/constants/mechanics';
 import { IndividualSimUI, registerSpecConfig } from '../../core/individual_sim_ui';
 import { Player } from '../../core/player';
 import { PlayerClasses } from '../../core/player_classes';
 import { APLRotation } from '../../core/proto/apl';
-import { Debuffs, Faction, IndividualBuffs, PartyBuffs, PseudoStat, Race, RaidBuffs, Spec, Stat, TristateEffect } from '../../core/proto/common';
+import { Debuffs, Faction, IndividualBuffs, PartyBuffs, PseudoStat, Race, RaidBuffs, Spec, Stat } from '../../core/proto/common';
 import { Stats } from '../../core/proto_utils/stats';
 import * as WarriorInputs from '../inputs';
 import * as Presets from './presets';
@@ -26,6 +25,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecArmsWarrior, {
 		Stat.StatMeleeCrit,
 		Stat.StatMeleeHaste,
 		Stat.StatArmorPenetration,
+		Stat.StatMastery,
 		Stat.StatArmor,
 	],
 	epPseudoStats: [PseudoStat.PseudoStatMainHandDps, PseudoStat.PseudoStatOffHandDps],
@@ -44,6 +44,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecArmsWarrior, {
 		Stat.StatMeleeHaste,
 		Stat.StatArmorPenetration,
 		Stat.StatArmor,
+		Stat.StatMastery,
 	],
 	// modifyDisplayStats: (player: Player<Spec.SpecArmsWarrior>) => {
 	// 	let stats = new Stats();
@@ -101,8 +102,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecArmsWarrior, {
 			communion: true,
 		}),
 		partyBuffs: PartyBuffs.create({}),
-			individualBuffs: IndividualBuffs.create({
-		}),
+		individualBuffs: IndividualBuffs.create({}),
 		debuffs: Debuffs.create({
 			bloodFrenzy: true,
 			mangle: true,

--- a/ui/warrior/fury/sim.ts
+++ b/ui/warrior/fury/sim.ts
@@ -1,11 +1,10 @@
 import * as BuffDebuffInputs from '../../core/components/inputs/buffs_debuffs';
 import * as OtherInputs from '../../core/components/other_inputs';
-import * as Mechanics from '../../core/constants/mechanics';
 import { IndividualSimUI, registerSpecConfig } from '../../core/individual_sim_ui';
 import { Player } from '../../core/player';
 import { PlayerClasses } from '../../core/player_classes';
 import { APLRotation } from '../../core/proto/apl';
-import { Debuffs, Faction, IndividualBuffs, PartyBuffs, PseudoStat, Race, RaidBuffs, Spec, Stat, TristateEffect } from '../../core/proto/common';
+import { Debuffs, Faction, IndividualBuffs, PartyBuffs, PseudoStat, Race, RaidBuffs, Spec, Stat } from '../../core/proto/common';
 import { Stats } from '../../core/proto_utils/stats';
 import * as WarriorInputs from '../inputs';
 import * as Presets from './presets';
@@ -27,6 +26,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFuryWarrior, {
 		Stat.StatMeleeHaste,
 		Stat.StatArmorPenetration,
 		Stat.StatArmor,
+		Stat.StatMastery,
 	],
 	epPseudoStats: [PseudoStat.PseudoStatMainHandDps, PseudoStat.PseudoStatOffHandDps],
 	// Reference stat against which to calculate EP. I think all classes use either spell power or attack power.
@@ -44,6 +44,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFuryWarrior, {
 		Stat.StatMeleeHaste,
 		Stat.StatArmorPenetration,
 		Stat.StatArmor,
+		Stat.StatMastery,
 	],
 	// modifyDisplayStats: (player: Player<Spec.SpecFuryWarrior>) => {
 	// 	//let stats = new Stats();
@@ -101,8 +102,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFuryWarrior, {
 			communion: true,
 		}),
 		partyBuffs: PartyBuffs.create({}),
-		individualBuffs: IndividualBuffs.create({
-		}),
+		individualBuffs: IndividualBuffs.create({}),
 		debuffs: Debuffs.create({
 			bloodFrenzy: true,
 			mangle: true,

--- a/ui/warrior/protection/sim.ts
+++ b/ui/warrior/protection/sim.ts
@@ -39,6 +39,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecProtectionWarrior, {
 		Stat.StatNatureResistance,
 		Stat.StatShadowResistance,
 		Stat.StatFrostResistance,
+		Stat.StatMastery,
 	],
 	epPseudoStats: [PseudoStat.PseudoStatMainHandDps],
 	// Reference stat against which to calculate EP. I think all classes use either spell power or attack power.
@@ -66,6 +67,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecProtectionWarrior, {
 		Stat.StatNatureResistance,
 		Stat.StatShadowResistance,
 		Stat.StatFrostResistance,
+		Stat.StatMastery,
 	],
 
 	defaults: {
@@ -119,8 +121,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecProtectionWarrior, {
 			communion: true,
 		}),
 		partyBuffs: PartyBuffs.create({}),
-		individualBuffs: IndividualBuffs.create({
-		}),
+		individualBuffs: IndividualBuffs.create({}),
 		debuffs: Debuffs.create({
 			sunderArmor: true,
 			mangle: true,


### PR DESCRIPTION
I was playing around with the new Cata sim and noticed the warrrior sim was not showing Mastery.
- Added missing mastery in character display stats in the Sim UI for Warrior
- Fixed minor typo
