### PR TITLE
Remove visual ArP, add missing visual Mastery and food buffs

### DIFF
--- a/sim/core/consumes.go
+++ b/sim/core/consumes.go
@@ -138,7 +138,9 @@ func applyConsumeEffects(agent Agent) {
 			})
 		case proto.BattleElixir_ElixirOfArmorPiercing:
 			character.AddStats(stats.Stats{
-				stats.ArmorPenetration: 45,
+				stats.Agility: 25,
+				stats.MeleeCrit: 25,
+				stats.SpellCrit: 25,
 			})
 		case proto.BattleElixir_ElixirOfDeadlyStrikes:
 			character.AddStats(stats.Stats{
@@ -252,8 +254,9 @@ func applyConsumeEffects(agent Agent) {
 		})
 	case proto.Food_FoodHeartyRhino:
 		character.AddStats(stats.Stats{
-			stats.ArmorPenetration: 40,
-			stats.Stamina:          40,
+			stats.MeleeCrit: 40,
+			stats.SpellCrit: 40,
+			stats.Stamina:   40,
 		})
 	case proto.Food_FoodMegaMammothMeal:
 		character.AddStats(stats.Stats{

--- a/ui/core/components/character_stats.tsx
+++ b/ui/core/components/character_stats.tsx
@@ -303,8 +303,6 @@ export class CharacterStats extends Component {
 			displayStr += ` (${(rawValue / Mechanics.HASTE_RATING_PER_HASTE_PERCENT).toFixed(2)}%)`;
 		} else if (stat == Stat.StatSpellHaste) {
 			displayStr += ` (${(rawValue / Mechanics.HASTE_RATING_PER_HASTE_PERCENT).toFixed(2)}%)`;
-		} else if (stat == Stat.StatArmorPenetration) {
-			displayStr += ` (${(rawValue / Mechanics.ARMOR_PEN_PER_PERCENT_ARMOR).toFixed(2)}%)`;
 		} else if (stat == Stat.StatExpertise) {
 			// As of 06/20, Blizzard has changed Expertise to no longer truncate at quarter percent intervals. Note that
 			// in-game character sheet tooltips will still display the truncated values, but it has been tested to behave

--- a/ui/core/components/inputs/consumables.ts
+++ b/ui/core/components/inputs/consumables.ts
@@ -578,7 +578,7 @@ export const FOOD_CONFIG = [
 	{ config: FoodDragonfinFilet, stats: [Stat.StatStrength] },
 	{ config: FoodCuttlesteak, stats: [Stat.StatSpirit] },
 	{ config: FoodMegaMammothMeal, stats: [Stat.StatAttackPower, Stat.StatRangedAttackPower] },
-	{ config: FoodHeartyRhino, stats: [Stat.StatArmorPenetration] },
+	{ config: FoodHeartyRhino, stats: [Stat.StatMeleeCrit, Stat.StatSpellCrit] },
 	{ config: FoodRhinoliciousWormsteak, stats: [Stat.StatExpertise] },
 	{ config: FoodFirecrackerSalmon, stats: [Stat.StatSpellPower] },
 	{ config: FoodSnapperExtreme, stats: [Stat.StatMeleeHit, Stat.StatSpellHit] },

--- a/ui/death_knight/blood/sim.ts
+++ b/ui/death_knight/blood/sim.ts
@@ -38,6 +38,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecBloodDeathKnight, {
 		Stat.StatNatureResistance,
 		Stat.StatShadowResistance,
 		Stat.StatFrostResistance,
+		Stat.StatMastery,
 	],
 	epPseudoStats: [PseudoStat.PseudoStatMainHandDps, PseudoStat.PseudoStatOffHandDps],
 	// Reference stat against which to calculate EP. I think all classes use either spell power or attack power.

--- a/ui/death_knight/frost/sim.ts
+++ b/ui/death_knight/frost/sim.ts
@@ -27,7 +27,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFrostDeathKnight, {
 		Stat.StatMeleeHaste,
 		Stat.StatMastery,
 		Stat.StatSpellHit,
-		Stat.StatSpellCrit
+		Stat.StatSpellCrit,
 	],
 	epPseudoStats: [PseudoStat.PseudoStatMainHandDps, PseudoStat.PseudoStatOffHandDps],
 	// Reference stat against which to calculate EP. I think all classes use either spell power or attack power.
@@ -93,7 +93,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFrostDeathKnight, {
 			sunderArmor: true,
 			brittleBones: true,
 			ebonPlaguebringer: true,
-			shadowAndFlame: true
+			shadowAndFlame: true,
 		}),
 	},
 
@@ -110,14 +110,8 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFrostDeathKnight, {
 	playerIconInputs: [],
 	petConsumeInputs: [],
 	// Buff and Debuff inputs to include/exclude, overriding the EP-based defaults.
-	includeBuffDebuffInputs: [
-		BuffDebuffInputs.SpellDamageDebuff
-	],
-	excludeBuffDebuffInputs: [
-		BuffDebuffInputs.DamageReduction,
-		BuffDebuffInputs.MeleeAttackSpeedDebuff,
-		BuffDebuffInputs.BleedDebuff
-	],
+	includeBuffDebuffInputs: [BuffDebuffInputs.SpellDamageDebuff],
+	excludeBuffDebuffInputs: [BuffDebuffInputs.DamageReduction, BuffDebuffInputs.MeleeAttackSpeedDebuff, BuffDebuffInputs.BleedDebuff],
 	// Inputs to include in the 'Other' section on the settings tab.
 	otherInputs: {
 		inputs: [
@@ -129,7 +123,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFrostDeathKnight, {
 			// OtherInputs.TankAssignment,
 			// OtherInputs.InFrontOfTarget,
 			OtherInputs.InputDelay,
-			OtherInputs.DarkIntentUptime
+			OtherInputs.DarkIntentUptime,
 		],
 	},
 	itemSwapSlots: [ItemSlot.ItemSlotMainHand, ItemSlot.ItemSlotOffHand],
@@ -146,9 +140,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFrostDeathKnight, {
 			Presets.SINGLE_TARGET_ROTATION_PRESET_DEFAULT,
 			//Presets.AOE_ROTATION_PRESET_DEFAULT,
 		],
-		gear: [
-			Presets.P1_GEAR_PRESET,
-		],
+		gear: [Presets.P1_GEAR_PRESET],
 	},
 
 	raidSimPresets: [

--- a/ui/death_knight/frost/sim.ts
+++ b/ui/death_knight/frost/sim.ts
@@ -27,8 +27,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFrostDeathKnight, {
 		Stat.StatMeleeHaste,
 		Stat.StatMastery,
 		Stat.StatSpellHit,
-		Stat.StatSpellCrit,
-		Stat.StatArmorPenetration,
+		Stat.StatSpellCrit
 	],
 	epPseudoStats: [PseudoStat.PseudoStatMainHandDps, PseudoStat.PseudoStatOffHandDps],
 	// Reference stat against which to calculate EP. I think all classes use either spell power or attack power.
@@ -60,7 +59,6 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFrostDeathKnight, {
 				[Stat.StatMeleeHaste]: 1.85,
 				[Stat.StatMeleeHit]: 1.92,
 				[Stat.StatMeleeCrit]: 0.76,
-				[Stat.StatArmorPenetration]: 0.77,
 				[Stat.StatSpellHit]: 0.8,
 				[Stat.StatSpellCrit]: 0.34,
 			},

--- a/ui/death_knight/unholy/sim.ts
+++ b/ui/death_knight/unholy/sim.ts
@@ -41,7 +41,6 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecUnholyDeathKnight, {
 		Stat.StatMastery,
 		Stat.StatSpellHit,
 		Stat.StatSpellCrit,
-		Stat.StatArmorPenetration,
 	],
 	epPseudoStats: [PseudoStat.PseudoStatMainHandDps, PseudoStat.PseudoStatOffHandDps],
 	// Reference stat against which to calculate EP. I think all classes use either spell power or attack power.
@@ -73,7 +72,6 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecUnholyDeathKnight, {
 				[Stat.StatMeleeHaste]: 1.85,
 				[Stat.StatMeleeHit]: 1.92,
 				[Stat.StatMeleeCrit]: 0.76,
-				[Stat.StatArmorPenetration]: 0.77,
 				[Stat.StatSpellHit]: 0.8,
 				[Stat.StatSpellCrit]: 0.34,
 			},

--- a/ui/druid/balance/sim.ts
+++ b/ui/druid/balance/sim.ts
@@ -17,7 +17,16 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecBalanceDruid, {
 	knownIssues: [],
 
 	// All stats for which EP should be calculated.
-	epStats: [Stat.StatIntellect, Stat.StatSpirit, Stat.StatSpellPower, Stat.StatSpellHit, Stat.StatSpellCrit, Stat.StatSpellHaste, Stat.StatMP5],
+	epStats: [
+		Stat.StatIntellect,
+		Stat.StatSpirit,
+		Stat.StatSpellPower,
+		Stat.StatSpellHit,
+		Stat.StatSpellCrit,
+		Stat.StatSpellHaste,
+		Stat.StatMP5,
+		Stat.StatMastery,
+	],
 	// Reference stat against which to calculate EP. I think all classes use either spell power or attack power.
 	epReferenceStat: Stat.StatSpellPower,
 	// Which stats to display in the Character Stats section, at the bottom of the left-hand sidebar.
@@ -31,6 +40,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecBalanceDruid, {
 		Stat.StatSpellCrit,
 		Stat.StatSpellHaste,
 		Stat.StatMP5,
+		Stat.StatMastery,
 	],
 
 	defaults: {

--- a/ui/druid/restoration/sim.ts
+++ b/ui/druid/restoration/sim.ts
@@ -16,7 +16,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecRestorationDruid, {
 	knownIssues: [],
 
 	// All stats for which EP should be calculated.
-	epStats: [Stat.StatIntellect, Stat.StatSpirit, Stat.StatSpellPower, Stat.StatSpellCrit, Stat.StatSpellHaste, Stat.StatMP5],
+	epStats: [Stat.StatIntellect, Stat.StatSpirit, Stat.StatSpellPower, Stat.StatSpellCrit, Stat.StatSpellHaste, Stat.StatMP5, Stat.StatMastery],
 	// Reference stat against which to calculate EP. I think all classes use either spell power or attack power.
 	epReferenceStat: Stat.StatSpellPower,
 	// Which stats to display in the Character Stats section, at the bottom of the left-hand sidebar.
@@ -30,6 +30,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecRestorationDruid, {
 		Stat.StatSpellCrit,
 		Stat.StatSpellHaste,
 		Stat.StatMP5,
+		Stat.StatMastery,
 	],
 
 	defaults: {

--- a/ui/hunter/beast_mastery/sim.ts
+++ b/ui/hunter/beast_mastery/sim.ts
@@ -28,8 +28,8 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecBeastMasteryHunter, {
 		Stat.StatMeleeHit,
 		Stat.StatMeleeCrit,
 		Stat.StatMeleeHaste,
-		Stat.StatArmorPenetration,
 		Stat.StatMP5,
+		Stat.StatMastery,
 	],
 	epPseudoStats: [PseudoStat.PseudoStatRangedDps],
 	// Reference stat against which to calculate EP.
@@ -57,8 +57,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecBeastMasteryHunter, {
 				[Stat.StatRangedAttackPower]: 1.0,
 				[Stat.StatMeleeHit]: 2,
 				[Stat.StatMeleeCrit]: 1.5,
-				[Stat.StatMeleeHaste]: 1.39,
-				[Stat.StatArmorPenetration]: 1.32,
+				[Stat.StatMeleeHaste]: 1.39
 			},
 			{
 				[PseudoStat.PseudoStatRangedDps]: 6.32,

--- a/ui/hunter/marksmanship/sim.ts
+++ b/ui/hunter/marksmanship/sim.ts
@@ -42,8 +42,8 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecMarksmanshipHunter, {
 		Stat.StatMeleeHit,
 		Stat.StatMeleeCrit,
 		Stat.StatMeleeHaste,
-		Stat.StatArmorPenetration,
 		Stat.StatMP5,
+		Stat.StatMastery,
 	],
 	epPseudoStats: [PseudoStat.PseudoStatRangedDps],
 	// Reference stat against which to calculate EP.
@@ -92,7 +92,6 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecMarksmanshipHunter, {
 				[Stat.StatMeleeHit]: 2,
 				[Stat.StatMeleeCrit]: 1.5,
 				[Stat.StatMeleeHaste]: 1.39,
-				[Stat.StatArmorPenetration]: 1.32,
 			},
 			{
 				[PseudoStat.PseudoStatRangedDps]: 6.32,

--- a/ui/hunter/survival/sim.ts
+++ b/ui/hunter/survival/sim.ts
@@ -142,7 +142,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecSurvivalHunter, {
 			OtherInputs.InputDelay,
 			OtherInputs.TankAssignment,
 			OtherInputs.InFrontOfTarget,
-			OtherInputs.DarkIntentUptime
+			OtherInputs.DarkIntentUptime,
 		],
 	},
 	encounterPicker: {

--- a/ui/mage/arcane/sim.ts
+++ b/ui/mage/arcane/sim.ts
@@ -20,7 +20,16 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecArcaneMage, {
 	knownIssues: [],
 
 	// All stats for which EP should be calculated.
-	epStats: [Stat.StatIntellect, Stat.StatSpirit, Stat.StatSpellPower, Stat.StatSpellHit, Stat.StatSpellCrit, Stat.StatSpellHaste, Stat.StatMP5],
+	epStats: [
+		Stat.StatIntellect,
+		Stat.StatSpirit,
+		Stat.StatSpellPower,
+		Stat.StatSpellHit,
+		Stat.StatSpellCrit,
+		Stat.StatSpellHaste,
+		Stat.StatMP5,
+		Stat.StatMastery,
+	],
 	// Reference stat against which to calculate EP. I think all classes use either spell power or attack power.
 	epReferenceStat: Stat.StatSpellPower,
 	// Which stats to display in the Character Stats section, at the bottom of the left-hand sidebar.
@@ -35,6 +44,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecArcaneMage, {
 		Stat.StatSpellCrit,
 		Stat.StatSpellHaste,
 		Stat.StatMP5,
+		Stat.StatMastery,
 	],
 	// modifyDisplayStats: (player: Player<Spec.SpecArcaneMage>) => {
 	// 	let stats = new Stats();

--- a/ui/mage/fire/sim.ts
+++ b/ui/mage/fire/sim.ts
@@ -19,7 +19,16 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFireMage, {
 	knownIssues: [],
 
 	// All stats for which EP should be calculated.
-	epStats: [Stat.StatIntellect, Stat.StatSpirit, Stat.StatSpellPower, Stat.StatSpellHit, Stat.StatSpellCrit, Stat.StatSpellHaste, Stat.StatMP5],
+	epStats: [
+		Stat.StatIntellect,
+		Stat.StatSpirit,
+		Stat.StatSpellPower,
+		Stat.StatSpellHit,
+		Stat.StatSpellCrit,
+		Stat.StatSpellHaste,
+		Stat.StatMP5,
+		Stat.StatMastery,
+	],
 	// Reference stat against which to calculate EP. I think all classes use either spell power or attack power.
 	epReferenceStat: Stat.StatSpellPower,
 	// Which stats to display in the Character Stats section, at the bottom of the left-hand sidebar.
@@ -34,6 +43,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFireMage, {
 		Stat.StatSpellCrit,
 		Stat.StatSpellHaste,
 		Stat.StatMP5,
+		Stat.StatMastery,
 	],
 	// modifyDisplayStats: (player: Player<Spec.SpecFireMage>) => {
 	// 	let stats = new Stats();
@@ -110,7 +120,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFireMage, {
 	excludeBuffDebuffInputs: [],
 	// Inputs to include in the 'Other' section on the settings tab.
 	otherInputs: {
-		inputs: [OtherInputs.InputDelay, OtherInputs.DistanceFromTarget, OtherInputs.TankAssignment, OtherInputs.DarkIntentUptime,],
+		inputs: [OtherInputs.InputDelay, OtherInputs.DistanceFromTarget, OtherInputs.TankAssignment, OtherInputs.DarkIntentUptime],
 	},
 	encounterPicker: {
 		// Whether to include 'Execute Duration (%)' in the 'Encounter' section of the settings tab.

--- a/ui/mage/frost/sim.ts
+++ b/ui/mage/frost/sim.ts
@@ -19,7 +19,16 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFrostMage, {
 	knownIssues: [],
 
 	// All stats for which EP should be calculated.
-	epStats: [Stat.StatIntellect, Stat.StatSpirit, Stat.StatSpellPower, Stat.StatSpellHit, Stat.StatSpellCrit, Stat.StatSpellHaste, Stat.StatMP5],
+	epStats: [
+		Stat.StatIntellect,
+		Stat.StatSpirit,
+		Stat.StatSpellPower,
+		Stat.StatSpellHit,
+		Stat.StatSpellCrit,
+		Stat.StatSpellHaste,
+		Stat.StatMP5,
+		Stat.StatMastery,
+	],
 	// Reference stat against which to calculate EP. I think all classes use either spell power or attack power.
 	epReferenceStat: Stat.StatSpellPower,
 	// Which stats to display in the Character Stats section, at the bottom of the left-hand sidebar.
@@ -34,6 +43,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFrostMage, {
 		Stat.StatSpellCrit,
 		Stat.StatSpellHaste,
 		Stat.StatMP5,
+		Stat.StatMastery,
 	],
 	// modifyDisplayStats: (player: Player<Spec.SpecFrostMage>) => {
 	// 	let stats = new Stats();

--- a/ui/paladin/holy/sim.ts
+++ b/ui/paladin/holy/sim.ts
@@ -17,7 +17,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecHolyPaladin, {
 	knownIssues: [],
 
 	// All stats for which EP should be calculated.
-	epStats: [Stat.StatIntellect, Stat.StatSpirit, Stat.StatSpellPower, Stat.StatSpellCrit, Stat.StatSpellHaste, Stat.StatMP5],
+	epStats: [Stat.StatIntellect, Stat.StatSpirit, Stat.StatSpellPower, Stat.StatSpellCrit, Stat.StatSpellHaste, Stat.StatMP5, Stat.StatMastery],
 	// Reference stat against which to calculate EP. I think all classes use either spell power or attack power.
 	epReferenceStat: Stat.StatSpellPower,
 	// Which stats to display in the Character Stats section, at the bottom of the left-hand sidebar.
@@ -31,6 +31,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecHolyPaladin, {
 		Stat.StatSpellCrit,
 		Stat.StatSpellHaste,
 		Stat.StatMP5,
+		Stat.StatMastery,
 	],
 	defaults: {
 		// Default equipped gear.

--- a/ui/paladin/protection/sim.ts
+++ b/ui/paladin/protection/sim.ts
@@ -31,7 +31,6 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecProtectionPaladin, {
 		Stat.StatMeleeCrit,
 		Stat.StatExpertise,
 		Stat.StatMeleeHaste,
-		Stat.StatArmorPenetration,
 		Stat.StatSpellPower,
 		Stat.StatArmor,
 		Stat.StatBonusArmor,
@@ -44,6 +43,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecProtectionPaladin, {
 		Stat.StatNatureResistance,
 		Stat.StatShadowResistance,
 		Stat.StatFrostResistance,
+		Stat.StatMastery,
 	],
 	epPseudoStats: [PseudoStat.PseudoStatMainHandDps],
 	// Reference stat against which to calculate EP. I think all classes use either spell power or attack power.
@@ -61,7 +61,6 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecProtectionPaladin, {
 		Stat.StatMeleeCrit,
 		Stat.StatMeleeHaste,
 		Stat.StatExpertise,
-		Stat.StatArmorPenetration,
 		Stat.StatSpellPower,
 		Stat.StatSpellHit,
 		Stat.StatDefense,
@@ -73,6 +72,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecProtectionPaladin, {
 		Stat.StatNatureResistance,
 		Stat.StatShadowResistance,
 		Stat.StatFrostResistance,
+		Stat.StatMastery,
 	],
 	// modifyDisplayStats: (player: Player<Spec.SpecProtectionPaladin>) => {
 	// 	let stats = new Stats();
@@ -106,7 +106,6 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecProtectionPaladin, {
 				[Stat.StatMeleeHit]: 0.79,
 				[Stat.StatMeleeCrit]: 0.3,
 				[Stat.StatMeleeHaste]: 0.17,
-				[Stat.StatArmorPenetration]: 0.04,
 				[Stat.StatSpellPower]: 0.13,
 				[Stat.StatBlock]: 0.52,
 				[Stat.StatBlockValue]: 0.28,

--- a/ui/paladin/retribution/sim.ts
+++ b/ui/paladin/retribution/sim.ts
@@ -30,11 +30,11 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecRetributionPaladin, {
 		Stat.StatMeleeCrit,
 		Stat.StatMeleeHaste,
 		Stat.StatExpertise,
-		Stat.StatArmorPenetration,
 		Stat.StatSpellPower,
 		Stat.StatSpellCrit,
 		Stat.StatSpellHit,
 		Stat.StatSpellHaste,
+		Stat.StatMastery,
 	],
 	epPseudoStats: [PseudoStat.PseudoStatMainHandDps],
 	// Reference stat against which to calculate EP. I think all classes use either spell power or attack power.
@@ -50,13 +50,13 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecRetributionPaladin, {
 		Stat.StatMeleeCrit,
 		Stat.StatMeleeHaste,
 		Stat.StatExpertise,
-		Stat.StatArmorPenetration,
 		Stat.StatSpellHaste,
 		Stat.StatSpellPower,
 		Stat.StatSpellCrit,
 		Stat.StatSpellHit,
 		Stat.StatMana,
 		Stat.StatHealth,
+		Stat.StatMastery,
 	],
 	// modifyDisplayStats: (player: Player<Spec.SpecRetributionPaladin>) => {
 	// 	let stats = new Stats();
@@ -93,7 +93,6 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecRetributionPaladin, {
 				[Stat.StatMeleeHit]: 1.96,
 				[Stat.StatMeleeCrit]: 1.16,
 				[Stat.StatMeleeHaste]: 1.44,
-				[Stat.StatArmorPenetration]: 0.76,
 				[Stat.StatExpertise]: 1.8,
 			},
 			{
@@ -124,8 +123,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecRetributionPaladin, {
 			communion: true,
 		}),
 		partyBuffs: PartyBuffs.create({}),
-		individualBuffs: IndividualBuffs.create({
-		}),
+		individualBuffs: IndividualBuffs.create({}),
 		debuffs: Debuffs.create({
 			exposeArmor: true,
 			bloodFrenzy: true,

--- a/ui/priest/discipline/sim.ts
+++ b/ui/priest/discipline/sim.ts
@@ -17,7 +17,16 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecDisciplinePriest, {
 	knownIssues: [],
 
 	// All stats for which EP should be calculated.
-	epStats: [Stat.StatIntellect, Stat.StatSpirit, Stat.StatSpellPower, Stat.StatSpellHit, Stat.StatSpellCrit, Stat.StatSpellHaste, Stat.StatMP5],
+	epStats: [
+		Stat.StatIntellect,
+		Stat.StatSpirit,
+		Stat.StatSpellPower,
+		Stat.StatSpellHit,
+		Stat.StatSpellCrit,
+		Stat.StatSpellHaste,
+		Stat.StatMP5,
+		Stat.StatMastery,
+	],
 	// Reference stat against which to calculate EP. I think all classes use either spell power or attack power.
 	epReferenceStat: Stat.StatSpellPower,
 	// Which stats to display in the Character Stats section, at the bottom of the left-hand sidebar.
@@ -32,6 +41,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecDisciplinePriest, {
 		Stat.StatSpellCrit,
 		Stat.StatSpellHaste,
 		Stat.StatMP5,
+		Stat.StatMastery,
 	],
 	// modifyDisplayStats: (player: Player<Spec.SpecDisciplinePriest>) => {
 	// 	let stats = new Stats();

--- a/ui/priest/holy/sim.ts
+++ b/ui/priest/holy/sim.ts
@@ -17,7 +17,16 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecHolyPriest, {
 	knownIssues: [],
 
 	// All stats for which EP should be calculated.
-	epStats: [Stat.StatIntellect, Stat.StatSpirit, Stat.StatSpellPower, Stat.StatSpellHit, Stat.StatSpellCrit, Stat.StatSpellHaste, Stat.StatMP5],
+	epStats: [
+		Stat.StatIntellect,
+		Stat.StatSpirit,
+		Stat.StatSpellPower,
+		Stat.StatSpellHit,
+		Stat.StatSpellCrit,
+		Stat.StatSpellHaste,
+		Stat.StatMP5,
+		Stat.StatMastery,
+	],
 	// Reference stat against which to calculate EP. I think all classes use either spell power or attack power.
 	epReferenceStat: Stat.StatSpellPower,
 	// Which stats to display in the Character Stats section, at the bottom of the left-hand sidebar.
@@ -32,6 +41,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecHolyPriest, {
 		Stat.StatSpellCrit,
 		Stat.StatSpellHaste,
 		Stat.StatMP5,
+		Stat.StatMastery,
 	],
 	// modifyDisplayStats: (player: Player<Spec.SpecHolyPriest>) => {
 	// 	let stats = new Stats();

--- a/ui/shaman/enhancement/sim.ts
+++ b/ui/shaman/enhancement/sim.ts
@@ -52,7 +52,6 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecEnhancementShaman, {
 		Stat.StatMeleeCrit,
 		Stat.StatMeleeHaste,
 		Stat.StatExpertise,
-		Stat.StatArmorPenetration,
 		Stat.StatSpellPower,
 		Stat.StatSpellHit,
 		Stat.StatSpellCrit,
@@ -74,7 +73,6 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecEnhancementShaman, {
 		Stat.StatMeleeCrit,
 		Stat.StatMeleeHaste,
 		Stat.StatExpertise,
-		Stat.StatArmorPenetration,
 		Stat.StatSpellPower,
 		Stat.StatSpellHit,
 		Stat.StatSpellCrit,
@@ -99,7 +97,6 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecEnhancementShaman, {
 				[Stat.StatMeleeHit]: 1.38,
 				[Stat.StatMeleeCrit]: 0.81,
 				[Stat.StatMeleeHaste]: 1.61, //haste is complicated
-				[Stat.StatArmorPenetration]: 0.48,
 				[Stat.StatExpertise]: 0, //default EP assumes cap
 			},
 			{

--- a/ui/shaman/restoration/sim.ts
+++ b/ui/shaman/restoration/sim.ts
@@ -18,7 +18,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecRestorationShaman, {
 	warnings: [],
 
 	// All stats for which EP should be calculated.
-	epStats: [Stat.StatIntellect, Stat.StatSpirit, Stat.StatSpellPower, Stat.StatSpellCrit, Stat.StatSpellHaste, Stat.StatMP5],
+	epStats: [Stat.StatIntellect, Stat.StatSpirit, Stat.StatSpellPower, Stat.StatSpellCrit, Stat.StatSpellHaste, Stat.StatMP5, Stat.StatMastery],
 	// Reference stat against which to calculate EP. I think all classes use either spell power or attack power.
 	epReferenceStat: Stat.StatSpellPower,
 	// Which stats to display in the Character Stats section, at the bottom of the left-hand sidebar.
@@ -32,6 +32,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecRestorationShaman, {
 		Stat.StatSpellCrit,
 		Stat.StatSpellHaste,
 		Stat.StatMP5,
+		Stat.StatMastery,
 	],
 	// modifyDisplayStats: (player: Player<Spec.SpecRestorationShaman>) => {
 	// 	let stats = new Stats();

--- a/ui/warlock/affliction/sim.ts
+++ b/ui/warlock/affliction/sim.ts
@@ -16,7 +16,16 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecAfflictionWarlock, {
 	knownIssues: ['Drain Soul is currently disabled for APL rotations'],
 
 	// All stats for which EP should be calculated.
-	epStats: [Stat.StatIntellect, Stat.StatSpirit, Stat.StatSpellPower, Stat.StatSpellHit, Stat.StatSpellCrit, Stat.StatSpellHaste, Stat.StatStamina],
+	epStats: [
+		Stat.StatIntellect,
+		Stat.StatSpirit,
+		Stat.StatSpellPower,
+		Stat.StatSpellHit,
+		Stat.StatSpellCrit,
+		Stat.StatSpellHaste,
+		Stat.StatStamina,
+		Stat.StatMastery,
+	],
 	// Reference stat against which to calculate EP. DPS classes use either spell power or attack power.
 	epReferenceStat: Stat.StatSpellPower,
 	// Which stats to display in the Character Stats section, at the bottom of the left-hand sidebar.
@@ -30,6 +39,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecAfflictionWarlock, {
 		Stat.StatSpellHaste,
 		Stat.StatMP5,
 		Stat.StatStamina,
+		Stat.StatMastery,
 	],
 
 	defaults: {
@@ -68,8 +78,8 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecAfflictionWarlock, {
 
 	// IconInputs to include in the 'Player' section on the settings tab.
 	playerIconInputs: [
-		// WarlockInputs.PetInput(), 
-		// WarlockInputs.ArmorInput(), 
+		// WarlockInputs.PetInput(),
+		// WarlockInputs.ArmorInput(),
 		// WarlockInputs.WeaponImbueInput()
 	],
 
@@ -89,7 +99,13 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecAfflictionWarlock, {
 	petConsumeInputs: [],
 	// Inputs to include in the 'Other' section on the settings tab.
 	otherInputs: {
-		inputs: [WarlockInputs.DetonateSeed(), OtherInputs.InputDelay, OtherInputs.DistanceFromTarget, OtherInputs.TankAssignment, OtherInputs.ChannelClipDelay],
+		inputs: [
+			WarlockInputs.DetonateSeed(),
+			OtherInputs.InputDelay,
+			OtherInputs.DistanceFromTarget,
+			OtherInputs.TankAssignment,
+			OtherInputs.ChannelClipDelay,
+		],
 	},
 	itemSwapSlots: [ItemSlot.ItemSlotMainHand, ItemSlot.ItemSlotOffHand, ItemSlot.ItemSlotRanged],
 	encounterPicker: {

--- a/ui/warlock/demonology/sim.ts
+++ b/ui/warlock/demonology/sim.ts
@@ -16,7 +16,16 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecDemonologyWarlock, {
 	knownIssues: ['Drain Soul is currently disabled for APL rotations'],
 
 	// All stats for which EP should be calculated.
-	epStats: [Stat.StatIntellect, Stat.StatSpirit, Stat.StatSpellPower, Stat.StatSpellHit, Stat.StatSpellCrit, Stat.StatSpellHaste, Stat.StatStamina],
+	epStats: [
+		Stat.StatIntellect,
+		Stat.StatSpirit,
+		Stat.StatSpellPower,
+		Stat.StatSpellHit,
+		Stat.StatSpellCrit,
+		Stat.StatSpellHaste,
+		Stat.StatStamina,
+		Stat.StatMastery,
+	],
 	// Reference stat against which to calculate EP. DPS classes use either spell power or attack power.
 	epReferenceStat: Stat.StatSpellPower,
 	// Which stats to display in the Character Stats section, at the bottom of the left-hand sidebar.
@@ -30,6 +39,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecDemonologyWarlock, {
 		Stat.StatSpellHaste,
 		Stat.StatMP5,
 		Stat.StatStamina,
+		Stat.StatMastery,
 	],
 
 	defaults: {
@@ -68,8 +78,8 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecDemonologyWarlock, {
 
 	// IconInputs to include in the 'Player' section on the settings tab.
 	playerIconInputs: [
-		// WarlockInputs.PetInput(), 
-		// WarlockInputs.ArmorInput(), 
+		// WarlockInputs.PetInput(),
+		// WarlockInputs.ArmorInput(),
 		// WarlockInputs.WeaponImbueInput()
 	],
 
@@ -89,7 +99,13 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecDemonologyWarlock, {
 	petConsumeInputs: [],
 	// Inputs to include in the 'Other' section on the settings tab.
 	otherInputs: {
-		inputs: [WarlockInputs.DetonateSeed(), OtherInputs.InputDelay, OtherInputs.DistanceFromTarget, OtherInputs.TankAssignment, OtherInputs.ChannelClipDelay],
+		inputs: [
+			WarlockInputs.DetonateSeed(),
+			OtherInputs.InputDelay,
+			OtherInputs.DistanceFromTarget,
+			OtherInputs.TankAssignment,
+			OtherInputs.ChannelClipDelay,
+		],
 	},
 	itemSwapSlots: [ItemSlot.ItemSlotMainHand, ItemSlot.ItemSlotOffHand, ItemSlot.ItemSlotRanged],
 	encounterPicker: {

--- a/ui/warlock/destruction/sim.ts
+++ b/ui/warlock/destruction/sim.ts
@@ -16,7 +16,16 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecDestructionWarlock, {
 	knownIssues: ['Drain Soul is currently disabled for APL rotations'],
 
 	// All stats for which EP should be calculated.
-	epStats: [Stat.StatIntellect, Stat.StatSpirit, Stat.StatSpellPower, Stat.StatSpellHit, Stat.StatSpellCrit, Stat.StatSpellHaste, Stat.StatStamina],
+	epStats: [
+		Stat.StatIntellect,
+		Stat.StatSpirit,
+		Stat.StatSpellPower,
+		Stat.StatSpellHit,
+		Stat.StatSpellCrit,
+		Stat.StatSpellHaste,
+		Stat.StatStamina,
+		Stat.StatMastery,
+	],
 	// Reference stat against which to calculate EP. DPS classes use either spell power or attack power.
 	epReferenceStat: Stat.StatSpellPower,
 	// Which stats to display in the Character Stats section, at the bottom of the left-hand sidebar.
@@ -30,6 +39,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecDestructionWarlock, {
 		Stat.StatSpellHaste,
 		Stat.StatMP5,
 		Stat.StatStamina,
+		Stat.StatMastery,
 	],
 
 	defaults: {
@@ -68,8 +78,8 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecDestructionWarlock, {
 
 	// IconInputs to include in the 'Player' section on the settings tab.
 	playerIconInputs: [
-		// WarlockInputs.PetInput(), 
-		// WarlockInputs.ArmorInput(), 
+		// WarlockInputs.PetInput(),
+		// WarlockInputs.ArmorInput(),
 		// WarlockInputs.WeaponImbueInput()
 	],
 
@@ -89,7 +99,13 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecDestructionWarlock, {
 	petConsumeInputs: [],
 	// Inputs to include in the 'Other' section on the settings tab.
 	otherInputs: {
-		inputs: [WarlockInputs.DetonateSeed(), OtherInputs.InputDelay, OtherInputs.DistanceFromTarget, OtherInputs.TankAssignment, OtherInputs.ChannelClipDelay],
+		inputs: [
+			WarlockInputs.DetonateSeed(),
+			OtherInputs.InputDelay,
+			OtherInputs.DistanceFromTarget,
+			OtherInputs.TankAssignment,
+			OtherInputs.ChannelClipDelay,
+		],
 	},
 	itemSwapSlots: [ItemSlot.ItemSlotMainHand, ItemSlot.ItemSlotOffHand, ItemSlot.ItemSlotRanged],
 	encounterPicker: {

--- a/ui/warrior/arms/sim.ts
+++ b/ui/warrior/arms/sim.ts
@@ -24,9 +24,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecArmsWarrior, {
 		Stat.StatMeleeHit,
 		Stat.StatMeleeCrit,
 		Stat.StatMeleeHaste,
-		Stat.StatArmorPenetration,
 		Stat.StatMastery,
-		Stat.StatArmor,
 	],
 	epPseudoStats: [PseudoStat.PseudoStatMainHandDps, PseudoStat.PseudoStatOffHandDps],
 	// Reference stat against which to calculate EP. I think all classes use either spell power or attack power.
@@ -42,8 +40,6 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecArmsWarrior, {
 		Stat.StatMeleeHit,
 		Stat.StatMeleeCrit,
 		Stat.StatMeleeHaste,
-		Stat.StatArmorPenetration,
-		Stat.StatArmor,
 		Stat.StatMastery,
 	],
 	// modifyDisplayStats: (player: Player<Spec.SpecArmsWarrior>) => {
@@ -70,8 +66,9 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecArmsWarrior, {
 				[Stat.StatMeleeHit]: 0.79,
 				[Stat.StatMeleeCrit]: 2.12,
 				[Stat.StatMeleeHaste]: 1.72,
-				[Stat.StatArmorPenetration]: 2.17,
-				[Stat.StatArmor]: 0.03,
+				// @todo: Calculate actual weights
+				// This probably applies for all weights
+				// [Stat.StatMastery]: 0,
 			},
 			{
 				[PseudoStat.PseudoStatMainHandDps]: 6.29,

--- a/ui/warrior/fury/sim.ts
+++ b/ui/warrior/fury/sim.ts
@@ -24,8 +24,6 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFuryWarrior, {
 		Stat.StatMeleeHit,
 		Stat.StatMeleeCrit,
 		Stat.StatMeleeHaste,
-		Stat.StatArmorPenetration,
-		Stat.StatArmor,
 		Stat.StatMastery,
 	],
 	epPseudoStats: [PseudoStat.PseudoStatMainHandDps, PseudoStat.PseudoStatOffHandDps],
@@ -42,8 +40,6 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFuryWarrior, {
 		Stat.StatMeleeHit,
 		Stat.StatMeleeCrit,
 		Stat.StatMeleeHaste,
-		Stat.StatArmorPenetration,
-		Stat.StatArmor,
 		Stat.StatMastery,
 	],
 	// modifyDisplayStats: (player: Player<Spec.SpecFuryWarrior>) => {
@@ -70,8 +66,9 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFuryWarrior, {
 				[Stat.StatMeleeHit]: 0.79,
 				[Stat.StatMeleeCrit]: 2.12,
 				[Stat.StatMeleeHaste]: 1.72,
-				[Stat.StatArmorPenetration]: 2.17,
-				[Stat.StatArmor]: 0.03,
+				// @todo: Calculate actual weights
+				// This probably applies for all weights
+				// [Stat.StatMastery]: 0,
 			},
 			{
 				[PseudoStat.PseudoStatMainHandDps]: 6.29,

--- a/ui/warrior/protection/sim.ts
+++ b/ui/warrior/protection/sim.ts
@@ -29,7 +29,6 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecProtectionWarrior, {
 		Stat.StatMeleeHaste,
 		Stat.StatArmor,
 		Stat.StatBonusArmor,
-		Stat.StatArmorPenetration,
 		Stat.StatDefense,
 		Stat.StatBlock,
 		Stat.StatBlockValue,
@@ -57,7 +56,6 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecProtectionWarrior, {
 		Stat.StatMeleeHit,
 		Stat.StatMeleeCrit,
 		Stat.StatMeleeHaste,
-		Stat.StatArmorPenetration,
 		Stat.StatDefense,
 		Stat.StatBlock,
 		Stat.StatBlockValue,
@@ -86,12 +84,14 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecProtectionWarrior, {
 				[Stat.StatMeleeHit]: 1.432,
 				[Stat.StatMeleeCrit]: 0.925,
 				[Stat.StatMeleeHaste]: 0.431,
-				[Stat.StatArmorPenetration]: 1.055,
 				[Stat.StatBlock]: 1.32,
 				[Stat.StatBlockValue]: 1.373,
 				[Stat.StatDodge]: 2.606,
 				[Stat.StatParry]: 2.649,
 				[Stat.StatDefense]: 3.305,
+				// @todo: Calculate actual weights
+				// This probably applies for all weights
+				// [Stat.StatMastery]: 0,
 			},
 			{
 				[PseudoStat.PseudoStatMainHandDps]: 6.081,


### PR DESCRIPTION
- Removed deprecated ArP stat from sim profile (EP & Display)
- Added Mastery to ep/display stats for all profiles
- Updated WOTLK food and elixir with deprecated ArP stat to new stats