### PR TITLE
Arcane Mage updates

### DIFF
--- a/sim/mage/arcane_blast.go
+++ b/sim/mage/arcane_blast.go
@@ -16,9 +16,9 @@ func (mage *Mage) registerArcaneBlastSpell() {
 		Kind:       core.SpellMod_DamageDone_Flat,
 	})
 	abCostMod := mage.AddDynamicMod(core.SpellModConfig{
-		ClassMask:  MageSpellArcaneBlast | MageSpellArcaneExplosion,
+		ClassMask:  MageSpellArcaneBlast,
 		FloatValue: 1.5,
-		Kind:       core.SpellMod_PowerCost_Flat,
+		Kind:       core.SpellMod_PowerCost_Pct,
 	})
 	abCastMod := mage.AddDynamicMod(core.SpellModConfig{
 		ClassMask: MageSpellArcaneBlast,
@@ -55,12 +55,12 @@ func (mage *Mage) registerArcaneBlastSpell() {
 		Flags:          SpellFlagMage | ArcaneMissileSpells | core.SpellFlagAPL,
 		ClassSpellMask: MageSpellArcaneBlast,
 		ManaCost: core.ManaCostOptions{
-			BaseCost: 0.07,
+			BaseCost: 0.05,
 		},
 		Cast: core.CastConfig{
 			DefaultCast: core.Cast{
 				GCD:      core.GCDDefault,
-				CastTime: time.Millisecond * 2500,
+				CastTime: time.Millisecond * 2000,
 			},
 		},
 

--- a/sim/mage/arcane_explosion.go
+++ b/sim/mage/arcane_explosion.go
@@ -14,7 +14,7 @@ func (mage *Mage) registerArcaneExplosionSpell() {
 		ClassSpellMask: MageSpellArcaneExplosion,
 
 		ManaCost: core.ManaCostOptions{
-			BaseCost: 0.22,
+			BaseCost: 0.15,
 		},
 		Cast: core.CastConfig{
 			DefaultCast: core.Cast{

--- a/sim/mage/talents_arcane.go
+++ b/sim/mage/talents_arcane.go
@@ -238,6 +238,7 @@ func (mage *Mage) applyArcanePotency() {
 	})
 
 	var procTime time.Duration
+	const ArcanePotencyClassMask = MageSpellArcaneBlast | MageSpellArcaneBarrage | MageSpellArcaneMissilesCast | MageSpellArcaneExplosion
 	mage.ArcanePotencyAura = mage.RegisterAura(core.Aura{
 		Label:     "Arcane Potency",
 		ActionID:  core.ActionID{SpellID: 57531},
@@ -257,6 +258,11 @@ func (mage *Mage) applyArcanePotency() {
 			if sim.CurrentTime == procTime {
 				return
 			}
+
+			if spell.ClassSpellMask&ArcanePotencyClassMask == 0 {
+				return
+			}
+
 			if spell != mage.ArcaneMissilesTickSpell && spell != mage.ArcaneMissiles {
 				if aura != nil && aura.GetStacks() != 0 {
 					aura.RemoveStack(sim)


### PR DESCRIPTION
- Made Arcane Blast mana scaling Pct
- Removed mana scaling from Arcane Explosion from Arcane Blast debuff
- Fixed Arcane Blast & Arcane Explosion mana costs
- Fixed Arcane Potency being consumed by non-damaging spells