### PR TITLE
[Shaman] Crash fix and clearcasting bug fix

### DIFF
--- a/proto/shaman.proto
+++ b/proto/shaman.proto
@@ -145,9 +145,10 @@ enum WaterTotem {
 }
 
 enum CallTotem {
-	Elements = 0;
-	Ancestors = 1;
-	Spirits = 2;
+	NoCall = 0;
+	Elements = 1;
+	Ancestors = 2;
+	Spirits = 3;
 }
 
 message TotemSet {

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -40,2047 +40,2047 @@ character_stats_results: {
 dps_results: {
  key: "TestElemental-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 26809.08015
-  tps: 536.60211
+  dps: 26878.91181
+  tps: 532.54408
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 25451.30796
-  tps: 420.65119
+  dps: 25522.19064
+  tps: 414.50534
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 25515.40133
-  tps: 420.7792
+  dps: 25586.44433
+  tps: 414.67835
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 26522.47105
-  tps: 415.82276
+  dps: 26586.11235
+  tps: 409.84339
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 26887.53035
-  tps: 418.38329
+  dps: 26952.28664
+  tps: 411.91173
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 26186.63352
-  tps: 535.79628
+  dps: 26254.45137
+  tps: 531.73419
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 26186.63352
-  tps: 535.79628
+  dps: 26254.45137
+  tps: 531.73419
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BattlegearoftheRagingElements"
  value: {
-  dps: 19000.50074
-  tps: 395.64365
+  dps: 19032.51124
+  tps: 395.00655
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 25598.63361
-  tps: 417.84133
+  dps: 25653.75178
+  tps: 413.08357
   hps: 89.04794
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 25613.02106
-  tps: 417.65149
+  dps: 25674.13771
+  tps: 411.95035
   hps: 89.04794
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 26208.75356
-  tps: 540.24047
+  dps: 26276.6173
+  tps: 535.62674
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 26624.55079
-  tps: 416.11563
+  dps: 26688.49906
+  tps: 410.91832
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 26638.36831
-  tps: 415.64203
+  dps: 26701.15718
+  tps: 409.74928
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BindingPromise-67037"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlackBruise-50035"
  value: {
-  dps: 20310.22567
-  tps: 516.8418
+  dps: 20361.91149
+  tps: 513.30462
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlackBruise-50692"
  value: {
-  dps: 20310.22567
-  tps: 516.8418
+  dps: 20361.91149
+  tps: 513.30462
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 18243.16885
-  tps: 411.26084
+  dps: 18272.50621
+  tps: 410.59157
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 18231.10967
-  tps: 406.55051
+  dps: 18258.84531
+  tps: 406.0957
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 25382.97706
-  tps: 421.82739
+  dps: 25437.03815
+  tps: 416.68464
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 25462.56264
-  tps: 421.29988
+  dps: 25517.76249
+  tps: 415.90355
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 25420.53231
-  tps: 423.90054
+  dps: 25470.50735
+  tps: 418.79074
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 25417.28498
-  tps: 419.16463
+  dps: 25486.86615
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 25201.9941
-  tps: 417.48586
+  dps: 25274.8353
+  tps: 410.80818
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 25899.19398
-  tps: 417.08502
+  dps: 25955.56105
+  tps: 411.59441
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 25799.16791
-  tps: 419.50774
+  dps: 25855.90486
+  tps: 413.77998
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BottledLightning-66879"
  value: {
-  dps: 25613.22613
-  tps: 420.34646
+  dps: 25685.85139
+  tps: 414.18091
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 26259.16752
-  tps: 534.70187
+  dps: 26327.15101
+  tps: 530.60736
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 26365.28614
-  tps: 535.75972
+  dps: 26433.57606
+  tps: 531.52944
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 26993.11324
-  tps: 538.15256
+  dps: 27063.43348
+  tps: 533.93212
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 26993.11324
-  tps: 538.15256
+  dps: 27063.43348
+  tps: 533.93212
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 26993.11324
-  tps: 538.15256
+  dps: 27063.43348
+  tps: 533.93212
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 26858.89354
-  tps: 536.11372
+  dps: 26930.77742
+  tps: 532.01297
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 26833.03268
-  tps: 536.30695
+  dps: 26902.91435
+  tps: 532.30876
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 26569.61235
-  tps: 422.53032
+  dps: 26641.10667
+  tps: 416.08443
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
   hps: 64
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CrushingWeight-59506"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CrushingWeight-65118"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 25041.37005
-  tps: 418.38711
+  dps: 25111.63564
+  tps: 412.10453
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 25149.79876
-  tps: 471.06867
+  dps: 25215.69473
+  tps: 464.44546
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 25559.44786
-  tps: 433.00578
+  dps: 25630.62691
+  tps: 427.24434
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 25997.24266
-  tps: 422.54449
+  dps: 26070.24099
+  tps: 416.24027
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DeadlyGladiator'sTotemofSurvival-42602"
  value: {
-  dps: 26677.55475
-  tps: 531.51337
+  dps: 26743.18822
+  tps: 528.14283
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Death'sChoice-47464"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 24981.24029
-  tps: 418.79066
+  dps: 25050.83201
+  tps: 412.51074
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 25226.93357
-  tps: 420.9029
+  dps: 25291.94404
+  tps: 415.03284
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 25268.36557
-  tps: 419.72
+  dps: 25338.55884
+  tps: 413.45488
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Defender'sCode-40257"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 26232.68045
-  tps: 535.30789
+  dps: 26302.46473
+  tps: 531.20308
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 26215.77962
-  tps: 535.39997
+  dps: 26283.64336
+  tps: 531.39771
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 26095.35513
-  tps: 423.21361
+  dps: 26160.14317
+  tps: 417.46907
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 25928.63419
-  tps: 422.63799
+  dps: 25994.71407
+  tps: 416.67952
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 26186.63352
-  tps: 535.79628
+  dps: 26254.45137
+  tps: 531.73419
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 26154.91847
-  tps: 429.19987
+  dps: 26218.20162
+  tps: 423.70322
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 26365.28614
-  tps: 541.9437
+  dps: 26433.57606
+  tps: 537.18124
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 26639.58179
-  tps: 540.53482
+  dps: 26709.8505
+  tps: 535.88236
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 26232.68045
-  tps: 535.30789
+  dps: 26302.46473
+  tps: 531.20308
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 26208.75356
-  tps: 535.50112
+  dps: 26276.6173
+  tps: 531.49886
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 26205.92843
-  tps: 535.54798
+  dps: 26273.79217
+  tps: 531.54572
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 25333.18052
-  tps: 421.8225
+  dps: 25394.62855
+  tps: 415.95433
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 26186.63352
-  tps: 535.79628
+  dps: 26254.45137
+  tps: 531.73419
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 26186.63352
-  tps: 535.79628
+  dps: 26254.45137
+  tps: 531.73419
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 25136.89236
-  tps: 448.56714
+  dps: 25201.77687
+  tps: 442.82923
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 25374.28643
-  tps: 418.46521
+  dps: 25445.55585
+  tps: 412.18263
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FallofMortality-59500"
  value: {
-  dps: 25997.24266
-  tps: 422.54449
+  dps: 26070.24099
+  tps: 416.24027
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FallofMortality-65124"
  value: {
-  dps: 26128.06692
-  tps: 423.04428
+  dps: 26201.4228
+  tps: 416.69513
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 25900.71873
-  tps: 416.10817
+  dps: 25965.11204
+  tps: 410.35451
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 26447.16047
-  tps: 422.2234
+  dps: 26518.04334
+  tps: 415.80501
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 26306.45278
-  tps: 422.19307
+  dps: 26379.72898
+  tps: 415.88371
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 25420.53231
-  tps: 423.90054
+  dps: 25470.50735
+  tps: 418.79074
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 25100.31158
-  tps: 422.94325
+  dps: 25170.25768
+  tps: 416.57964
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 26299.66057
-  tps: 532.87734
+  dps: 26361.77212
+  tps: 529.05643
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FluidDeath-58181"
  value: {
-  dps: 25944.6042
-  tps: 417.14902
+  dps: 26003.01767
+  tps: 411.88569
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 25263.18353
-  tps: 419.94879
+  dps: 25333.57683
+  tps: 413.81566
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForgeEmber-37660"
  value: {
-  dps: 25270.10434
-  tps: 418.60414
+  dps: 25341.1385
+  tps: 412.35188
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 26365.28614
-  tps: 537.34442
+  dps: 26433.57606
+  tps: 533.11989
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 26259.16752
-  tps: 536.28379
+  dps: 26327.15101
+  tps: 532.19502
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 26243.48055
-  tps: 536.26827
+  dps: 26311.4325
+  tps: 532.13325
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FuriousGladiator'sTotemofSurvival-42603"
  value: {
-  dps: 26741.62236
-  tps: 531.64415
+  dps: 26807.39768
+  tps: 528.27916
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 25228.74197
-  tps: 417.33744
+  dps: 25301.58317
+  tps: 410.59388
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FuturesightRune-38763"
  value: {
-  dps: 25270.96532
-  tps: 420.46724
+  dps: 25335.94198
+  tps: 414.53844
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GaleofShadows-56138"
  value: {
-  dps: 26223.22395
-  tps: 425.0797
+  dps: 26287.67144
+  tps: 419.66876
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GaleofShadows-56462"
  value: {
-  dps: 26173.98877
-  tps: 433.44623
+  dps: 26230.02451
+  tps: 428.24769
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GearDetector-61462"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 25482.2061
-  tps: 420.7819
+  dps: 25553.17316
+  tps: 414.62023
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 25558.75799
-  tps: 420.90358
+  dps: 25630.54904
+  tps: 414.76955
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 25093.11705
-  tps: 458.52844
+  dps: 25148.22361
+  tps: 453.41699
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HarmlightToken-63839"
  value: {
-  dps: 25831.56803
-  tps: 579.20815
+  dps: 25904.6887
+  tps: 573.99235
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HatefulGladiator'sTotemofSurvival-42601"
  value: {
-  dps: 26609.8676
-  tps: 531.30003
+  dps: 26675.41295
+  tps: 527.92503
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 26334.96336
-  tps: 429.10126
+  dps: 26391.90267
+  tps: 423.97905
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 26498.11074
-  tps: 433.21061
+  dps: 26558.24969
+  tps: 428.1575
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofRage-59224"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofRage-65072"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofSolace-55868"
  value: {
-  dps: 25475.20545
-  tps: 425.0797
+  dps: 25537.71275
+  tps: 419.66876
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofSolace-56393"
  value: {
-  dps: 25518.85382
-  tps: 427.77094
+  dps: 25577.11522
+  tps: 422.33226
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofThunder-55845"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofThunder-56370"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Heartpierce-49982"
  value: {
-  dps: 26993.11324
-  tps: 538.15256
+  dps: 27063.43348
+  tps: 533.93212
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Heartpierce-50641"
  value: {
-  dps: 26993.11324
-  tps: 538.15256
+  dps: 27063.43348
+  tps: 533.93212
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 25476.32205
-  tps: 419.16463
+  dps: 25546.77621
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 26232.68045
-  tps: 535.30789
+  dps: 26302.46473
+  tps: 531.20308
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 26208.75356
-  tps: 535.50112
+  dps: 26276.6173
+  tps: 531.49886
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 26205.92843
-  tps: 535.54798
+  dps: 26273.79217
+  tps: 531.54572
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 25424.7147
-  tps: 425.06288
+  dps: 25476.82045
+  tps: 419.59109
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 25424.7147
-  tps: 425.06288
+  dps: 25476.82045
+  tps: 419.59109
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 25462.56264
-  tps: 421.29988
+  dps: 25517.76249
+  tps: 415.90355
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 25420.53231
-  tps: 423.90054
+  dps: 25470.50735
+  tps: 418.79074
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-IncisorFragment-37723"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 26259.16752
-  tps: 539.91493
+  dps: 26327.15101
+  tps: 535.4005
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 25805.82098
-  tps: 421.96316
+  dps: 25861.19734
+  tps: 416.66432
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 26260.12908
-  tps: 537.30623
+  dps: 26324.54874
+  tps: 533.19427
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 24963.7936
-  tps: 431.42657
+  dps: 25032.75146
+  tps: 424.57092
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 24963.7936
-  tps: 432.2326
+  dps: 25032.75146
+  tps: 425.52474
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 25382.97706
-  tps: 421.82739
+  dps: 25437.03815
+  tps: 416.68464
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 25764.97637
-  tps: 417.72911
+  dps: 25826.97387
+  tps: 411.53376
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 25900.71873
-  tps: 416.10817
+  dps: 25965.11204
+  tps: 410.35451
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 25368.28335
-  tps: 422.32675
+  dps: 25432.69539
+  tps: 416.59408
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 25368.28335
-  tps: 422.32675
+  dps: 25432.69539
+  tps: 416.59408
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 25804.8384
-  tps: 421.61105
+  dps: 25862.09827
+  tps: 416.02288
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LastWord-50179"
  value: {
-  dps: 26993.11324
-  tps: 538.15256
+  dps: 27063.43348
+  tps: 533.93212
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LastWord-50708"
  value: {
-  dps: 26993.11324
-  tps: 538.15256
+  dps: 27063.43348
+  tps: 533.93212
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LeadenDespair-55816"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LeadenDespair-56347"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 25944.6042
-  tps: 417.14902
+  dps: 26003.01767
+  tps: 411.88569
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 25719.8846
-  tps: 417.6388
+  dps: 25782.82058
+  tps: 411.6117
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 25944.6042
-  tps: 417.07405
+  dps: 26003.01767
+  tps: 411.81028
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 25944.6042
-  tps: 417.07405
+  dps: 26003.01767
+  tps: 411.81028
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 25263.67402
-  tps: 416.73976
+  dps: 25320.09483
+  tps: 411.31503
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 25365.63394
-  tps: 419.92848
+  dps: 25424.24384
+  tps: 414.53269
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 25018.05771
-  tps: 418.60414
+  dps: 25088.28328
+  tps: 412.35188
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 25721.28731
-  tps: 417.51813
+  dps: 25784.27401
+  tps: 411.18689
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 25900.71873
-  tps: 416.10817
+  dps: 25965.11204
+  tps: 410.35451
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 25424.7147
-  tps: 425.06288
+  dps: 25476.82045
+  tps: 419.59109
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 25424.7147
-  tps: 425.06288
+  dps: 25476.82045
+  tps: 419.59109
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 26414.08668
-  tps: 426.92802
+  dps: 26474.46354
+  tps: 421.75834
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 25303.15144
-  tps: 419.82179
+  dps: 25374.14093
+  tps: 413.67508
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 25115.1622
-  tps: 418.36741
+  dps: 25185.21629
+  tps: 411.77541
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 26205.92843
-  tps: 535.54798
+  dps: 26273.79217
+  tps: 531.54572
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 26208.75356
-  tps: 535.50112
+  dps: 26276.6173
+  tps: 531.49886
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 26186.63352
-  tps: 535.79628
+  dps: 26254.45137
+  tps: 531.73419
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 26186.63352
-  tps: 535.79628
+  dps: 26254.45137
+  tps: 531.73419
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 26186.63352
-  tps: 535.79628
+  dps: 26254.45137
+  tps: 531.73419
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Rainsong-55854"
  value: {
-  dps: 25764.97637
-  tps: 417.69898
+  dps: 25826.97387
+  tps: 411.50363
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Rainsong-56377"
  value: {
-  dps: 25900.71873
-  tps: 416.08154
+  dps: 25965.11204
+  tps: 410.32788
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RegaliaoftheRagingElements"
  value: {
-  dps: 23865.15439
-  tps: 516.91563
+  dps: 23916.24546
+  tps: 513.38347
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 25504.34154
-  tps: 616.2564
+  dps: 25566.65973
+  tps: 611.32564
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 25578.06265
-  tps: 641.16167
+  dps: 25640.5698
+  tps: 636.30483
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 26809.08015
-  tps: 536.60211
+  dps: 26878.91181
+  tps: 532.54408
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RelentlessGladiator'sTotemofSurvival-42604"
  value: {
-  dps: 26803.10402
-  tps: 531.92693
+  dps: 26869.04941
+  tps: 528.56625
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 26809.08015
-  tps: 536.60211
+  dps: 26878.91181
+  tps: 532.54408
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 27111.19572
-  tps: 536.58694
+  dps: 27182.94585
+  tps: 532.34128
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 26357.5396
-  tps: 536.32496
+  dps: 26425.57822
+  tps: 532.68317
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 25843.73493
-  tps: 415.82276
+  dps: 25905.56607
+  tps: 409.84339
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 25900.71873
-  tps: 416.10817
+  dps: 25965.11204
+  tps: 410.35451
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SavageGladiator'sTotemofSurvival-42594"
  value: {
-  dps: 26574.06451
-  tps: 531.14311
+  dps: 26639.51114
+  tps: 527.76363
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SeaStar-55256"
  value: {
-  dps: 26153.6999
-  tps: 417.49945
+  dps: 26217.76199
+  tps: 411.1682
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SeaStar-56290"
  value: {
-  dps: 26321.31508
-  tps: 416.08154
+  dps: 26386.072
+  tps: 410.32788
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Shadowmourne-49623"
  value: {
-  dps: 26993.11324
-  tps: 538.15256
+  dps: 27063.43348
+  tps: 533.93212
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ShieldedSkyflareDiamond"
  value: {
-  dps: 26186.63352
-  tps: 535.79628
+  dps: 26254.45137
+  tps: 531.73419
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 25674.1162
-  tps: 418.32269
+  dps: 25737.69418
+  tps: 412.28989
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 25094.42286
-  tps: 422.63878
+  dps: 25160.92569
+  tps: 416.69746
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 25222.63129
-  tps: 421.167
+  dps: 25288.04687
+  tps: 415.11531
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SkycallTotem-33506"
  value: {
-  dps: 26563.75136
-  tps: 531.45849
+  dps: 26627.11237
+  tps: 528.23579
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SkyshatterHarness"
  value: {
-  dps: 12350.11388
-  tps: 299.07415
+  dps: 12400.94217
+  tps: 298.32398
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SkyshatterRegalia"
  value: {
-  dps: 13679.24416
-  tps: 318.94729
+  dps: 13743.06141
+  tps: 319.45411
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 25389.9172
-  tps: 424.25257
+  dps: 25460.648
+  tps: 417.99473
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 25448.33323
-  tps: 424.9
+  dps: 25519.20748
+  tps: 418.62367
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Sorrowsong-55879"
  value: {
-  dps: 25929.29547
-  tps: 421.29988
+  dps: 25985.26853
+  tps: 415.90355
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Sorrowsong-56400"
  value: {
-  dps: 25281.79885
-  tps: 426.89051
+  dps: 25347.30048
+  tps: 420.82529
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 25843.73493
-  tps: 415.82276
+  dps: 25905.56607
+  tps: 409.84339
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SoulCasket-58183"
  value: {
-  dps: 26008.23295
-  tps: 425.06288
+  dps: 26061.15214
+  tps: 419.59109
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SoulPreserver-37111"
  value: {
-  dps: 25169.76576
-  tps: 419.59432
+  dps: 25239.89749
+  tps: 413.40536
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SouloftheDead-40382"
  value: {
-  dps: 25034.48375
-  tps: 421.85973
+  dps: 25104.74934
+  tps: 415.74414
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SparkofLife-37657"
  value: {
-  dps: 25224.8177
-  tps: 417.93475
+  dps: 25278.16093
+  tps: 412.43788
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 25120.29363
-  tps: 418.73007
+  dps: 25176.74762
+  tps: 413.42237
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Spiritwalker'sRegalia"
  value: {
-  dps: 24993.28207
-  tps: 506.45473
+  dps: 25047.43117
+  tps: 503.24898
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Stonebreaker'sTotem-33507"
  value: {
-  dps: 26432.34132
-  tps: 531.78753
+  dps: 26494.46453
+  tps: 528.51051
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 25795.81023
-  tps: 419.26198
+  dps: 25869.39058
+  tps: 412.91174
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-StumpofTime-62465"
  value: {
-  dps: 27169.28782
-  tps: 415.69001
+  dps: 27225.55688
+  tps: 410.41739
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-StumpofTime-62470"
  value: {
-  dps: 26813.06436
-  tps: 417.14902
+  dps: 26873.36194
+  tps: 411.88569
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 26208.75356
-  tps: 535.50112
+  dps: 26276.6173
+  tps: 531.49886
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 26205.92843
-  tps: 535.54798
+  dps: 26273.79217
+  tps: 531.54572
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 26198.01965
-  tps: 535.5786
+  dps: 26265.88339
+  tps: 531.57635
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 26017.48966
-  tps: 421.03323
+  dps: 26074.40096
+  tps: 415.79225
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 25289.95624
-  tps: 418.03251
+  dps: 25351.81389
+  tps: 412.8909
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TearofBlood-55819"
  value: {
-  dps: 25651.56982
-  tps: 421.36509
+  dps: 25723.62463
+  tps: 415.13249
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TearofBlood-56351"
  value: {
-  dps: 25880.27554
-  tps: 422.19307
+  dps: 25952.9674
+  tps: 415.88371
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 25229.68356
-  tps: 419.82281
+  dps: 25299.98404
+  tps: 413.66768
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 26034.44971
-  tps: 422.17862
+  dps: 26089.7944
+  tps: 416.96177
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 26125.82168
-  tps: 424.85196
+  dps: 26185.61126
+  tps: 418.82801
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 26612.00251
-  tps: 428.86803
+  dps: 26684.05669
+  tps: 422.58248
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 26186.63352
-  tps: 535.79628
+  dps: 26254.45137
+  tps: 531.73419
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 25462.56264
-  tps: 421.29988
+  dps: 25517.76249
+  tps: 415.90355
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 25420.53231
-  tps: 423.90054
+  dps: 25470.50735
+  tps: 418.79074
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TidefuryRaiment"
  value: {
-  dps: 16506.68353
-  tps: 375.13163
+  dps: 16533.79787
+  tps: 375.09745
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 25365.11397
-  tps: 419.70144
+  dps: 25425.50029
+  tps: 414.2993
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 25365.11397
-  tps: 419.70144
+  dps: 25425.50029
+  tps: 414.2993
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 26259.16752
-  tps: 536.28379
+  dps: 26327.15101
+  tps: 532.19502
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 26243.48055
-  tps: 536.26827
+  dps: 26311.4325
+  tps: 532.13325
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 25331.96086
-  tps: 422.11246
+  dps: 25402.40788
+  tps: 415.49737
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TotemofQuakingEarth-47667"
  value: {
-  dps: 26450.31012
-  tps: 530.75011
+  dps: 26515.83788
+  tps: 527.49351
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 26243.48055
-  tps: 536.26827
+  dps: 26311.4325
+  tps: 532.13325
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 26259.16752
-  tps: 536.28379
+  dps: 26327.15101
+  tps: 532.19502
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 26102.12527
-  tps: 520.64067
+  dps: 26159.26168
+  tps: 514.81203
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 17745.62125
-  tps: 399.62473
+  dps: 17775.10805
+  tps: 399.7798
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-UnheededWarning-59520"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 25955.87782
-  tps: 418.36128
+  dps: 26023.16491
+  tps: 412.31909
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 25424.7147
-  tps: 425.06288
+  dps: 25476.82045
+  tps: 419.59109
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 25424.7147
-  tps: 425.06288
+  dps: 25476.82045
+  tps: 419.59109
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 22515.52038
-  tps: 523.14406
+  dps: 22577.26694
+  tps: 518.91697
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 25442.6447
-  tps: 419.16463
+  dps: 25512.26072
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 26053.88239
-  tps: 417.14413
+  dps: 26119.39469
+  tps: 411.17588
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 25611.45235
-  tps: 429.88062
+  dps: 25668.51506
+  tps: 424.34624
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 25251.92944
-  tps: 417.13529
+  dps: 25324.77065
+  tps: 410.39173
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 25431.99953
-  tps: 424.5836
+  dps: 25488.05123
+  tps: 419.06072
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 26017.55631
-  tps: 418.33612
+  dps: 26088.7495
+  tps: 412.07498
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 24963.7936
-  tps: 419.16463
+  dps: 25032.75146
+  tps: 412.93156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-VolcanicRegalia"
  value: {
-  dps: 23972.45029
-  tps: 493.16189
+  dps: 24019.41411
+  tps: 490.49354
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WingedTalisman-37844"
  value: {
-  dps: 25485.68441
-  tps: 418.03255
+  dps: 25548.02306
+  tps: 412.89095
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 25977.19644
-  tps: 424.31209
+  dps: 26048.09729
+  tps: 417.77382
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 26383.62496
-  tps: 430.20032
+  dps: 26444.17852
+  tps: 424.3985
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 25382.97706
-  tps: 421.82739
+  dps: 25437.03815
+  tps: 416.68464
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WrathfulGladiator'sTotemofSurvival-51513"
  value: {
-  dps: 26874.00575
-  tps: 532.25507
+  dps: 26940.1433
+  tps: 528.88593
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 25232.32063
-  tps: 419.65872
+  dps: 25292.32052
+  tps: 413.99038
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 25232.32063
-  tps: 419.65872
+  dps: 25292.32052
+  tps: 413.99038
  }
 }
 dps_results: {
  key: "TestElemental-Average-Default"
  value: {
-  dps: 27406.6968
-  tps: 529.90209
+  dps: 27475.04815
+  tps: 525.90955
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-Standard-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 28750.98935
-  tps: 9152.24005
+  dps: 28817.33031
+  tps: 9060.91888
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-Standard-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 27373.97376
-  tps: 530.79533
+  dps: 27437.31017
+  tps: 527.7436
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-Standard-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 33094.77021
-  tps: 695.07015
+  dps: 33166.09169
+  tps: 693.69697
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-Standard-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 22307.35996
-  tps: 8967.65552
+  dps: 22351.48979
+  tps: 8967.97116
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-Standard-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 20824.99567
-  tps: 511.0805
+  dps: 20864.2241
+  tps: 511.43412
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-Standard-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 23974.29026
-  tps: 592.73946
+  dps: 24002.79579
+  tps: 593.06464
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-Standard-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 28724.76746
-  tps: 9118.16913
+  dps: 28785.44089
+  tps: 9038.1495
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-Standard-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 26993.11324
-  tps: 538.15256
+  dps: 27063.43348
+  tps: 533.93212
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-Standard-default-FullBuffs-ShortSingleTarget"
  value: {
-  dps: 32526.44638
-  tps: 689.35811
+  dps: 32594.32034
+  tps: 688.51626
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-Standard-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 22176.9014
-  tps: 8989.51936
+  dps: 22226.15384
+  tps: 8989.8527
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-Standard-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 20819.4293
-  tps: 509.6889
+  dps: 20860.84165
+  tps: 509.90005
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-Standard-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 23308.26345
-  tps: 576.6768
+  dps: 23332.19037
+  tps: 577.00196
  }
 }
 dps_results: {
  key: "TestElemental-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 26961.44459
-  tps: 538.15256
+  dps: 27031.76483
+  tps: 533.93212
  }
 }

--- a/sim/shaman/talents.go
+++ b/sim/shaman/talents.go
@@ -124,6 +124,9 @@ func (shaman *Shaman) applyElementalFocus() {
 		return
 	}
 
+	var triggeringSpell *core.Spell
+	var triggerTime time.Duration
+
 	affectedSpells := SpellMaskLightningBolt | SpellMaskChainLightning | SpellMaskLavaBurst | SpellMaskFireNova | SpellMaskEarthShock | SpellMaskFlameShock | SpellMaskFrostShock
 	costReductionMod := shaman.AddDynamicMod(core.SpellModConfig{
 		Kind:       core.SpellMod_PowerCost_Pct,
@@ -165,6 +168,9 @@ func (shaman *Shaman) applyElementalFocus() {
 			if !spell.Flags.Matches(SpellFlagShock|SpellFlagFocusable) || (spell.ClassSpellMask&(SpellMaskOverload|SpellMaskThunderstorm) != 0) {
 				return
 			}
+			if spell == triggeringSpell && sim.CurrentTime == triggerTime {
+				return
+			}
 			aura.RemoveStack(sim)
 		},
 	})
@@ -182,6 +188,8 @@ func (shaman *Shaman) applyElementalFocus() {
 			if !result.Outcome.Matches(core.OutcomeCrit) {
 				return
 			}
+			triggeringSpell = spell
+			triggerTime = sim.CurrentTime
 			clearcastingAura.Activate(sim)
 			clearcastingAura.SetStacks(sim, maxStacks)
 		},

--- a/sim/shaman/totems.go
+++ b/sim/shaman/totems.go
@@ -118,6 +118,9 @@ func (shaman *Shaman) registerStoneskinTotemSpell() {
 }
 
 func (shaman *Shaman) registerTotemCall(spellID int32, totemSet *proto.TotemSet) {
+	if totemSet == nil {
+		return
+	}
 	airTotem := shaman.getAirTotemSpell(totemSet.Air)
 	earthTotem := shaman.getEarthTotemSpell(totemSet.Earth)
 	fireTotem := shaman.getFireTotemSpell(totemSet.Fire)

--- a/ui/shaman/elemental/presets.ts
+++ b/ui/shaman/elemental/presets.ts
@@ -12,6 +12,7 @@ import {
 	ShamanTotems,
 	WaterTotem,
 	TotemSet,
+	CallTotem,
 } from '../../core/proto/shaman.js';
 import { SavedTalents } from '../../core/proto/ui.js';
 import DefaultApl from './apls/default.apl.json';
@@ -68,6 +69,7 @@ export const TalentsImprovedShields = {
 export const DefaultOptions = ElementalShamanOptions.create({
 	classOptions: {
 		shield: ShamanShield.LightningShield,
+		call: CallTotem.Elements,
 		totems: ShamanTotems.create({
 			elements: TotemSet.create({
 				earth: EarthTotem.StrengthOfEarthTotem,

--- a/ui/shaman/enhancement/presets.ts
+++ b/ui/shaman/enhancement/presets.ts
@@ -14,6 +14,7 @@ import {
 	ShamanTotems,
 	WaterTotem,
 	TotemSet,
+	CallTotem,
 } from '../../core/proto/shaman.js';
 import { SavedTalents } from '../../core/proto/ui.js';
 import DefaultApl from './apls/default.apl.json';
@@ -52,6 +53,7 @@ export const StandardTalents = {
 export const DefaultOptions = EnhancementShamanOptions.create({
 	classOptions: {
 		shield: ShamanShield.LightningShield,
+		call: CallTotem.Elements,
 		totems: ShamanTotems.create({
 			elements: TotemSet.create({
 				earth: EarthTotem.StrengthOfEarthTotem,

--- a/ui/shaman/inputs.ts
+++ b/ui/shaman/inputs.ts
@@ -54,7 +54,7 @@ export function TotemsSection(parentElem: HTMLElement, simUI: IndividualSimUI<an
 			{ actionId: ActionId.fromSpellId(66844), value: CallTotem.Spirits },
 		],
 		equals: (a: CallTotem, b: CallTotem) => a == b,
-		zeroValue: CallTotem.Elements,
+		zeroValue: CallTotem.NoCall,
 		changedEvent: (player: Player<ShamanSpecs>) => player.specOptionsChangeEmitter,
 		getValue: (player: Player<ShamanSpecs>) => player.getSpecOptions().classOptions?.call || CallTotem.Elements,
 		setValue: (eventID: EventID, player: Player<ShamanSpecs>, newValue: number) => {


### PR DESCRIPTION
Fixed a crash occruing when loading the new totem call thing with an old incompatible settings
Fixed no travel time spells consuming their own procced Clearcasting

Fixes #308, #298