### PR TITLE
Update Spell Class Scaling to use the same pattern in all classes

### DIFF
--- a/sim/core/apl_values_aura.go
+++ b/sim/core/apl_values_aura.go
@@ -13,6 +13,9 @@ type APLValueAuraIsActive struct {
 }
 
 func (rot *APLRotation) newValueAuraIsActive(config *proto.APLValueAuraIsActive) APLValue {
+	if config.AuraId == nil {
+		return nil
+	}
 	aura := rot.GetAPLAura(rot.GetSourceUnit(config.SourceUnit), config.AuraId)
 	if aura.Get() == nil {
 		return nil
@@ -38,6 +41,9 @@ type APLValueAuraIsActiveWithReactionTime struct {
 }
 
 func (rot *APLRotation) newValueAuraIsActiveWithReactionTime(config *proto.APLValueAuraIsActiveWithReactionTime) APLValue {
+	if config.AuraId == nil {
+		return nil
+	}
 	aura := rot.GetAPLAura(rot.GetSourceUnit(config.SourceUnit), config.AuraId)
 	if aura.Get() == nil {
 		return nil
@@ -64,6 +70,9 @@ type APLValueAuraRemainingTime struct {
 }
 
 func (rot *APLRotation) newValueAuraRemainingTime(config *proto.APLValueAuraRemainingTime) APLValue {
+	if config.AuraId == nil {
+		return nil
+	}
 	aura := rot.GetAPLAura(rot.GetSourceUnit(config.SourceUnit), config.AuraId)
 	if aura.Get() == nil {
 		return nil
@@ -88,6 +97,9 @@ type APLValueAuraNumStacks struct {
 }
 
 func (rot *APLRotation) newValueAuraNumStacks(config *proto.APLValueAuraNumStacks) APLValue {
+	if config.AuraId == nil {
+		return nil
+	}
 	aura := rot.GetAPLAura(rot.GetSourceUnit(config.SourceUnit), config.AuraId)
 	if aura.Get() == nil {
 		return nil
@@ -116,6 +128,9 @@ type APLValueAuraInternalCooldown struct {
 }
 
 func (rot *APLRotation) newValueAuraInternalCooldown(config *proto.APLValueAuraInternalCooldown) APLValue {
+	if config.AuraId == nil {
+		return nil
+	}
 	aura := rot.GetAPLICDAura(rot.GetSourceUnit(config.SourceUnit), config.AuraId)
 	if aura.Get() == nil {
 		return nil
@@ -141,6 +156,9 @@ type APLValueAuraICDIsReadyWithReactionTime struct {
 }
 
 func (rot *APLRotation) newValueAuraICDIsReadyWithReactionTime(config *proto.APLValueAuraICDIsReadyWithReactionTime) APLValue {
+	if config.AuraId == nil {
+		return nil
+	}
 	aura := rot.GetAPLICDAura(rot.GetSourceUnit(config.SourceUnit), config.AuraId)
 	if aura.Get() == nil {
 		return nil
@@ -168,6 +186,9 @@ type APLValueAuraShouldRefresh struct {
 }
 
 func (rot *APLRotation) newValueAuraShouldRefresh(config *proto.APLValueAuraShouldRefresh) APLValue {
+	if config.AuraId == nil {
+		return nil
+	}
 	aura := rot.GetAPLAura(rot.GetTargetUnit(config.SourceUnit), config.AuraId)
 	if aura.Get() == nil {
 		return nil

--- a/sim/core/utils.go
+++ b/sim/core/utils.go
@@ -208,8 +208,12 @@ func CalcScalingSpellAverageEffect(class proto.Class, spellEffectCoefficient flo
 // spellEffectVariance is the value in the "Variance" column of the SpellEffect DB2 table
 func CalcScalingSpellEffectVarianceMinMax(class proto.Class, spellEffectCoefficient float64, spellEffectVariance float64) (float64, float64) {
 	avgEffect := CalcScalingSpellAverageEffect(class, spellEffectCoefficient)
-	min := avgEffect * (1 - spellEffectVariance/2.0)
-	max := avgEffect * (1 + spellEffectVariance/2.0)
+	return ApplyVarianceMinMax(avgEffect, spellEffectVariance)
+}
+
+func ApplyVarianceMinMax(avgEffect float64, variance float64) (float64, float64) {
+	min := avgEffect * (1 - variance/2.0)
+	max := avgEffect * (1 + variance/2.0)
 	return min, max
 }
 

--- a/sim/death_knight/blood/heart_strike.go
+++ b/sim/death_knight/blood/heart_strike.go
@@ -35,7 +35,7 @@ func (dk *BloodDeathKnight) registerHeartStrikeSpell() {
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			baseDamage := dk.ClassBaseScaling*0.72799998522 +
+			baseDamage := dk.ClassSpellScaling*0.72799998522 +
 				spell.Unit.MHNormalizedWeaponDamage(sim, spell.MeleeAttackPower())
 
 			currentTarget := target
@@ -69,7 +69,7 @@ func (dk *BloodDeathKnight) registerDrwHeartStrikeSpell() *core.Spell {
 		Flags:       core.SpellFlagMeleeMetrics,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			baseDamage := dk.ClassBaseScaling*0.72799998522 +
+			baseDamage := dk.ClassSpellScaling*0.72799998522 +
 				spell.Unit.MHNormalizedWeaponDamage(sim, spell.MeleeAttackPower())
 
 			currentTarget := target

--- a/sim/death_knight/blood_boil.go
+++ b/sim/death_knight/blood_boil.go
@@ -32,7 +32,7 @@ func (dk *DeathKnight) registerBloodBoilSpell() {
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			anyHit := false
 			for idx, aoeTarget := range sim.Encounter.TargetUnits {
-				baseDamage := dk.ClassBaseScaling*0.31700000167 + 0.08*spell.MeleeAttackPower()
+				baseDamage := dk.ClassSpellScaling*0.31700000167 + 0.08*spell.MeleeAttackPower()
 				baseDamage *= core.TernaryFloat64(dk.DiseasesAreActive(aoeTarget), 1.5, 1.0)
 				baseDamage *= sim.Encounter.AOECapMultiplier()
 
@@ -60,7 +60,7 @@ func (dk *DeathKnight) registerDrwBloodBoilSpell() *core.Spell {
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			for idx, aoeTarget := range sim.Encounter.TargetUnits {
-				baseDamage := dk.ClassBaseScaling*0.31700000167 + 0.08*spell.MeleeAttackPower()
+				baseDamage := dk.ClassSpellScaling*0.31700000167 + 0.08*spell.MeleeAttackPower()
 				baseDamage *= core.TernaryFloat64(dk.RuneWeapon.DiseasesAreActive(aoeTarget), 1.5, 1.0)
 				baseDamage *= sim.Encounter.AOECapMultiplier()
 

--- a/sim/death_knight/death_coil.go
+++ b/sim/death_knight/death_coil.go
@@ -28,7 +28,7 @@ func (dk *DeathKnight) registerDeathCoilSpell() {
 		ThreatMultiplier: 1.0,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			baseDamage := dk.ClassBaseScaling*0.87599998713 + spell.MeleeAttackPower()*0.23
+			baseDamage := dk.ClassSpellScaling*0.87599998713 + spell.MeleeAttackPower()*0.23
 			spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMagicHitAndCrit)
 		},
 	})
@@ -41,7 +41,7 @@ func (dk *DeathKnight) registerDrwDeathCoilSpell() *core.Spell {
 		ProcMask:    core.ProcMaskSpellDamage,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			baseDamage := dk.ClassBaseScaling*0.87599998713 + spell.MeleeAttackPower()*0.23
+			baseDamage := dk.ClassSpellScaling*0.87599998713 + spell.MeleeAttackPower()*0.23
 			spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMagicHitAndCrit)
 		},
 	})

--- a/sim/death_knight/death_knight.go
+++ b/sim/death_knight/death_knight.go
@@ -46,7 +46,7 @@ type DeathKnight struct {
 	core.Character
 	Talents *proto.DeathKnightTalents
 
-	ClassBaseScaling float64
+	ClassSpellScaling float64
 
 	Inputs DeathKnightInputs
 
@@ -140,10 +140,10 @@ func (dk *DeathKnight) HasMinorGlyph(glyph proto.DeathKnightMinorGlyph) bool {
 
 func NewDeathKnight(character *core.Character, inputs DeathKnightInputs, talents string, deathRuneConvertSpellId int32) *DeathKnight {
 	dk := &DeathKnight{
-		Character:        *character,
-		Talents:          &proto.DeathKnightTalents{},
-		Inputs:           inputs,
-		ClassBaseScaling: 1125.227400,
+		Character:         *character,
+		Talents:           &proto.DeathKnightTalents{},
+		Inputs:            inputs,
+		ClassSpellScaling: core.GetClassSpellScalingCoefficient(proto.Class_ClassDeathKnight),
 	}
 	core.FillTalentsProto(dk.Talents.ProtoReflect(), talents, TalentTreeSizes)
 

--- a/sim/death_knight/death_strike.go
+++ b/sim/death_knight/death_strike.go
@@ -54,7 +54,7 @@ func (dk *DeathKnight) registerDeathStrikeSpell() {
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			baseDamage := dk.ClassBaseScaling*0.14699999988 +
+			baseDamage := dk.ClassSpellScaling*0.14699999988 +
 				spell.Unit.OHNormalizedWeaponDamage(sim, spell.MeleeAttackPower())
 
 			result := spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeSpecialCritOnly)
@@ -90,7 +90,7 @@ func (dk *DeathKnight) registerDeathStrikeSpell() {
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			baseDamage := dk.ClassBaseScaling*0.29399999976 +
+			baseDamage := dk.ClassSpellScaling*0.29399999976 +
 				spell.Unit.MHNormalizedWeaponDamage(sim, spell.MeleeAttackPower())
 
 			result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeMeleeWeaponSpecialHitAndCrit)
@@ -113,7 +113,7 @@ func (dk *DeathKnight) registerDrwDeathStrikeSpell() *core.Spell {
 		Flags:       core.SpellFlagMeleeMetrics,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			baseDamage := dk.ClassBaseScaling*0.29399999976 +
+			baseDamage := dk.ClassSpellScaling*0.29399999976 +
 				spell.Unit.MHNormalizedWeaponDamage(sim, spell.MeleeAttackPower())
 
 			spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeWeaponSpecialHitAndCrit)

--- a/sim/death_knight/festering_strike.go
+++ b/sim/death_knight/festering_strike.go
@@ -26,7 +26,7 @@ func (dk *DeathKnight) registerFesteringStrikeSpell() {
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			baseDamage := dk.ClassBaseScaling*0.24899999797 +
+			baseDamage := dk.ClassSpellScaling*0.24899999797 +
 				spell.Unit.OHNormalizedWeaponDamage(sim, spell.MeleeAttackPower())
 
 			spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeSpecialCritOnly)
@@ -60,7 +60,7 @@ func (dk *DeathKnight) registerFesteringStrikeSpell() {
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			baseDamage := dk.ClassBaseScaling*0.49799999595 +
+			baseDamage := dk.ClassSpellScaling*0.49799999595 +
 				spell.Unit.MHNormalizedWeaponDamage(sim, spell.MeleeAttackPower())
 
 			result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeMeleeWeaponSpecialHitAndCrit)
@@ -97,7 +97,7 @@ func (dk *DeathKnight) registerDrwFesteringStrikeSpell() *core.Spell {
 		Flags:       core.SpellFlagMeleeMetrics,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			baseDamage := dk.ClassBaseScaling*0.49799999595 +
+			baseDamage := dk.ClassSpellScaling*0.49799999595 +
 				spell.Unit.MHNormalizedWeaponDamage(sim, spell.MeleeAttackPower())
 
 			result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeMeleeWeaponSpecialHitAndCrit)

--- a/sim/death_knight/frost/frost_strike.go
+++ b/sim/death_knight/frost/frost_strike.go
@@ -21,7 +21,7 @@ func (dk *FrostDeathKnight) registerFrostStrikeSpell() {
 		ThreatMultiplier:         1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			baseDamage := dk.ClassBaseScaling*0.12399999797 +
+			baseDamage := dk.ClassSpellScaling*0.12399999797 +
 				spell.Unit.OHNormalizedWeaponDamage(sim, spell.MeleeAttackPower())
 
 			spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeSpecialCritOnly)
@@ -53,7 +53,7 @@ func (dk *FrostDeathKnight) registerFrostStrikeSpell() {
 		ThreatMultiplier:         1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			baseDamage := dk.ClassBaseScaling*0.24699999392 +
+			baseDamage := dk.ClassSpellScaling*0.24699999392 +
 				spell.Unit.MHNormalizedWeaponDamage(sim, spell.MeleeAttackPower())
 
 			result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeMeleeWeaponSpecialHitAndCrit)

--- a/sim/death_knight/howling_blast.go
+++ b/sim/death_knight/howling_blast.go
@@ -38,7 +38,7 @@ func (dk *DeathKnight) registerHowlingBlastSpell() {
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			for idx, aoeTarget := range sim.Encounter.TargetUnits {
-				baseDamage := dk.ClassBaseScaling*1.17499995232 + 0.44*spell.MeleeAttackPower()
+				baseDamage := dk.ClassSpellScaling*1.17499995232 + 0.44*spell.MeleeAttackPower()
 
 				if aoeTarget != target {
 					spell.DamageMultiplier *= 0.5

--- a/sim/death_knight/icy_touch.go
+++ b/sim/death_knight/icy_touch.go
@@ -30,7 +30,7 @@ func (dk *DeathKnight) registerIcyTouchSpell() {
 		ThreatMultiplier: 1.0,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			baseDamage := dk.ClassBaseScaling*0.46799999475 + spell.MeleeAttackPower()*0.2
+			baseDamage := dk.ClassSpellScaling*0.46799999475 + spell.MeleeAttackPower()*0.2
 
 			result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeMagicHitAndCrit)
 			spell.SpendRefundableCost(sim, result)
@@ -51,7 +51,7 @@ func (dk *DeathKnight) registerDrwIcyTouchSpell() *core.Spell {
 		ProcMask:    core.ProcMaskSpellDamage,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			baseDamage := dk.ClassBaseScaling*0.46799999475 + spell.MeleeAttackPower()*0.2
+			baseDamage := dk.ClassSpellScaling*0.46799999475 + spell.MeleeAttackPower()*0.2
 
 			result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeMagicHitAndCrit)
 

--- a/sim/death_knight/obliterate.go
+++ b/sim/death_knight/obliterate.go
@@ -21,7 +21,7 @@ func (dk *DeathKnight) registerObliterateSpell() {
 		ThreatMultiplier:         1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			baseDamage := dk.ClassBaseScaling*0.28900000453 +
+			baseDamage := dk.ClassSpellScaling*0.28900000453 +
 				spell.Unit.OHNormalizedWeaponDamage(sim, spell.MeleeAttackPower())
 
 			spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeSpecialCritOnly)
@@ -55,7 +55,7 @@ func (dk *DeathKnight) registerObliterateSpell() {
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			baseDamage := dk.ClassBaseScaling*0.57800000906 +
+			baseDamage := dk.ClassSpellScaling*0.57800000906 +
 				spell.Unit.MHNormalizedWeaponDamage(sim, spell.MeleeAttackPower())
 
 			baseDamage *= dk.GetDiseaseMulti(target, 1.0, 0.125)

--- a/sim/death_knight/plague_strike.go
+++ b/sim/death_knight/plague_strike.go
@@ -19,7 +19,7 @@ func (dk *DeathKnight) registerPlagueStrikeSpell() {
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			baseDamage := dk.ClassBaseScaling*0.18700000644 +
+			baseDamage := dk.ClassSpellScaling*0.18700000644 +
 				spell.Unit.OHNormalizedWeaponDamage(sim, spell.MeleeAttackPower())
 
 			spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeSpecialCritOnly)
@@ -50,7 +50,7 @@ func (dk *DeathKnight) registerPlagueStrikeSpell() {
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			baseDamage := dk.ClassBaseScaling*0.37400001287 +
+			baseDamage := dk.ClassSpellScaling*0.37400001287 +
 				spell.Unit.MHNormalizedWeaponDamage(sim, spell.MeleeAttackPower())
 
 			result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeMeleeWeaponSpecialHitAndCrit)
@@ -74,7 +74,7 @@ func (dk *DeathKnight) registerDrwPlagueStrikeSpell() *core.Spell {
 		Flags:       core.SpellFlagMeleeMetrics,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			baseDamage := dk.ClassBaseScaling*0.37400001287 +
+			baseDamage := dk.ClassSpellScaling*0.37400001287 +
 				spell.Unit.MHNormalizedWeaponDamage(sim, spell.MeleeAttackPower())
 
 			result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeMeleeWeaponSpecialHitAndCrit)

--- a/sim/death_knight/unholy/scourge_strike.go
+++ b/sim/death_knight/unholy/scourge_strike.go
@@ -56,7 +56,7 @@ func (dk *UnholyDeathKnight) registerScourgeStrikeSpell() {
 		ThreatMultiplier: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			baseDamage := dk.ClassBaseScaling*0.55500000715 +
+			baseDamage := dk.ClassSpellScaling*0.55500000715 +
 				spell.Unit.MHNormalizedWeaponDamage(sim, spell.MeleeAttackPower())
 
 			result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeMeleeWeaponSpecialHitAndCrit)

--- a/sim/druid/druid.go
+++ b/sim/druid/druid.go
@@ -11,7 +11,6 @@ import (
 const (
 	SpellFlagNaturesGrace = core.SpellFlagAgentReserved1
 	SpellFlagOmenTrigger  = core.SpellFlagAgentReserved2
-	SpellScalingConstant  = 986.626460 // for level 85
 )
 
 var TalentTreeSizes = [3]int{20, 22, 21}
@@ -20,6 +19,8 @@ type Druid struct {
 	core.Character
 	SelfBuffs
 	Talents *proto.DruidTalents
+
+	ClassSpellScaling float64
 
 	StartingForm DruidForm
 
@@ -274,11 +275,12 @@ func (druid *Druid) Reset(_ *core.Simulation) {
 
 func New(char *core.Character, form DruidForm, selfBuffs SelfBuffs, talents string) *Druid {
 	druid := &Druid{
-		Character:    *char,
-		SelfBuffs:    selfBuffs,
-		Talents:      &proto.DruidTalents{},
-		StartingForm: form,
-		form:         form,
+		Character:         *char,
+		SelfBuffs:         selfBuffs,
+		Talents:           &proto.DruidTalents{},
+		StartingForm:      form,
+		form:              form,
+		ClassSpellScaling: core.GetClassSpellScalingCoefficient(proto.Class_ClassDruid),
 	}
 
 	core.FillTalentsProto(druid.Talents.ProtoReflect(), talents, TalentTreeSizes)

--- a/sim/druid/ferocious_bite.go
+++ b/sim/druid/ferocious_bite.go
@@ -13,10 +13,10 @@ func (druid *Druid) registerFerociousBiteSpell() {
 	resourceCoefficient := 0.58399999142
 
 	// Scaled parameters for spell code
-	avgBaseDamage := coefficient * SpellScalingConstant
+	avgBaseDamage := coefficient * druid.ClassSpellScaling
 	damageSpread := variance * avgBaseDamage
 	minBaseDamage := avgBaseDamage - damageSpread/2
-	dmgPerComboPoint := resourceCoefficient * SpellScalingConstant
+	dmgPerComboPoint := resourceCoefficient * druid.ClassSpellScaling
 	scalingPerComboPoint := 0.125
 	ripRefreshChance := 0.5 * float64(druid.Talents.BloodInTheWater)
 

--- a/sim/druid/thrash.go
+++ b/sim/druid/thrash.go
@@ -13,10 +13,10 @@ func (druid *Druid) registerThrashBearSpell() {
 	bleedCoefficient := 0.58899998665
 
 	// Scaled parameters for spell code
-	avgBaseDamage := hitCoefficient * SpellScalingConstant // second factor is defined in druid.go
+	avgBaseDamage := hitCoefficient * druid.ClassSpellScaling // second factor is defined in druid.go
 	damageSpread := hitVariance * avgBaseDamage
 	flatBaseDamage := avgBaseDamage - damageSpread/2
-	flatBleedDamage := bleedCoefficient * SpellScalingConstant
+	flatBleedDamage := bleedCoefficient * druid.ClassSpellScaling
 
 	druid.Thrash = druid.RegisterSpell(Bear, core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 77758},

--- a/sim/hunter/hunter.go
+++ b/sim/hunter/hunter.go
@@ -15,6 +15,8 @@ const ThoridalTheStarsFuryItemID = 34334
 type Hunter struct {
 	core.Character
 
+	ClassSpellScaling float64
+
 	Talents             *proto.HunterTalents
 	Options             *proto.HunterOptions
 	BeastMasteryOptions *proto.BeastMasteryHunter_Options
@@ -83,9 +85,10 @@ func (hunter *Hunter) GetHunter() *Hunter {
 
 func NewHunter(character *core.Character, options *proto.Player, hunterOptions *proto.HunterOptions) *Hunter {
 	hunter := &Hunter{
-		Character: *character,
-		Talents:   &proto.HunterTalents{},
-		Options:   hunterOptions,
+		Character:         *character,
+		Talents:           &proto.HunterTalents{},
+		Options:           hunterOptions,
+		ClassSpellScaling: core.GetClassSpellScalingCoefficient(proto.Class_ClassHunter),
 	}
 
 	core.FillTalentsProto(hunter.Talents.ProtoReflect(), options.TalentsString, TalentTreeSizes)

--- a/sim/priest/devouring_plague.go
+++ b/sim/priest/devouring_plague.go
@@ -41,7 +41,7 @@ func (priest *Priest) registerDevouringPlagueSpell() {
 			BonusCoefficient: 0.163,
 
 			OnSnapshot: func(sim *core.Simulation, target *core.Unit, dot *core.Dot, _ bool) {
-				dot.Snapshot(target, 0.144*priest.ScalingBaseDamage)
+				dot.Snapshot(target, 0.144*priest.ClassSpellScaling)
 			},
 			OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
 				dot.CalcAndDealPeriodicSnapshotDamage(sim, target, dot.OutcomeSnapshotCrit)
@@ -63,7 +63,7 @@ func (priest *Priest) registerDevouringPlagueSpell() {
 				dot := spell.Dot(target)
 				return dot.CalcSnapshotDamage(sim, target, dot.OutcomeExpectedMagicSnapshotCrit)
 			} else {
-				baseDamage := 0.144 * priest.ScalingBaseDamage
+				baseDamage := 0.144 * priest.ClassSpellScaling
 				return spell.CalcPeriodicDamage(sim, target, baseDamage, spell.OutcomeExpectedMagicCrit)
 			}
 		},

--- a/sim/priest/mind_sear.go
+++ b/sim/priest/mind_sear.go
@@ -24,7 +24,7 @@ func (priest *Priest) getMindSearTickSpell(numTicks int32) *core.Spell {
 	config := priest.getMindSearBaseConfig()
 	config.ActionID = core.ActionID{SpellID: 48045}.WithTag(numTicks)
 	config.ApplyEffects = func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-		damage := priest.ScalingBaseDamage * 0.23
+		damage := priest.ClassSpellScaling * 0.23
 		spell.CalcAndDealDamage(sim, target, damage, spell.OutcomeMagicHitAndCrit)
 	}
 	return priest.RegisterSpell(config)
@@ -75,7 +75,7 @@ func (priest *Priest) newMindSearSpell(numTicksIdx int32) *core.Spell {
 		}
 	}
 	config.ExpectedTickDamage = func(sim *core.Simulation, target *core.Unit, spell *core.Spell, _ bool) *core.SpellResult {
-		baseDamage := priest.ScalingBaseDamage * 0.23
+		baseDamage := priest.ClassSpellScaling * 0.23
 		return spell.CalcPeriodicDamage(sim, target, baseDamage, spell.OutcomeExpectedMagicCrit)
 	}
 

--- a/sim/priest/priest.go
+++ b/sim/priest/priest.go
@@ -62,7 +62,7 @@ type Priest struct {
 
 	ProcPrayerOfMending core.ApplySpellResults
 
-	ScalingBaseDamage    float64
+	ClassSpellScaling    float64
 	ShadowCritMultiplier float64
 
 	// set bonus cache
@@ -115,10 +115,6 @@ func (priest *Priest) AddPartyBuffs(_ *proto.PartyBuffs) {
 }
 
 func (priest *Priest) Initialize() {
-
-	// base scaling value for a level 85 priest
-	priest.ScalingBaseDamage = 945.188842773437500
-
 	if priest.SelfBuffs.UseInnerFire {
 		priest.AddStat(stats.SpellPower, 531)
 		priest.ApplyEquipScaling(stats.Armor, 1.6)
@@ -192,9 +188,10 @@ func (priest *Priest) Reset(_ *core.Simulation) {
 
 func New(char *core.Character, selfBuffs SelfBuffs, talents string) *Priest {
 	priest := &Priest{
-		Character: *char,
-		SelfBuffs: selfBuffs,
-		Talents:   &proto.PriestTalents{},
+		Character:         *char,
+		SelfBuffs:         selfBuffs,
+		Talents:           &proto.PriestTalents{},
+		ClassSpellScaling: core.GetClassSpellScalingCoefficient(proto.Class_ClassPriest),
 	}
 
 	core.FillTalentsProto(priest.Talents.ProtoReflect(), talents, TalentTreeSizes)
@@ -302,9 +299,9 @@ const (
 )
 
 func (priest *Priest) calcBaseDamage(sim *core.Simulation, coefficient float64, variance float64) float64 {
-	baseDamage := priest.ScalingBaseDamage * coefficient
+	baseDamage := priest.ClassSpellScaling * coefficient
 	if variance > 0 {
-		delta := priest.ScalingBaseDamage * variance * 0.5
+		delta := priest.ClassSpellScaling * variance * 0.5
 		baseDamage += sim.Roll(-delta, delta)
 	}
 

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -55,21 +55,21 @@ dps_results: {
  key: "TestShadow-AllItems-Althor'sAbacus-50366"
  value: {
   dps: 26885.15147
-  tps: 25648.43855
+  tps: 25648.43854
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 27033.81596
+  dps: 27033.81595
   tps: 25768.17373
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 27079.00987
-  tps: 25813.07733
+  dps: 27079.00986
+  tps: 25813.07732
  }
 }
 dps_results: {
@@ -127,20 +127,20 @@ dps_results: {
  key: "TestShadow-AllItems-BellofEnragingResonance-59326"
  value: {
   dps: 28044.29888
-  tps: 26653.25877
+  tps: 26653.25876
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BindingPromise-67037"
  value: {
-  dps: 26418.71821
-  tps: 25218.92006
+  dps: 26418.7182
+  tps: 25218.92005
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 18773.76707
+  dps: 18773.76706
   tps: 17943.58664
  }
 }
@@ -148,21 +148,21 @@ dps_results: {
  key: "TestShadow-AllItems-Blood-SoakedAleMug-63843"
  value: {
   dps: 26702.94123
-  tps: 25502.92335
+  tps: 25502.92334
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodofIsiset-55995"
  value: {
   dps: 26766.21439
-  tps: 25555.28562
+  tps: 25555.28561
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodofIsiset-56414"
  value: {
   dps: 26815.65808
-  tps: 25604.72931
+  tps: 25604.7293
  }
 }
 dps_results: {
@@ -182,8 +182,8 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 26418.71821
-  tps: 25218.92006
+  dps: 26418.7182
+  tps: 25218.92005
  }
 }
 dps_results: {
@@ -196,15 +196,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 26418.71821
-  tps: 25218.92006
+  dps: 26418.7182
+  tps: 25218.92005
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 26418.71821
-  tps: 25218.92006
+  dps: 26418.7182
+  tps: 25218.92005
  }
 }
 dps_results: {
@@ -231,7 +231,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-BottledLightning-66879"
  value: {
-  dps: 27088.29352
+  dps: 27088.29351
   tps: 25839.39576
  }
 }
@@ -267,7 +267,7 @@ dps_results: {
  key: "TestShadow-AllItems-ChaoticSkyflareDiamond"
  value: {
   dps: 28322.87469
-  tps: 26940.25125
+  tps: 26940.25124
  }
 }
 dps_results: {
@@ -295,7 +295,7 @@ dps_results: {
  key: "TestShadow-AllItems-CorrodedSkeletonKey-50356"
  value: {
   dps: 26426.12506
-  tps: 25218.92006
+  tps: 25218.92005
   hps: 64
  }
 }
@@ -344,8 +344,8 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 26418.71821
-  tps: 25218.92006
+  dps: 26418.7182
+  tps: 25218.92005
  }
 }
 dps_results: {
@@ -372,14 +372,14 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 27399.33735
+  dps: 27399.33734
   tps: 26131.51397
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Death'sChoice-47464"
  value: {
-  dps: 26381.04941
+  dps: 26381.0494
   tps: 25177.71563
  }
 }
@@ -393,29 +393,29 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 26576.85225
+  dps: 26576.85224
   tps: 25364.77683
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 26581.66615
+  dps: 26581.66614
   tps: 25370.56985
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Defender'sCode-40257"
  value: {
-  dps: 26418.71821
-  tps: 25218.92006
+  dps: 26418.7182
+  tps: 25218.92005
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 27939.88332
-  tps: 26553.03591
+  dps: 27939.88331
+  tps: 26553.0359
  }
 }
 dps_results: {
@@ -450,28 +450,28 @@ dps_results: {
  key: "TestShadow-AllItems-ElectrosparkHeartstarter-67118"
  value: {
   dps: 26870.51643
-  tps: 25651.44044
+  tps: 25651.44043
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 28068.78268
+  dps: 28068.78267
   tps: 26689.24688
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 28275.21589
+  dps: 28275.21588
   tps: 26857.44522
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 27939.88332
-  tps: 26553.03591
+  dps: 27939.88331
+  tps: 26553.0359
  }
 }
 dps_results: {
@@ -484,7 +484,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 27852.72255
+  dps: 27852.72254
   tps: 26477.4393
  }
 }
@@ -547,7 +547,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-FallofMortality-59500"
  value: {
-  dps: 27399.33735
+  dps: 27399.33734
   tps: 26131.51397
  }
 }
@@ -568,15 +568,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 27235.53583
-  tps: 25986.00637
+  dps: 27235.53582
+  tps: 25986.00636
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 26418.71821
-  tps: 25218.92006
+  dps: 26418.7182
+  tps: 25218.92005
  }
 }
 dps_results: {
@@ -603,7 +603,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 27909.38626
+  dps: 27909.38625
   tps: 26557.86151
  }
 }
@@ -624,7 +624,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-ForgeEmber-37660"
  value: {
-  dps: 26612.70937
+  dps: 26612.70936
   tps: 25387.80655
  }
 }
@@ -632,7 +632,7 @@ dps_results: {
  key: "TestShadow-AllItems-ForlornShadowspiritDiamond"
  value: {
   dps: 27930.38076
-  tps: 26520.81911
+  tps: 26520.8191
  }
 }
 dps_results: {
@@ -652,7 +652,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 26794.43148
+  dps: 26794.43147
   tps: 25567.9481
  }
 }
@@ -666,7 +666,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-FuturesightRune-38763"
  value: {
-  dps: 26638.81472
+  dps: 26638.81471
   tps: 25409.56357
  }
 }
@@ -687,7 +687,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-GarbofFaith"
  value: {
-  dps: 17550.1335
+  dps: 17550.13349
   tps: 16806.09575
  }
 }
@@ -715,7 +715,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 26875.97619
+  dps: 26875.97618
   tps: 25633.05171
  }
 }
@@ -729,8 +729,8 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 26481.73241
-  tps: 25265.47542
+  dps: 26481.7324
+  tps: 25265.47541
  }
 }
 dps_results: {
@@ -750,7 +750,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-HarmlightToken-63839"
  value: {
-  dps: 27208.5136
+  dps: 27208.51359
   tps: 25960.86464
  }
 }
@@ -792,7 +792,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-HeartofSolace-55868"
  value: {
-  dps: 26867.24163
+  dps: 26867.24162
   tps: 25639.93548
  }
 }
@@ -842,14 +842,14 @@ dps_results: {
  key: "TestShadow-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
   dps: 26853.48411
-  tps: 25646.60473
+  tps: 25646.60472
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 27939.88332
-  tps: 26553.03591
+  dps: 27939.88331
+  tps: 26553.0359
  }
 }
 dps_results: {
@@ -862,43 +862,43 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 27852.72255
+  dps: 27852.72254
   tps: 26477.4393
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 26901.73474
-  tps: 25701.93659
+  dps: 26901.73473
+  tps: 25701.93658
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 26901.73474
-  tps: 25701.93659
+  dps: 26901.73473
+  tps: 25701.93658
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 26752.21223
+  dps: 26752.21222
   tps: 25542.75274
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 26801.72482
+  dps: 26801.72481
   tps: 25592.26533
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-IncisorFragment-37723"
  value: {
-  dps: 26418.71821
-  tps: 25218.92006
+  dps: 26418.7182
+  tps: 25218.92005
  }
 }
 dps_results: {
@@ -918,7 +918,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 27260.05942
+  dps: 27260.05941
   tps: 26000.01901
  }
 }
@@ -947,7 +947,7 @@ dps_results: {
  key: "TestShadow-AllItems-JujuofNimbleness-63840"
  value: {
   dps: 26702.94123
-  tps: 25502.92335
+  tps: 25502.92334
  }
 }
 dps_results: {
@@ -981,7 +981,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 26721.36146
+  dps: 26721.36145
   tps: 25500.26469
  }
 }
@@ -1002,8 +1002,8 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 26418.71821
-  tps: 25218.92006
+  dps: 26418.7182
+  tps: 25218.92005
  }
 }
 dps_results: {
@@ -1087,7 +1087,7 @@ dps_results: {
  key: "TestShadow-AllItems-MarkofKhardros-56458"
  value: {
   dps: 27345.89657
-  tps: 26145.87869
+  tps: 26145.87868
  }
 }
 dps_results: {
@@ -1100,8 +1100,8 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 26479.51307
-  tps: 25262.70103
+  dps: 26479.51306
+  tps: 25262.70102
  }
 }
 dps_results: {
@@ -1156,14 +1156,14 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 26775.78085
-  tps: 25548.47896
+  dps: 26775.78084
+  tps: 25548.47895
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 27852.72255
+  dps: 27852.72254
   tps: 26477.4393
  }
 }
@@ -1177,7 +1177,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 26381.92342
+  dps: 26381.92341
   tps: 25177.71563
  }
 }
@@ -1282,7 +1282,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 26895.08665
+  dps: 26895.08664
   tps: 25664.02441
  }
 }
@@ -1311,7 +1311,7 @@ dps_results: {
  key: "TestShadow-AllItems-RevitalizingSkyflareDiamond"
  value: {
   dps: 27824.21156
-  tps: 26472.68345
+  tps: 26472.68344
  }
 }
 dps_results: {
@@ -1331,8 +1331,8 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 26418.71821
-  tps: 25218.92006
+  dps: 26418.7182
+  tps: 25218.92005
  }
 }
 dps_results: {
@@ -1359,22 +1359,22 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-SeaStar-55256"
  value: {
-  dps: 26888.50312
+  dps: 26888.50311
   tps: 25642.52478
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SeaStar-56290"
  value: {
-  dps: 27293.80775
-  tps: 26007.98769
+  dps: 27293.80774
+  tps: 26007.98768
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 26418.71821
-  tps: 25218.92006
+  dps: 26418.7182
+  tps: 25218.92005
  }
 }
 dps_results: {
@@ -1408,14 +1408,14 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 27227.44615
-  tps: 26027.648
+  dps: 27227.44614
+  tps: 26027.64799
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 27333.351
+  dps: 27333.35099
   tps: 26133.55284
  }
 }
@@ -1444,7 +1444,7 @@ dps_results: {
  key: "TestShadow-AllItems-Sorrowsong-56400"
  value: {
   dps: 27462.14567
-  tps: 26209.37534
+  tps: 26209.37533
  }
 }
 dps_results: {
@@ -1485,8 +1485,8 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 26418.71821
-  tps: 25218.92006
+  dps: 26418.7182
+  tps: 25218.92005
  }
 }
 dps_results: {
@@ -1520,7 +1520,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 27852.72255
+  dps: 27852.72254
   tps: 26477.4393
  }
 }
@@ -1556,7 +1556,7 @@ dps_results: {
  key: "TestShadow-AllItems-TalismanofTrollDivinity-37734"
  value: {
   dps: 26426.12506
-  tps: 25218.92006
+  tps: 25218.92005
  }
 }
 dps_results: {
@@ -1569,7 +1569,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-TearofBlood-55819"
  value: {
-  dps: 26987.02885
+  dps: 26987.02884
   tps: 25734.28006
  }
 }
@@ -1583,7 +1583,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 26748.95718
+  dps: 26748.95717
   tps: 25500.87126
  }
 }
@@ -1597,7 +1597,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 27678.52112
+  dps: 27678.52111
   tps: 26390.29825
  }
 }
@@ -1618,8 +1618,8 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 28303.29961
-  tps: 27056.97551
+  dps: 28303.2996
+  tps: 27056.9755
  }
 }
 dps_results: {
@@ -1647,14 +1647,14 @@ dps_results: {
  key: "TestShadow-AllItems-Tia'sGrace-55874"
  value: {
   dps: 26766.21439
-  tps: 25555.28562
+  tps: 25555.28561
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Tia'sGrace-56394"
  value: {
   dps: 26815.65808
-  tps: 25604.72931
+  tps: 25604.7293
  }
 }
 dps_results: {
@@ -1710,7 +1710,7 @@ dps_results: {
  key: "TestShadow-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
   dps: 27864.68175
-  tps: 26588.61009
+  tps: 26588.61008
  }
 }
 dps_results: {
@@ -1723,22 +1723,22 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 26418.71821
-  tps: 25218.92006
+  dps: 26418.7182
+  tps: 25218.92005
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 26901.73474
-  tps: 25701.93659
+  dps: 26901.73473
+  tps: 25701.93658
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 26901.73474
-  tps: 25701.93659
+  dps: 26901.73473
+  tps: 25701.93658
  }
 }
 dps_results: {
@@ -1758,64 +1758,64 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 26418.71821
-  tps: 25218.92006
+  dps: 26418.7182
+  tps: 25218.92005
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 26418.71821
-  tps: 25218.92006
+  dps: 26418.7182
+  tps: 25218.92005
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 26418.71821
-  tps: 25218.92006
+  dps: 26418.7182
+  tps: 25218.92005
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
   dps: 27404.34537
-  tps: 26107.65939
+  tps: 26107.65938
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 26418.71821
-  tps: 25218.92006
+  dps: 26418.7182
+  tps: 25218.92005
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 26418.71821
-  tps: 25218.92006
+  dps: 26418.7182
+  tps: 25218.92005
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 27154.05013
+  dps: 27154.05012
   tps: 25942.45168
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 26853.06248
+  dps: 26853.06247
   tps: 25639.2695
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 26418.71821
-  tps: 25218.92006
+  dps: 26418.7182
+  tps: 25218.92005
  }
 }
 dps_results: {
@@ -1828,8 +1828,8 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 26418.71821
-  tps: 25218.92006
+  dps: 26418.7182
+  tps: 25218.92005
  }
 }
 dps_results: {
@@ -1842,7 +1842,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 27248.09126
+  dps: 27248.09125
   tps: 25977.06931
  }
 }
@@ -1856,7 +1856,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-WingedTalisman-37844"
  value: {
-  dps: 26631.19609
+  dps: 26631.19608
   tps: 25410.51121
  }
 }
@@ -1884,14 +1884,14 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 27121.0064
+  dps: 27121.00639
   tps: 25920.98851
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 27121.0064
+  dps: 27121.00639
   tps: 25920.98851
  }
 }
@@ -1899,7 +1899,7 @@ dps_results: {
  key: "TestShadow-AllItems-Zabra'sRaiment"
  value: {
   dps: 18632.69302
-  tps: 17800.75456
+  tps: 17800.75455
  }
 }
 dps_results: {
@@ -1912,29 +1912,29 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Average-Default"
  value: {
-  dps: 28385.17433
+  dps: 28385.17432
   tps: 27097.12919
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Basic-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 28104.87997
-  tps: 38864.20258
+  dps: 28104.87996
+  tps: 38864.20257
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Basic-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 28104.87997
+  dps: 28104.87996
   tps: 26719.14922
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Basic-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 36536.30534
-  tps: 33671.98555
+  dps: 36536.30533
+  tps: 33671.98554
  }
 }
 dps_results: {
@@ -1954,29 +1954,29 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Basic-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 18216.40047
+  dps: 18216.40046
   tps: 17128.56491
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Basic-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 28104.87997
-  tps: 38864.20258
+  dps: 28104.87996
+  tps: 38864.20257
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Basic-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 28104.87997
+  dps: 28104.87996
   tps: 26719.14922
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Basic-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 36536.30534
-  tps: 33671.98555
+  dps: 36536.30533
+  tps: 33671.98554
  }
 }
 dps_results: {
@@ -1996,7 +1996,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Basic-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 18216.40047
+  dps: 18216.40046
   tps: 17128.56491
  }
 }
@@ -2038,7 +2038,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-Settings-Troll-p1-Basic-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 19124.40219
+  dps: 19124.40218
   tps: 18024.46209
  }
 }

--- a/sim/priest/shadow_word_death.go
+++ b/sim/priest/shadow_word_death.go
@@ -38,7 +38,7 @@ func (priest *Priest) registerShadowWordDeathSpell() {
 			if sim.IsExecutePhase25() {
 				spell.DamageMultiplier *= 3
 			}
-			spell.CalcAndDealDamage(sim, target, priest.ScalingBaseDamage*0.357, spell.OutcomeMagicHitAndCrit)
+			spell.CalcAndDealDamage(sim, target, priest.ClassSpellScaling*0.357, spell.OutcomeMagicHitAndCrit)
 			if sim.IsExecutePhase25() {
 				spell.DamageMultiplier /= 3
 			}
@@ -47,7 +47,7 @@ func (priest *Priest) registerShadowWordDeathSpell() {
 			if sim.IsExecutePhase25() {
 				spell.DamageMultiplier *= 3
 			}
-			result := spell.CalcDamage(sim, target, priest.ScalingBaseDamage*0.357, spell.OutcomeExpectedMagicHitAndCrit)
+			result := spell.CalcDamage(sim, target, priest.ClassSpellScaling*0.357, spell.OutcomeExpectedMagicHitAndCrit)
 			if sim.IsExecutePhase25() {
 				spell.DamageMultiplier /= 3
 			}

--- a/sim/priest/talents.go
+++ b/sim/priest/talents.go
@@ -634,7 +634,7 @@ func (priest *Priest) applyShadowyApparition() {
 		BonusCoefficient: spellScaling,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			baseDamage := priest.ScalingBaseDamage * levelScaling
+			baseDamage := priest.ClassSpellScaling * levelScaling
 
 			// snapshot values on spawn
 			dmgMulti := spell.DamageMultiplier

--- a/sim/priest/vampiric_touch.go
+++ b/sim/priest/vampiric_touch.go
@@ -51,7 +51,7 @@ func (priest *Priest) registerVampiricTouchSpell() {
 			BonusCoefficient: 0.352,
 
 			OnSnapshot: func(sim *core.Simulation, target *core.Unit, dot *core.Dot, _ bool) {
-				dot.Snapshot(target, priest.ScalingBaseDamage*0.101)
+				dot.Snapshot(target, priest.ClassSpellScaling*0.101)
 			},
 
 			OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
@@ -76,7 +76,7 @@ func (priest *Priest) registerVampiricTouchSpell() {
 				dot := spell.Dot(target)
 				return dot.CalcSnapshotDamage(sim, target, dot.OutcomeExpectedMagicSnapshotCrit)
 			} else {
-				baseDamage := priest.ScalingBaseDamage * 0.101
+				baseDamage := priest.ClassSpellScaling * 0.101
 				return spell.CalcPeriodicDamage(sim, target, baseDamage, spell.OutcomeExpectedMagicCrit)
 			}
 		},

--- a/sim/rogue/ambush.go
+++ b/sim/rogue/ambush.go
@@ -7,7 +7,7 @@ import (
 )
 
 func (rogue *Rogue) registerAmbushSpell() {
-	baseDamage := RogueBaseDamageScalar * 0.32699999213
+	baseDamage := rogue.ClassSpellScaling * 0.32699999213
 
 	rogue.Ambush = rogue.RegisterSpell(core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 8676},

--- a/sim/rogue/assassination/TestAssassination.results
+++ b/sim/rogue/assassination/TestAssassination.results
@@ -40,2181 +40,2181 @@ character_stats_results: {
 dps_results: {
  key: "TestAssassination-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 28928.02547
-  tps: 20538.89809
+  dps: 28928.02112
+  tps: 20538.895
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 27342.11226
-  tps: 19412.8997
+  dps: 27342.10796
+  tps: 19412.89665
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 27505.72529
-  tps: 19529.06495
+  dps: 27505.72095
+  tps: 19529.06188
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 26693.43235
-  tps: 18952.33697
+  dps: 26693.42827
+  tps: 18952.33407
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 28402.67091
-  tps: 20165.89634
+  dps: 28402.66659
+  tps: 20165.89328
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 28402.67091
-  tps: 20165.89634
+  dps: 28402.66659
+  tps: 20165.89328
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 26967.92009
-  tps: 19147.22327
+  dps: 26967.916
+  tps: 19147.22036
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
   hps: 82.64541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
   hps: 82.64541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 28427.79219
-  tps: 20183.73245
+  dps: 28427.78788
+  tps: 20183.7294
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 27085.9626
-  tps: 19231.03345
+  dps: 27085.95847
+  tps: 19231.03051
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 27161.17754
-  tps: 19284.43606
+  dps: 27161.17339
+  tps: 19284.43311
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BindingPromise-67037"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 19597.93347
-  tps: 13914.53276
+  dps: 19597.92983
+  tps: 13914.53018
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 27900.07718
-  tps: 19809.0548
+  dps: 27900.07304
+  tps: 19809.05186
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 27053.65065
-  tps: 19208.09196
+  dps: 27053.6465
+  tps: 19208.08902
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 27105.06685
-  tps: 19244.59746
+  dps: 27105.0627
+  tps: 19244.59451
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 28281.29251
-  tps: 20079.71768
+  dps: 28281.28842
+  tps: 20079.71478
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 27193.89137
-  tps: 19307.66287
+  dps: 27193.88729
+  tps: 19307.65998
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 27060.76216
-  tps: 19213.14113
+  dps: 27060.75802
+  tps: 19213.1382
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 27920.04224
-  tps: 19823.22999
+  dps: 27920.03814
+  tps: 19823.22708
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 27156.28857
-  tps: 19280.96488
+  dps: 27156.28449
+  tps: 19280.96199
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BonescytheBattlegear"
  value: {
-  dps: 20168.89343
-  tps: 14319.91434
+  dps: 20168.88975
+  tps: 14319.91172
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BottledLightning-66879"
  value: {
-  dps: 26806.18803
-  tps: 19032.3935
+  dps: 26806.18393
+  tps: 19032.39059
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 28402.67091
-  tps: 19762.57842
+  dps: 28402.66659
+  tps: 19762.57542
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 28402.67091
-  tps: 19762.57842
+  dps: 28402.66659
+  tps: 19762.57542
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 28723.76868
-  tps: 20393.87576
+  dps: 28723.76432
+  tps: 20393.87267
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 28783.20951
-  tps: 20436.07876
+  dps: 28783.20516
+  tps: 20436.07566
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 28751.34984
-  tps: 20413.45838
+  dps: 28751.34549
+  tps: 20413.45529
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
   hps: 64
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CrushingWeight-59506"
  value: {
-  dps: 27775.14906
-  tps: 19720.35583
+  dps: 27775.14487
+  tps: 19720.35286
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CrushingWeight-65118"
  value: {
-  dps: 27922.87026
-  tps: 19825.23789
+  dps: 27922.86604
+  tps: 19825.23489
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 26836.93935
-  tps: 19054.22694
+  dps: 26836.93523
+  tps: 19054.22402
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 26800.04584
-  tps: 19028.03255
+  dps: 26800.04173
+  tps: 19028.02963
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 27033.88494
-  tps: 19194.05831
+  dps: 27033.88086
+  tps: 19194.05541
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 27657.87911
-  tps: 19637.09417
+  dps: 27657.87501
+  tps: 19637.09126
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 28413.00975
-  tps: 20173.23692
+  dps: 28413.00564
+  tps: 20173.23401
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 27146.05548
-  tps: 19273.69939
+  dps: 27146.05132
+  tps: 19273.69644
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Death'sChoice-47464"
  value: {
-  dps: 27716.67809
-  tps: 19678.84144
+  dps: 27716.67401
+  tps: 19678.83855
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 26810.02697
-  tps: 19035.11915
+  dps: 26810.02287
+  tps: 19035.11624
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 27338.92791
-  tps: 19410.63882
+  dps: 27338.92379
+  tps: 19410.63589
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 27504.5339
-  tps: 19528.21907
+  dps: 27504.52975
+  tps: 19528.21612
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Defender'sCode-40257"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 28458.23279
-  tps: 20205.34528
+  dps: 28458.22848
+  tps: 20205.34222
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 28431.28259
-  tps: 20186.21064
+  dps: 28431.27829
+  tps: 20186.20758
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 26860.194
-  tps: 19070.73774
+  dps: 26860.18987
+  tps: 19070.73481
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 26858.01965
-  tps: 19069.19395
+  dps: 26858.01555
+  tps: 19069.19104
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 28402.67091
-  tps: 20165.89634
+  dps: 28402.66659
+  tps: 20165.89328
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 28402.67091
-  tps: 20165.89634
+  dps: 28402.66659
+  tps: 20165.89328
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 28402.67091
-  tps: 20165.89634
+  dps: 28402.66659
+  tps: 20165.89328
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 28458.23279
-  tps: 20205.34528
+  dps: 28458.22848
+  tps: 20205.34222
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 28427.79219
-  tps: 20183.73245
+  dps: 28427.78788
+  tps: 20183.7294
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 28422.29465
-  tps: 20179.8292
+  dps: 28422.29035
+  tps: 20179.82615
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 26870.67702
-  tps: 19078.18068
+  dps: 26870.67291
+  tps: 19078.17776
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 28333.69202
-  tps: 20116.92133
+  dps: 28333.68787
+  tps: 20116.91839
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 28527.99093
-  tps: 20254.87356
+  dps: 28527.98677
+  tps: 20254.8706
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 28402.67091
-  tps: 20165.89634
+  dps: 28402.66659
+  tps: 20165.89328
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 28402.67091
-  tps: 20165.89634
+  dps: 28402.66659
+  tps: 20165.89328
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 26772.89199
-  tps: 19008.75331
+  dps: 26772.88788
+  tps: 19008.7504
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 26807.66825
-  tps: 19033.44446
+  dps: 26807.66415
+  tps: 19033.44154
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FallofMortality-59500"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FallofMortality-65124"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 29021.60328
-  tps: 20605.33833
+  dps: 29021.59892
+  tps: 20605.33523
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 27613.27452
-  tps: 19605.42491
+  dps: 27613.27036
+  tps: 19605.42196
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 28493.40704
-  tps: 20230.319
+  dps: 28493.40271
+  tps: 20230.31592
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForgeEmber-37660"
  value: {
-  dps: 26761.17319
-  tps: 19000.43297
+  dps: 26761.1691
+  tps: 19000.43006
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 28402.67091
-  tps: 20165.89634
+  dps: 28402.66659
+  tps: 20165.89328
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 28402.67091
-  tps: 20165.89634
+  dps: 28402.66659
+  tps: 20165.89328
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 28402.67091
-  tps: 20165.89634
+  dps: 28402.66659
+  tps: 20165.89328
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 27736.25743
-  tps: 19692.74277
+  dps: 27736.25329
+  tps: 19692.73984
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 27110.6519
-  tps: 19248.56285
+  dps: 27110.64782
+  tps: 19248.55996
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuturesightRune-38763"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GaleofShadows-56138"
  value: {
-  dps: 26917.75799
-  tps: 19111.60818
+  dps: 26917.75385
+  tps: 19111.60524
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GaleofShadows-56462"
  value: {
-  dps: 27102.07091
-  tps: 19242.47034
+  dps: 27102.06673
+  tps: 19242.46738
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GearDetector-61462"
  value: {
-  dps: 27688.16995
-  tps: 19658.60066
+  dps: 27688.16579
+  tps: 19658.59771
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Gladiator'sVestments"
  value: {
-  dps: 22944.8868
-  tps: 16290.86962
+  dps: 22944.88314
+  tps: 16290.86703
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 26857.90983
-  tps: 19069.11598
+  dps: 26857.90571
+  tps: 19069.11305
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 27619.49371
-  tps: 19609.84054
+  dps: 27619.4896
+  tps: 19609.83761
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 27942.09901
-  tps: 19838.8903
+  dps: 27942.0949
+  tps: 19838.88738
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HarmlightToken-63839"
  value: {
-  dps: 26781.68505
-  tps: 19014.99639
+  dps: 26781.68098
+  tps: 19014.99349
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 27354.55761
-  tps: 19421.7359
+  dps: 27354.55348
+  tps: 19421.73297
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 27287.20246
-  tps: 19373.91375
+  dps: 27287.19824
+  tps: 19373.91075
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 27259.52295
-  tps: 19354.2613
+  dps: 27259.51874
+  tps: 19354.2583
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofRage-59224"
  value: {
-  dps: 27799.13628
-  tps: 19737.38676
+  dps: 27799.13212
+  tps: 19737.3838
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofRage-65072"
  value: {
-  dps: 27956.36464
-  tps: 19849.0189
+  dps: 27956.36046
+  tps: 19849.01593
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofSolace-55868"
  value: {
-  dps: 26917.75799
-  tps: 19111.60818
+  dps: 26917.75385
+  tps: 19111.60524
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofSolace-56393"
  value: {
-  dps: 27690.59901
-  tps: 19660.3253
+  dps: 27690.59484
+  tps: 19660.32233
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofThunder-55845"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofThunder-56370"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 27734.54592
-  tps: 19691.5276
+  dps: 27734.54179
+  tps: 19691.52467
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Heartpierce-49982"
  value: {
-  dps: 28928.02547
-  tps: 20538.89809
+  dps: 28928.02112
+  tps: 20538.895
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Heartpierce-50641"
  value: {
-  dps: 28928.02547
-  tps: 20538.89809
+  dps: 28928.02112
+  tps: 20538.895
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 28458.23279
-  tps: 20205.34528
+  dps: 28458.22848
+  tps: 20205.34222
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 28427.79219
-  tps: 20183.73245
+  dps: 28427.78788
+  tps: 20183.7294
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 28422.29465
-  tps: 20179.8292
+  dps: 28422.29035
+  tps: 20179.82615
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 27734.78862
-  tps: 19691.69992
+  dps: 27734.78445
+  tps: 19691.69696
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 27734.78862
-  tps: 19691.69992
+  dps: 27734.78445
+  tps: 19691.69696
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 27053.65065
-  tps: 19208.09196
+  dps: 27053.6465
+  tps: 19208.08902
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 27105.06685
-  tps: 19244.59746
+  dps: 27105.0627
+  tps: 19244.59451
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IncisorFragment-37723"
  value: {
-  dps: 27024.94299
-  tps: 19187.70952
+  dps: 27024.9389
+  tps: 19187.70662
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 28402.67091
-  tps: 20165.89634
+  dps: 28402.66659
+  tps: 20165.89328
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 26963.28278
-  tps: 19143.93077
+  dps: 26963.27865
+  tps: 19143.92784
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 28444.53364
-  tps: 20195.61888
+  dps: 28444.52931
+  tps: 20195.61581
   hps: 65.01959
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 27900.07718
-  tps: 19809.0548
+  dps: 27900.07304
+  tps: 19809.05186
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 28354.9863
-  tps: 20132.04027
+  dps: 28354.98202
+  tps: 20132.03724
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 28930.96614
-  tps: 20540.98596
+  dps: 28930.96179
+  tps: 20540.98287
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 27074.64704
-  tps: 19222.9994
+  dps: 27074.64291
+  tps: 19222.99647
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 27074.64704
-  tps: 19222.9994
+  dps: 27074.64291
+  tps: 19222.99647
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 26794.58904
-  tps: 19024.15822
+  dps: 26794.58493
+  tps: 19024.1553
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-LeadenDespair-55816"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-LeadenDespair-56347"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 28221.6881
-  tps: 20037.39855
+  dps: 28221.68392
+  tps: 20037.39558
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 28338.57994
-  tps: 20120.39176
+  dps: 28338.57576
+  tps: 20120.38879
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 28077.36746
-  tps: 19934.9309
+  dps: 28077.36311
+  tps: 19934.92781
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 27325.55885
-  tps: 19401.14679
+  dps: 27325.5547
+  tps: 19401.14384
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 27474.86264
-  tps: 19507.15247
+  dps: 27474.85846
+  tps: 19507.1495
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 27455.43792
-  tps: 19493.36092
+  dps: 27455.43377
+  tps: 19493.35798
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 27560.36492
-  tps: 19567.85909
+  dps: 27560.36076
+  tps: 19567.85614
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 26942.32838
-  tps: 19129.05315
+  dps: 26942.32424
+  tps: 19129.05021
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 27483.24157
-  tps: 19513.10151
+  dps: 27483.23732
+  tps: 19513.09849
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 27960.28826
-  tps: 19851.80467
+  dps: 27960.28393
+  tps: 19851.80159
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 27161.15725
-  tps: 19284.42165
+  dps: 27161.15309
+  tps: 19284.41869
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 27161.15725
-  tps: 19284.42165
+  dps: 27161.15309
+  tps: 19284.41869
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 27290.95154
-  tps: 19376.5756
+  dps: 27290.94736
+  tps: 19376.57262
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 26735.91804
-  tps: 18982.50181
+  dps: 26735.91397
+  tps: 18982.49892
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 27221.90841
-  tps: 19327.55497
+  dps: 27221.90428
+  tps: 19327.55204
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 28422.29465
-  tps: 20179.8292
+  dps: 28422.29035
+  tps: 20179.82615
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 28427.79219
-  tps: 20183.73245
+  dps: 28427.78788
+  tps: 20183.7294
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 27004.66881
-  tps: 19173.31486
+  dps: 27004.66468
+  tps: 19173.31192
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 27297.82627
-  tps: 19381.45665
+  dps: 27297.82208
+  tps: 19381.45368
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 28402.67091
-  tps: 20165.89634
+  dps: 28402.66659
+  tps: 20165.89328
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 28402.67091
-  tps: 20165.89634
+  dps: 28402.66659
+  tps: 20165.89328
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 28402.67091
-  tps: 20165.89634
+  dps: 28402.66659
+  tps: 20165.89328
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 28555.47181
-  tps: 20274.38499
+  dps: 28555.46758
+  tps: 20274.38198
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Rainsong-55854"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Rainsong-56377"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 26738.06225
-  tps: 18984.0242
+  dps: 26738.05817
+  tps: 18984.0213
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 26756.8659
-  tps: 18997.37479
+  dps: 26756.86182
+  tps: 18997.37189
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 28812.65359
-  tps: 20456.98405
+  dps: 28812.64923
+  tps: 20456.98095
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 28807.3661
-  tps: 20453.22993
+  dps: 28807.36175
+  tps: 20453.22684
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 28723.76868
-  tps: 20393.87576
+  dps: 28723.76432
+  tps: 20393.87267
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 28402.67091
-  tps: 20165.89634
+  dps: 28402.66659
+  tps: 20165.89328
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 27822.31909
-  tps: 19753.84656
+  dps: 27822.3148
+  tps: 19753.8435
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 28044.79319
-  tps: 19911.80317
+  dps: 28044.78886
+  tps: 19911.80009
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 27923.53233
-  tps: 19825.70796
+  dps: 27923.52817
+  tps: 19825.705
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SeaStar-55256"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SeaStar-56290"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 21697.49606
-  tps: 15405.2222
+  dps: 21697.49241
+  tps: 15405.21961
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ShieldedSkyflareDiamond"
  value: {
-  dps: 28402.67091
-  tps: 20165.89634
+  dps: 28402.66659
+  tps: 20165.89328
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 27428.03386
-  tps: 19473.90404
+  dps: 27428.0297
+  tps: 19473.90108
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 28120.0058
-  tps: 19965.20412
+  dps: 28120.00161
+  tps: 19965.20114
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 28297.84662
-  tps: 20091.4711
+  dps: 28297.84241
+  tps: 20091.46811
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Slayer'sArmor"
  value: {
-  dps: 15134.7174
-  tps: 10745.64936
+  dps: 15134.71424
+  tps: 10745.64711
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Sorrowsong-55879"
  value: {
-  dps: 27053.65065
-  tps: 19208.09196
+  dps: 27053.6465
+  tps: 19208.08902
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Sorrowsong-56400"
  value: {
-  dps: 27105.06685
-  tps: 19244.59746
+  dps: 27105.0627
+  tps: 19244.59451
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 27584.81965
-  tps: 19585.22195
+  dps: 27584.81536
+  tps: 19585.2189
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SoulCasket-58183"
  value: {
-  dps: 27161.15725
-  tps: 19284.42165
+  dps: 27161.15309
+  tps: 19284.41869
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SoulPreserver-37111"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SouloftheDead-40382"
  value: {
-  dps: 26807.94851
-  tps: 19033.64344
+  dps: 26807.9444
+  tps: 19033.64052
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SparkofLife-37657"
  value: {
-  dps: 26699.66872
-  tps: 18956.76479
+  dps: 26699.66461
+  tps: 18956.76187
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 27017.52243
-  tps: 19182.44092
+  dps: 27017.51828
+  tps: 19182.43798
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 26910.02402
-  tps: 19106.11705
+  dps: 26910.0199
+  tps: 19106.11413
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-StumpofTime-62465"
  value: {
-  dps: 27495.45825
-  tps: 19521.77536
+  dps: 27495.4539
+  tps: 19521.77227
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-StumpofTime-62470"
  value: {
-  dps: 27495.45825
-  tps: 19521.77536
+  dps: 27495.4539
+  tps: 19521.77227
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 28427.79219
-  tps: 20183.73245
+  dps: 28427.78788
+  tps: 20183.7294
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 28422.29465
-  tps: 20179.8292
+  dps: 28422.29035
+  tps: 20179.82615
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 28413.49903
-  tps: 20173.58431
+  dps: 28413.49472
+  tps: 20173.58125
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 26926.69113
-  tps: 19117.9507
+  dps: 26926.687
+  tps: 19117.94777
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 27357.42899
-  tps: 19423.77459
+  dps: 27357.42483
+  tps: 19423.77163
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TearofBlood-55819"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TearofBlood-56351"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 26996.00218
-  tps: 19167.16155
+  dps: 26995.99805
+  tps: 19167.15861
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 27105.06685
-  tps: 19244.59746
+  dps: 27105.0627
+  tps: 19244.59451
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 20022.45744
-  tps: 14215.94478
+  dps: 20022.45388
+  tps: 14215.94225
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 27185.30956
-  tps: 19301.56979
+  dps: 27185.30539
+  tps: 19301.56683
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 27274.7613
-  tps: 19365.08053
+  dps: 27274.75711
+  tps: 19365.07755
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 28540.73656
-  tps: 20263.92296
+  dps: 28540.73223
+  tps: 20263.91988
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 28201.87416
-  tps: 20023.33066
+  dps: 28201.86998
+  tps: 20023.32769
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 28409.51282
-  tps: 20170.7541
+  dps: 28409.50864
+  tps: 20170.75113
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 27710.81674
-  tps: 19674.67989
+  dps: 27710.81238
+  tps: 19674.67679
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 27702.22774
-  tps: 19668.58169
+  dps: 27702.22337
+  tps: 19668.57859
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 28402.67091
-  tps: 20165.89634
+  dps: 28402.66659
+  tps: 20165.89328
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 28402.67091
-  tps: 20165.89634
+  dps: 28402.66659
+  tps: 20165.89328
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 26696.59533
-  tps: 18954.58268
+  dps: 26696.59124
+  tps: 18954.57978
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 28402.67091
-  tps: 20165.89634
+  dps: 28402.66659
+  tps: 20165.89328
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 28402.67091
-  tps: 20165.89634
+  dps: 28402.66659
+  tps: 20165.89328
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 26690.05755
-  tps: 18949.94086
+  dps: 26690.05345
+  tps: 18949.93795
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 20694.9505
-  tps: 14693.41486
+  dps: 20694.94684
+  tps: 14693.41226
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-UnheededWarning-59520"
  value: {
-  dps: 28435.68557
-  tps: 20189.33675
+  dps: 28435.68146
+  tps: 20189.33384
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 28614.76957
-  tps: 20316.48639
+  dps: 28614.76537
+  tps: 20316.48341
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 28614.76957
-  tps: 20316.48639
+  dps: 28614.76537
+  tps: 20316.48341
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 20282.7532
-  tps: 14400.75477
+  dps: 20282.74955
+  tps: 14400.75218
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 28089.02358
-  tps: 19943.20674
+  dps: 28089.01948
+  tps: 19943.20383
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 27223.69022
-  tps: 19328.82005
+  dps: 27223.68614
+  tps: 19328.81716
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 27613.48478
-  tps: 19605.57419
+  dps: 27613.48041
+  tps: 19605.57109
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 27001.94839
-  tps: 19171.38336
+  dps: 27001.94421
+  tps: 19171.38039
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 27134.11387
-  tps: 19265.22085
+  dps: 27134.10972
+  tps: 19265.2179
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 27170.48363
-  tps: 19291.04337
+  dps: 27170.47944
+  tps: 19291.04041
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 27190.76052
-  tps: 19305.43997
+  dps: 27190.75635
+  tps: 19305.43701
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 28001.72836
-  tps: 19881.22714
+  dps: 28001.72427
+  tps: 19881.22423
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 27203.72957
-  tps: 19314.648
+  dps: 27203.7255
+  tps: 19314.6451
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WindDancer'sRegalia"
  value: {
-  dps: 26220.49111
-  tps: 18616.54869
+  dps: 26220.48699
+  tps: 18616.54576
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WingedTalisman-37844"
  value: {
-  dps: 26661.01784
-  tps: 18929.32267
+  dps: 26661.01377
+  tps: 18929.31977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 26847.92963
-  tps: 19062.03004
+  dps: 26847.9255
+  tps: 19062.0271
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 27015.63088
-  tps: 19181.09793
+  dps: 27015.62671
+  tps: 19181.09496
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 27002.23445
-  tps: 19171.58646
+  dps: 27002.23031
+  tps: 19171.58352
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 27018.94184
-  tps: 19183.44871
+  dps: 27018.9377
+  tps: 19183.44577
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 27018.94184
-  tps: 19183.44871
+  dps: 27018.9377
+  tps: 19183.44577
  }
 }
 dps_results: {
  key: "TestAssassination-Average-Default"
  value: {
-  dps: 29048.28655
-  tps: 20624.28345
+  dps: 29048.28218
+  tps: 20624.28035
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination_test-Assassination-mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 28928.02547
-  tps: 20538.89809
+  dps: 28928.02112
+  tps: 20538.895
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination_test-Assassination-mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 28928.02547
-  tps: 20538.89809
+  dps: 28928.02112
+  tps: 20538.895
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination_test-Assassination-mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 38256.63627
-  tps: 27162.21175
+  dps: 38256.63083
+  tps: 27162.20789
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination_test-Assassination-mutilate-NoBuffs-LongMultiTarget"
  value: {
-  dps: 17462.04502
-  tps: 12398.05196
+  dps: 17462.04145
+  tps: 12398.04943
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination_test-Assassination-mutilate-NoBuffs-LongSingleTarget"
  value: {
-  dps: 17462.04502
-  tps: 12398.05196
+  dps: 17462.04145
+  tps: 12398.04943
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination_test-Assassination-mutilate-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 19273.17067
-  tps: 13683.95118
+  dps: 19273.16688
+  tps: 13683.94849
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination_test-MH Deadly OH Deadly-mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21079.1346
-  tps: 14966.18556
+  dps: 21079.13345
+  tps: 14966.18475
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination_test-MH Deadly OH Deadly-mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 21079.1346
-  tps: 14966.18556
+  dps: 21079.13345
+  tps: 14966.18475
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination_test-MH Deadly OH Deadly-mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 27833.87085
-  tps: 19762.0483
+  dps: 27833.8694
+  tps: 19762.04727
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination_test-MH Deadly OH Deadly-mutilate-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12783.23721
-  tps: 9076.09842
+  dps: 12783.23626
+  tps: 9076.09774
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination_test-MH Deadly OH Deadly-mutilate-NoBuffs-LongSingleTarget"
  value: {
-  dps: 12783.23721
-  tps: 9076.09842
+  dps: 12783.23626
+  tps: 9076.09774
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination_test-MH Deadly OH Deadly-mutilate-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 14456.69203
-  tps: 10264.25134
+  dps: 14456.69098
+  tps: 10264.2506
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Deadly-mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 27539.26274
-  tps: 19552.87654
+  dps: 27539.25893
+  tps: 19552.87384
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Deadly-mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 27539.26274
-  tps: 19552.87654
+  dps: 27539.25893
+  tps: 19552.87384
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Deadly-mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 36183.13714
-  tps: 25690.02737
+  dps: 36183.13242
+  tps: 25690.02402
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Deadly-mutilate-NoBuffs-LongMultiTarget"
  value: {
-  dps: 16610.98213
-  tps: 11793.79731
+  dps: 16610.97901
+  tps: 11793.7951
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Deadly-mutilate-NoBuffs-LongSingleTarget"
  value: {
-  dps: 16610.98213
-  tps: 11793.79731
+  dps: 16610.97901
+  tps: 11793.7951
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Deadly-mutilate-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 18130.62102
-  tps: 12872.74092
+  dps: 18130.61779
+  tps: 12872.73863
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Instant-mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 16319.60949
-  tps: 11586.92274
+  dps: 16319.60711
+  tps: 11586.92105
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Instant-mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 16319.60949
-  tps: 11586.92274
+  dps: 16319.60711
+  tps: 11586.92105
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Instant-mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 20549.19754
-  tps: 14589.93025
+  dps: 20549.1948
+  tps: 14589.92831
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Instant-mutilate-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9584.6524
-  tps: 6805.1032
+  dps: 9584.65047
+  tps: 6805.10183
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Instant-mutilate-NoBuffs-LongSingleTarget"
  value: {
-  dps: 9584.6524
-  tps: 6805.1032
+  dps: 9584.65047
+  tps: 6805.10183
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Instant-mutilate-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 10660.25749
-  tps: 7568.78282
+  dps: 10660.25544
+  tps: 7568.78136
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination_test-Assassination-mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 29224.00418
-  tps: 20749.04297
+  dps: 29223.99983
+  tps: 20749.03988
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination_test-Assassination-mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 29224.00418
-  tps: 20749.04297
+  dps: 29223.99983
+  tps: 20749.03988
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination_test-Assassination-mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 38885.88144
-  tps: 27608.97582
+  dps: 38885.87601
+  tps: 27608.97196
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination_test-Assassination-mutilate-NoBuffs-LongMultiTarget"
  value: {
-  dps: 17651.36809
-  tps: 12532.47135
+  dps: 17651.36453
+  tps: 12532.46882
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination_test-Assassination-mutilate-NoBuffs-LongSingleTarget"
  value: {
-  dps: 17651.36809
-  tps: 12532.47135
+  dps: 17651.36453
+  tps: 12532.46882
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination_test-Assassination-mutilate-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 19620.24643
-  tps: 13930.37496
+  dps: 19620.24263
+  tps: 13930.37227
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Deadly OH Deadly-mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21291.51482
-  tps: 15116.97552
+  dps: 21291.51367
+  tps: 15116.97471
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Deadly OH Deadly-mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 21291.51482
-  tps: 15116.97552
+  dps: 21291.51367
+  tps: 15116.97471
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Deadly OH Deadly-mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 28298.83434
-  tps: 20092.17238
+  dps: 28298.83288
+  tps: 20092.17135
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Deadly OH Deadly-mutilate-NoBuffs-LongMultiTarget"
  value: {
-  dps: 12920.62189
-  tps: 9173.64155
+  dps: 12920.62094
+  tps: 9173.64087
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Deadly OH Deadly-mutilate-NoBuffs-LongSingleTarget"
  value: {
-  dps: 12920.62189
-  tps: 9173.64155
+  dps: 12920.62094
+  tps: 9173.64087
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Deadly OH Deadly-mutilate-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 14721.08335
-  tps: 10451.96918
+  dps: 14721.0823
+  tps: 10451.96843
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Deadly-mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 27818.90729
-  tps: 19751.42417
+  dps: 27818.90348
+  tps: 19751.42147
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Deadly-mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 27818.90729
-  tps: 19751.42417
+  dps: 27818.90348
+  tps: 19751.42147
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Deadly-mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 36770.30164
-  tps: 26106.91417
+  dps: 36770.29692
+  tps: 26106.91081
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Deadly-mutilate-NoBuffs-LongMultiTarget"
  value: {
-  dps: 16786.93782
-  tps: 11918.72585
+  dps: 16786.93471
+  tps: 11918.72364
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Deadly-mutilate-NoBuffs-LongSingleTarget"
  value: {
-  dps: 16786.93782
-  tps: 11918.72585
+  dps: 16786.93471
+  tps: 11918.72364
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Deadly-mutilate-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 18450.16414
-  tps: 13099.61654
+  dps: 18450.16092
+  tps: 13099.61425
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Instant-mutilate-FullBuffs-LongMultiTarget"
  value: {
-  dps: 16476.7674
-  tps: 11698.50485
+  dps: 16476.76502
+  tps: 11698.50316
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Instant-mutilate-FullBuffs-LongSingleTarget"
  value: {
-  dps: 16476.7674
-  tps: 11698.50485
+  dps: 16476.76502
+  tps: 11698.50316
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Instant-mutilate-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 20889.67322
-  tps: 14831.66798
+  dps: 20889.67048
+  tps: 14831.66604
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Instant-mutilate-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9689.29432
-  tps: 6879.39897
+  dps: 9689.2924
+  tps: 6879.3976
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Instant-mutilate-NoBuffs-LongSingleTarget"
  value: {
-  dps: 9689.29432
-  tps: 6879.39897
+  dps: 9689.2924
+  tps: 6879.3976
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Instant-mutilate-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 10858.47843
-  tps: 7709.51968
+  dps: 10858.47638
+  tps: 7709.51823
  }
 }
 dps_results: {
  key: "TestAssassination-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 19069.62929
-  tps: 13539.4368
+  dps: 19069.62661
+  tps: 13539.43489
  }
 }

--- a/sim/rogue/assassination/mutilate.go
+++ b/sim/rogue/assassination/mutilate.go
@@ -17,7 +17,7 @@ func (sinRogue *AssassinationRogue) newMutilateHitSpell(isMH bool) *core.Spell {
 		actionID = core.ActionID{SpellID: MutilateSpellID, Tag: 2}
 		procMask = core.ProcMaskMeleeOHSpecial
 	}
-	mutBaseDamage := rogue.RogueBaseDamageScalar * 0.17900000513
+	mutBaseDamage := sinRogue.ClassSpellScaling * 0.17900000513
 	t11Bonus := core.TernaryFloat64(sinRogue.HasSetBonus(rogue.Tier11, 2), 5*core.CritRatingPerCritChance, 0)
 
 	return sinRogue.RegisterSpell(core.SpellConfig{

--- a/sim/rogue/backstab.go
+++ b/sim/rogue/backstab.go
@@ -9,7 +9,7 @@ import (
 
 func (rogue *Rogue) registerBackstabSpell() {
 	hasGlyph := rogue.HasPrimeGlyph(proto.RoguePrimeGlyph_GlyphOfBackstab)
-	baseDamage := RogueBaseDamageScalar * .307
+	baseDamage := rogue.ClassSpellScaling * .307
 	murderousIntentMetrics := rogue.NewEnergyMetrics(core.ActionID{SpellID: 79132})
 	glyphOfBackstabMetrics := rogue.NewEnergyMetrics(core.ActionID{SpellID: 56800})
 	t11Bonus := core.TernaryFloat64(rogue.HasSetBonus(Tier11, 2), 5*core.CritRatingPerCritChance, 0)

--- a/sim/rogue/combat/TestCombat.results
+++ b/sim/rogue/combat/TestCombat.results
@@ -40,2237 +40,2237 @@ character_stats_results: {
 dps_results: {
  key: "TestCombat-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 28887.65611
-  tps: 20510.23584
+  dps: 28887.65451
+  tps: 20510.2347
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 27296.74938
-  tps: 19380.69206
+  dps: 27296.74781
+  tps: 19380.69094
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 27326.23978
-  tps: 19401.63025
+  dps: 27326.2382
+  tps: 19401.62912
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 26932.06291
-  tps: 19121.76467
+  dps: 26932.06139
+  tps: 19121.76359
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 28326.66289
-  tps: 20111.93065
+  dps: 28326.6613
+  tps: 20111.92953
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 28326.66289
-  tps: 20111.93065
+  dps: 28326.6613
+  tps: 20111.92953
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 27225.9561
-  tps: 19330.42883
+  dps: 27225.95459
+  tps: 19330.42776
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
   hps: 81.89597
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
   hps: 81.89597
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 28361.52993
-  tps: 20136.68625
+  dps: 28361.52835
+  tps: 20136.68513
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 27261.90236
-  tps: 19355.95067
+  dps: 27261.90083
+  tps: 19355.94959
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 27297.19225
-  tps: 19381.0065
+  dps: 27297.19072
+  tps: 19381.00541
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BindingPromise-67037"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BlackBruise-50035"
  value: {
-  dps: 26311.30835
-  tps: 18681.02893
+  dps: 26311.30676
+  tps: 18681.0278
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BlackBruise-50692"
  value: {
-  dps: 26551.59518
-  tps: 18851.63258
+  dps: 26551.59359
+  tps: 18851.63145
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 19306.42171
-  tps: 13707.55941
+  dps: 19306.42035
+  tps: 13707.55845
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 28144.42469
-  tps: 19982.54153
+  dps: 28144.42316
+  tps: 19982.54044
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 27229.00269
-  tps: 19332.59191
+  dps: 27229.00116
+  tps: 19332.59082
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 27238.9304
-  tps: 19339.64058
+  dps: 27238.92886
+  tps: 19339.63949
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 28776.52271
-  tps: 20431.33112
+  dps: 28776.52119
+  tps: 20431.33004
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 27392.40526
-  tps: 19448.60773
+  dps: 27392.40374
+  tps: 19448.60665
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 27240.24335
-  tps: 19340.57278
+  dps: 27240.24182
+  tps: 19340.57169
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 28199.13036
-  tps: 20021.38256
+  dps: 28199.12884
+  tps: 20021.38148
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 27420.94438
-  tps: 19468.87051
+  dps: 27420.94286
+  tps: 19468.86943
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BonescytheBattlegear"
  value: {
-  dps: 19767.88953
-  tps: 14035.20157
+  dps: 19767.88817
+  tps: 14035.2006
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BottledLightning-66879"
  value: {
-  dps: 27032.14043
-  tps: 19192.8197
+  dps: 27032.1389
+  tps: 19192.81862
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 28326.66289
-  tps: 19709.69204
+  dps: 28326.6613
+  tps: 19709.69094
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 28326.66289
-  tps: 19709.69204
+  dps: 28326.6613
+  tps: 19709.69094
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 28887.65611
-  tps: 20510.23584
+  dps: 28887.65451
+  tps: 20510.2347
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 28887.65611
-  tps: 20510.23584
+  dps: 28887.65451
+  tps: 20510.2347
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 28662.8072
-  tps: 20350.59311
+  dps: 28662.8056
+  tps: 20350.59198
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 28737.53168
-  tps: 20403.64749
+  dps: 28737.53008
+  tps: 20403.64636
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 28699.80955
-  tps: 20376.86478
+  dps: 28699.80795
+  tps: 20376.86365
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
   hps: 64
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CrushingWeight-59506"
  value: {
-  dps: 28010.69883
-  tps: 19887.59617
+  dps: 28010.69727
+  tps: 19887.59506
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CrushingWeight-65118"
  value: {
-  dps: 28101.97351
-  tps: 19952.40119
+  dps: 28101.97196
+  tps: 19952.40009
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 27017.97265
-  tps: 19182.76058
+  dps: 27017.97112
+  tps: 19182.7595
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 27050.26386
-  tps: 19205.68734
+  dps: 27050.26234
+  tps: 19205.68626
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 27321.91336
-  tps: 19398.55849
+  dps: 27321.91184
+  tps: 19398.55741
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 28104.81054
-  tps: 19954.41548
+  dps: 28104.80902
+  tps: 19954.41441
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 28842.32426
-  tps: 20478.05023
+  dps: 28842.32275
+  tps: 20478.04915
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 27427.64849
-  tps: 19473.63043
+  dps: 27427.64695
+  tps: 19473.62933
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Death'sChoice-47464"
  value: {
-  dps: 28052.10619
-  tps: 19916.99539
+  dps: 28052.10467
+  tps: 19916.99431
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 27006.68272
-  tps: 19174.74473
+  dps: 27006.6812
+  tps: 19174.74365
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 27584.58221
-  tps: 19585.05337
+  dps: 27584.58067
+  tps: 19585.05228
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 27693.56409
-  tps: 19662.43051
+  dps: 27693.56256
+  tps: 19662.42942
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Defender'sCode-40257"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 28397.04116
-  tps: 20161.89922
+  dps: 28397.03957
+  tps: 20161.8981
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 28371.54711
-  tps: 20143.79845
+  dps: 28371.54552
+  tps: 20143.79732
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 27169.52977
-  tps: 19290.36614
+  dps: 27169.52824
+  tps: 19290.36505
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 27113.19872
-  tps: 19250.37109
+  dps: 27113.19719
+  tps: 19250.37
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 28326.66289
-  tps: 20111.93065
+  dps: 28326.6613
+  tps: 20111.92953
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 28326.66289
-  tps: 20111.93065
+  dps: 28326.6613
+  tps: 20111.92953
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 28326.66289
-  tps: 20111.93065
+  dps: 28326.6613
+  tps: 20111.92953
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 28397.04116
-  tps: 20161.89922
+  dps: 28397.03957
+  tps: 20161.8981
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 28361.52993
-  tps: 20136.68625
+  dps: 28361.52835
+  tps: 20136.68513
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 28356.7526
-  tps: 20133.29435
+  dps: 28356.75102
+  tps: 20133.29322
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 26868.94499
-  tps: 19076.95094
+  dps: 26868.94347
+  tps: 19076.94987
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 28600.26684
-  tps: 20306.18945
+  dps: 28600.2653
+  tps: 20306.18836
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 28848.76525
-  tps: 20482.62333
+  dps: 28848.76371
+  tps: 20482.62223
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 28326.66289
-  tps: 20111.93065
+  dps: 28326.6613
+  tps: 20111.92953
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 28326.66289
-  tps: 20111.93065
+  dps: 28326.6613
+  tps: 20111.92953
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 27009.45865
-  tps: 19176.71564
+  dps: 27009.45713
+  tps: 19176.71457
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 27007.33122
-  tps: 19175.20517
+  dps: 27007.3297
+  tps: 19175.20409
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FallofMortality-59500"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FallofMortality-65124"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 29125.65402
-  tps: 20679.21435
+  dps: 29125.65243
+  tps: 20679.21323
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 27705.10645
-  tps: 19670.62558
+  dps: 27705.10491
+  tps: 19670.62449
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 28390.74502
-  tps: 20157.42897
+  dps: 28390.74343
+  tps: 20157.42783
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForgeEmber-37660"
  value: {
-  dps: 26986.18573
-  tps: 19160.19187
+  dps: 26986.18421
+  tps: 19160.19079
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 28326.66289
-  tps: 20111.93065
+  dps: 28326.6613
+  tps: 20111.92953
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 28326.66289
-  tps: 20111.93065
+  dps: 28326.6613
+  tps: 20111.92953
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 28326.66289
-  tps: 20111.93065
+  dps: 28326.6613
+  tps: 20111.92953
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 27851.25835
-  tps: 19774.39343
+  dps: 27851.25682
+  tps: 19774.39234
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 27366.42902
-  tps: 19430.16461
+  dps: 27366.4275
+  tps: 19430.16353
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuturesightRune-38763"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GaleofShadows-56138"
  value: {
-  dps: 27269.04533
-  tps: 19361.02218
+  dps: 27269.04379
+  tps: 19361.02109
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GaleofShadows-56462"
  value: {
-  dps: 27293.99449
-  tps: 19378.73609
+  dps: 27293.99295
+  tps: 19378.73499
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GearDetector-61462"
  value: {
-  dps: 27703.09909
-  tps: 19669.20036
+  dps: 27703.09757
+  tps: 19669.19927
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Gladiator'sVestments"
  value: {
-  dps: 22929.1571
-  tps: 16279.70154
+  dps: 22929.15573
+  tps: 16279.70057
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 27026.16377
-  tps: 19188.57627
+  dps: 27026.16225
+  tps: 19188.5752
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 27784.4907
-  tps: 19726.9884
+  dps: 27784.48918
+  tps: 19726.98732
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 28212.72875
-  tps: 20031.03742
+  dps: 28212.72722
+  tps: 20031.03633
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-HarmlightToken-63839"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 27428.55446
-  tps: 19474.27367
+  dps: 27428.55293
+  tps: 19474.27258
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-HeartofRage-59224"
  value: {
-  dps: 27553.92899
-  tps: 19563.28958
+  dps: 27553.92747
+  tps: 19563.2885
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-HeartofRage-65072"
  value: {
-  dps: 27638.91645
-  tps: 19623.63068
+  dps: 27638.91493
+  tps: 19623.6296
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-HeartofSolace-55868"
  value: {
-  dps: 27269.04533
-  tps: 19361.02218
+  dps: 27269.04379
+  tps: 19361.02109
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-HeartofSolace-56393"
  value: {
-  dps: 27871.46612
-  tps: 19788.74095
+  dps: 27871.46458
+  tps: 19788.73985
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-HeartofThunder-55845"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-HeartofThunder-56370"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 27905.32618
-  tps: 19812.78159
+  dps: 27905.32466
+  tps: 19812.78051
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Heartpierce-49982"
  value: {
-  dps: 28887.65611
-  tps: 20510.23584
+  dps: 28887.65451
+  tps: 20510.2347
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Heartpierce-50641"
  value: {
-  dps: 28887.65611
-  tps: 20510.23584
+  dps: 28887.65451
+  tps: 20510.2347
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 28397.04116
-  tps: 20161.89922
+  dps: 28397.03957
+  tps: 20161.8981
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 28361.52993
-  tps: 20136.68625
+  dps: 28361.52835
+  tps: 20136.68513
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 28356.7526
-  tps: 20133.29435
+  dps: 28356.75102
+  tps: 20133.29322
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 27952.58929
-  tps: 19846.3384
+  dps: 27952.58774
+  tps: 19846.3373
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 27952.58929
-  tps: 19846.3384
+  dps: 27952.58774
+  tps: 19846.3373
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 27229.00269
-  tps: 19332.59191
+  dps: 27229.00116
+  tps: 19332.59082
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 27238.9304
-  tps: 19339.64058
+  dps: 27238.92886
+  tps: 19339.63949
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-IncisorFragment-37723"
  value: {
-  dps: 27426.26644
-  tps: 19472.64917
+  dps: 27426.26492
+  tps: 19472.64809
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 28326.66289
-  tps: 20111.93065
+  dps: 28326.6613
+  tps: 20111.92953
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 27152.33472
-  tps: 19278.15765
+  dps: 27152.33319
+  tps: 19278.15656
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 28387.92741
-  tps: 20155.42846
+  dps: 28387.92581
+  tps: 20155.42733
   hps: 64.33846
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 28144.42469
-  tps: 19982.54153
+  dps: 28144.42316
+  tps: 19982.54044
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 28381.01696
-  tps: 20150.52204
+  dps: 28381.0154
+  tps: 20150.52093
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 28791.15377
-  tps: 20441.71918
+  dps: 28791.15219
+  tps: 20441.71805
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 27357.81907
-  tps: 19424.05154
+  dps: 27357.81755
+  tps: 19424.05046
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 27357.81907
-  tps: 19424.05154
+  dps: 27357.81755
+  tps: 19424.05046
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 26909.53481
-  tps: 19105.76971
+  dps: 26909.53328
+  tps: 19105.76863
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-LastWord-50179"
  value: {
-  dps: 28887.65611
-  tps: 20510.23584
+  dps: 28887.65451
+  tps: 20510.2347
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-LastWord-50708"
  value: {
-  dps: 28887.65611
-  tps: 20510.23584
+  dps: 28887.65451
+  tps: 20510.2347
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-LeadenDespair-55816"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-LeadenDespair-56347"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 28098.96594
-  tps: 19950.26581
+  dps: 28098.96442
+  tps: 19950.26474
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 28250.91127
-  tps: 20058.147
+  dps: 28250.90975
+  tps: 20058.14592
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 28005.99626
-  tps: 19884.25734
+  dps: 28005.99466
+  tps: 19884.25621
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 27291.1606
-  tps: 19376.72403
+  dps: 27291.15908
+  tps: 19376.72295
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 27415.49926
-  tps: 19465.00448
+  dps: 27415.49774
+  tps: 19465.0034
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 27662.01995
-  tps: 19640.03417
+  dps: 27662.01841
+  tps: 19640.03307
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 27783.56363
-  tps: 19726.33018
+  dps: 27783.56209
+  tps: 19726.32908
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 27028.81994
-  tps: 19190.46216
+  dps: 27028.81841
+  tps: 19190.46107
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 27549.4112
-  tps: 19560.08195
+  dps: 27549.40964
+  tps: 19560.08085
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 27843.80737
-  tps: 19769.10323
+  dps: 27843.80579
+  tps: 19769.10211
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 27427.64849
-  tps: 19473.63043
+  dps: 27427.64695
+  tps: 19473.62933
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 27427.64849
-  tps: 19473.63043
+  dps: 27427.64695
+  tps: 19473.62933
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 27356.64586
-  tps: 19423.21856
+  dps: 27356.64432
+  tps: 19423.21746
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 27002.39072
-  tps: 19171.69741
+  dps: 27002.3892
+  tps: 19171.69633
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 27446.94541
-  tps: 19487.33124
+  dps: 27446.94389
+  tps: 19487.33016
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 28356.7526
-  tps: 20133.29435
+  dps: 28356.75102
+  tps: 20133.29322
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 28361.52993
-  tps: 20136.68625
+  dps: 28361.52835
+  tps: 20136.68513
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 27258.42204
-  tps: 19353.47965
+  dps: 27258.42051
+  tps: 19353.47856
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 27389.40763
-  tps: 19446.47942
+  dps: 27389.40609
+  tps: 19446.47832
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 28326.66289
-  tps: 20111.93065
+  dps: 28326.6613
+  tps: 20111.92953
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 28326.66289
-  tps: 20111.93065
+  dps: 28326.6613
+  tps: 20111.92953
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 28326.66289
-  tps: 20111.93065
+  dps: 28326.6613
+  tps: 20111.92953
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 28668.23865
-  tps: 20354.44944
+  dps: 28668.2371
+  tps: 20354.44834
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Rainsong-55854"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Rainsong-56377"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 26986.93239
-  tps: 19160.722
+  dps: 26986.93088
+  tps: 19160.72092
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 26998.74823
-  tps: 19169.11124
+  dps: 26998.74671
+  tps: 19169.11017
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 28750.96772
-  tps: 20413.18708
+  dps: 28750.96613
+  tps: 20413.18595
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 28746.56531
-  tps: 20410.06137
+  dps: 28746.56372
+  tps: 20410.06024
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 28662.8072
-  tps: 20350.59311
+  dps: 28662.8056
+  tps: 20350.59198
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 28326.66289
-  tps: 20111.93065
+  dps: 28326.6613
+  tps: 20111.92953
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 27765.57981
-  tps: 19713.56167
+  dps: 27765.57824
+  tps: 19713.56055
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 27863.10655
-  tps: 19782.80565
+  dps: 27863.10497
+  tps: 19782.80453
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 27952.37025
-  tps: 19846.18287
+  dps: 27952.36871
+  tps: 19846.18179
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SeaStar-55256"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SeaStar-56290"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 21760.71594
-  tps: 15450.10832
+  dps: 21760.71458
+  tps: 15450.10735
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Shadowmourne-49623"
  value: {
-  dps: 28887.65611
-  tps: 20510.23584
+  dps: 28887.65451
+  tps: 20510.2347
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ShieldedSkyflareDiamond"
  value: {
-  dps: 28326.66289
-  tps: 20111.93065
+  dps: 28326.6613
+  tps: 20111.92953
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 27592.11645
-  tps: 19590.40268
+  dps: 27592.11491
+  tps: 19590.40158
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 28213.01546
-  tps: 20031.24098
+  dps: 28213.01392
+  tps: 20031.23988
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 28355.97927
-  tps: 20132.74528
+  dps: 28355.97773
+  tps: 20132.74419
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Slayer'sArmor"
  value: {
-  dps: 14916.70446
-  tps: 10590.86017
+  dps: 14916.70324
+  tps: 10590.8593
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Sorrowsong-55879"
  value: {
-  dps: 27229.00269
-  tps: 19332.59191
+  dps: 27229.00116
+  tps: 19332.59082
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Sorrowsong-56400"
  value: {
-  dps: 27238.9304
-  tps: 19339.64058
+  dps: 27238.92886
+  tps: 19339.63949
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 27568.49688
-  tps: 19573.63279
+  dps: 27568.4953
+  tps: 19573.63167
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SoulCasket-58183"
  value: {
-  dps: 27427.64849
-  tps: 19473.63043
+  dps: 27427.64695
+  tps: 19473.62933
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SoulPreserver-37111"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SouloftheDead-40382"
  value: {
-  dps: 27010.50216
-  tps: 19177.45653
+  dps: 27010.50063
+  tps: 19177.45545
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SparkofLife-37657"
  value: {
-  dps: 26967.59056
-  tps: 19146.9893
+  dps: 26967.58905
+  tps: 19146.98822
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 27155.66615
-  tps: 19280.52297
+  dps: 27155.66462
+  tps: 19280.52188
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-StumpofTime-62465"
  value: {
-  dps: 27422.27084
-  tps: 19469.81229
+  dps: 27422.26924
+  tps: 19469.81116
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-StumpofTime-62470"
  value: {
-  dps: 27422.27084
-  tps: 19469.81229
+  dps: 27422.26924
+  tps: 19469.81116
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 28361.52993
-  tps: 20136.68625
+  dps: 28361.52835
+  tps: 20136.68513
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 28356.7526
-  tps: 20133.29435
+  dps: 28356.75102
+  tps: 20133.29322
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 28343.44725
-  tps: 20123.84754
+  dps: 28343.44566
+  tps: 20123.84642
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 27536.55087
-  tps: 19550.95112
+  dps: 27536.54933
+  tps: 19550.95003
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TearofBlood-55819"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TearofBlood-56351"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 27130.63174
-  tps: 19262.74854
+  dps: 27130.63021
+  tps: 19262.74745
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 27238.9304
-  tps: 19339.64058
+  dps: 27238.92886
+  tps: 19339.63949
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 19740.69341
-  tps: 14015.89232
+  dps: 19740.69208
+  tps: 14015.89138
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 28466.06393
-  tps: 20210.90539
+  dps: 28466.06234
+  tps: 20210.90426
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 28363.26053
-  tps: 20137.91497
+  dps: 28363.25899
+  tps: 20137.91388
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 28530.10402
-  tps: 20256.37385
+  dps: 28530.10248
+  tps: 20256.37276
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 28186.09946
-  tps: 20012.13062
+  dps: 28186.09782
+  tps: 20012.12945
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 28425.48704
-  tps: 20182.0958
+  dps: 28425.48538
+  tps: 20182.09462
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 28326.66289
-  tps: 20111.93065
+  dps: 28326.6613
+  tps: 20111.92953
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 28326.66289
-  tps: 20111.93065
+  dps: 28326.6613
+  tps: 20111.92953
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 26847.74015
-  tps: 19061.89551
+  dps: 26847.73863
+  tps: 19061.89443
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 28326.66289
-  tps: 20111.93065
+  dps: 28326.6613
+  tps: 20111.92953
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 28326.66289
-  tps: 20111.93065
+  dps: 28326.6613
+  tps: 20111.92953
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 26903.14281
-  tps: 19101.2314
+  dps: 26903.1413
+  tps: 19101.23032
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 20428.67929
-  tps: 14504.3623
+  dps: 20428.67793
+  tps: 14504.36133
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-UnheededWarning-59520"
  value: {
-  dps: 28679.45527
-  tps: 20362.41324
+  dps: 28679.45374
+  tps: 20362.41216
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 28828.48959
-  tps: 20468.22761
+  dps: 28828.48804
+  tps: 20468.22651
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 28828.48959
-  tps: 20468.22761
+  dps: 28828.48804
+  tps: 20468.22651
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 25300.27314
-  tps: 17963.19393
+  dps: 25300.27167
+  tps: 17963.19289
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 19680.92252
-  tps: 13973.45499
+  dps: 19680.92118
+  tps: 13973.45404
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 28242.38904
-  tps: 20052.09622
+  dps: 28242.38752
+  tps: 20052.09514
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 27419.42306
-  tps: 19467.79037
+  dps: 27419.42154
+  tps: 19467.7893
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 27515.28306
-  tps: 19535.85097
+  dps: 27515.28145
+  tps: 19535.84983
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 27364.86973
-  tps: 19429.05751
+  dps: 27364.86818
+  tps: 19429.05641
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 27272.06559
-  tps: 19363.16657
+  dps: 27272.06406
+  tps: 19363.16548
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 27497.38516
-  tps: 19523.14346
+  dps: 27497.38361
+  tps: 19523.14237
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 28400.08776
-  tps: 20164.06231
+  dps: 28400.08624
+  tps: 20164.06123
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 27496.71314
-  tps: 19522.66633
+  dps: 27496.71162
+  tps: 19522.66525
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-WindDancer'sRegalia"
  value: {
-  dps: 25892.91958
-  tps: 18383.9729
+  dps: 25892.91804
+  tps: 18383.97181
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-WingedTalisman-37844"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 26909.26329
-  tps: 19105.57694
+  dps: 26909.26177
+  tps: 19105.57586
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 27153.1694
-  tps: 19278.75027
+  dps: 27153.16787
+  tps: 19278.74919
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 27246.20003
-  tps: 19344.80202
+  dps: 27246.1985
+  tps: 19344.80093
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 27246.20003
-  tps: 19344.80202
+  dps: 27246.1985
+  tps: 19344.80093
  }
 }
 dps_results: {
  key: "TestCombat-Average-Default"
  value: {
-  dps: 28800.74076
-  tps: 20448.52594
+  dps: 28800.73917
+  tps: 20448.52481
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat_test-Combat-combat-FullBuffs-LongMultiTarget"
  value: {
-  dps: 28549.24413
-  tps: 20269.96333
+  dps: 28549.24257
+  tps: 20269.96223
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat_test-Combat-combat-FullBuffs-LongSingleTarget"
  value: {
-  dps: 28887.65611
-  tps: 20510.23584
+  dps: 28887.65451
+  tps: 20510.2347
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat_test-Combat-combat-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 34720.45394
-  tps: 24651.5223
+  dps: 34720.4521
+  tps: 24651.52099
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat_test-Combat-combat-NoBuffs-LongMultiTarget"
  value: {
-  dps: 16661.12197
-  tps: 11829.3966
+  dps: 16661.12077
+  tps: 11829.39574
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat_test-Combat-combat-NoBuffs-LongSingleTarget"
  value: {
-  dps: 16834.17214
-  tps: 11952.26222
+  dps: 16834.17089
+  tps: 11952.26133
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat_test-Combat-combat-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 16962.20983
-  tps: 12043.16898
+  dps: 16962.20855
+  tps: 12043.16807
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Deadly-combat-FullBuffs-LongMultiTarget"
  value: {
-  dps: 24820.22481
-  tps: 17622.35961
+  dps: 24820.22449
+  tps: 17622.35939
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Deadly-combat-FullBuffs-LongSingleTarget"
  value: {
-  dps: 24796.267
-  tps: 17605.34957
+  dps: 24796.26668
+  tps: 17605.34934
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Deadly-combat-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 29877.09963
-  tps: 21212.74074
+  dps: 29877.09926
+  tps: 21212.74047
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Deadly-combat-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14703.14936
-  tps: 10439.23605
+  dps: 14703.14909
+  tps: 10439.23585
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Deadly-combat-NoBuffs-LongSingleTarget"
  value: {
-  dps: 14643.57607
-  tps: 10396.93901
+  dps: 14643.5758
+  tps: 10396.93882
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Deadly-combat-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 14793.19525
-  tps: 10503.16863
+  dps: 14793.19496
+  tps: 10503.16842
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Instant-combat-FullBuffs-LongMultiTarget"
  value: {
-  dps: 27621.67555
-  tps: 19611.38964
+  dps: 27621.67432
+  tps: 19611.38877
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Instant-combat-FullBuffs-LongSingleTarget"
  value: {
-  dps: 27906.26604
-  tps: 19813.44889
+  dps: 27906.26476
+  tps: 19813.44798
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Instant-combat-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 33567.31322
-  tps: 23832.79239
+  dps: 33567.31176
+  tps: 23832.79135
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Instant-combat-NoBuffs-LongMultiTarget"
  value: {
-  dps: 16205.38513
-  tps: 11505.82344
+  dps: 16205.38415
+  tps: 11505.82275
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Instant-combat-NoBuffs-LongSingleTarget"
  value: {
-  dps: 16352.97745
-  tps: 11610.61399
+  dps: 16352.97643
+  tps: 11610.61327
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Instant-combat-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 16341.91895
-  tps: 11602.76246
+  dps: 16341.91796
+  tps: 11602.76175
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat_test-MH Instant OH Instant-combat-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25185.81834
-  tps: 17881.93102
+  dps: 25185.81689
+  tps: 17881.92999
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat_test-MH Instant OH Instant-combat-FullBuffs-LongSingleTarget"
  value: {
-  dps: 25464.928
-  tps: 18080.09888
+  dps: 25464.92653
+  tps: 18080.09784
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat_test-MH Instant OH Instant-combat-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 31119.19614
-  tps: 22094.62926
+  dps: 31119.19443
+  tps: 22094.62805
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat_test-MH Instant OH Instant-combat-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14631.9671
-  tps: 10388.69664
+  dps: 14631.96595
+  tps: 10388.69582
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat_test-MH Instant OH Instant-combat-NoBuffs-LongSingleTarget"
  value: {
-  dps: 14771.26273
-  tps: 10487.59654
+  dps: 14771.26157
+  tps: 10487.59571
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat_test-MH Instant OH Instant-combat-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 15031.09117
-  tps: 10672.07473
+  dps: 15031.08996
+  tps: 10672.07387
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat_test-Combat-combat-FullBuffs-LongMultiTarget"
  value: {
-  dps: 28808.72368
-  tps: 20454.19381
+  dps: 28808.72213
+  tps: 20454.19271
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat_test-Combat-combat-FullBuffs-LongSingleTarget"
  value: {
-  dps: 29152.78796
-  tps: 20698.47945
+  dps: 29152.78636
+  tps: 20698.47832
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat_test-Combat-combat-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 35258.79583
-  tps: 25033.74504
+  dps: 35258.79399
+  tps: 25033.74374
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat_test-Combat-combat-NoBuffs-LongMultiTarget"
  value: {
-  dps: 16841.35554
-  tps: 11957.36243
+  dps: 16841.35433
+  tps: 11957.36158
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat_test-Combat-combat-NoBuffs-LongSingleTarget"
  value: {
-  dps: 17018.44091
-  tps: 12083.09305
+  dps: 17018.43966
+  tps: 12083.09216
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat_test-Combat-combat-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 17314.27181
-  tps: 12293.13299
+  dps: 17314.27053
+  tps: 12293.13208
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Deadly-combat-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25049.77198
-  tps: 17785.33811
+  dps: 25049.77166
+  tps: 17785.33788
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Deadly-combat-FullBuffs-LongSingleTarget"
  value: {
-  dps: 25024.42436
-  tps: 17767.3413
+  dps: 25024.42404
+  tps: 17767.34107
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Deadly-combat-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 30346.73318
-  tps: 21546.18056
+  dps: 30346.73281
+  tps: 21546.1803
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Deadly-combat-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14862.261
-  tps: 10552.20531
+  dps: 14862.26073
+  tps: 10552.20512
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Deadly-combat-NoBuffs-LongSingleTarget"
  value: {
-  dps: 14800.71855
-  tps: 10508.51017
+  dps: 14800.71828
+  tps: 10508.50998
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Deadly-combat-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 15102.86964
-  tps: 10723.03745
+  dps: 15102.86935
+  tps: 10723.03724
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Instant-combat-FullBuffs-LongMultiTarget"
  value: {
-  dps: 27877.50233
-  tps: 19793.02665
+  dps: 27877.5011
+  tps: 19793.02578
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Instant-combat-FullBuffs-LongSingleTarget"
  value: {
-  dps: 28165.72984
-  tps: 19997.66819
+  dps: 28165.72855
+  tps: 19997.66727
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Instant-combat-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 34092.64001
-  tps: 24205.77441
+  dps: 34092.63854
+  tps: 24205.77337
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Instant-combat-NoBuffs-LongMultiTarget"
  value: {
-  dps: 16380.34485
-  tps: 11630.04484
+  dps: 16380.34387
+  tps: 11630.04415
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Instant-combat-NoBuffs-LongSingleTarget"
  value: {
-  dps: 16530.80112
-  tps: 11736.8688
+  dps: 16530.8001
+  tps: 11736.86807
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Instant-combat-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 16685.11597
-  tps: 11846.43234
+  dps: 16685.11497
+  tps: 11846.43163
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat_test-MH Instant OH Instant-combat-FullBuffs-LongMultiTarget"
  value: {
-  dps: 25421.48857
-  tps: 18049.25689
+  dps: 25421.48712
+  tps: 18049.25586
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat_test-MH Instant OH Instant-combat-FullBuffs-LongSingleTarget"
  value: {
-  dps: 25704.40955
-  tps: 18250.13078
+  dps: 25704.40808
+  tps: 18250.12974
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat_test-MH Instant OH Instant-combat-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 31623.13535
-  tps: 22452.4261
+  dps: 31623.13365
+  tps: 22452.42489
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat_test-MH Instant OH Instant-combat-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14790.88494
-  tps: 10501.52831
+  dps: 14790.88379
+  tps: 10501.52749
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat_test-MH Instant OH Instant-combat-NoBuffs-LongSingleTarget"
  value: {
-  dps: 14933.19757
-  tps: 10602.57027
+  dps: 14933.1964
+  tps: 10602.56945
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat_test-MH Instant OH Instant-combat-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 15357.84639
-  tps: 10904.07094
+  dps: 15357.84517
+  tps: 10904.07007
  }
 }
 dps_results: {
  key: "TestCombat-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 27472.32034
-  tps: 19505.34744
+  dps: 27472.31883
+  tps: 19505.34637
  }
 }

--- a/sim/rogue/gouge.go
+++ b/sim/rogue/gouge.go
@@ -9,7 +9,7 @@ import (
 
 func (rogue *Rogue) registerGougeSpell() {
 	hasGlyph := rogue.HasMajorGlyph(proto.RogueMajorGlyph_GlyphOfGouge)
-	baseDamage := RogueBaseDamageScalar * 0.10400000215
+	baseDamage := rogue.ClassSpellScaling * 0.10400000215
 
 	rogue.Gouge = rogue.RegisterSpell(core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 1776},

--- a/sim/rogue/poisons.go
+++ b/sim/rogue/poisons.go
@@ -211,7 +211,7 @@ const (
 
 func (rogue *Rogue) makeInstantPoison(procSource PoisonProcSource) *core.Spell {
 	isShivProc := procSource == ShivProc
-	ipBaseDamage := 0.31299999356 * RogueBaseDamageScalar
+	ipBaseDamage := 0.31299999356 * rogue.ClassSpellScaling
 	return rogue.RegisterSpell(core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 8680, Tag: int32(procSource)},
 		SpellSchool: core.SpellSchoolNature,
@@ -235,7 +235,7 @@ func (rogue *Rogue) makeInstantPoison(procSource PoisonProcSource) *core.Spell {
 
 func (rogue *Rogue) makeWoundPoison(procSource PoisonProcSource) *core.Spell {
 	isShivProc := procSource == ShivProc
-	wpBaseDamage := 0.24500000477 * RogueBaseDamageScalar
+	wpBaseDamage := 0.24500000477 * rogue.ClassSpellScaling
 	return rogue.RegisterSpell(core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 13218, Tag: int32(procSource)},
 		SpellSchool: core.SpellSchoolNature,

--- a/sim/rogue/rogue.go
+++ b/sim/rogue/rogue.go
@@ -16,11 +16,12 @@ const (
 
 var TalentTreeSizes = [3]int{19, 19, 19}
 
-const RogueBaseDamageScalar = 1125.23
 const RogueBleedTag = "RogueBleed"
 
 type Rogue struct {
 	core.Character
+
+	ClassSpellScaling float64
 
 	Talents              *proto.RogueTalents
 	Options              *proto.RogueOptions
@@ -202,9 +203,10 @@ func (rogue *Rogue) SpellCritMultiplier() float64 {
 
 func NewRogue(character *core.Character, options *proto.RogueOptions, talents string) *Rogue {
 	rogue := &Rogue{
-		Character: *character,
-		Talents:   &proto.RogueTalents{},
-		Options:   options,
+		Character:         *character,
+		Talents:           &proto.RogueTalents{},
+		Options:           options,
+		ClassSpellScaling: core.GetClassSpellScalingCoefficient(proto.Class_ClassRogue),
 	}
 
 	core.FillTalentsProto(rogue.Talents.ProtoReflect(), talents, TalentTreeSizes)

--- a/sim/rogue/sinister_strike.go
+++ b/sim/rogue/sinister_strike.go
@@ -9,7 +9,7 @@ import (
 
 func (rogue *Rogue) registerSinisterStrikeSpell() {
 	hasGlyphOfSinisterStrike := rogue.HasPrimeGlyph(proto.RoguePrimeGlyph_GlyphOfSinisterStrike)
-	baseDamage := RogueBaseDamageScalar * 0.1780000031
+	baseDamage := rogue.ClassSpellScaling * 0.1780000031
 	t11Bonus := core.TernaryFloat64(rogue.HasSetBonus(Tier11, 2), 5*core.CritRatingPerCritChance, 0)
 
 	rogue.SinisterStrike = rogue.RegisterSpell(core.SpellConfig{

--- a/sim/rogue/subtlety/TestSubtlety.results
+++ b/sim/rogue/subtlety/TestSubtlety.results
@@ -40,2185 +40,2185 @@ character_stats_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 23939.86997
-  tps: 16997.30768
+  dps: 23939.86724
+  tps: 16997.30574
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
   hps: 119.03946
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
   hps: 134.69317
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 22891.92046
-  tps: 16253.26352
+  dps: 22891.9177
+  tps: 16253.26157
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 23168.01147
-  tps: 16449.28815
+  dps: 23168.00869
+  tps: 16449.28617
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-AshtongueTalismanofLethality-32492"
  value: {
-  dps: 21868.33686
-  tps: 15526.51917
+  dps: 21868.33427
+  tps: 15526.51734
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 23228.67914
-  tps: 16492.36219
+  dps: 23228.67648
+  tps: 16492.3603
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 23228.67914
-  tps: 16492.36219
+  dps: 23228.67648
+  tps: 16492.3603
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 22682.11967
-  tps: 16104.30497
+  dps: 22682.11699
+  tps: 16104.30307
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
   hps: 86.32308
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
   hps: 86.32308
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 23285.47454
-  tps: 16532.68692
+  dps: 23285.47187
+  tps: 16532.68503
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 22726.17357
-  tps: 16135.58324
+  dps: 22726.17087
+  tps: 16135.58132
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 22588.11772
-  tps: 16037.56358
+  dps: 22588.11504
+  tps: 16037.56168
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BindingPromise-67037"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 14630.337
-  tps: 10387.53927
+  dps: 14630.3349
+  tps: 10387.53778
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 22935.68647
-  tps: 16284.33739
+  dps: 22935.68382
+  tps: 16284.33551
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 21898.49073
-  tps: 15547.92842
+  dps: 21898.48813
+  tps: 15547.92657
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 22025.20947
-  tps: 15637.89873
+  dps: 22025.20686
+  tps: 15637.89687
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 23278.88693
-  tps: 16528.00972
+  dps: 23278.88432
+  tps: 16528.00787
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 22179.36164
-  tps: 15747.34677
+  dps: 22179.35906
+  tps: 15747.34493
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 22700.68042
-  tps: 16117.4831
+  dps: 22700.67772
+  tps: 16117.48118
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 22987.82946
-  tps: 16321.35892
+  dps: 22987.82684
+  tps: 16321.35705
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 22151.23741
-  tps: 15727.37856
+  dps: 22151.23482
+  tps: 15727.37672
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BonescytheBattlegear"
  value: {
-  dps: 15215.67893
-  tps: 10803.13204
+  dps: 15215.67678
+  tps: 10803.13051
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BottledLightning-66879"
  value: {
-  dps: 22325.07299
-  tps: 15850.80182
+  dps: 22325.07034
+  tps: 15850.79994
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 23228.67914
-  tps: 16162.51495
+  dps: 23228.67648
+  tps: 16162.51309
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 23228.67914
-  tps: 16162.51495
+  dps: 23228.67648
+  tps: 16162.51309
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 23705.02404
-  tps: 16830.56707
+  dps: 23705.02132
+  tps: 16830.56514
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 23751.06762
-  tps: 16863.25801
+  dps: 23751.0649
+  tps: 16863.25608
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 23763.50415
-  tps: 16872.08795
+  dps: 23763.50143
+  tps: 16872.08601
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
   hps: 64
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-CrushingWeight-59506"
  value: {
-  dps: 23354.69799
-  tps: 16581.83558
+  dps: 23354.69524
+  tps: 16581.83362
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-CrushingWeight-65118"
  value: {
-  dps: 22789.54993
-  tps: 16180.58045
+  dps: 22789.54725
+  tps: 16180.57855
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 22296.54346
-  tps: 15830.54586
+  dps: 22296.54082
+  tps: 15830.54398
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 22945.48716
-  tps: 16291.29588
+  dps: 22945.48443
+  tps: 16291.29395
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 22141.94425
-  tps: 15720.78042
+  dps: 22141.94165
+  tps: 15720.77857
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 23097.78329
-  tps: 16399.42614
+  dps: 23097.78063
+  tps: 16399.42425
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 23689.34164
-  tps: 16819.43256
+  dps: 23689.33898
+  tps: 16819.43068
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 22437.10977
-  tps: 15930.34794
+  dps: 22437.10711
+  tps: 15930.34605
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Death'sChoice-47464"
  value: {
-  dps: 22525.14783
-  tps: 15992.85496
+  dps: 22525.14525
+  tps: 15992.85313
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 22121.66005
-  tps: 15706.37864
+  dps: 22121.65743
+  tps: 15706.37678
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 23152.5789
-  tps: 16438.33102
+  dps: 23152.57618
+  tps: 16438.32909
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 22763.26127
-  tps: 16161.9155
+  dps: 22763.25861
+  tps: 16161.91362
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Defender'sCode-40257"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 23271.14747
-  tps: 16522.5147
+  dps: 23271.14481
+  tps: 16522.51281
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 23264.93455
-  tps: 16518.10353
+  dps: 23264.93189
+  tps: 16518.10164
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 22048.82091
-  tps: 15654.66285
+  dps: 22048.81828
+  tps: 15654.66098
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 22357.88008
-  tps: 15874.09486
+  dps: 22357.87742
+  tps: 15874.09297
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 23228.67914
-  tps: 16492.36219
+  dps: 23228.67648
+  tps: 16492.3603
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 23228.67914
-  tps: 16492.36219
+  dps: 23228.67648
+  tps: 16492.3603
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 23228.67914
-  tps: 16492.36219
+  dps: 23228.67648
+  tps: 16492.3603
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 23271.14747
-  tps: 16522.5147
+  dps: 23271.14481
+  tps: 16522.51281
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 23285.47454
-  tps: 16532.68692
+  dps: 23285.47187
+  tps: 16532.68503
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 23267.0088
-  tps: 16519.57625
+  dps: 23267.00614
+  tps: 16519.57436
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 22697.69966
-  tps: 16115.36676
+  dps: 22697.69694
+  tps: 16115.36482
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 24144.29391
-  tps: 17142.44867
+  dps: 24144.29115
+  tps: 17142.44671
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 25059.02745
-  tps: 17791.90949
+  dps: 25059.02459
+  tps: 17791.90746
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 23228.67914
-  tps: 16492.36219
+  dps: 23228.67648
+  tps: 16492.3603
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 23228.67914
-  tps: 16492.36219
+  dps: 23228.67648
+  tps: 16492.3603
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 22484.16698
-  tps: 15963.75855
+  dps: 22484.16431
+  tps: 15963.75666
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 22247.65489
-  tps: 15795.83497
+  dps: 22247.65225
+  tps: 15795.8331
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-FallofMortality-59500"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-FallofMortality-65124"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 24359.35586
-  tps: 17295.14266
+  dps: 24359.35308
+  tps: 17295.14069
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 22319.74085
-  tps: 15847.01601
+  dps: 22319.73824
+  tps: 15847.01415
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 23184.73575
-  tps: 16461.16238
+  dps: 23184.73309
+  tps: 16461.16049
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ForgeEmber-37660"
  value: {
-  dps: 22148.05968
-  tps: 15725.12237
+  dps: 22148.05705
+  tps: 15725.12051
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 23228.67914
-  tps: 16492.36219
+  dps: 23228.67648
+  tps: 16492.3603
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 23228.67914
-  tps: 16492.36219
+  dps: 23228.67648
+  tps: 16492.3603
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 23228.67914
-  tps: 16492.36219
+  dps: 23228.67648
+  tps: 16492.3603
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 23108.67688
-  tps: 16407.16059
+  dps: 23108.67418
+  tps: 16407.15867
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 22146.02867
-  tps: 15723.68035
+  dps: 22146.02608
+  tps: 15723.67852
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-FuturesightRune-38763"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-GaleofShadows-56138"
  value: {
-  dps: 22297.63178
-  tps: 15831.31857
+  dps: 22297.62912
+  tps: 15831.31668
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-GaleofShadows-56462"
  value: {
-  dps: 22683.1209
-  tps: 16105.01584
+  dps: 22683.11819
+  tps: 16105.01391
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-GearDetector-61462"
  value: {
-  dps: 22765.32613
-  tps: 16163.38155
+  dps: 22765.32347
+  tps: 16163.37966
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Gladiator'sVestments"
  value: {
-  dps: 18080.90909
-  tps: 12837.44546
+  dps: 18080.90686
+  tps: 12837.44387
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
   hps: 45.924
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
   hps: 51.858
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 22568.27776
-  tps: 16023.47721
+  dps: 22568.27507
+  tps: 16023.4753
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 23395.62052
-  tps: 16610.89057
+  dps: 23395.6178
+  tps: 16610.88864
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 23441.80707
-  tps: 16643.68302
+  dps: 23441.80438
+  tps: 16643.68111
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-HarmlightToken-63839"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 22060.84546
-  tps: 15663.20028
+  dps: 22060.84289
+  tps: 15663.19845
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-HeartofRage-59224"
  value: {
-  dps: 22605.06909
-  tps: 16049.59906
+  dps: 22605.06645
+  tps: 16049.59718
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-HeartofRage-65072"
  value: {
-  dps: 22652.35488
-  tps: 16083.17197
+  dps: 22652.35224
+  tps: 16083.17009
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-HeartofSolace-55868"
  value: {
-  dps: 22297.63178
-  tps: 15831.31857
+  dps: 22297.62912
+  tps: 15831.31668
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-HeartofSolace-56393"
  value: {
-  dps: 23027.86835
-  tps: 16349.78653
+  dps: 23027.86564
+  tps: 16349.7846
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-HeartofThunder-55845"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-HeartofThunder-56370"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 23227.60635
-  tps: 16491.60051
+  dps: 23227.60367
+  tps: 16491.59861
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Heartpierce-49982"
  value: {
-  dps: 23939.86997
-  tps: 16997.30768
+  dps: 23939.86724
+  tps: 16997.30574
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Heartpierce-50641"
  value: {
-  dps: 23939.86997
-  tps: 16997.30768
+  dps: 23939.86724
+  tps: 16997.30574
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 23271.14747
-  tps: 16522.5147
+  dps: 23271.14481
+  tps: 16522.51281
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 23285.47454
-  tps: 16532.68692
+  dps: 23285.47187
+  tps: 16532.68503
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 23267.0088
-  tps: 16519.57625
+  dps: 23267.00614
+  tps: 16519.57436
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 22777.92589
-  tps: 16172.32738
+  dps: 22777.92324
+  tps: 16172.3255
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 22777.92589
-  tps: 16172.32738
+  dps: 22777.92324
+  tps: 16172.3255
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 21898.49073
-  tps: 15547.92842
+  dps: 21898.48813
+  tps: 15547.92657
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 22025.20947
-  tps: 15637.89873
+  dps: 22025.20686
+  tps: 15637.89687
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-IncisorFragment-37723"
  value: {
-  dps: 22153.81545
-  tps: 15729.20897
+  dps: 22153.81284
+  tps: 15729.20712
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 23228.67914
-  tps: 16492.36219
+  dps: 23228.67648
+  tps: 16492.3603
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 22096.05771
-  tps: 15688.20097
+  dps: 22096.05507
+  tps: 15688.1991
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 23349.1138
-  tps: 16577.8708
+  dps: 23349.11113
+  tps: 16577.8689
   hps: 66.16551
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 22935.68647
-  tps: 16284.33739
+  dps: 22935.68382
+  tps: 16284.33551
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 23455.37804
-  tps: 16653.31841
+  dps: 23455.37533
+  tps: 16653.31648
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 24520.16131
-  tps: 17409.31453
+  dps: 24520.15849
+  tps: 17409.31253
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 22407.38881
-  tps: 15909.24605
+  dps: 22407.38614
+  tps: 15909.24416
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 22407.38881
-  tps: 15909.24605
+  dps: 22407.38614
+  tps: 15909.24416
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 22409.1267
-  tps: 15910.47996
+  dps: 22409.12403
+  tps: 15910.47806
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-LeadenDespair-55816"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-LeadenDespair-56347"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 23546.90485
-  tps: 16718.30244
+  dps: 23546.90215
+  tps: 16718.30052
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 23747.89375
-  tps: 16861.00456
+  dps: 23747.89104
+  tps: 16861.00264
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 23454.21805
-  tps: 16652.49481
+  dps: 23454.21527
+  tps: 16652.49284
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 22430.09772
-  tps: 15925.36938
+  dps: 22430.09507
+  tps: 15925.3675
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 22499.38832
-  tps: 15974.56571
+  dps: 22499.38567
+  tps: 15974.56383
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 22289.03076
-  tps: 15825.21184
+  dps: 22289.02816
+  tps: 15825.21
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 22333.31904
-  tps: 15856.65652
+  dps: 22333.31644
+  tps: 15856.65467
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 22809.15636
-  tps: 16194.50102
+  dps: 22809.15362
+  tps: 16194.49907
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 22362.95094
-  tps: 15877.69517
+  dps: 22362.94828
+  tps: 15877.69328
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 23472.71548
-  tps: 16665.62799
+  dps: 23472.71269
+  tps: 16665.62601
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 22437.10977
-  tps: 15930.34794
+  dps: 22437.10711
+  tps: 15930.34605
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 22437.10977
-  tps: 15930.34794
+  dps: 22437.10711
+  tps: 15930.34605
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 21982.47192
-  tps: 15607.55506
+  dps: 21982.46933
+  tps: 15607.55323
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 22399.70107
-  tps: 15903.78776
+  dps: 22399.69841
+  tps: 15903.78587
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 22905.37048
-  tps: 16262.81304
+  dps: 22905.36778
+  tps: 16262.81112
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 23267.0088
-  tps: 16519.57625
+  dps: 23267.00614
+  tps: 16519.57436
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 23285.47454
-  tps: 16532.68692
+  dps: 23285.47187
+  tps: 16532.68503
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 21897.19818
-  tps: 15547.01071
+  dps: 21897.1956
+  tps: 15547.00887
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 22265.72287
-  tps: 15808.66324
+  dps: 22265.72023
+  tps: 15808.66137
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 23228.67914
-  tps: 16492.36219
+  dps: 23228.67648
+  tps: 16492.3603
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 23228.67914
-  tps: 16492.36219
+  dps: 23228.67648
+  tps: 16492.3603
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 23228.67914
-  tps: 16492.36219
+  dps: 23228.67648
+  tps: 16492.3603
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 23825.9128
-  tps: 16916.39809
+  dps: 23825.91006
+  tps: 16916.39615
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Rainsong-55854"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Rainsong-56377"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 22079.71691
-  tps: 15676.59901
+  dps: 22079.71428
+  tps: 15676.59714
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 22090.83897
-  tps: 15684.49567
+  dps: 22090.83634
+  tps: 15684.4938
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 23768.08836
-  tps: 16875.34274
+  dps: 23768.08564
+  tps: 16875.3408
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 23757.38569
-  tps: 16867.74384
+  dps: 23757.38297
+  tps: 16867.74191
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 23705.02404
-  tps: 16830.56707
+  dps: 23705.02132
+  tps: 16830.56514
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 23228.67914
-  tps: 16492.36219
+  dps: 23228.67648
+  tps: 16492.3603
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 23198.59983
-  tps: 16471.00588
+  dps: 23198.59708
+  tps: 16471.00392
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 23502.75203
-  tps: 16686.95394
+  dps: 23502.74924
+  tps: 16686.95196
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 22602.77048
-  tps: 16047.96704
+  dps: 22602.76788
+  tps: 16047.9652
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SeaStar-55256"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SeaStar-56290"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 17514.78578
-  tps: 12435.4979
+  dps: 17514.78351
+  tps: 12435.49629
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ShieldedSkyflareDiamond"
  value: {
-  dps: 23228.67914
-  tps: 16492.36219
+  dps: 23228.67648
+  tps: 16492.3603
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 22745.74012
-  tps: 16149.47548
+  dps: 22745.73744
+  tps: 16149.47358
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 23005.27199
-  tps: 16333.74311
+  dps: 23005.26935
+  tps: 16333.74124
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 23073.59129
-  tps: 16382.24982
+  dps: 23073.58866
+  tps: 16382.24795
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Slayer'sArmor"
  value: {
-  dps: 10435.1125
-  tps: 7408.92988
+  dps: 10435.11081
+  tps: 7408.92867
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Sorrowsong-55879"
  value: {
-  dps: 21898.49073
-  tps: 15547.92842
+  dps: 21898.48813
+  tps: 15547.92657
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Sorrowsong-56400"
  value: {
-  dps: 22025.20947
-  tps: 15637.89873
+  dps: 22025.20686
+  tps: 15637.89687
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 23048.20931
-  tps: 16364.22861
+  dps: 23048.20655
+  tps: 16364.22665
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SoulCasket-58183"
  value: {
-  dps: 22437.10977
-  tps: 15930.34794
+  dps: 22437.10711
+  tps: 15930.34605
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SoulPreserver-37111"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SouloftheDead-40382"
  value: {
-  dps: 22250.70564
-  tps: 15798.00101
+  dps: 22250.703
+  tps: 15797.99913
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SparkofLife-37657"
  value: {
-  dps: 22599.59312
-  tps: 16045.71112
+  dps: 22599.59041
+  tps: 16045.70919
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 22319.23541
-  tps: 15846.65714
+  dps: 22319.23277
+  tps: 15846.65527
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-StumpofTime-62465"
  value: {
-  dps: 23083.67353
-  tps: 16389.40821
+  dps: 23083.67076
+  tps: 16389.40624
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-StumpofTime-62470"
  value: {
-  dps: 23083.67353
-  tps: 16389.40821
+  dps: 23083.67076
+  tps: 16389.40624
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 23285.47454
-  tps: 16532.68692
+  dps: 23285.47187
+  tps: 16532.68503
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 23267.0088
-  tps: 16519.57625
+  dps: 23267.00614
+  tps: 16519.57436
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 23231.69562
-  tps: 16494.50389
+  dps: 23231.69296
+  tps: 16494.502
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 23075.03824
-  tps: 16383.27715
+  dps: 23075.03551
+  tps: 16383.27521
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TearofBlood-55819"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TearofBlood-56351"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 21661.16654
-  tps: 15379.42825
+  dps: 21661.16397
+  tps: 15379.42642
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 22025.20947
-  tps: 15637.89873
+  dps: 22025.20686
+  tps: 15637.89687
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TerrorbladeBattlegear"
  value: {
-  dps: 15289.54581
-  tps: 10855.57753
+  dps: 15289.54371
+  tps: 10855.57603
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 23472.95358
-  tps: 16665.79704
+  dps: 23472.95089
+  tps: 16665.79513
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 23187.07353
-  tps: 16462.8222
+  dps: 23187.07087
+  tps: 16462.82032
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 23666.22805
-  tps: 16803.02191
+  dps: 23666.22535
+  tps: 16803.02
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 23443.54414
-  tps: 16644.91634
+  dps: 23443.54134
+  tps: 16644.91435
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 23494.90969
-  tps: 16681.38588
+  dps: 23494.90689
+  tps: 16681.38389
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 23228.67914
-  tps: 16492.36219
+  dps: 23228.67648
+  tps: 16492.3603
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 23228.67914
-  tps: 16492.36219
+  dps: 23228.67648
+  tps: 16492.3603
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 22364.68679
-  tps: 15878.92762
+  dps: 22364.68413
+  tps: 15878.92573
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 23228.67914
-  tps: 16492.36219
+  dps: 23228.67648
+  tps: 16492.3603
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 23228.67914
-  tps: 16492.36219
+  dps: 23228.67648
+  tps: 16492.3603
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 22330.41408
-  tps: 15854.594
+  dps: 22330.4114
+  tps: 15854.5921
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 15784.46
-  tps: 11206.9666
+  dps: 15784.45785
+  tps: 11206.96508
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-UnheededWarning-59520"
  value: {
-  dps: 23110.29608
-  tps: 16408.31022
+  dps: 23110.29348
+  tps: 16408.30837
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 23661.41796
-  tps: 16799.60675
+  dps: 23661.41528
+  tps: 16799.60485
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 23661.41796
-  tps: 16799.60675
+  dps: 23661.41528
+  tps: 16799.60485
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-VanCleef'sBattlegear"
  value: {
-  dps: 15975.97162
-  tps: 11342.93985
+  dps: 15975.96941
+  tps: 11342.93828
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 23232.07842
-  tps: 16494.77568
+  dps: 23232.07578
+  tps: 16494.7738
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 22196.81831
-  tps: 15759.741
+  dps: 22196.81573
+  tps: 15759.73917
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 23020.84306
-  tps: 16344.79857
+  dps: 23020.8403
+  tps: 16344.79661
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 22342.58816
-  tps: 15863.23759
+  dps: 22342.58549
+  tps: 15863.2357
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 22636.97611
-  tps: 16072.25304
+  dps: 22636.97343
+  tps: 16072.25113
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 22217.27659
-  tps: 15774.26638
+  dps: 22217.27394
+  tps: 15774.2645
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 22310.9484
-  tps: 15840.77336
+  dps: 22310.94575
+  tps: 15840.77148
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 23321.80934
-  tps: 16558.48463
+  dps: 23321.80668
+  tps: 16558.48274
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 22196.21881
-  tps: 15759.31536
+  dps: 22196.21623
+  tps: 15759.31352
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-WindDancer'sRegalia"
  value: {
-  dps: 21292.09994
-  tps: 15117.39096
+  dps: 21292.09736
+  tps: 15117.38913
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-WingedTalisman-37844"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 21867.19533
-  tps: 15525.70868
+  dps: 21867.19274
+  tps: 15525.70685
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 22160.48514
-  tps: 15733.94445
+  dps: 22160.48249
+  tps: 15733.94257
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 22104.96544
-  tps: 15694.52546
+  dps: 22104.96282
+  tps: 15694.5236
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 22104.96544
-  tps: 15694.52546
+  dps: 22104.96282
+  tps: 15694.5236
  }
 }
 dps_results: {
  key: "TestSubtlety-Average-Default"
  value: {
-  dps: 24300.79884
-  tps: 17253.56718
+  dps: 24300.79608
+  tps: 17253.56522
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Deadly-subtlety-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21640.62123
-  tps: 15364.84107
+  dps: 21640.61925
+  tps: 15364.83967
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Deadly-subtlety-FullBuffs-LongSingleTarget"
  value: {
-  dps: 21640.62123
-  tps: 15364.84107
+  dps: 21640.61925
+  tps: 15364.83967
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Deadly-subtlety-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 27204.59012
-  tps: 19315.25899
+  dps: 27204.58777
+  tps: 19315.25731
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Deadly-subtlety-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9162.42596
-  tps: 6505.32243
+  dps: 9162.42494
+  tps: 6505.32171
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Deadly-subtlety-NoBuffs-LongSingleTarget"
  value: {
-  dps: 9162.42596
-  tps: 6505.32243
+  dps: 9162.42494
+  tps: 6505.32171
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Deadly-subtlety-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 9068.99498
-  tps: 6438.98643
+  dps: 9068.99396
+  tps: 6438.98571
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Instant-subtlety-FullBuffs-LongMultiTarget"
  value: {
-  dps: 23327.5656
-  tps: 16562.57158
+  dps: 23327.56299
+  tps: 16562.56972
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Instant-subtlety-FullBuffs-LongSingleTarget"
  value: {
-  dps: 23327.5656
-  tps: 16562.57158
+  dps: 23327.56299
+  tps: 16562.56972
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Instant-subtlety-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 29012.17564
-  tps: 20598.64471
+  dps: 29012.1726
+  tps: 20598.64254
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Instant-subtlety-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9286.1938
-  tps: 6593.1976
+  dps: 9286.19249
+  tps: 6593.19667
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Instant-subtlety-NoBuffs-LongSingleTarget"
  value: {
-  dps: 9286.1938
-  tps: 6593.1976
+  dps: 9286.19249
+  tps: 6593.19667
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Instant-subtlety-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 9836.33158
-  tps: 6983.79542
+  dps: 9836.33018
+  tps: 6983.79443
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Instant OH Instant-subtlety-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18298.52226
-  tps: 12991.95081
+  dps: 18298.52009
+  tps: 12991.94926
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Instant OH Instant-subtlety-FullBuffs-LongSingleTarget"
  value: {
-  dps: 18298.52226
-  tps: 12991.95081
+  dps: 18298.52009
+  tps: 12991.94926
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Instant OH Instant-subtlety-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 24407.13926
-  tps: 17329.06887
+  dps: 24407.13656
+  tps: 17329.06695
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Instant OH Instant-subtlety-NoBuffs-LongMultiTarget"
  value: {
-  dps: 5900.27848
-  tps: 4189.19772
+  dps: 5900.27762
+  tps: 4189.19711
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Instant OH Instant-subtlety-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5900.27848
-  tps: 4189.19772
+  dps: 5900.27762
+  tps: 4189.19711
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Instant OH Instant-subtlety-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6858.91794
-  tps: 4869.83173
+  dps: 6858.91691
+  tps: 4869.831
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p1_subtlety_test-Subtlety-subtlety-FullBuffs-LongMultiTarget"
  value: {
-  dps: 23939.86997
-  tps: 16997.30768
+  dps: 23939.86724
+  tps: 16997.30574
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p1_subtlety_test-Subtlety-subtlety-FullBuffs-LongSingleTarget"
  value: {
-  dps: 23939.86997
-  tps: 16997.30768
+  dps: 23939.86724
+  tps: 16997.30574
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p1_subtlety_test-Subtlety-subtlety-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 31046.64604
-  tps: 22043.11869
+  dps: 31046.64268
+  tps: 22043.1163
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p1_subtlety_test-Subtlety-subtlety-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10013.50731
-  tps: 7109.59019
+  dps: 10013.50584
+  tps: 7109.58914
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p1_subtlety_test-Subtlety-subtlety-NoBuffs-LongSingleTarget"
  value: {
-  dps: 10013.50731
-  tps: 7109.59019
+  dps: 10013.50584
+  tps: 7109.58914
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p1_subtlety_test-Subtlety-subtlety-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 10698.23779
-  tps: 7595.74883
+  dps: 10698.2362
+  tps: 7595.7477
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Deadly-subtlety-FullBuffs-LongMultiTarget"
  value: {
-  dps: 21776.62827
-  tps: 15461.40607
+  dps: 21776.6263
+  tps: 15461.40467
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Deadly-subtlety-FullBuffs-LongSingleTarget"
  value: {
-  dps: 21776.62827
-  tps: 15461.40607
+  dps: 21776.6263
+  tps: 15461.40467
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Deadly-subtlety-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 27525.31363
-  tps: 19542.97268
+  dps: 27525.31128
+  tps: 19542.97101
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Deadly-subtlety-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9320.06429
-  tps: 6617.24564
+  dps: 9320.06325
+  tps: 6617.24491
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Deadly-subtlety-NoBuffs-LongSingleTarget"
  value: {
-  dps: 9320.06429
-  tps: 6617.24564
+  dps: 9320.06325
+  tps: 6617.24491
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Deadly-subtlety-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 9192.46647
-  tps: 6526.65119
+  dps: 9192.46544
+  tps: 6526.65047
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Instant-subtlety-FullBuffs-LongMultiTarget"
  value: {
-  dps: 23487.24244
-  tps: 16675.94214
+  dps: 23487.23984
+  tps: 16675.94028
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Instant-subtlety-FullBuffs-LongSingleTarget"
  value: {
-  dps: 23487.24244
-  tps: 16675.94214
+  dps: 23487.23984
+  tps: 16675.94028
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Instant-subtlety-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 29337.60145
-  tps: 20829.69703
+  dps: 29337.59841
+  tps: 20829.69487
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Instant-subtlety-NoBuffs-LongMultiTarget"
  value: {
-  dps: 9457.7824
-  tps: 6715.02551
+  dps: 9457.78107
+  tps: 6715.02456
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Instant-subtlety-NoBuffs-LongSingleTarget"
  value: {
-  dps: 9457.7824
-  tps: 6715.02551
+  dps: 9457.78107
+  tps: 6715.02456
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Instant-subtlety-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 9698.63552
-  tps: 6886.03122
+  dps: 9698.63417
+  tps: 6886.03026
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Instant OH Instant-subtlety-FullBuffs-LongMultiTarget"
  value: {
-  dps: 18431.19001
-  tps: 13086.14491
+  dps: 18431.18784
+  tps: 13086.14337
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Instant OH Instant-subtlety-FullBuffs-LongSingleTarget"
  value: {
-  dps: 18431.19001
-  tps: 13086.14491
+  dps: 18431.18784
+  tps: 13086.14337
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Instant OH Instant-subtlety-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 24691.49035
-  tps: 17530.95815
+  dps: 24691.48765
+  tps: 17530.95623
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Instant OH Instant-subtlety-NoBuffs-LongMultiTarget"
  value: {
-  dps: 5949.72492
-  tps: 4224.30469
+  dps: 5949.72405
+  tps: 4224.30408
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Instant OH Instant-subtlety-NoBuffs-LongSingleTarget"
  value: {
-  dps: 5949.72492
-  tps: 4224.30469
+  dps: 5949.72405
+  tps: 4224.30408
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Instant OH Instant-subtlety-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 6961.40153
-  tps: 4942.59509
+  dps: 6961.40051
+  tps: 4942.59436
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p1_subtlety_test-Subtlety-subtlety-FullBuffs-LongMultiTarget"
  value: {
-  dps: 24114.76493
-  tps: 17121.4831
+  dps: 24114.7622
+  tps: 17121.48116
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p1_subtlety_test-Subtlety-subtlety-FullBuffs-LongSingleTarget"
  value: {
-  dps: 24114.76493
-  tps: 17121.4831
+  dps: 24114.7622
+  tps: 17121.48116
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p1_subtlety_test-Subtlety-subtlety-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 31410.52218
-  tps: 22301.47075
+  dps: 31410.51882
+  tps: 22301.46836
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p1_subtlety_test-Subtlety-subtlety-NoBuffs-LongMultiTarget"
  value: {
-  dps: 10086.38267
-  tps: 7161.3317
+  dps: 10086.38119
+  tps: 7161.33065
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p1_subtlety_test-Subtlety-subtlety-NoBuffs-LongSingleTarget"
  value: {
-  dps: 10086.38267
-  tps: 7161.3317
+  dps: 10086.38119
+  tps: 7161.33065
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p1_subtlety_test-Subtlety-subtlety-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 10828.46916
-  tps: 7688.21311
+  dps: 10828.46757
+  tps: 7688.21197
  }
 }
 dps_results: {
  key: "TestSubtlety-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 1446.90132
-  tps: 1027.29994
+  dps: 1446.90126
+  tps: 1027.29989
  }
 }

--- a/sim/shaman/shaman.go
+++ b/sim/shaman/shaman.go
@@ -27,6 +27,7 @@ func NewShaman(character *core.Character, talents string, totems *proto.ShamanTo
 		Totems:              totems,
 		SelfBuffs:           selfBuffs,
 		ThunderstormInRange: thunderstormRange,
+		ClassSpellScaling:   core.GetClassSpellScalingCoefficient(proto.Class_ClassShaman),
 	}
 	// shaman.waterShieldManaMetrics = shaman.NewManaMetrics(core.ActionID{SpellID: 57960})
 
@@ -72,6 +73,8 @@ const (
 // Shaman represents a shaman character.
 type Shaman struct {
 	core.Character
+
+	ClassSpellScaling float64
 
 	ThunderstormInRange bool // flag if thunderstorm will be in range.
 

--- a/sim/warrior/warrior.go
+++ b/sim/warrior/warrior.go
@@ -73,6 +73,8 @@ const EnrageTag = "EnrageEffect"
 type Warrior struct {
 	core.Character
 
+	ClassSpellScaling float64
+
 	Talents *proto.WarriorTalents
 
 	WarriorInputs
@@ -170,9 +172,10 @@ func (warrior *Warrior) Reset(_ *core.Simulation) {
 
 func NewWarrior(character *core.Character, talents string, inputs WarriorInputs) *Warrior {
 	warrior := &Warrior{
-		Character:     *character,
-		Talents:       &proto.WarriorTalents{},
-		WarriorInputs: inputs,
+		Character:         *character,
+		Talents:           &proto.WarriorTalents{},
+		WarriorInputs:     inputs,
+		ClassSpellScaling: core.GetClassSpellScalingCoefficient(proto.Class_ClassWarrior),
 	}
 	core.FillTalentsProto(warrior.Talents.ProtoReflect(), talents, TalentTreeSizes)
 


### PR DESCRIPTION
Shaman needs to update its spell implementations to use the scaling value * coeff instead of hardcoded values. I didn't touch warlock and mage because we have big PRs for them in the pipeline and dont want to introduce conflicts

Rogue tests changed because rogue was using less precise base scale then what we have from the db.
Same for priest having 1 less presicion then the known value