### PR TITLE
[UI] Allow gem tab opening from item overview

### DIFF
--- a/ui/scss/core/components/_gear_picker.scss
+++ b/ui/scss/core/components/_gear_picker.scss
@@ -46,19 +46,25 @@ $favorite-cell-width: 2rem;
 		margin-bottom: $block-spacer;
 	}
 
-	.item-picker-icon {
-		@include wowhead-background-icon;
+	.item-picker-icon-wrapper {
+		position: relative;
 		width: 4rem;
 		height: 4rem;
 		border: $border-default;
+	}
 
-		.item-picker-sockets-container {
-			@include vertical-bottom;
-			@include horizontal-center;
-			width: 100%;
-			display: flex;
-			justify-content: center;
-		}
+	.item-picker-icon {
+		@include wowhead-background-icon;
+		height: 100%;
+		width: 100%;
+	}
+
+	.item-picker-sockets-container {
+		@include vertical-bottom;
+		@include horizontal-center;
+		width: 100%;
+		display: flex;
+		justify-content: center;
 	}
 
 	.item-picker-labels-container {


### PR DESCRIPTION
Changing gems is quite cumbersome because you need to open the item modal and then manually swap to the Gem. I've added support to also jump to the different gem slot tabs through the small overview gem icon on each gear slot.

Also optimized the check for which list to rerender by looking for the actual available lists and comparing it to what was opened.

https://github.com/wowsims/cata/assets/1216787/5844bb53-668e-4e04-a44f-eda5af261764

