### PR TITLE
[Warrior] Fixes

### DIFF
--- a/sim/warrior/arms/deadly_calm.go
+++ b/sim/warrior/arms/deadly_calm.go
@@ -39,9 +39,6 @@ func (war *ArmsWarrior) RegisterDeadlyCalm() {
 		ClassSpellMask: warrior.SpellMaskDeadlyCalm,
 
 		Cast: core.CastConfig{
-			DefaultCast: core.Cast{
-				GCD: 0,
-			},
 			CD: core.Cooldown{
 				Timer:    war.NewTimer(),
 				Duration: time.Minute * 2,

--- a/sim/warrior/arms/deadly_calm.go
+++ b/sim/warrior/arms/deadly_calm.go
@@ -20,10 +20,11 @@ func (war *ArmsWarrior) RegisterDeadlyCalm() {
 		FloatValue: -1,
 	})
 
-	war.DeadlyCalmAura = war.RegisterAura(core.Aura{
+	dcAura := war.RegisterAura(core.Aura{
 		Label:    "Deadly Calm",
 		ActionID: dcActionID,
 		Duration: time.Second * 10,
+		Tag:      warrior.InnerRageExclusionTag,
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
 			dcMod.Activate()
 		},
@@ -43,15 +44,19 @@ func (war *ArmsWarrior) RegisterDeadlyCalm() {
 				Timer:    war.NewTimer(),
 				Duration: time.Minute * 2,
 			},
+			SharedCD: core.Cooldown{
+				Timer:    war.RecklessnessDeadlyCalmLock(),
+				Duration: 10 * time.Second,
+			},
 		},
 		ProcMask: core.ProcMaskEmpty,
 		RageCost: core.RageCostOptions{Cost: 0},
 
 		ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
-			return !war.InnerRageAura.IsActive() && !war.RecklessnessAura.IsActive()
+			return !war.HasActiveAuraWithTag(warrior.InnerRageExclusionTag)
 		},
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			war.DeadlyCalmAura.Activate(sim)
+			dcAura.Activate(sim)
 		},
 	})
 

--- a/sim/warrior/arms/deadly_calm.go
+++ b/sim/warrior/arms/deadly_calm.go
@@ -20,11 +20,10 @@ func (war *ArmsWarrior) RegisterDeadlyCalm() {
 		FloatValue: -1,
 	})
 
-	dcAura := war.RegisterAura(core.Aura{
+	war.DeadlyCalmAura = war.RegisterAura(core.Aura{
 		Label:    "Deadly Calm",
 		ActionID: dcActionID,
 		Duration: time.Second * 10,
-		Tag:      warrior.InnerRageExclusionTag,
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
 			dcMod.Activate()
 		},
@@ -50,11 +49,12 @@ func (war *ArmsWarrior) RegisterDeadlyCalm() {
 		},
 		ProcMask: core.ProcMaskEmpty,
 		RageCost: core.RageCostOptions{Cost: 0},
+
 		ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
-			return !war.HasActiveAuraWithTag(warrior.InnerRageExclusionTag)
+			return !war.InnerRageAura.IsActive() && !war.RecklessnessAura.IsActive()
 		},
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			dcAura.Activate(sim)
+			war.DeadlyCalmAura.Activate(sim)
 		},
 	})
 

--- a/sim/warrior/arms/mortal_strike.go
+++ b/sim/warrior/arms/mortal_strike.go
@@ -28,6 +28,7 @@ func (war *ArmsWarrior) RegisterMortalStrike() {
 				Timer:    war.NewTimer(),
 				Duration: time.Millisecond * 4500,
 			},
+			IgnoreHaste: true,
 		},
 
 		DamageMultiplier: 1.0,

--- a/sim/warrior/arms/sweeping_strikes.go
+++ b/sim/warrior/arms/sweeping_strikes.go
@@ -68,6 +68,7 @@ func (war *ArmsWarrior) RegisterSweepingStrikes() {
 				Timer:    war.NewTimer(),
 				Duration: time.Minute * 1,
 			},
+			IgnoreHaste: true,
 		},
 		ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
 			return war.StanceMatches(warrior.BattleStance | warrior.BerserkerStance)

--- a/sim/warrior/arms/sweeping_strikes.go
+++ b/sim/warrior/arms/sweeping_strikes.go
@@ -61,14 +61,10 @@ func (war *ArmsWarrior) RegisterSweepingStrikes() {
 			Cost: 30,
 		},
 		Cast: core.CastConfig{
-			DefaultCast: core.Cast{
-				GCD: 0,
-			},
 			CD: core.Cooldown{
 				Timer:    war.NewTimer(),
 				Duration: time.Minute * 1,
 			},
-			IgnoreHaste: true,
 		},
 		ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
 			return war.StanceMatches(warrior.BattleStance | warrior.BerserkerStance)

--- a/sim/warrior/berserker_rage.go
+++ b/sim/warrior/berserker_rage.go
@@ -34,10 +34,6 @@ func (warrior *Warrior) RegisterBerserkerRageSpell() {
 		ClassSpellMask: SpellMaskBerserkerRage,
 
 		Cast: core.CastConfig{
-			DefaultCast: core.Cast{
-				GCD: 0,
-			},
-			IgnoreHaste: true,
 			CD: core.Cooldown{
 				Timer:    warrior.NewTimer(),
 				Duration: time.Second * 30,

--- a/sim/warrior/colossus_smash.go
+++ b/sim/warrior/colossus_smash.go
@@ -44,6 +44,7 @@ func (warrior *Warrior) RegisterColossusSmash() {
 				Timer:    warrior.NewTimer(),
 				Duration: time.Second * 20,
 			},
+			IgnoreHaste: true,
 		},
 
 		DamageMultiplier: 1.0,

--- a/sim/warrior/fury/raging_blow.go
+++ b/sim/warrior/fury/raging_blow.go
@@ -36,6 +36,7 @@ func (war *FuryWarrior) RegisterRagingBlow() {
 			DefaultCast: core.Cast{
 				GCD: core.GCDDefault,
 			},
+			IgnoreHaste: true,
 
 			CD: core.Cooldown{
 				Timer:    war.NewTimer(),

--- a/sim/warrior/inner_rage.go
+++ b/sim/warrior/inner_rage.go
@@ -6,6 +6,8 @@ import (
 	"github.com/wowsims/cata/sim/core"
 )
 
+const InnerRageExclusionTag = "InnerRageDeadlyCalm"
+
 func (warrior *Warrior) RegisterInnerRage() {
 	actionID := core.ActionID{SpellID: 1134}
 
@@ -19,6 +21,7 @@ func (warrior *Warrior) RegisterInnerRage() {
 		Label:    "Inner Rage",
 		ActionID: actionID,
 		Duration: time.Second * 15,
+		Tag:      InnerRageExclusionTag,
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
 			costMod.Activate()
 		},
@@ -43,13 +46,8 @@ func (warrior *Warrior) RegisterInnerRage() {
 			},
 		},
 		ThreatMultiplier: 0.0,
-
 		ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
-			if warrior.DeadlyCalmAura != nil {
-				return !warrior.DeadlyCalmAura.IsActive()
-			}
-			return true
-
+			return !warrior.HasActiveAuraWithTag(InnerRageExclusionTag)
 		},
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			warrior.InnerRageAura.Activate(sim)

--- a/sim/warrior/inner_rage.go
+++ b/sim/warrior/inner_rage.go
@@ -6,8 +6,6 @@ import (
 	"github.com/wowsims/cata/sim/core"
 )
 
-const InnerRageExclusionTag = "InnerRageDeadlyCalm"
-
 func (warrior *Warrior) RegisterInnerRage() {
 	actionID := core.ActionID{SpellID: 1134}
 
@@ -21,7 +19,6 @@ func (warrior *Warrior) RegisterInnerRage() {
 		Label:    "Inner Rage",
 		ActionID: actionID,
 		Duration: time.Second * 15,
-		Tag:      InnerRageExclusionTag,
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
 			costMod.Activate()
 		},
@@ -46,8 +43,13 @@ func (warrior *Warrior) RegisterInnerRage() {
 			},
 		},
 		ThreatMultiplier: 0.0,
+
 		ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
-			return !warrior.HasActiveAuraWithTag(InnerRageExclusionTag)
+			if warrior.DeadlyCalmAura != nil {
+				return !warrior.DeadlyCalmAura.IsActive()
+			}
+			return true
+
 		},
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			warrior.InnerRageAura.Activate(sim)

--- a/sim/warrior/recklessness.go
+++ b/sim/warrior/recklessness.go
@@ -15,7 +15,7 @@ func (warrior *Warrior) RegisterRecklessnessCD() {
 		FloatValue: 50 * core.CritRatingPerCritChance,
 	})
 
-	warrior.RecklessnessAura = warrior.RegisterAura(core.Aura{
+	reckAura := warrior.RegisterAura(core.Aura{
 		Label:    "Recklessness",
 		ActionID: actionID,
 		Duration: time.Second * 12,
@@ -39,18 +39,15 @@ func (warrior *Warrior) RegisterRecklessnessCD() {
 				Timer:    warrior.NewTimer(),
 				Duration: time.Minute * 5,
 			},
-			IgnoreHaste: true,
-		},
 
-		ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
-			if warrior.DeadlyCalmAura != nil {
-				return !warrior.DeadlyCalmAura.IsActive()
-			}
-			return true
+			SharedCD: core.Cooldown{
+				Timer:    warrior.RecklessnessDeadlyCalmLock(),
+				Duration: 12 * time.Second,
+			},
 		},
 
 		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, spell *core.Spell) {
-			warrior.RecklessnessAura.Activate(sim)
+			reckAura.Activate(sim)
 		},
 	})
 

--- a/sim/warrior/recklessness.go
+++ b/sim/warrior/recklessness.go
@@ -39,6 +39,7 @@ func (warrior *Warrior) RegisterRecklessnessCD() {
 				Timer:    warrior.NewTimer(),
 				Duration: time.Minute * 5,
 			},
+			IgnoreHaste: true,
 		},
 
 		ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {

--- a/sim/warrior/recklessness.go
+++ b/sim/warrior/recklessness.go
@@ -15,7 +15,7 @@ func (warrior *Warrior) RegisterRecklessnessCD() {
 		FloatValue: 50 * core.CritRatingPerCritChance,
 	})
 
-	reckAura := warrior.RegisterAura(core.Aura{
+	warrior.RecklessnessAura = warrior.RegisterAura(core.Aura{
 		Label:    "Recklessness",
 		ActionID: actionID,
 		Duration: time.Second * 12,
@@ -41,8 +41,15 @@ func (warrior *Warrior) RegisterRecklessnessCD() {
 			},
 		},
 
+		ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
+			if warrior.DeadlyCalmAura != nil {
+				return !warrior.DeadlyCalmAura.IsActive()
+			}
+			return true
+		},
+
 		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, spell *core.Spell) {
-			reckAura.Activate(sim)
+			warrior.RecklessnessAura.Activate(sim)
 		},
 	})
 

--- a/sim/warrior/slam.go
+++ b/sim/warrior/slam.go
@@ -26,7 +26,7 @@ func (warrior *Warrior) RegisterSlamSpell() {
 			IgnoreHaste: true,
 			ModifyCast: func(sim *core.Simulation, spell *core.Spell, cast *core.Cast) {
 
-				// Slam now has a "Haste Affects Melee Ability Casttime" flag in cata, which doesn't change slam gcd but increases the cast speed
+				// Slam now has a "Haste Affects Melee Ability Casttime" flag in cata, which doesn't affect the gcd
 				warrior.Slam.CurCast.CastTime = spell.Unit.ApplyCastSpeedForSpell(spell.CurCast.CastTime, spell)
 
 				if cast.CastTime > 0 {

--- a/sim/warrior/slam.go
+++ b/sim/warrior/slam.go
@@ -23,8 +23,12 @@ func (warrior *Warrior) RegisterSlamSpell() {
 				GCD:      core.GCDDefault,
 				CastTime: time.Millisecond * 1500,
 			},
-			IgnoreHaste: false, // Slam now has a "Haste Affects Melee Ability Casttime" flag in cata
+			IgnoreHaste: true,
 			ModifyCast: func(sim *core.Simulation, spell *core.Spell, cast *core.Cast) {
+
+				// Slam now has a "Haste Affects Melee Ability Casttime" flag in cata, which doesn't change slam gcd but increases the cast speed
+				warrior.Slam.CurCast.CastTime = spell.Unit.ApplyCastSpeedForSpell(spell.CurCast.CastTime, spell)
+
 				if cast.CastTime > 0 {
 					warrior.AutoAttacks.DelayMeleeBy(sim, cast.CastTime)
 				}

--- a/sim/warrior/warrior.go
+++ b/sim/warrior/warrior.go
@@ -116,6 +116,8 @@ type Warrior struct {
 	ShieldBlockAura   *core.Aura
 	ThunderstruckAura *core.Aura
 	InnerRageAura     *core.Aura
+	RecklessnessAura  *core.Aura
+	DeadlyCalmAura    *core.Aura
 
 	DemoralizingShoutAuras core.AuraArray
 	SunderArmorAuras       core.AuraArray

--- a/sim/warrior/warrior.go
+++ b/sim/warrior/warrior.go
@@ -102,9 +102,10 @@ type Warrior struct {
 	Whirlwind         *core.Spell
 	DeepWounds        *core.Spell
 
-	hsCleaveCD   *core.Timer
-	HeroicStrike *core.Spell
-	Cleave       *core.Spell
+	recklessnessDeadlyCalmCD *core.Timer
+	hsCleaveCD               *core.Timer
+	HeroicStrike             *core.Spell
+	Cleave                   *core.Spell
 
 	BattleStanceAura    *core.Aura
 	DefensiveStanceAura *core.Aura
@@ -116,8 +117,6 @@ type Warrior struct {
 	ShieldBlockAura   *core.Aura
 	ThunderstruckAura *core.Aura
 	InnerRageAura     *core.Aura
-	RecklessnessAura  *core.Aura
-	DeadlyCalmAura    *core.Aura
 
 	DemoralizingShoutAuras core.AuraArray
 	SunderArmorAuras       core.AuraArray
@@ -207,6 +206,11 @@ func (warrior *Warrior) HasMinorGlyph(glyph proto.WarriorMinorGlyph) bool {
 func (warrior *Warrior) IntensifyRageCooldown(baseCd time.Duration) time.Duration {
 	baseCd /= 100
 	return []time.Duration{baseCd * 100, baseCd * 90, baseCd * 80}[warrior.Talents.IntensifyRage]
+}
+
+// Shared cooldown for Deadly Calm and Recklessness Activation
+func (warrior *Warrior) RecklessnessDeadlyCalmLock() *core.Timer {
+	return warrior.Character.GetOrInitTimer(&warrior.recklessnessDeadlyCalmCD)
 }
 
 // Agent is a generic way to access underlying warrior on any of the agents.


### PR DESCRIPTION
Recklessness and Deadly Calm cannot be used together, also updated Inner Rage to use the same logic
Slam is affected by haste but the GCD is still 1.5. Would like some feedback on this part if possible.
Multiple spells were missing the IgnoreHaste flag, added the ones I could find.