### PR TITLE
Fix used rseed on label rand init

### DIFF
--- a/sim/core/sim.go
+++ b/sim/core/sim.go
@@ -221,7 +221,7 @@ func (sim *Simulation) labelRand(label string) Rand {
 	labelRng, ok := sim.testRands[label]
 	if !ok {
 		// Add rseed to the label, so we still have run-run variance for stat weights.
-		labelRng = NewSplitMix(uint64(makeTestRandSeed(sim.rseed, label)))
+		labelRng = NewSplitMix(uint64(makeTestRandSeed(sim.rand.GetSeed(), label)))
 		sim.testRands[label] = labelRng
 	}
 	return labelRng

--- a/sim/death_knight/blood/TestBlood.results
+++ b/sim/death_knight/blood/TestBlood.results
@@ -1439,16 +1439,16 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 13786.50982
-  tps: 69370.06273
+  dps: 13786.5421
+  tps: 69370.22409
   hps: 4688.68612
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 13786.83716
-  tps: 69371.91665
+  dps: 13786.87333
+  tps: 69372.09747
   hps: 4688.68612
  }
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -371,8 +371,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 21528.16042
-  tps: 15288.49345
+  dps: 21528.19335
+  tps: 15288.51684
  }
 }
 dps_results: {

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -371,8 +371,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 21527.5878
-  tps: 15288.08689
+  dps: 21527.60911
+  tps: 15288.10203
  }
 }
 dps_results: {

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -46,15 +46,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 38028.64158
-  tps: 343.34506
+  dps: 38003.65402
+  tps: 343.37358
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 38113.79874
-  tps: 343.54192
+  dps: 38088.7523
+  tps: 343.57264
  }
 }
 dps_results: {
@@ -88,8 +88,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
@@ -125,8 +125,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
@@ -146,8 +146,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-BindingPromise-67037"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
@@ -181,50 +181,50 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 37831.28203
-  tps: 346.69814
+  dps: 37833.38317
+  tps: 346.26475
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 37855.12907
-  tps: 346.75753
+  dps: 37857.23021
+  tps: 346.32414
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 37873.61589
-  tps: 347.89281
+  dps: 37875.71703
+  tps: 347.45941
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 37892.55117
-  tps: 341.68365
+  dps: 37868.98981
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
@@ -237,15 +237,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
@@ -258,15 +258,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BottledLightning-66879"
  value: {
-  dps: 38113.79874
-  tps: 343.54192
+  dps: 38088.7523
+  tps: 343.57264
  }
 }
 dps_results: {
@@ -328,86 +328,86 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
   hps: 64
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CrushingWeight-59506"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CrushingWeight-65118"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 37611.28579
-  tps: 412.52907
+  dps: 37589.31957
+  tps: 411.98485
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 38193.84099
-  tps: 367.68769
+  dps: 38169.08384
+  tps: 367.36807
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 38781.61012
-  tps: 345.04349
+  dps: 38756.10194
+  tps: 345.08525
  }
 }
 dps_results: {
@@ -420,15 +420,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Death'sChoice-47464"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
@@ -448,8 +448,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Defender'sCode-40257"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
@@ -539,22 +539,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
@@ -574,29 +574,29 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 37606.76139
-  tps: 382.27866
+  dps: 37610.65672
+  tps: 382.50481
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 37860.4849
-  tps: 341.68365
+  dps: 37835.60473
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FallofMortality-59500"
  value: {
-  dps: 38781.61012
-  tps: 345.04349
+  dps: 38756.10194
+  tps: 345.08525
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FallofMortality-65124"
  value: {
-  dps: 38969.85225
-  tps: 345.53672
+  dps: 38944.21392
+  tps: 345.57246
  }
 }
 dps_results: {
@@ -616,29 +616,29 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 39135.55545
-  tps: 344.65113
+  dps: 39111.0514
+  tps: 344.69033
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 37873.61589
-  tps: 347.89281
+  dps: 37875.71703
+  tps: 347.45941
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 37531.14452
-  tps: 344.05162
+  dps: 37506.50093
+  tps: 344.06422
  }
 }
 dps_results: {
@@ -658,15 +658,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 37768.68816
-  tps: 342.76132
+  dps: 37743.88034
+  tps: 342.78284
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForgeEmber-37660"
  value: {
-  dps: 37713.05086
-  tps: 341.68365
+  dps: 37688.97057
+  tps: 341.67373
  }
 }
 dps_results: {
@@ -700,22 +700,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FuturesightRune-38763"
  value: {
-  dps: 37864.32125
-  tps: 342.90487
+  dps: 37839.64358
+  tps: 342.92037
  }
 }
 dps_results: {
@@ -735,22 +735,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-GearDetector-61462"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 38073.46114
-  tps: 343.44867
+  dps: 38048.44259
+  tps: 343.47835
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 38167.58221
-  tps: 343.66628
+  dps: 38142.49858
+  tps: 343.69838
  }
 }
 dps_results: {
@@ -763,29 +763,29 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HarmlightToken-63839"
  value: {
-  dps: 38553.81481
-  tps: 573.57214
+  dps: 38528.67654
+  tps: 573.6077
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
@@ -812,15 +812,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-HeartofRage-59224"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofRage-65072"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
@@ -833,29 +833,29 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-HeartofSolace-56393"
  value: {
-  dps: 38197.35016
-  tps: 347.26468
+  dps: 38159.0854
+  tps: 347.6571
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofThunder-55845"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofThunder-56370"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
@@ -875,8 +875,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 38123.5747
-  tps: 341.68365
+  dps: 38098.49706
+  tps: 341.67373
  }
 }
 dps_results: {
@@ -903,36 +903,36 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 37966.37612
-  tps: 347.65451
+  dps: 37968.47727
+  tps: 347.22112
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 37966.37612
-  tps: 347.65451
+  dps: 37968.47727
+  tps: 347.22112
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 37855.12907
-  tps: 346.75753
+  dps: 37857.23021
+  tps: 346.32414
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 37873.61589
-  tps: 347.89281
+  dps: 37875.71703
+  tps: 347.45941
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-IncisorFragment-37723"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
@@ -945,15 +945,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 38679.32853
-  tps: 344.2875
+  dps: 38682.07129
+  tps: 343.8541
  }
 }
 dps_results: {
@@ -966,22 +966,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 37342.90239
-  tps: 348.54691
+  dps: 37318.38895
+  tps: 348.33577
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 37342.90239
-  tps: 349.07501
+  dps: 37318.38895
+  tps: 348.86386
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 37831.28203
-  tps: 346.69814
+  dps: 37833.38317
+  tps: 346.26475
  }
 }
 dps_results: {
@@ -1036,36 +1036,36 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LeadenDespair-55816"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LeadenDespair-56347"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
@@ -1078,15 +1078,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
@@ -1127,8 +1127,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
@@ -1148,15 +1148,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 37966.37612
-  tps: 347.65451
+  dps: 37968.47727
+  tps: 347.22112
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 37966.37612
-  tps: 347.65451
+  dps: 37968.47727
+  tps: 347.22112
  }
 }
 dps_results: {
@@ -1169,22 +1169,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 37768.68816
-  tps: 342.76132
+  dps: 37743.88034
+  tps: 342.78284
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
@@ -1204,36 +1204,36 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
@@ -1260,22 +1260,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
@@ -1302,15 +1302,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 38418.41661
-  tps: 779.54881
+  dps: 38437.11014
+  tps: 778.79372
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 38545.14605
-  tps: 834.5503
+  dps: 38563.77456
+  tps: 833.67998
  }
 }
 dps_results: {
@@ -1365,8 +1365,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
@@ -1379,8 +1379,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
@@ -1400,8 +1400,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
@@ -1428,15 +1428,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
@@ -1477,22 +1477,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 37947.96639
-  tps: 346.12855
+  dps: 37923.0346
+  tps: 346.13202
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 38024.15963
-  tps: 346.64122
+  dps: 37999.17517
+  tps: 346.63556
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Sorrowsong-55879"
  value: {
-  dps: 38577.146
-  tps: 346.75753
+  dps: 38583.67372
+  tps: 346.32414
  }
 }
 dps_results: {
@@ -1512,22 +1512,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-SoulCasket-58183"
  value: {
-  dps: 38672.97423
-  tps: 347.65451
+  dps: 38676.08926
+  tps: 347.22112
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SoulPreserver-37111"
  value: {
-  dps: 37629.74754
-  tps: 342.41214
+  dps: 37605.03578
+  tps: 342.42922
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SouloftheDead-40382"
  value: {
-  dps: 37342.90239
-  tps: 344.87965
+  dps: 37318.38895
+  tps: 344.85695
  }
 }
 dps_results: {
@@ -1540,8 +1540,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 37709.45429
-  tps: 342.22036
+  dps: 37670.57633
+  tps: 342.27362
  }
 }
 dps_results: {
@@ -1561,8 +1561,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 38212.40176
-  tps: 343.76984
+  dps: 38187.28715
+  tps: 343.8031
  }
 }
 dps_results: {
@@ -1603,64 +1603,64 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 38657.84536
-  tps: 342.55615
+  dps: 38645.05127
+  tps: 342.537
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 37819.5009
-  tps: 341.4251
+  dps: 37780.62293
+  tps: 341.47836
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TearofBlood-55819"
  value: {
-  dps: 38306.52283
-  tps: 343.98463
+  dps: 38281.34314
+  tps: 344.01997
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TearofBlood-56351"
  value: {
-  dps: 38620.25972
-  tps: 344.65113
+  dps: 38594.8631
+  tps: 344.69033
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 37719.38665
-  tps: 342.64002
+  dps: 37694.61291
+  tps: 342.65996
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 38836.82586
-  tps: 346.20413
+  dps: 38841.22588
+  tps: 345.77073
  }
 }
 dps_results: {
@@ -1673,29 +1673,29 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 39464.29748
-  tps: 346.39089
+  dps: 39486.03984
+  tps: 346.54576
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
@@ -1708,15 +1708,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 37855.12907
-  tps: 346.75753
+  dps: 37857.23021
+  tps: 346.32414
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 37873.61589
-  tps: 347.89281
+  dps: 37875.71703
+  tps: 347.45941
  }
 }
 dps_results: {
@@ -1729,15 +1729,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 37871.93423
-  tps: 340.75523
+  dps: 37833.05627
+  tps: 340.80849
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 37871.93423
-  tps: 340.75523
+  dps: 37833.05627
+  tps: 340.80849
  }
 }
 dps_results: {
@@ -1799,8 +1799,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-UnheededWarning-59520"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
@@ -1813,15 +1813,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 37966.37612
-  tps: 347.65451
+  dps: 37968.47727
+  tps: 347.22112
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 37966.37612
-  tps: 347.65451
+  dps: 37968.47727
+  tps: 347.22112
  }
 }
 dps_results: {
@@ -1834,36 +1834,36 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 37923.28811
-  tps: 341.68365
+  dps: 37899.77999
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
@@ -1876,43 +1876,43 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 38328.71084
-  tps: 350.75959
+  dps: 38334.0645
+  tps: 351.11311
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 37983.12312
-  tps: 347.39931
+  dps: 37981.21411
+  tps: 346.68125
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
@@ -1925,8 +1925,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 37342.90239
-  tps: 341.68365
+  dps: 37318.38895
+  tps: 341.67373
  }
 }
 dps_results: {
@@ -1939,8 +1939,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-WingedTalisman-37844"
  value: {
-  dps: 38120.00194
-  tps: 341.42557
+  dps: 38080.15153
+  tps: 341.47883
  }
 }
 dps_results: {
@@ -1960,8 +1960,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 37831.28203
-  tps: 346.69814
+  dps: 37833.38317
+  tps: 346.26475
  }
 }
 dps_results: {

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -46,15 +46,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 38003.65402
-  tps: 343.37358
+  dps: 25579.57471
+  tps: 434.93991
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 38088.7523
-  tps: 343.57264
+  dps: 25642.70833
+  tps: 435.34464
  }
 }
 dps_results: {
@@ -88,8 +88,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
@@ -125,8 +125,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
@@ -146,8 +146,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-BindingPromise-67037"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
@@ -181,50 +181,50 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 37833.38317
-  tps: 346.26475
+  dps: 25398.74059
+  tps: 436.66037
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 37857.23021
-  tps: 346.32414
+  dps: 25360.92022
+  tps: 437.35243
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 37875.71703
-  tps: 347.45941
+  dps: 25391.59368
+  tps: 437.87879
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 37868.98981
-  tps: 341.67373
+  dps: 25499.62286
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25341.6078
+  tps: 429.50245
  }
 }
 dps_results: {
@@ -237,15 +237,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
@@ -258,15 +258,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BottledLightning-66879"
  value: {
-  dps: 38088.7523
-  tps: 343.57264
+  dps: 25747.02448
+  tps: 434.73798
  }
 }
 dps_results: {
@@ -328,86 +328,86 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
   hps: 64
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CrushingWeight-59506"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CrushingWeight-65118"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25152.15203
+  tps: 431.13593
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 37589.31957
-  tps: 411.98485
+  dps: 25302.91525
+  tps: 485.68249
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 38169.08384
-  tps: 367.36807
+  dps: 25683.24508
+  tps: 446.30516
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 38756.10194
-  tps: 345.08525
+  dps: 26113.67257
+  tps: 438.05419
  }
 }
 dps_results: {
@@ -420,15 +420,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Death'sChoice-47464"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25107.76196
+  tps: 431.54212
  }
 }
 dps_results: {
@@ -448,8 +448,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Defender'sCode-40257"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
@@ -539,22 +539,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
@@ -574,29 +574,29 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 37610.65672
-  tps: 382.50481
+  dps: 25344.50204
+  tps: 461.88072
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 37835.60473
-  tps: 341.67373
+  dps: 25495.05616
+  tps: 431.13593
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FallofMortality-59500"
  value: {
-  dps: 38756.10194
-  tps: 345.08525
+  dps: 26113.67257
+  tps: 438.05419
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FallofMortality-65124"
  value: {
-  dps: 38944.21392
-  tps: 345.57246
+  dps: 26241.578
+  tps: 438.73127
  }
 }
 dps_results: {
@@ -616,29 +616,29 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 39111.0514
-  tps: 344.69033
+  dps: 26399.01969
+  tps: 437.50548
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 37875.71703
-  tps: 347.45941
+  dps: 25391.59368
+  tps: 437.87879
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 37506.50093
-  tps: 344.06422
+  dps: 25210.34465
+  tps: 435.35012
  }
 }
 dps_results: {
@@ -658,15 +658,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 37743.88034
-  tps: 342.78284
+  dps: 25386.23124
+  tps: 433.76501
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForgeEmber-37660"
  value: {
-  dps: 37688.97057
-  tps: 341.67373
+  dps: 25393.43038
+  tps: 431.26302
  }
 }
 dps_results: {
@@ -700,22 +700,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25353.5693
+  tps: 429.37749
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FuturesightRune-38763"
  value: {
-  dps: 37839.64358
-  tps: 342.92037
+  dps: 25379.54537
+  tps: 433.52853
  }
 }
 dps_results: {
@@ -735,22 +735,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-GearDetector-61462"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 38048.44259
-  tps: 343.47835
+  dps: 25609.49249
+  tps: 435.15494
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 38142.49858
-  tps: 343.69838
+  dps: 25682.03289
+  tps: 435.49931
  }
 }
 dps_results: {
@@ -763,29 +763,29 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HarmlightToken-63839"
  value: {
-  dps: 38528.67654
-  tps: 573.6077
+  dps: 25965.91163
+  tps: 595.02891
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
@@ -812,15 +812,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-HeartofRage-59224"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofRage-65072"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
@@ -833,29 +833,29 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-HeartofSolace-56393"
  value: {
-  dps: 38159.0854
-  tps: 347.6571
+  dps: 25654.55707
+  tps: 438.47228
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofThunder-55845"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofThunder-56370"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
@@ -875,8 +875,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 38098.49706
-  tps: 341.67373
+  dps: 25590.75958
+  tps: 431.76499
  }
 }
 dps_results: {
@@ -903,36 +903,36 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 37968.47727
-  tps: 347.22112
+  dps: 25508.34696
+  tps: 437.37338
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 37968.47727
-  tps: 347.22112
+  dps: 25508.34696
+  tps: 437.37338
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 37857.23021
-  tps: 346.32414
+  dps: 25360.92022
+  tps: 437.35243
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 37875.71703
-  tps: 347.45941
+  dps: 25391.59368
+  tps: 437.87879
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-IncisorFragment-37723"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
@@ -945,15 +945,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 38682.07129
-  tps: 343.8541
+  dps: 25965.9705
+  tps: 434.58572
  }
 }
 dps_results: {
@@ -966,22 +966,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 37318.38895
-  tps: 348.33577
+  dps: 25074.81962
+  tps: 442.43896
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 37318.38895
-  tps: 348.86386
+  dps: 25074.81962
+  tps: 443.13823
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 37833.38317
-  tps: 346.26475
+  dps: 25398.74059
+  tps: 436.66037
  }
 }
 dps_results: {
@@ -1036,36 +1036,36 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LeadenDespair-55816"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LeadenDespair-56347"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
@@ -1078,15 +1078,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
@@ -1127,8 +1127,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25144.30872
+  tps: 431.26302
  }
 }
 dps_results: {
@@ -1148,15 +1148,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 37968.47727
-  tps: 347.22112
+  dps: 25508.34696
+  tps: 437.37338
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 37968.47727
-  tps: 347.22112
+  dps: 25508.34696
+  tps: 437.37338
  }
 }
 dps_results: {
@@ -1169,22 +1169,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 37743.88034
-  tps: 342.78284
+  dps: 25425.5762
+  tps: 433.52724
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25252.6607
+  tps: 430.91794
  }
 }
 dps_results: {
@@ -1204,36 +1204,36 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
@@ -1260,22 +1260,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
@@ -1302,15 +1302,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 38437.11014
-  tps: 778.79372
+  dps: 25653.01668
+  tps: 626.61734
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 38563.77456
-  tps: 833.67998
+  dps: 25725.41632
+  tps: 650.7005
  }
 }
 dps_results: {
@@ -1365,8 +1365,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
@@ -1379,8 +1379,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
@@ -1400,8 +1400,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
@@ -1428,15 +1428,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
@@ -1477,22 +1477,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 37923.0346
-  tps: 346.13202
+  dps: 25523.76058
+  tps: 438.30551
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 37999.17517
-  tps: 346.63556
+  dps: 25576.58293
+  tps: 438.99195
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Sorrowsong-55879"
  value: {
-  dps: 38583.67372
-  tps: 346.32414
+  dps: 25824.29344
+  tps: 437.35243
  }
 }
 dps_results: {
@@ -1512,22 +1512,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-SoulCasket-58183"
  value: {
-  dps: 38676.08926
-  tps: 347.22112
+  dps: 26051.52334
+  tps: 437.37338
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SoulPreserver-37111"
  value: {
-  dps: 37605.03578
-  tps: 342.42922
+  dps: 25284.60882
+  tps: 433.04614
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SouloftheDead-40382"
  value: {
-  dps: 37318.38895
-  tps: 344.85695
+  dps: 25152.15649
+  tps: 435.58663
  }
 }
 dps_results: {
@@ -1540,8 +1540,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 37670.57633
-  tps: 342.27362
+  dps: 25180.5661
+  tps: 432.29499
  }
 }
 dps_results: {
@@ -1561,8 +1561,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 38187.28715
-  tps: 343.8031
+  dps: 25939.8585
+  tps: 433.97974
  }
 }
 dps_results: {
@@ -1603,64 +1603,64 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 38645.05127
-  tps: 342.537
+  dps: 26020.73213
+  tps: 437.28265
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 37780.62293
-  tps: 341.47836
+  dps: 25319.68261
+  tps: 432.44769
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TearofBlood-55819"
  value: {
-  dps: 38281.34314
-  tps: 344.01997
+  dps: 25787.29509
+  tps: 436.13338
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TearofBlood-56351"
  value: {
-  dps: 38594.8631
-  tps: 344.69033
+  dps: 25999.50665
+  tps: 437.50548
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 37694.61291
-  tps: 342.65996
+  dps: 25349.90596
+  tps: 433.51317
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 38841.22588
-  tps: 345.77073
+  dps: 26076.19684
+  tps: 436.35824
  }
 }
 dps_results: {
@@ -1673,29 +1673,29 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 39486.03984
-  tps: 346.54576
+  dps: 26468.45466
+  tps: 444.71303
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
@@ -1708,15 +1708,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 37857.23021
-  tps: 346.32414
+  dps: 25360.92022
+  tps: 437.35243
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 37875.71703
-  tps: 347.45941
+  dps: 25391.59368
+  tps: 437.87879
  }
 }
 dps_results: {
@@ -1729,15 +1729,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 37833.05627
-  tps: 340.80849
+  dps: 25350.58638
+  tps: 432.09266
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 37833.05627
-  tps: 340.80849
+  dps: 25350.58638
+  tps: 432.09266
  }
 }
 dps_results: {
@@ -1799,8 +1799,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-UnheededWarning-59520"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
@@ -1813,15 +1813,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 37968.47727
-  tps: 347.22112
+  dps: 25508.34696
+  tps: 437.37338
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 37968.47727
-  tps: 347.22112
+  dps: 25508.34696
+  tps: 437.37338
  }
 }
 dps_results: {
@@ -1834,36 +1834,36 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 37899.77999
-  tps: 341.67373
+  dps: 25523.37831
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
@@ -1876,43 +1876,43 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 38334.0645
-  tps: 351.11311
+  dps: 25634.50527
+  tps: 444.11157
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25368.69117
+  tps: 429.19097
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 37981.21411
-  tps: 346.68125
+  dps: 25414.19142
+  tps: 436.66113
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
@@ -1925,8 +1925,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 37318.38895
-  tps: 341.67373
+  dps: 25074.81962
+  tps: 431.76499
  }
 }
 dps_results: {
@@ -1939,8 +1939,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-WingedTalisman-37844"
  value: {
-  dps: 38080.15153
-  tps: 341.47883
+  dps: 25512.70565
+  tps: 432.44779
  }
 }
 dps_results: {
@@ -1960,8 +1960,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 37833.38317
-  tps: 346.26475
+  dps: 25398.74059
+  tps: 436.66037
  }
 }
 dps_results: {


### PR DESCRIPTION
Changes labeled rands to use the current rand seed instead of the base seed on initialization.

"Lazy initialization" of rarely used labels with the base seed in later iterations causes test differences if going multi-threaded. This fixes that.