### PR TITLE
Update warrior multipliers and colossus smash

### DIFF
--- a/sim/warrior/arms/glyphs.go
+++ b/sim/warrior/arms/glyphs.go
@@ -35,7 +35,7 @@ func (war *ArmsWarrior) applyGlyphOfMortalStrike() {
 
 	war.AddStaticMod(core.SpellModConfig{
 		ClassMask:  warrior.SpellMaskMortalStrike,
-		Kind:       core.SpellMod_DamageDone_Pct,
+		Kind:       core.SpellMod_DamageDone_Flat,
 		FloatValue: 0.1,
 	})
 }

--- a/sim/warrior/arms/talents.go
+++ b/sim/warrior/arms/talents.go
@@ -90,7 +90,7 @@ func (war *ArmsWarrior) applyImprovedSlam() {
 
 	war.AddStaticMod(core.SpellModConfig{
 		ClassMask:  warrior.SpellMaskSlam,
-		Kind:       core.SpellMod_DamageDone_Pct,
+		Kind:       core.SpellMod_DamageDone_Flat,
 		FloatValue: 0.1 * float64(war.Talents.ImprovedSlam),
 	})
 }

--- a/sim/warrior/colossus_smash.go
+++ b/sim/warrior/colossus_smash.go
@@ -47,14 +47,13 @@ func (warrior *Warrior) RegisterColossusSmash() {
 			IgnoreHaste: true,
 		},
 
-		DamageMultiplier: 1.0,
+		DamageMultiplier: 1.5,
 		CritMultiplier:   warrior.DefaultMeleeCritMultiplier(),
 
 		BonusCoefficient: 1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			baseDamage := 120.0 +
-				1.5*spell.Unit.MHNormalizedWeaponDamage(sim, spell.MeleeAttackPower())
+			baseDamage := 120.0 + spell.Unit.MHNormalizedWeaponDamage(sim, spell.MeleeAttackPower())
 			result := spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeWeaponSpecialHitAndCrit)
 			if !result.Landed() {
 				spell.IssueRefund(sim)

--- a/sim/warrior/fury/glyphs.go
+++ b/sim/warrior/fury/glyphs.go
@@ -15,7 +15,7 @@ func (war *FuryWarrior) ApplyGlyphs() {
 func (war *FuryWarrior) applyGlyphOfBloodthirst() {
 	war.AddStaticMod(core.SpellModConfig{
 		ClassMask:  warrior.SpellMaskBloodthirst,
-		Kind:       core.SpellMod_DamageDone_Pct,
+		Kind:       core.SpellMod_DamageDone_Flat,
 		FloatValue: 0.1,
 	})
 }

--- a/sim/warrior/fury/talents.go
+++ b/sim/warrior/fury/talents.go
@@ -116,7 +116,7 @@ func (war *FuryWarrior) applyMeatCleaver() {
 
 	buffMod := war.AddDynamicMod(core.SpellModConfig{
 		ClassMask:  warrior.SpellMaskCleave | warrior.SpellMaskWhirlwind,
-		Kind:       core.SpellMod_DamageDone_Pct,
+		Kind:       core.SpellMod_DamageDone_Flat,
 		FloatValue: 0.0,
 	})
 

--- a/sim/warrior/items.go
+++ b/sim/warrior/items.go
@@ -13,7 +13,7 @@ var ItemSetEarthenWarplate = core.NewItemSet(core.ItemSet{
 		2: func(agent core.Agent) {
 			agent.GetCharacter().AddStaticMod(core.SpellModConfig{
 				ClassMask:  SpellMaskBloodthirst | SpellMaskMortalStrike,
-				Kind:       core.SpellMod_DamageDone_Pct,
+				Kind:       core.SpellMod_DamageDone_Flat,
 				FloatValue: 0.05,
 			})
 		},
@@ -62,7 +62,7 @@ var ItemSetEarthenBattleplate = core.NewItemSet(core.ItemSet{
 		2: func(agent core.Agent) {
 			agent.GetCharacter().AddStaticMod(core.SpellModConfig{
 				ClassMask:  SpellMaskShieldSlam,
-				Kind:       core.SpellMod_DamageDone_Pct,
+				Kind:       core.SpellMod_DamageDone_Flat,
 				FloatValue: 0.05,
 			})
 		},

--- a/sim/warrior/protection/glyphs.go
+++ b/sim/warrior/protection/glyphs.go
@@ -26,7 +26,7 @@ func (war *ProtectionWarrior) applyGlyphOfDevastate() {
 func (war *ProtectionWarrior) applyGlyphOfShieldSlam() {
 	war.AddStaticMod(core.SpellModConfig{
 		ClassMask:  warrior.SpellMaskShieldSlam,
-		Kind:       core.SpellMod_DamageDone_Pct,
+		Kind:       core.SpellMod_DamageDone_Flat,
 		FloatValue: 0.1,
 	})
 }

--- a/sim/warrior/protection/talents.go
+++ b/sim/warrior/protection/talents.go
@@ -73,7 +73,7 @@ func (war *ProtectionWarrior) applyImprovedRevenge() {
 
 	war.AddStaticMod(core.SpellModConfig{
 		ClassMask:  warrior.SpellMaskRevenge,
-		Kind:       core.SpellMod_DamageDone_Pct,
+		Kind:       core.SpellMod_DamageDone_Flat,
 		FloatValue: 0.3 * float64(war.Talents.ImprovedRevenge),
 	})
 
@@ -151,7 +151,7 @@ func (war *ProtectionWarrior) applyThunderstruck() {
 
 	war.AddStaticMod(core.SpellModConfig{
 		ClassMask:  warrior.SpellMaskRend | warrior.SpellMaskCleave | warrior.SpellMaskThunderClap,
-		Kind:       core.SpellMod_DamageDone_Pct,
+		Kind:       core.SpellMod_DamageDone_Flat,
 		FloatValue: 0.03 * float64(war.Talents.Thunderstruck),
 	})
 

--- a/sim/warrior/talents.go
+++ b/sim/warrior/talents.go
@@ -17,7 +17,7 @@ func (warrior *Warrior) ApplyCommonTalents() {
 }
 
 func (warrior *Warrior) applyArmsCommonTalents() {
-	warrior.applyWarMachine()
+	warrior.applyWarAcademy()
 	warrior.RegisterDeepWounds()
 }
 
@@ -37,7 +37,7 @@ func (warrior *Warrior) applyProtectionCommonTalents() {
 	warrior.applyGagOrder()
 }
 
-func (warrior *Warrior) applyWarMachine() {
+func (warrior *Warrior) applyWarAcademy() {
 	if warrior.Talents.WarAcademy == 0 {
 		return
 	}
@@ -48,7 +48,7 @@ func (warrior *Warrior) applyWarMachine() {
 			SpellMaskDevastate |
 			SpellMaskVictoryRush |
 			SpellMaskSlam,
-		Kind:       core.SpellMod_DamageDone_Pct,
+		Kind:       core.SpellMod_DamageDone_Flat,
 		FloatValue: (0.05 * float64(warrior.Talents.WarAcademy)),
 	})
 }


### PR DESCRIPTION
Updated based on **Apply Aura: Modifies Damage/Healing Done** for additive and **Apply Aura: Mod Damage Done %** for multiplicative
https://www.wowhead.com/cata/spell=58368/glyph-of-mortal-strike
https://www.wowhead.com/cata/spell=12330/improved-slam
https://www.wowhead.com/cata/spell=58367/glyph-of-bloodthirst
https://www.wowhead.com/cata/spell=85738/meat-cleaver
https://www.wowhead.com/cata/spell=90293/item-warrior-t11-dps-2p-bonus
https://www.wowhead.com/cata/spell=90296/item-warrior-t11-protection-2p-bonus
https://www.wowhead.com/cata/spell=58375/glyph-of-shield-slam
https://www.wowhead.com/cata/spell=12799/improved-revenge
https://www.wowhead.com/cata/spell=80980/thunderstruck
https://www.wowhead.com/cata/spell=84572/war-academy