### PR TITLE
[Mage] Crit multiplier change & DoT crits

### DIFF
--- a/sim/mage/arcane/arcane_barrage.go
+++ b/sim/mage/arcane/arcane_barrage.go
@@ -32,7 +32,7 @@ func (arcane *ArcaneMage) registerArcaneBarrageSpell() {
 		},
 
 		DamageMultiplier: 1,
-		CritMultiplier:   arcane.DefaultSpellCritMultiplier(),
+		CritMultiplier:   arcane.DefaultMageCritMultiplier(),
 		BonusCoefficient: 0.907,
 		ThreatMultiplier: 1,
 

--- a/sim/mage/arcane_blast.go
+++ b/sim/mage/arcane_blast.go
@@ -77,7 +77,7 @@ func (mage *Mage) registerArcaneBlastSpell() {
 		},
 
 		DamageMultiplier: 1,
-		CritMultiplier:   mage.DefaultSpellCritMultiplier(),
+		CritMultiplier:   mage.DefaultMageCritMultiplier(),
 		BonusCoefficient: 1.0,
 		ThreatMultiplier: 1,
 

--- a/sim/mage/arcane_explosion.go
+++ b/sim/mage/arcane_explosion.go
@@ -23,7 +23,7 @@ func (mage *Mage) registerArcaneExplosionSpell() {
 		},
 
 		DamageMultiplier: 1,
-		CritMultiplier:   mage.DefaultSpellCritMultiplier(),
+		CritMultiplier:   mage.DefaultMageCritMultiplier(),
 		BonusCoefficient: 0.186,
 		ThreatMultiplier: 1 - 0.4*float64(mage.Talents.ImprovedArcaneExplosion),
 

--- a/sim/mage/arcane_missiles.go
+++ b/sim/mage/arcane_missiles.go
@@ -34,7 +34,7 @@ func (mage *Mage) registerArcaneMissilesSpell() {
 		MissileSpeed:   20,
 
 		DamageMultiplier: 1,
-		CritMultiplier:   mage.DefaultSpellCritMultiplier(),
+		CritMultiplier:   mage.DefaultMageCritMultiplier(),
 		ThreatMultiplier: 1,
 		BonusCoefficient: 0.278,
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/mage/blast_wave.go
+++ b/sim/mage/blast_wave.go
@@ -30,7 +30,7 @@ func (mage *Mage) registerBlastWaveSpell() {
 			},
 		},
 		DamageMultiplierAdditive: 1,
-		CritMultiplier:           mage.DefaultSpellCritMultiplier(),
+		CritMultiplier:           mage.DefaultMageCritMultiplier(),
 		BonusCoefficient:         0.193,
 		ThreatMultiplier:         1,
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/mage/blizzard.go
+++ b/sim/mage/blizzard.go
@@ -34,7 +34,7 @@ func (mage *Mage) registerBlizzardSpell() {
 		ClassSpellMask: MageSpellBlizzard,
 
 		DamageMultiplier: 1,
-		CritMultiplier:   mage.DefaultSpellCritMultiplier(),
+		CritMultiplier:   mage.DefaultMageCritMultiplier(),
 		BonusCoefficient: 0.162,
 		ThreatMultiplier: 1,
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/mage/combustion.go
+++ b/sim/mage/combustion.go
@@ -66,7 +66,7 @@ func (mage *Mage) registerCombustionSpell() {
 			},
 		},
 		DamageMultiplierAdditive: 1,
-		CritMultiplier:           mage.DefaultSpellCritMultiplier(),
+		CritMultiplier:           mage.DefaultMageCritMultiplier(),
 		BonusCoefficient:         1.113,
 		ThreatMultiplier:         1,
 

--- a/sim/mage/deep_freeze.go
+++ b/sim/mage/deep_freeze.go
@@ -32,7 +32,7 @@ func (mage *Mage) registerDeepFreezeSpell() {
 		},
 
 		DamageMultiplier: 1,
-		CritMultiplier:   mage.DefaultSpellCritMultiplier(),
+		CritMultiplier:   mage.DefaultMageCritMultiplier(),
 		BonusCoefficient: 2.058,
 		ThreatMultiplier: 1,
 

--- a/sim/mage/dragons_breath.go
+++ b/sim/mage/dragons_breath.go
@@ -30,7 +30,7 @@ func (mage *Mage) registerDragonsBreathSpell() {
 			},
 		},
 		DamageMultiplierAdditive: 1,
-		CritMultiplier:           mage.DefaultSpellCritMultiplier(),
+		CritMultiplier:           mage.DefaultMageCritMultiplier(),
 		BonusCoefficient:         0.193,
 		ThreatMultiplier:         1,
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/mage/fire/pyroblast.go
+++ b/sim/mage/fire/pyroblast.go
@@ -57,7 +57,7 @@ func (fire *FireMage) registerPyroblastSpell() {
 		},
 
 		DamageMultiplier: 1,
-		CritMultiplier:   fire.DefaultSpellCritMultiplier(),
+		CritMultiplier:   fire.DefaultMageCritMultiplier(),
 		ThreatMultiplier: 1,
 
 		Dot: core.DotConfig{

--- a/sim/mage/fire_blast.go
+++ b/sim/mage/fire_blast.go
@@ -28,7 +28,7 @@ func (mage *Mage) registerFireBlastSpell() {
 		},
 
 		DamageMultiplierAdditive: 1,
-		CritMultiplier:           mage.DefaultSpellCritMultiplier(),
+		CritMultiplier:           mage.DefaultMageCritMultiplier(),
 		BonusCoefficient:         0.429,
 		ThreatMultiplier:         1,
 

--- a/sim/mage/fireball.go
+++ b/sim/mage/fireball.go
@@ -28,7 +28,7 @@ func (mage *Mage) registerFireballSpell() {
 		},
 
 		DamageMultiplierAdditive: 1,
-		CritMultiplier:           mage.DefaultSpellCritMultiplier(),
+		CritMultiplier:           mage.DefaultMageCritMultiplier(),
 		BonusCoefficient:         1.236,
 		ThreatMultiplier:         1,
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/mage/flamestrike.go
+++ b/sim/mage/flamestrike.go
@@ -39,12 +39,13 @@ func (mage *Mage) registerFlamestrikeSpell() {
 			TickLength:    time.Second * 2,
 			OnSnapshot: func(sim *core.Simulation, _ *core.Unit, dot *core.Dot, _ bool) {
 				target := mage.CurrentTarget
-				dot.SnapshotBaseDamage = 0.103 * mage.ClassSpellScaling
+				baseDamage := 0.103 * mage.ClassSpellScaling
+				dot.Snapshot(target, baseDamage)
 				dot.SnapshotAttackerMultiplier = dot.Spell.AttackerDamageMultiplier(dot.Spell.Unit.AttackTables[target.UnitIndex], true)
 			},
 			OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
 				for _, aoeTarget := range sim.Encounter.TargetUnits {
-					dot.CalcAndDealPeriodicSnapshotDamage(sim, aoeTarget, dot.OutcomeTick)
+					dot.CalcAndDealPeriodicSnapshotDamage(sim, aoeTarget, dot.OutcomeSnapshotCrit)
 				}
 			},
 			BonusCoefficient: 0.061,

--- a/sim/mage/flamestrike.go
+++ b/sim/mage/flamestrike.go
@@ -26,7 +26,7 @@ func (mage *Mage) registerFlamestrikeSpell() {
 		},
 
 		DamageMultiplierAdditive: 1,
-		CritMultiplier:           mage.DefaultSpellCritMultiplier(),
+		CritMultiplier:           mage.DefaultMageCritMultiplier(),
 		BonusCoefficient:         0.146,
 		ThreatMultiplier:         1,
 

--- a/sim/mage/freeze.go
+++ b/sim/mage/freeze.go
@@ -26,7 +26,7 @@ func (mage *Mage) registerFreezeSpell() {
 		},
 
 		DamageMultiplierAdditive: 1,
-		CritMultiplier:           mage.DefaultSpellCritMultiplier(),
+		CritMultiplier:           mage.DefaultMageCritMultiplier(),
 		BonusCoefficient:         0.029,
 		ThreatMultiplier:         1,
 

--- a/sim/mage/frostbolt.go
+++ b/sim/mage/frostbolt.go
@@ -33,7 +33,7 @@ func (mage *Mage) registerFrostboltSpell() {
 		},
 
 		DamageMultiplierAdditive: 1,
-		CritMultiplier:           mage.DefaultSpellCritMultiplier(),
+		CritMultiplier:           mage.DefaultMageCritMultiplier(),
 		BonusCoefficient:         0.943,
 		ThreatMultiplier:         1,
 

--- a/sim/mage/frostfire_bolt.go
+++ b/sim/mage/frostfire_bolt.go
@@ -31,7 +31,7 @@ func (mage *Mage) registerFrostfireBoltSpell() {
 		},
 
 		DamageMultiplier: 1,
-		CritMultiplier:   mage.DefaultSpellCritMultiplier(),
+		CritMultiplier:   mage.DefaultMageCritMultiplier(),
 		BonusCoefficient: 0.977,
 		ThreatMultiplier: 1,
 

--- a/sim/mage/ice_lance.go
+++ b/sim/mage/ice_lance.go
@@ -23,7 +23,7 @@ func (mage *Mage) registerIceLanceSpell() {
 		},
 
 		DamageMultiplierAdditive: 1,
-		CritMultiplier:           mage.DefaultSpellCritMultiplier(),
+		CritMultiplier:           mage.DefaultMageCritMultiplier(),
 		BonusCoefficient:         0.378,
 		ThreatMultiplier:         1,
 

--- a/sim/mage/living_bomb.go
+++ b/sim/mage/living_bomb.go
@@ -59,7 +59,7 @@ func (mage *Mage) registerLivingBombSpell() {
 		},
 
 		DamageMultiplierAdditive: 1,
-		CritMultiplier:           mage.DefaultSpellCritMultiplier(),
+		CritMultiplier:           mage.DefaultMageCritMultiplier(),
 		ThreatMultiplier:         1,
 
 		Dot: core.DotConfig{

--- a/sim/mage/living_bomb.go
+++ b/sim/mage/living_bomb.go
@@ -82,7 +82,7 @@ func (mage *Mage) registerLivingBombSpell() {
 				dot.Snapshot(target, 0.25*mage.ClassSpellScaling)
 			},
 			OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
-				dot.CalcAndDealPeriodicSnapshotDamage(sim, target, dot.OutcomeTickCounted)
+				dot.CalcAndDealPeriodicSnapshotDamage(sim, target, dot.OutcomeSnapshotCrit)
 			},
 		},
 

--- a/sim/mage/mage.go
+++ b/sim/mage/mage.go
@@ -274,6 +274,10 @@ func (mage *Mage) hasChillEffect(spell *core.Spell) bool {
 	return spell.ClassSpellMask&MageSpellChill > 0 || (spell.ClassSpellMask == MageSpellBlizzard && mage.Talents.IceShards > 0)
 }
 
+func (mage *Mage) DefaultMageCritMultiplier() float64 {
+	return mage.SpellCritMultiplier(1.33, 0)
+}
+
 const (
 	MageSpellFlagNone      int64 = 0
 	MageSpellArcaneBarrage int64 = 1 << iota

--- a/sim/mage/scorch.go
+++ b/sim/mage/scorch.go
@@ -15,8 +15,7 @@ func (mage *Mage) registerScorchSpell() {
 		ClassSpellMask: MageSpellScorch,
 
 		ManaCost: core.ManaCostOptions{
-			BaseCost: 0.08 -
-				0.04*float64(mage.Talents.ImprovedScorch),
+			BaseCost: 0.08,
 		},
 		Cast: core.CastConfig{
 			DefaultCast: core.Cast{
@@ -29,7 +28,7 @@ func (mage *Mage) registerScorchSpell() {
 
 		DamageMultiplierAdditive: 1,
 
-		CritMultiplier:   mage.DefaultSpellCritMultiplier(),
+		CritMultiplier:   mage.DefaultMageCritMultiplier(),
 		BonusCoefficient: 0.512,
 		ThreatMultiplier: 1,
 


### PR DESCRIPTION
Changed mage spells to use new crit multiplier data (primary modifier = 1.33).
Pets still use default (confirmed in logs).

Added ability for Living Bomb and Flamestrike to crit.