### PR TITLE
[UI] Add fix for phase change filter when 0

### DIFF
--- a/ui/core/components/other_inputs.ts
+++ b/ui/core/components/other_inputs.ts
@@ -68,7 +68,6 @@ export function makePhaseSelector(parent: HTMLElement, sim: Sim): EnumPicker<Sim
 	return new EnumPicker<Sim>(parent, sim, {
 		extraCssClasses: ['phase-selector'],
 		values: [
-			{ name: 'Prepatch', value: 0 },
 			{ name: 'Phase 1 (Cataclysm)', value: 1 }
 		],
 		changedEvent: (sim: Sim) => sim.phaseChangeEmitter,

--- a/ui/core/sim.ts
+++ b/ui/core/sim.ts
@@ -411,7 +411,7 @@ export class Sim {
 		return this.phase;
 	}
 	setPhase(eventID: EventID, newPhase: number) {
-		if (newPhase != this.phase && newPhase > 0) {
+		if (newPhase != this.phase) {
 			this.phase = newPhase;
 			this.phaseChangeEmitter.emit(eventID);
 		}


### PR DESCRIPTION
Partially fixes #247 
- Pre-patch is phase 0, thus the `> 0` check had to be removed
- Other filters don't work since `sources` is populated by AtlasLootClassic and there's no Cataclysm dataset yet.