### PR TITLE
Fixed spell queueing code to work properly with MCDs within sequences.

### DIFF
--- a/sim/core/apl.go
+++ b/sim/core/apl.go
@@ -29,6 +29,9 @@ type APLRotation struct {
 	// Used to avoid recursive APL loops.
 	inLoop bool
 
+	// Used to override MCD restrictions within sequences.
+	inSequence bool
+
 	// Validation warnings that occur during proto parsing.
 	// We return these back to the user for display in the UI.
 	curWarnings          []string

--- a/sim/core/apl_actions_casting.go
+++ b/sim/core/apl_actions_casting.go
@@ -27,7 +27,7 @@ func (rot *APLRotation) newActionCastSpell(config *proto.APLActionCastSpell) APL
 	}
 }
 func (action *APLActionCastSpell) IsReady(sim *Simulation) bool {
-	return action.spell.CanCastOrQueue(sim, action.target.Get()) && (!action.spell.Flags.Matches(SpellFlagMCD) || action.spell.Unit.GCD.IsReady(sim))
+	return action.spell.CanCastOrQueue(sim, action.target.Get()) && (!action.spell.Flags.Matches(SpellFlagMCD) || action.spell.Unit.GCD.IsReady(sim) || action.spell.Unit.Rotation.inSequence)
 }
 func (action *APLActionCastSpell) Execute(sim *Simulation) {
 	action.spell.CastOrQueue(sim, action.target.Get())
@@ -57,7 +57,7 @@ func (rot *APLRotation) newActionCastFriendlySpell(config *proto.APLActionCastFr
 	}
 }
 func (action *APLActionCastFriendlySpell) IsReady(sim *Simulation) bool {
-	return action.spell.CanCastOrQueue(sim, action.target.Get()) && (!action.spell.Flags.Matches(SpellFlagMCD) || action.spell.Unit.GCD.IsReady(sim))
+	return action.spell.CanCastOrQueue(sim, action.target.Get()) && (!action.spell.Flags.Matches(SpellFlagMCD) || action.spell.Unit.GCD.IsReady(sim) || action.spell.Unit.Rotation.inSequence)
 }
 func (action *APLActionCastFriendlySpell) Execute(sim *Simulation) {
 	action.spell.CastOrQueue(sim, action.target.Get())

--- a/sim/core/spell.go
+++ b/sim/core/spell.go
@@ -476,7 +476,7 @@ func (spell *Spell) CanCast(sim *Simulation, target *Unit) bool {
 		return false
 	}
 
-	if spell.DefaultCast.GCD > 0 && !spell.Unit.GCD.IsReady(sim) {
+	if ((spell.DefaultCast.GCD > 0) || (spell.Flags.Matches(SpellFlagMCD) && spell.Unit.Rotation.inSequence)) && !spell.Unit.GCD.IsReady(sim) {
 		//if sim.Log != nil {
 		//	sim.Log("Cant cast because of GCD")
 		//}

--- a/sim/core/spell_queueing.go
+++ b/sim/core/spell_queueing.go
@@ -123,7 +123,7 @@ func (spell *Spell) CastOrQueue(sim *Simulation, target *Unit) {
 		// Determine which timer the spell is waiting on
 		queueTime := max(spell.Unit.Hardcast.Expires, BothTimersReadyAt(spell.CD.Timer, spell.SharedCD.Timer))
 
-		if spell.DefaultCast.GCD > 0 {
+		if (spell.DefaultCast.GCD > 0) || spell.Flags.Matches(SpellFlagMCD) {
 			queueTime = max(queueTime, spell.Unit.GCD.ReadyAt())
 		}
 


### PR DESCRIPTION
 On branch spell_queueing
 Changes to be committed:
	modified:   sim/core/apl.go
	modified:   sim/core/apl_actions_casting.go
	modified:   sim/core/apl_actions_sequences.go
	modified:   sim/core/spell.go
	modified:   sim/core/spell_queueing.go