### PR TITLE
Add shield to off-hand enchants

### DIFF
--- a/ui/core/proto_utils/enchants.ts
+++ b/ui/core/proto_utils/enchants.ts
@@ -1,6 +1,4 @@
-import {
-	UIEnchant as Enchant,
-} from '../proto/ui.js';
+import { UIEnchant as Enchant } from '../proto/ui.js';
 
 let descriptionsPromise: Promise<Record<number, string>> | null = null;
 function fetchEnchantDescriptions(): Promise<Record<number, string>> {
@@ -9,7 +7,7 @@ function fetchEnchantDescriptions(): Promise<Record<number, string>> {
 			.then(response => response.json())
 			.then(json => {
 				const descriptionsMap: Record<number, string> = {};
-				for (let idStr in json) {
+				for (const idStr in json) {
 					descriptionsMap[parseInt(idStr)] = json[idStr];
 				}
 				return descriptionsMap;

--- a/ui/core/proto_utils/utils.ts
+++ b/ui/core/proto_utils/utils.ts
@@ -1761,11 +1761,21 @@ export function enchantAppliesToItem(enchant: Enchant, item: Item): boolean {
 
 	if (enchant.enchantType == EnchantType.EnchantTypeTwoHand && item.handType != HandType.HandTypeTwoHand) return false;
 
-	if ((enchant.enchantType == EnchantType.EnchantTypeShield) != (item.weaponType == WeaponType.WeaponTypeShield)) return false;
+	if (
+		(enchant.enchantType == EnchantType.EnchantTypeShield || enchant.enchantType == EnchantType.EnchantTypeOffHand) !==
+		(item.weaponType == WeaponType.WeaponTypeShield)
+	)
+		return false;
 
 	if (enchant.enchantType == EnchantType.EnchantTypeStaff && item.weaponType != WeaponType.WeaponTypeStaff) return false;
 
-	if ((item.weaponType == WeaponType.WeaponTypeOffHand) != (enchant.enchantType == EnchantType.EnchantTypeOffHand)) return false;
+	if (
+		(enchant.enchantType == EnchantType.EnchantTypeOffHand) !==
+		(item.weaponType == WeaponType.WeaponTypeOffHand ||
+			// All off-hand enchants can be applied to shields as well
+			(item.weaponType == WeaponType.WeaponTypeShield && enchant.enchantType == EnchantType.EnchantTypeOffHand))
+	)
+		return false;
 
 	if (sharedSlots.includes(ItemSlot.ItemSlotRanged)) {
 		if (
@@ -1815,7 +1825,7 @@ export function makeBlessingsAssignments(numPaladins: number): BlessingsAssignme
 	const assignments = makeBlankBlessingsAssignments(numPaladins);
 	for (let i = 1; i < Object.keys(Spec).length; i++) {
 		const spec = i;
-		const blessings = [Blessings.BlessingOfKings, Blessings.BlessingOfMight]
+		const blessings = [Blessings.BlessingOfKings, Blessings.BlessingOfMight];
 		for (let j = 0; j < blessings.length; j++) {
 			if (j >= assignments.paladins.length) {
 				// Can't assign more blessings since we ran out of paladins


### PR DESCRIPTION
All Cata off-hand enchants are also applicable to shields. As I couldn't modify the enchants, not I wanted to duplicate them I decided to extend the FE filter to allow for this.