### PR TITLE
Rake base damage bugfix

### DIFF
--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -40,1804 +40,1804 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 23008.99962
-  tps: 16337.58632
+  dps: 22669.11689
+  tps: 16096.26958
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 21757.86004
-  tps: 15449.352
+  dps: 21430.71609
+  tps: 15217.0798
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 21757.86004
-  tps: 15449.352
+  dps: 21430.71609
+  tps: 15217.0798
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 22433.77696
-  tps: 15929.17823
+  dps: 22099.77907
+  tps: 15692.03973
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 22433.77696
-  tps: 15929.17823
+  dps: 22099.77907
+  tps: 15692.03973
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 21806.56285
-  tps: 15483.931
+  dps: 21478.52511
+  tps: 15251.0242
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
   hps: 84.91645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
   hps: 84.91645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 22475.17726
-  tps: 15958.57244
+  dps: 22140.63713
+  tps: 15721.04895
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 21873.36609
-  tps: 15531.28651
+  dps: 21542.54588
+  tps: 15296.40416
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 21891.94486
-  tps: 15544.47744
+  dps: 21559.04339
+  tps: 15308.11739
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BindingPromise-67037"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 16645.69424
-  tps: 11819.63949
+  dps: 16345.54782
+  tps: 11606.53554
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 22700.45642
-  tps: 16118.52065
+  dps: 22365.53141
+  tps: 15880.72389
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 21793.64786
-  tps: 15474.68657
+  dps: 21456.45376
+  tps: 15235.27875
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 21828.36504
-  tps: 15499.33577
+  dps: 21489.97189
+  tps: 15259.07663
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 23075.30557
-  tps: 16384.66354
+  dps: 22747.1512
+  tps: 16151.67394
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 21975.98088
-  tps: 15604.14301
+  dps: 21647.94314
+  tps: 15371.23621
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 21860.99942
-  tps: 15522.50618
+  dps: 21530.49165
+  tps: 15287.84566
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 22609.42418
-  tps: 16053.88775
+  dps: 22279.47368
+  tps: 15819.6229
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 21944.92157
-  tps: 15582.0909
+  dps: 21616.88383
+  tps: 15349.1841
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledLightning-66879"
  value: {
-  dps: 21659.05781
-  tps: 15379.12763
+  dps: 21331.71598
+  tps: 15146.71493
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 22433.77696
-  tps: 15610.59467
+  dps: 22099.77907
+  tps: 15378.19893
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 22433.77696
-  tps: 15610.59467
+  dps: 22099.77907
+  tps: 15378.19893
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 22804.9391
-  tps: 16192.70335
+  dps: 22465.62566
+  tps: 15951.7908
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 22882.17476
-  tps: 16247.54067
+  dps: 22542.18459
+  tps: 16006.14764
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 22848.26266
-  tps: 16223.46307
+  dps: 22508.37992
+  tps: 15982.14633
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
   hps: 64
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-59506"
  value: {
-  dps: 22358.01867
-  tps: 15875.38984
+  dps: 22031.10512
+  tps: 15643.28122
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-65118"
  value: {
-  dps: 22516.67834
-  tps: 15988.03821
+  dps: 22182.88642
+  tps: 15751.04594
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 21647.69273
-  tps: 15371.05843
+  dps: 21318.94179
+  tps: 15137.64525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 21676.13028
-  tps: 15391.39866
+  dps: 21347.69177
+  tps: 15158.20732
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 21918.35687
-  tps: 15563.22996
+  dps: 21590.68717
+  tps: 15330.58448
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 22216.10534
-  tps: 15774.63138
+  dps: 21888.81057
+  tps: 15542.25209
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 22908.10402
-  tps: 16265.95044
+  dps: 22579.43835
+  tps: 16032.59782
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 21867.28901
-  tps: 15529.27475
+  dps: 21527.5878
+  tps: 15288.08689
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Death'sChoice-47464"
  value: {
-  dps: 22511.80446
-  tps: 15984.57775
+  dps: 22183.82233
+  tps: 15751.71044
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 21630.32386
-  tps: 15358.72653
+  dps: 21302.10219
+  tps: 15125.68914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 22080.74393
-  tps: 15678.52478
+  dps: 21753.67937
+  tps: 15446.30894
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 22267.71907
-  tps: 15811.27713
+  dps: 21937.26435
+  tps: 15576.65427
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Defender'sCode-40257"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 22507.1698
-  tps: 15981.28715
+  dps: 22172.52832
+  tps: 15743.69169
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 22477.64503
-  tps: 15960.32456
+  dps: 22143.1049
+  tps: 15722.80107
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 21720.89887
-  tps: 15423.03479
+  dps: 21392.51195
+  tps: 15189.88007
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 21756.73573
-  tps: 15448.47895
+  dps: 21428.28012
+  tps: 15215.27547
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 22433.77696
-  tps: 15929.17823
+  dps: 22099.77907
+  tps: 15692.03973
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 21528.53487
-  tps: 15316.65249
+  dps: 21200.49713
+  tps: 15083.74569
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 22433.77696
-  tps: 15929.17823
+  dps: 22099.77907
+  tps: 15692.03973
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 22433.77696
-  tps: 15929.17823
+  dps: 22099.77907
+  tps: 15692.03973
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 22507.1698
-  tps: 15981.28715
+  dps: 22172.52832
+  tps: 15743.69169
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 22475.17726
-  tps: 15958.57244
+  dps: 22140.63713
+  tps: 15721.04895
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 22470.49256
-  tps: 15955.24631
+  dps: 22135.85108
+  tps: 15717.65085
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 21637.68815
-  tps: 15363.95518
+  dps: 21308.12054
+  tps: 15129.96217
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 23054.1761
-  tps: 16369.66162
+  dps: 22721.5011
+  tps: 16133.46237
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 23301.51069
-  tps: 16545.26918
+  dps: 22967.40466
+  tps: 16308.0539
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 22433.77696
-  tps: 15929.17823
+  dps: 22099.77907
+  tps: 15692.03973
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 22433.77696
-  tps: 15929.17823
+  dps: 22099.77907
+  tps: 15692.03973
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 21677.6431
-  tps: 15392.32319
+  dps: 21348.99629
+  tps: 15158.98396
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 21632.28765
-  tps: 15360.12082
+  dps: 21303.745
+  tps: 15126.85553
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-59500"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-65124"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 23206.28983
-  tps: 16477.73715
+  dps: 22876.56806
+  tps: 16243.6347
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 22253.58788
-  tps: 15801.24398
+  dps: 21915.19472
+  tps: 15560.98484
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 22492.23908
-  tps: 15970.68633
+  dps: 22156.30459
+  tps: 15732.17285
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FluidDeath-58181"
  value: {
-  dps: 23024.59553
-  tps: 16348.80899
+  dps: 22692.51868
+  tps: 16113.03443
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForgeEmber-37660"
  value: {
-  dps: 21617.65381
-  tps: 15349.73079
+  dps: 21289.31945
+  tps: 15116.61339
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 22433.77696
-  tps: 15929.17823
+  dps: 22099.77907
+  tps: 15692.03973
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 22433.77696
-  tps: 15929.17823
+  dps: 22099.77907
+  tps: 15692.03973
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 22433.77696
-  tps: 15929.17823
+  dps: 22099.77907
+  tps: 15692.03973
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 22418.01262
-  tps: 15917.98555
+  dps: 22087.1924
+  tps: 15683.10319
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 21911.85652
-  tps: 15558.61472
+  dps: 21583.81878
+  tps: 15325.70792
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuturesightRune-38763"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56138"
  value: {
-  dps: 21781.20068
-  tps: 15465.84907
+  dps: 21451.35059
+  tps: 15231.65551
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56462"
  value: {
-  dps: 21860.88174
-  tps: 15522.42263
+  dps: 21532.77945
+  tps: 15289.47
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GearDetector-61462"
  value: {
-  dps: 22355.73335
-  tps: 15873.76726
+  dps: 22030.36863
+  tps: 15642.75831
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 21656.55772
-  tps: 15377.50214
+  dps: 21328.11921
+  tps: 15144.3108
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 22351.86427
-  tps: 15871.02022
+  dps: 22022.67551
+  tps: 15637.2962
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 22677.96198
-  tps: 16102.54959
+  dps: 22346.92483
+  tps: 15867.51321
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HarmlightToken-63839"
  value: {
-  dps: 21534.38715
-  tps: 15290.61146
+  dps: 21206.78161
+  tps: 15058.01153
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 22043.6443
-  tps: 15652.18404
+  dps: 21708.31558
+  tps: 15414.10065
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-59224"
  value: {
-  dps: 22395.4216
-  tps: 15901.94592
+  dps: 22066.95971
+  tps: 15668.73798
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-65072"
  value: {
-  dps: 22545.13192
-  tps: 16008.24025
+  dps: 22218.45741
+  tps: 15776.30135
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-55868"
  value: {
-  dps: 21781.20068
-  tps: 15465.84907
+  dps: 21451.35059
+  tps: 15231.65551
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-56393"
  value: {
-  dps: 22338.64857
-  tps: 15861.63707
+  dps: 22010.54627
+  tps: 15628.68444
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-55845"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-56370"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 22445.75841
-  tps: 15937.68506
+  dps: 22116.50048
+  tps: 15703.91193
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-49982"
  value: {
-  dps: 23427.6631
-  tps: 16634.83739
+  dps: 23086.59352
+  tps: 16392.67799
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-50641"
  value: {
-  dps: 23503.1701
-  tps: 16688.44736
+  dps: 23159.6338
+  tps: 16444.53658
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 22507.1698
-  tps: 15981.28715
+  dps: 22172.52832
+  tps: 15743.69169
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 22475.17726
-  tps: 15958.57244
+  dps: 22140.63713
+  tps: 15721.04895
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 22470.49256
-  tps: 15955.24631
+  dps: 22135.85108
+  tps: 15717.65085
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 22345.99047
-  tps: 15866.84982
+  dps: 22006.28927
+  tps: 15625.66197
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 22345.99047
-  tps: 15866.84982
+  dps: 22006.28927
+  tps: 15625.66197
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 21793.64786
-  tps: 15474.68657
+  dps: 21456.45376
+  tps: 15235.27875
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 21828.36504
-  tps: 15499.33577
+  dps: 21489.97189
+  tps: 15259.07663
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IncisorFragment-37723"
  value: {
-  dps: 21906.70762
-  tps: 15554.95899
+  dps: 21578.66987
+  tps: 15322.0522
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 22433.77696
-  tps: 15929.17823
+  dps: 22099.77907
+  tps: 15692.03973
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 21732.6298
-  tps: 15431.36374
+  dps: 21397.5431
+  tps: 15193.45219
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 22522.31952
-  tps: 15992.04345
+  dps: 22185.35706
+  tps: 15752.8001
   hps: 60.89842
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 22700.45642
-  tps: 16118.52065
+  dps: 22365.53141
+  tps: 15880.72389
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 22695.50743
-  tps: 16115.08165
+  dps: 22365.26611
+  tps: 15880.61031
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 23070.44546
-  tps: 16381.28765
+  dps: 22741.35397
+  tps: 16147.6327
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 21893.2213
-  tps: 15545.38371
+  dps: 21563.00503
+  tps: 15310.93016
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 21893.2213
-  tps: 15545.38371
+  dps: 21563.00503
+  tps: 15310.93016
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 21723.74164
-  tps: 15425.05315
+  dps: 21395.15939
+  tps: 15191.75976
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50179"
  value: {
-  dps: 23140.17852
-  tps: 16430.72333
+  dps: 22800.29578
+  tps: 16189.40659
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50708"
  value: {
-  dps: 23159.87139
-  tps: 16444.70527
+  dps: 22819.98865
+  tps: 16203.38853
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-55816"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-56347"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 22851.89355
-  tps: 16226.04101
+  dps: 22518.03737
+  tps: 15989.00312
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 23016.91935
-  tps: 16343.20933
+  dps: 22683.92326
+  tps: 16106.7821
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 22246.134
-  tps: 15796.1013
+  dps: 21918.99005
+  tps: 15563.8291
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 22070.35771
-  tps: 15671.15056
+  dps: 21743.06403
+  tps: 15438.77205
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 22240.37806
-  tps: 15791.86501
+  dps: 21910.19402
+  tps: 15557.43434
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 22210.64328
-  tps: 15770.75331
+  dps: 21871.71531
+  tps: 15530.11445
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 22300.76004
-  tps: 15834.73622
+  dps: 21960.40597
+  tps: 15593.08483
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 21764.24872
-  tps: 15453.81318
+  dps: 21433.85629
+  tps: 15219.23455
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 21922.68635
-  tps: 15566.37868
+  dps: 21593.80591
+  tps: 15332.87357
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 22211.38855
-  tps: 15771.35725
+  dps: 21884.2446
+  tps: 15539.08504
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 21866.23833
-  tps: 15526.2258
+  dps: 21526.53712
+  tps: 15285.03794
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 21866.23833
-  tps: 15526.2258
+  dps: 21526.53712
+  tps: 15285.03794
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 21932.705
-  tps: 15573.41714
+  dps: 21591.92176
+  tps: 15331.46103
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 21709.68073
-  tps: 15415.0699
+  dps: 21382.10457
+  tps: 15182.49083
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 22074.13444
-  tps: 15673.83204
+  dps: 21746.52704
+  tps: 15441.23078
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 22470.49256
-  tps: 15955.24631
+  dps: 22135.85108
+  tps: 15717.65085
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 22475.17726
-  tps: 15958.57244
+  dps: 22140.63713
+  tps: 15721.04895
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 21741.64992
-  tps: 15437.76803
+  dps: 21406.58768
+  tps: 15199.87384
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 21907.66023
-  tps: 15555.63535
+  dps: 21566.60773
+  tps: 15313.48808
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 22433.77696
-  tps: 15929.17823
+  dps: 22099.77907
+  tps: 15692.03973
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 22433.77696
-  tps: 15929.17823
+  dps: 22099.77907
+  tps: 15692.03973
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 22433.77696
-  tps: 15929.17823
+  dps: 22099.77907
+  tps: 15692.03973
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 23090.65133
-  tps: 16395.55903
+  dps: 22763.27884
+  tps: 16163.12457
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 23255.63816
-  tps: 16512.69968
+  dps: 22925.79113
+  tps: 16278.50829
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-55854"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-56377"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 22889.1469
-  tps: 16252.49088
+  dps: 22549.26416
+  tps: 16011.17414
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 22875.89499
-  tps: 16243.08203
+  dps: 22536.58155
+  tps: 16002.16949
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 22804.9391
-  tps: 16192.70335
+  dps: 22465.62566
+  tps: 15951.7908
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 22433.77696
-  tps: 15929.17823
+  dps: 22099.77907
+  tps: 15692.03973
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 22160.83596
-  tps: 15735.4649
+  dps: 21833.692
+  tps: 15503.1927
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 22206.94968
-  tps: 15768.20565
+  dps: 21879.80573
+  tps: 15535.93344
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 22549.56715
-  tps: 16011.38926
+  dps: 22212.93589
+  tps: 15772.38107
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-55256"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-56290"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShieldedSkyflareDiamond"
  value: {
-  dps: 22433.77696
-  tps: 15929.17823
+  dps: 22099.77907
+  tps: 15692.03973
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 22169.60568
-  tps: 15741.61662
+  dps: 21839.77505
+  tps: 15507.43687
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 22695.36536
-  tps: 16114.90599
+  dps: 22356.33958
+  tps: 15874.19769
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 22849.85577
-  tps: 16224.59418
+  dps: 22510.11717
+  tps: 15983.37978
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-55879"
  value: {
-  dps: 21793.64786
-  tps: 15474.68657
+  dps: 21456.45376
+  tps: 15235.27875
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-56400"
  value: {
-  dps: 21828.36504
-  tps: 15499.33577
+  dps: 21489.97189
+  tps: 15259.07663
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 22001.33324
-  tps: 15622.21798
+  dps: 21674.18929
+  tps: 15389.94577
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulCasket-58183"
  value: {
-  dps: 21866.23833
-  tps: 15526.2258
+  dps: 21526.53712
+  tps: 15285.03794
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulPreserver-37111"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SouloftheDead-40382"
  value: {
-  dps: 21636.36856
-  tps: 15363.01826
+  dps: 21307.72176
+  tps: 15129.67903
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SparkofLife-37657"
  value: {
-  dps: 21677.72492
-  tps: 15392.38128
+  dps: 21348.3543
+  tps: 15158.52814
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 21818.99407
-  tps: 15492.75717
+  dps: 21492.10803
+  tps: 15260.66808
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 21539.08412
-  tps: 15293.94631
+  dps: 21211.04638
+  tps: 15061.03951
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62465"
  value: {
-  dps: 21757.90322
-  tps: 15449.45745
+  dps: 21430.75927
+  tps: 15217.18524
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62470"
  value: {
-  dps: 21757.90322
-  tps: 15449.45745
+  dps: 21430.75927
+  tps: 15217.18524
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 22475.17726
-  tps: 15958.57244
+  dps: 22140.63713
+  tps: 15721.04895
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 22470.49256
-  tps: 15955.24631
+  dps: 22135.85108
+  tps: 15717.65085
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 22457.55523
-  tps: 15946.0608
+  dps: 22123.0151
+  tps: 15708.53731
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 21538.47367
-  tps: 15293.51289
+  dps: 21210.13142
+  tps: 15060.38989
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 22218.57612
-  tps: 15776.38563
+  dps: 21894.44141
+  tps: 15546.24999
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-55819"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-56351"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 21754.72254
-  tps: 15447.04959
+  dps: 21418.87282
+  tps: 15208.59629
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 21828.36504
-  tps: 15499.33577
+  dps: 21489.97189
+  tps: 15259.07663
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 21551.40481
-  tps: 15302.694
+  dps: 21222.64461
+  tps: 15069.27426
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 22516.19648
-  tps: 15987.69609
+  dps: 22179.25429
+  tps: 15748.46713
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 22816.69529
-  tps: 16201.05024
+  dps: 22478.58416
+  tps: 15960.99134
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 21785.06114
-  tps: 15468.66478
+  dps: 21457.97024
+  tps: 15236.43025
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 21772.84129
-  tps: 15459.98869
+  dps: 21447.83312
+  tps: 15229.23289
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 22433.77696
-  tps: 15929.17823
+  dps: 22099.77907
+  tps: 15692.03973
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 22433.77696
-  tps: 15929.17823
+  dps: 22099.77907
+  tps: 15692.03973
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 21650.76813
-  tps: 15373.24196
+  dps: 21320.02504
+  tps: 15138.41437
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 22433.77696
-  tps: 15929.17823
+  dps: 22099.77907
+  tps: 15692.03973
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 22433.77696
-  tps: 15929.17823
+  dps: 22099.77907
+  tps: 15692.03973
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 21600.75972
-  tps: 15337.88556
+  dps: 21272.72198
+  tps: 15104.97876
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 17639.95371
-  tps: 12525.56372
+  dps: 17338.46581
+  tps: 12311.50731
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 23216.11452
-  tps: 16484.6379
+  dps: 22876.85896
+  tps: 16243.76645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 23216.11452
-  tps: 16484.6379
+  dps: 22876.85896
+  tps: 16243.76645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 19516.17
-  tps: 13857.67728
+  dps: 19187.12474
+  tps: 13624.05515
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 22859.93089
-  tps: 16231.74752
+  dps: 22532.32349
+  tps: 15999.14627
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 22001.00253
-  tps: 15621.90838
+  dps: 21672.96479
+  tps: 15389.00159
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 21757.90322
-  tps: 15449.45745
+  dps: 21430.75927
+  tps: 15217.18524
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 21868.6667
-  tps: 15527.94995
+  dps: 21537.41064
+  tps: 15292.75814
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 21886.08118
-  tps: 15540.31422
+  dps: 21554.94852
+  tps: 15305.21004
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 21872.70852
-  tps: 15530.81964
+  dps: 21546.03342
+  tps: 15298.88032
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 21886.227
-  tps: 15540.41776
+  dps: 21545.83543
+  tps: 15298.73975
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 22769.8151
-  tps: 16167.76531
+  dps: 22440.67675
+  tps: 15934.07708
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 21992.35199
-  tps: 15615.7665
+  dps: 21664.31424
+  tps: 15382.8597
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WingedTalisman-37844"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 21528.53487
-  tps: 15286.45635
+  dps: 21200.49713
+  tps: 15053.54955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 21758.93069
-  tps: 15450.03737
+  dps: 21422.93563
+  tps: 15211.48088
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 21835.53918
-  tps: 15504.42941
+  dps: 21498.03731
+  tps: 15264.80308
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 21835.53918
-  tps: 15504.42941
+  dps: 21498.03731
+  tps: 15264.80308
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 23195.25183
-  tps: 16469.90955
+  dps: 22853.26523
+  tps: 16227.09907
  }
 }
 dps_results: {
@@ -1850,15 +1850,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-aoe-FullBuffs-LongSingleTarget"
  value: {
-  dps: 13406.42046
-  tps: 9519.75512
+  dps: 13065.89079
+  tps: 9277.97905
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-aoe-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 15289.19413
-  tps: 10861.31077
+  dps: 14960.49952
+  tps: 10627.93759
  }
 }
 dps_results: {
@@ -1871,57 +1871,57 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-aoe-NoBuffs-LongSingleTarget"
  value: {
-  dps: 8516.95685
-  tps: 6049.73168
+  dps: 8200.77619
+  tps: 5825.24341
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-aoe-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 8421.91059
-  tps: 5987.03518
+  dps: 8118.4119
+  tps: 5771.55111
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 23008.99962
-  tps: 16337.58632
+  dps: 22669.11689
+  tps: 16096.26958
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 23008.99962
-  tps: 16337.58632
+  dps: 22669.11689
+  tps: 16096.26958
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 28501.91355
-  tps: 20242.34155
+  dps: 28172.59511
+  tps: 20008.52546
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15005.65101
-  tps: 10656.70454
+  dps: 14687.91219
+  tps: 10431.10998
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 15005.65101
-  tps: 10656.70454
+  dps: 14687.91219
+  tps: 10431.10998
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 16420.2527
-  tps: 11665.85809
+  dps: 16123.28911
+  tps: 11455.01393
  }
 }
 dps_results: {
@@ -1934,15 +1934,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-aoe-FullBuffs-LongSingleTarget"
  value: {
-  dps: 13406.42046
-  tps: 9519.75512
+  dps: 13065.89079
+  tps: 9277.97905
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-aoe-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 15289.19413
-  tps: 10861.31077
+  dps: 14960.49952
+  tps: 10627.93759
  }
 }
 dps_results: {
@@ -1955,63 +1955,63 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-aoe-NoBuffs-LongSingleTarget"
  value: {
-  dps: 8516.95685
-  tps: 6049.73168
+  dps: 8200.77619
+  tps: 5825.24341
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-aoe-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 8421.91059
-  tps: 5987.03518
+  dps: 8118.4119
+  tps: 5771.55111
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 23008.99962
-  tps: 16337.58632
+  dps: 22669.11689
+  tps: 16096.26958
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 23008.99962
-  tps: 16337.58632
+  dps: 22669.11689
+  tps: 16096.26958
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 28501.91355
-  tps: 20242.34155
+  dps: 28172.59511
+  tps: 20008.52546
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 15005.65101
-  tps: 10656.70454
+  dps: 14687.91219
+  tps: 10431.10998
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 15005.65101
-  tps: 10656.70454
+  dps: 14687.91219
+  tps: 10431.10998
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 16420.2527
-  tps: 11665.85809
+  dps: 16123.28911
+  tps: 11455.01393
  }
 }
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 19961.49886
-  tps: 14173.86078
+  dps: 19623.55419
+  tps: 13933.92006
  }
 }

--- a/sim/druid/rake.go
+++ b/sim/druid/rake.go
@@ -8,6 +8,12 @@ import (
 )
 
 func (druid *Druid) registerRakeSpell() {
+	// Raw parameters from spell database
+	coefficient := 0.05700000003
+
+	// Scaled parameters for spell code
+	flatBaseDamage := coefficient * druid.ClassSpellScaling // ~56
+
 	druid.Rake = druid.RegisterSpell(Cat, core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 1822},
 		SpellSchool: core.SpellSchoolPhysical,
@@ -37,7 +43,7 @@ func (druid *Druid) registerRakeSpell() {
 			NumberOfTicks: 3 + druid.Talents.EndlessCarnage,
 			TickLength:    time.Second * 3,
 			OnSnapshot: func(sim *core.Simulation, target *core.Unit, dot *core.Dot, isRollover bool) {
-				dot.SnapshotBaseDamage = 336 + 0.147*dot.Spell.MeleeAttackPower()
+				dot.SnapshotBaseDamage = flatBaseDamage + 0.147*dot.Spell.MeleeAttackPower()
 				attackTable := dot.Spell.Unit.AttackTables[target.UnitIndex]
 				dot.SnapshotCritChance = dot.Spell.PhysicalCritChance(attackTable)
 				dot.SnapshotAttackerMultiplier = dot.Spell.AttackerDamageMultiplier(attackTable, true)
@@ -48,7 +54,7 @@ func (druid *Druid) registerRakeSpell() {
 		},
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			baseDamage := 336 + 0.147*spell.MeleeAttackPower()
+			baseDamage := flatBaseDamage + 0.147*spell.MeleeAttackPower()
 			if druid.BleedCategories.Get(target).AnyActive() {
 				baseDamage *= 1.3
 			}
@@ -64,7 +70,7 @@ func (druid *Druid) registerRakeSpell() {
 		},
 
 		ExpectedInitialDamage: func(sim *core.Simulation, target *core.Unit, spell *core.Spell, _ bool) *core.SpellResult {
-			baseDamage := 336 + 0.147*spell.MeleeAttackPower()
+			baseDamage := flatBaseDamage + 0.147*spell.MeleeAttackPower()
 			initial := spell.CalcPeriodicDamage(sim, target, baseDamage, spell.OutcomeExpectedMagicAlwaysHit)
 
 			attackTable := spell.Unit.AttackTables[target.UnitIndex]
@@ -74,7 +80,7 @@ func (druid *Druid) registerRakeSpell() {
 			return initial
 		},
 		ExpectedTickDamage: func(sim *core.Simulation, target *core.Unit, spell *core.Spell, _ bool) *core.SpellResult {
-			tickBase := (336 + 0.147*spell.MeleeAttackPower())
+			tickBase := flatBaseDamage + 0.147*spell.MeleeAttackPower()
 			ticks := spell.CalcPeriodicDamage(sim, target, tickBase, spell.OutcomeExpectedMagicAlwaysHit)
 
 			attackTable := spell.Unit.AttackTables[target.UnitIndex]


### PR DESCRIPTION
Fixed a bug where Rake flat damage was not scaled down by number of ticks.

 On branch feral
 Changes to be committed:
	modified:   sim/druid/feral/TestFeral.results
	modified:   sim/druid/rake.go