### PR TITLE
Feral Rotation Updates + Movement Support

### DIFF
--- a/sim/core/attack.go
+++ b/sim/core/attack.go
@@ -43,7 +43,7 @@ func newWeaponFromUnarmed(critMultiplier float64) Weapon {
 		NormalizedSwingSpeed: 1,
 		CritMultiplier:       critMultiplier,
 		AttackPowerPerDPS:    DefaultAttackPowerPerDPS,
-		MaxRange:             5,
+		MaxRange:             MaxMeleeRange,
 	}
 }
 
@@ -63,7 +63,7 @@ func getWeaponMinRange(item *Item) float64 {
 func getWeaponMaxRange(item *Item) float64 {
 	switch item.RangedWeaponType {
 	case proto.RangedWeaponType_RangedWeaponTypeUnknown:
-		return 5
+		return MaxMeleeRange
 	case proto.RangedWeaponType_RangedWeaponTypeWand:
 	case proto.RangedWeaponType_RangedWeaponTypeThrown:
 		return 30

--- a/sim/core/character.go
+++ b/sim/core/character.go
@@ -104,9 +104,9 @@ func NewCharacter(party *Party, partyIndex int, player *proto.Player) Character 
 
 			StatDependencyManager: stats.NewStatDependencyManager(),
 
-			ReactionTime:       time.Duration(max(player.ReactionTimeMs, 10)) * time.Millisecond,
-			ChannelClipDelay:   max(0, time.Duration(player.ChannelClipDelayMs)*time.Millisecond),
-			DistanceFromTarget: player.DistanceFromTarget,
+			ReactionTime:            time.Duration(max(player.ReactionTimeMs, 10)) * time.Millisecond,
+			ChannelClipDelay:        max(0, time.Duration(player.ChannelClipDelayMs)*time.Millisecond),
+			StartDistanceFromTarget: player.DistanceFromTarget,
 		},
 
 		Name:  player.Name,

--- a/sim/core/constants.go
+++ b/sim/core/constants.go
@@ -9,6 +9,7 @@ const CharacterLevel = 85
 const GCDMin = time.Second * 1
 const GCDDefault = time.Millisecond * 1500
 const MaxSpellQueueWindow = time.Millisecond * 400
+const MaxMeleeRange = 5.0 // in yards
 
 const DefaultAttackPowerPerDPS = 14.0
 const ArmorPenPerPercentArmor = 13.99

--- a/sim/core/pet.go
+++ b/sim/core/pet.go
@@ -68,7 +68,7 @@ func NewPet(name string, owner *Character, baseStats stats.Stats, statInheritanc
 
 				ReactionTime: owner.ReactionTime,
 
-				DistanceFromTarget: 5,
+				StartDistanceFromTarget: MaxMeleeRange, // TODO: Match to owner and add movement logic to pet rotations
 			},
 			Name:       name,
 			Party:      owner.Party,

--- a/sim/core/unit.go
+++ b/sim/core/unit.go
@@ -552,6 +552,7 @@ func (unit *Unit) reset(sim *Simulation, _ Agent) {
 	unit.Hardcast.Expires = startingCDTime
 	unit.ChanneledDot = nil
 	unit.QueuedSpell = nil
+	unit.DistanceFromTarget = unit.StartDistanceFromTarget
 	unit.Metrics.reset()
 	unit.ResetStatDeps()
 	unit.statsWithoutDeps = unit.initialStatsWithoutDeps

--- a/sim/death_knight/blood/TestBlood.results
+++ b/sim/death_knight/blood/TestBlood.results
@@ -2133,7 +2133,7 @@ dps_results: {
  }
 }
 dps_results: {
- key: "TestBlood-Settings-Goblin-p1-Basic-p1-FullBuffs-LongMultiTarget"
+ key: "TestBlood-Settings-Goblin-p1-Basic-p1-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 17925.94555
   tps: 89411.20955
@@ -2141,7 +2141,7 @@ dps_results: {
  }
 }
 dps_results: {
- key: "TestBlood-Settings-Goblin-p1-Basic-p1-FullBuffs-LongSingleTarget"
+ key: "TestBlood-Settings-Goblin-p1-Basic-p1-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 13799.87055
   tps: 69388.51826
@@ -2149,7 +2149,7 @@ dps_results: {
  }
 }
 dps_results: {
- key: "TestBlood-Settings-Goblin-p1-Basic-p1-FullBuffs-ShortSingleTarget"
+ key: "TestBlood-Settings-Goblin-p1-Basic-p1-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 17685.42156
   tps: 81743.03042
@@ -2157,7 +2157,7 @@ dps_results: {
  }
 }
 dps_results: {
- key: "TestBlood-Settings-Goblin-p1-Basic-p1-NoBuffs-LongMultiTarget"
+ key: "TestBlood-Settings-Goblin-p1-Basic-p1-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 13457.62497
   tps: 67343.77441
@@ -2165,7 +2165,7 @@ dps_results: {
  }
 }
 dps_results: {
- key: "TestBlood-Settings-Goblin-p1-Basic-p1-NoBuffs-LongSingleTarget"
+ key: "TestBlood-Settings-Goblin-p1-Basic-p1-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 10461.64752
   tps: 52860.36424
@@ -2173,7 +2173,7 @@ dps_results: {
  }
 }
 dps_results: {
- key: "TestBlood-Settings-Goblin-p1-Basic-p1-NoBuffs-ShortSingleTarget"
+ key: "TestBlood-Settings-Goblin-p1-Basic-p1-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 11150.44523
   tps: 51619.18885
@@ -2181,7 +2181,7 @@ dps_results: {
  }
 }
 dps_results: {
- key: "TestBlood-Settings-Worgen-p1-Basic-p1-FullBuffs-LongMultiTarget"
+ key: "TestBlood-Settings-Worgen-p1-Basic-p1-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 17975.21354
   tps: 89712.00937
@@ -2189,7 +2189,7 @@ dps_results: {
  }
 }
 dps_results: {
- key: "TestBlood-Settings-Worgen-p1-Basic-p1-FullBuffs-LongSingleTarget"
+ key: "TestBlood-Settings-Worgen-p1-Basic-p1-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 13783.54362
   tps: 69351.72475
@@ -2197,7 +2197,7 @@ dps_results: {
  }
 }
 dps_results: {
- key: "TestBlood-Settings-Worgen-p1-Basic-p1-FullBuffs-ShortSingleTarget"
+ key: "TestBlood-Settings-Worgen-p1-Basic-p1-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 17761.08687
   tps: 82138.43393
@@ -2205,7 +2205,7 @@ dps_results: {
  }
 }
 dps_results: {
- key: "TestBlood-Settings-Worgen-p1-Basic-p1-NoBuffs-LongMultiTarget"
+ key: "TestBlood-Settings-Worgen-p1-Basic-p1-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 13463.70782
   tps: 67193.91582
@@ -2213,7 +2213,7 @@ dps_results: {
  }
 }
 dps_results: {
- key: "TestBlood-Settings-Worgen-p1-Basic-p1-NoBuffs-LongSingleTarget"
+ key: "TestBlood-Settings-Worgen-p1-Basic-p1-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 10403.1618
   tps: 52527.46197
@@ -2221,7 +2221,7 @@ dps_results: {
  }
 }
 dps_results: {
- key: "TestBlood-Settings-Worgen-p1-Basic-p1-NoBuffs-ShortSingleTarget"
+ key: "TestBlood-Settings-Worgen-p1-Basic-p1-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 11305.85591
   tps: 52430.88301

--- a/sim/death_knight/bloodworm_pet.go
+++ b/sim/death_knight/bloodworm_pet.go
@@ -78,7 +78,7 @@ func (bloodworm *BloodwormPet) Initialize() {
 					continue
 				}
 
-				if target.DistanceFromTarget > 5 {
+				if target.DistanceFromTarget > core.MaxMeleeRange {
 					continue
 				}
 

--- a/sim/death_knight/frost/TestFrost.results
+++ b/sim/death_knight/frost/TestFrost.results
@@ -1875,84 +1875,84 @@ dps_results: {
  }
 }
 dps_results: {
- key: "TestFrost-Settings-Human-p1-Basic-st-FullBuffs-LongMultiTarget"
+ key: "TestFrost-Settings-Human-p1-Basic-st-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 66561.18152
   tps: 64860.44857
  }
 }
 dps_results: {
- key: "TestFrost-Settings-Human-p1-Basic-st-FullBuffs-LongSingleTarget"
+ key: "TestFrost-Settings-Human-p1-Basic-st-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 28871.83523
   tps: 27021.74635
  }
 }
 dps_results: {
- key: "TestFrost-Settings-Human-p1-Basic-st-FullBuffs-ShortSingleTarget"
+ key: "TestFrost-Settings-Human-p1-Basic-st-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 36643.60998
   tps: 32875.66978
  }
 }
 dps_results: {
- key: "TestFrost-Settings-Human-p1-Basic-st-NoBuffs-LongMultiTarget"
+ key: "TestFrost-Settings-Human-p1-Basic-st-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 44532.54855
   tps: 43063.55407
  }
 }
 dps_results: {
- key: "TestFrost-Settings-Human-p1-Basic-st-NoBuffs-LongSingleTarget"
+ key: "TestFrost-Settings-Human-p1-Basic-st-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 20021.07061
   tps: 18406.47074
  }
 }
 dps_results: {
- key: "TestFrost-Settings-Human-p1-Basic-st-NoBuffs-ShortSingleTarget"
+ key: "TestFrost-Settings-Human-p1-Basic-st-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 24093.12631
   tps: 20050.80604
  }
 }
 dps_results: {
- key: "TestFrost-Settings-Orc-p1-Basic-st-FullBuffs-LongMultiTarget"
+ key: "TestFrost-Settings-Orc-p1-Basic-st-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 67073.60573
   tps: 65282.94804
  }
 }
 dps_results: {
- key: "TestFrost-Settings-Orc-p1-Basic-st-FullBuffs-LongSingleTarget"
+ key: "TestFrost-Settings-Orc-p1-Basic-st-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 29072.99794
   tps: 27166.91248
  }
 }
 dps_results: {
- key: "TestFrost-Settings-Orc-p1-Basic-st-FullBuffs-ShortSingleTarget"
+ key: "TestFrost-Settings-Orc-p1-Basic-st-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 37086.42272
   tps: 33313.23608
  }
 }
 dps_results: {
- key: "TestFrost-Settings-Orc-p1-Basic-st-NoBuffs-LongMultiTarget"
+ key: "TestFrost-Settings-Orc-p1-Basic-st-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 44856.18049
   tps: 43264.35966
  }
 }
 dps_results: {
- key: "TestFrost-Settings-Orc-p1-Basic-st-NoBuffs-LongSingleTarget"
+ key: "TestFrost-Settings-Orc-p1-Basic-st-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 20121.73826
   tps: 18438.14768
  }
 }
 dps_results: {
- key: "TestFrost-Settings-Orc-p1-Basic-st-NoBuffs-ShortSingleTarget"
+ key: "TestFrost-Settings-Orc-p1-Basic-st-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 24422.24396
   tps: 20250.20867

--- a/sim/death_knight/unholy/TestUnholy.results
+++ b/sim/death_knight/unholy/TestUnholy.results
@@ -1875,84 +1875,84 @@ dps_results: {
  }
 }
 dps_results: {
- key: "TestUnholy-Settings-Goblin-p1-Basic-st-FullBuffs-LongMultiTarget"
+ key: "TestUnholy-Settings-Goblin-p1-Basic-st-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 59222.05824
   tps: 69421.45149
  }
 }
 dps_results: {
- key: "TestUnholy-Settings-Goblin-p1-Basic-st-FullBuffs-LongSingleTarget"
+ key: "TestUnholy-Settings-Goblin-p1-Basic-st-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 33504.46424
   tps: 24100.27369
  }
 }
 dps_results: {
- key: "TestUnholy-Settings-Goblin-p1-Basic-st-FullBuffs-ShortSingleTarget"
+ key: "TestUnholy-Settings-Goblin-p1-Basic-st-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 44860.6237
   tps: 27750.70476
  }
 }
 dps_results: {
- key: "TestUnholy-Settings-Goblin-p1-Basic-st-NoBuffs-LongMultiTarget"
+ key: "TestUnholy-Settings-Goblin-p1-Basic-st-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 39107.37938
   tps: 44833.06334
  }
 }
 dps_results: {
- key: "TestUnholy-Settings-Goblin-p1-Basic-st-NoBuffs-LongSingleTarget"
+ key: "TestUnholy-Settings-Goblin-p1-Basic-st-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 22504.52636
   tps: 16246.84087
  }
 }
 dps_results: {
- key: "TestUnholy-Settings-Goblin-p1-Basic-st-NoBuffs-ShortSingleTarget"
+ key: "TestUnholy-Settings-Goblin-p1-Basic-st-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 27114.87309
   tps: 17620.59877
  }
 }
 dps_results: {
- key: "TestUnholy-Settings-Worgen-p1-Basic-st-FullBuffs-LongMultiTarget"
+ key: "TestUnholy-Settings-Worgen-p1-Basic-st-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 59842.68652
   tps: 70263.89737
  }
 }
 dps_results: {
- key: "TestUnholy-Settings-Worgen-p1-Basic-st-FullBuffs-LongSingleTarget"
+ key: "TestUnholy-Settings-Worgen-p1-Basic-st-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 33647.95992
   tps: 24237.95645
  }
 }
 dps_results: {
- key: "TestUnholy-Settings-Worgen-p1-Basic-st-FullBuffs-ShortSingleTarget"
+ key: "TestUnholy-Settings-Worgen-p1-Basic-st-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 45111.02301
   tps: 28018.60296
  }
 }
 dps_results: {
- key: "TestUnholy-Settings-Worgen-p1-Basic-st-NoBuffs-LongMultiTarget"
+ key: "TestUnholy-Settings-Worgen-p1-Basic-st-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 39350.34554
   tps: 45149.62075
  }
 }
 dps_results: {
- key: "TestUnholy-Settings-Worgen-p1-Basic-st-NoBuffs-LongSingleTarget"
+ key: "TestUnholy-Settings-Worgen-p1-Basic-st-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 22673.49907
   tps: 16446.35774
  }
 }
 dps_results: {
- key: "TestUnholy-Settings-Worgen-p1-Basic-st-NoBuffs-ShortSingleTarget"
+ key: "TestUnholy-Settings-Worgen-p1-Basic-st-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 27277.86936
   tps: 17677.53975

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -2080,15 +2080,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14687.91219
-  tps: 10431.10998
+  dps: 14685.96237
+  tps: 10429.7256
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 14687.91219
-  tps: 10431.10998
+  dps: 14685.96237
+  tps: 10429.7256
  }
 }
 dps_results: {
@@ -2164,15 +2164,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14687.91219
-  tps: 10431.10998
+  dps: 14685.96237
+  tps: 10429.7256
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 14687.91219
-  tps: 10431.10998
+  dps: 14685.96237
+  tps: 10429.7256
  }
 }
 dps_results: {

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -1847,336 +1847,336 @@ dps_results: {
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-aoe-FullBuffs-0.0yards-LongMultiTarget"
+ key: "TestFeral-Settings-Tauren-p1-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
+ value: {
+  dps: 57314.19582
+  tps: 40722.84412
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p1-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
+ value: {
+  dps: 16127.696
+  tps: 11450.66416
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p1-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
+ value: {
+  dps: 18127.72084
+  tps: 12870.6818
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p1-ExternalBleed-aoe-FullBuffs-5.0yards-LongMultiTarget"
  value: {
   dps: 57766.29981
   tps: 41043.83796
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-aoe-FullBuffs-0.0yards-LongSingleTarget"
+ key: "TestFeral-Settings-Tauren-p1-ExternalBleed-aoe-FullBuffs-5.0yards-LongSingleTarget"
  value: {
   dps: 16327.7542
   tps: 11593.97686
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-aoe-FullBuffs-0.0yards-ShortSingleTarget"
+ key: "TestFeral-Settings-Tauren-p1-ExternalBleed-aoe-FullBuffs-5.0yards-ShortSingleTarget"
  value: {
   dps: 18742.85769
   tps: 13313.78582
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-aoe-NoBuffs-0.0yards-LongMultiTarget"
+ key: "TestFeral-Settings-Tauren-p1-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
+ value: {
+  dps: 38626.9845
+  tps: 27456.19546
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p1-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
+ value: {
+  dps: 10468.67731
+  tps: 7435.30364
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p1-ExternalBleed-aoe-NoBuffs-25.0yards-ShortSingleTarget"
+ value: {
+  dps: 10108.60278
+  tps: 7184.58664
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p1-ExternalBleed-aoe-NoBuffs-5.0yards-LongMultiTarget"
  value: {
   dps: 39005.69389
   tps: 27725.15391
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-aoe-NoBuffs-0.0yards-LongSingleTarget"
+ key: "TestFeral-Settings-Tauren-p1-ExternalBleed-aoe-NoBuffs-5.0yards-LongSingleTarget"
  value: {
   dps: 10570.04305
   tps: 7507.49767
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-aoe-NoBuffs-0.0yards-ShortSingleTarget"
+ key: "TestFeral-Settings-Tauren-p1-ExternalBleed-aoe-NoBuffs-5.0yards-ShortSingleTarget"
  value: {
   dps: 10560.16065
   tps: 7505.19273
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-default-FullBuffs-0.0yards-LongMultiTarget"
+ key: "TestFeral-Settings-Tauren-p1-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 27559.9831
-  tps: 19568.85937
+  dps: 27447.39378
+  tps: 19487.64958
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-default-FullBuffs-0.0yards-LongSingleTarget"
+ key: "TestFeral-Settings-Tauren-p1-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 27559.9831
-  tps: 19568.85937
+  dps: 27447.39378
+  tps: 19487.64958
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-default-FullBuffs-0.0yards-ShortSingleTarget"
+ key: "TestFeral-Settings-Tauren-p1-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 34168.51921
-  tps: 24266.00551
+  dps: 33389.85097
+  tps: 23706.79419
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-default-NoBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 18097.19863
-  tps: 12851.77813
- }
-}
-dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-default-NoBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 18097.19863
-  tps: 12851.77813
- }
-}
-dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-default-NoBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 19938.79393
-  tps: 14164.02235
- }
-}
-dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-aoe-FullBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 57766.29981
-  tps: 41043.83796
- }
-}
-dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-aoe-FullBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 16327.7542
-  tps: 11593.97686
- }
-}
-dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-aoe-FullBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 18742.85769
-  tps: 13313.78582
- }
-}
-dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-aoe-NoBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 39005.69389
-  tps: 27725.15391
- }
-}
-dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-aoe-NoBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 10570.04305
-  tps: 7507.49767
- }
-}
-dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-aoe-NoBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 10560.16065
-  tps: 7505.19273
- }
-}
-dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-default-FullBuffs-0.0yards-LongMultiTarget"
+ key: "TestFeral-Settings-Tauren-p1-ExternalBleed-default-FullBuffs-5.0yards-LongMultiTarget"
  value: {
   dps: 27560.89923
   tps: 19569.50983
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-default-FullBuffs-0.0yards-LongSingleTarget"
+ key: "TestFeral-Settings-Tauren-p1-ExternalBleed-default-FullBuffs-5.0yards-LongSingleTarget"
  value: {
   dps: 27560.89923
   tps: 19569.50983
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-default-FullBuffs-0.0yards-ShortSingleTarget"
+ key: "TestFeral-Settings-Tauren-p1-ExternalBleed-default-FullBuffs-5.0yards-ShortSingleTarget"
  value: {
   dps: 34168.51921
   tps: 24266.00551
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-default-NoBuffs-0.0yards-LongMultiTarget"
+ key: "TestFeral-Settings-Tauren-p1-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
+ value: {
+  dps: 17954.59836
+  tps: 12750.53194
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p1-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
+ value: {
+  dps: 17954.59836
+  tps: 12750.53194
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p1-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
+ value: {
+  dps: 18971.72991
+  tps: 13477.4069
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p1-ExternalBleed-default-NoBuffs-5.0yards-LongMultiTarget"
  value: {
   dps: 18095.12231
   tps: 12850.30395
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-default-NoBuffs-0.0yards-LongSingleTarget"
+ key: "TestFeral-Settings-Tauren-p1-ExternalBleed-default-NoBuffs-5.0yards-LongSingleTarget"
  value: {
   dps: 18095.12231
   tps: 12850.30395
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-default-NoBuffs-0.0yards-ShortSingleTarget"
+ key: "TestFeral-Settings-Tauren-p1-ExternalBleed-default-NoBuffs-5.0yards-ShortSingleTarget"
  value: {
   dps: 19953.81228
   tps: 14174.68538
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-aoe-FullBuffs-0.0yards-LongMultiTarget"
+ key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
+ value: {
+  dps: 45148.00802
+  tps: 32084.70121
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
+ value: {
+  dps: 12954.75127
+  tps: 9197.8734
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
+ value: {
+  dps: 14519.37996
+  tps: 10308.75977
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-aoe-FullBuffs-5.0yards-LongMultiTarget"
  value: {
   dps: 45875.7393
   tps: 32601.46521
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-aoe-FullBuffs-0.0yards-LongSingleTarget"
+ key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-aoe-FullBuffs-5.0yards-LongSingleTarget"
  value: {
   dps: 13065.89079
   tps: 9277.97905
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-aoe-FullBuffs-0.0yards-ShortSingleTarget"
+ key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-aoe-FullBuffs-5.0yards-ShortSingleTarget"
  value: {
   dps: 14960.49952
   tps: 10627.93759
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-aoe-NoBuffs-0.0yards-LongMultiTarget"
+ key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
+ value: {
+  dps: 29820.07555
+  tps: 21203.2901
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
+ value: {
+  dps: 8126.97617
+  tps: 5772.8454
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-aoe-NoBuffs-25.0yards-ShortSingleTarget"
+ value: {
+  dps: 7761.622
+  tps: 5518.23029
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-aoe-NoBuffs-5.0yards-LongMultiTarget"
  value: {
   dps: 30110.88515
   tps: 21409.76493
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-aoe-NoBuffs-0.0yards-LongSingleTarget"
+ key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-aoe-NoBuffs-5.0yards-LongSingleTarget"
  value: {
   dps: 8200.77619
   tps: 5825.24341
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-aoe-NoBuffs-0.0yards-ShortSingleTarget"
+ key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-aoe-NoBuffs-5.0yards-ShortSingleTarget"
  value: {
   dps: 8118.4119
   tps: 5771.55111
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-FullBuffs-0.0yards-LongMultiTarget"
+ key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 22698.67081
-  tps: 16117.25286
+  dps: 22654.03814
+  tps: 16084.36708
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-FullBuffs-0.0yards-LongSingleTarget"
+ key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 22698.67081
-  tps: 16117.25286
+  dps: 22654.03814
+  tps: 16084.36708
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-FullBuffs-0.0yards-ShortSingleTarget"
+ key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 28172.59511
-  tps: 20008.52546
+  dps: 27360.59883
+  tps: 19426.02517
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 14614.64832
-  tps: 10379.09263
- }
-}
-dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 14614.64832
-  tps: 10379.09263
- }
-}
-dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 16049.09507
-  tps: 11402.33617
- }
-}
-dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-aoe-FullBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 45875.7393
-  tps: 32601.46521
- }
-}
-dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-aoe-FullBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 13065.89079
-  tps: 9277.97905
- }
-}
-dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-aoe-FullBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 14960.49952
-  tps: 10627.93759
- }
-}
-dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-aoe-NoBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 30110.88515
-  tps: 21409.76493
- }
-}
-dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-aoe-NoBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 8200.77619
-  tps: 5825.24341
- }
-}
-dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-aoe-NoBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 8118.4119
-  tps: 5771.55111
- }
-}
-dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-default-FullBuffs-0.0yards-LongMultiTarget"
+ key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-default-FullBuffs-5.0yards-LongMultiTarget"
  value: {
   dps: 22700.25886
   tps: 16118.38038
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-default-FullBuffs-0.0yards-LongSingleTarget"
+ key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-default-FullBuffs-5.0yards-LongSingleTarget"
  value: {
   dps: 22700.25886
   tps: 16118.38038
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-default-FullBuffs-0.0yards-ShortSingleTarget"
+ key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-default-FullBuffs-5.0yards-ShortSingleTarget"
  value: {
   dps: 28172.59511
   tps: 20008.52546
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-0.0yards-LongMultiTarget"
+ key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
+ value: {
+  dps: 14516.28075
+  tps: 10309.25165
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
+ value: {
+  dps: 14516.28075
+  tps: 10309.25165
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
+ value: {
+  dps: 15399.25116
+  tps: 10940.94699
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-default-NoBuffs-5.0yards-LongMultiTarget"
  value: {
   dps: 14629.37893
   tps: 10389.55136
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-0.0yards-LongSingleTarget"
+ key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-default-NoBuffs-5.0yards-LongSingleTarget"
  value: {
   dps: 14629.37893
   tps: 10389.55136
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-0.0yards-ShortSingleTarget"
+ key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-default-NoBuffs-5.0yards-ShortSingleTarget"
  value: {
   dps: 16104.24909
   tps: 11441.49552

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -39,1818 +39,1818 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 22700.25886
-  tps: 16118.38038
+  dps: 22691.02705
+  tps: 16111.90058
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 21480.8507
-  tps: 15252.67537
+  dps: 21498.87688
+  tps: 15265.54874
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 21480.8507
-  tps: 15252.67537
+  dps: 21498.87688
+  tps: 15265.54874
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 22141.69808
-  tps: 15721.80223
+  dps: 22132.90478
+  tps: 15715.63377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 22141.69808
-  tps: 15721.80223
+  dps: 22132.90478
+  tps: 15715.63377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 21529.58877
-  tps: 15287.2794
+  dps: 21534.89859
+  tps: 15291.12416
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
   hps: 84.91645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
   hps: 84.91645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 22170.70403
-  tps: 15742.39645
+  dps: 22161.82853
+  tps: 15736.16963
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 21555.62544
-  tps: 15305.69065
+  dps: 21545.15274
+  tps: 15298.32982
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 21574.42803
-  tps: 15319.04049
+  dps: 21581.06895
+  tps: 15323.83032
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BindingPromise-67037"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 16411.51056
-  tps: 11653.36909
+  dps: 16424.52139
+  tps: 11662.68156
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 22398.21696
-  tps: 15903.93063
+  dps: 22405.23571
+  tps: 15908.98873
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 21508.38981
-  tps: 15272.15335
+  dps: 21514.00123
+  tps: 15276.21225
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 21542.10235
-  tps: 15296.08926
+  dps: 21547.75469
+  tps: 15300.17721
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 22768.52843
-  tps: 16166.85177
+  dps: 22769.88769
+  tps: 16167.89163
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 21714.3969
-  tps: 15418.41838
+  dps: 21719.6551
+  tps: 15422.22649
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 21541.03323
-  tps: 15295.33018
+  dps: 21530.56053
+  tps: 15287.96935
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 22320.05701
-  tps: 15848.43707
+  dps: 22314.96483
+  tps: 15844.8964
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 21667.09126
-  tps: 15384.83138
+  dps: 21672.29443
+  tps: 15388.60042
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledLightning-66879"
  value: {
-  dps: 21374.16495
-  tps: 15176.8537
+  dps: 21376.14075
+  tps: 15178.33131
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 22141.69808
-  tps: 15407.36618
+  dps: 22132.90478
+  tps: 15401.32109
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 22141.69808
-  tps: 15407.36618
+  dps: 22132.90478
+  tps: 15401.32109
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 22508.88825
-  tps: 15982.50724
+  dps: 22499.69487
+  tps: 15976.05473
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 22567.56902
-  tps: 16024.17059
+  dps: 22558.57901
+  tps: 16017.86247
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 22539.2866
-  tps: 16004.09007
+  dps: 22530.00609
+  tps: 15997.57569
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
   hps: 64
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-59506"
  value: {
-  dps: 22074.99806
-  tps: 15674.44521
+  dps: 22057.7503
+  tps: 15662.27408
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-65118"
  value: {
-  dps: 22147.74146
-  tps: 15726.09303
+  dps: 22161.00275
+  tps: 15735.58332
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 21373.19321
-  tps: 15176.16376
+  dps: 21365.3597
+  tps: 15170.67676
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 21401.68608
-  tps: 15196.54328
+  dps: 21395.29032
+  tps: 15192.07708
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 21621.49698
-  tps: 15352.45944
+  dps: 21628.21144
+  tps: 15357.30149
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 21942.30776
-  tps: 15580.2351
+  dps: 21968.34387
+  tps: 15598.79552
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 22621.39329
-  tps: 16062.38582
+  dps: 22629.31279
+  tps: 16068.08346
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 21579.93035
-  tps: 15325.2501
+  dps: 21585.62734
+  tps: 15329.36975
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Death'sChoice-47464"
  value: {
-  dps: 22223.03018
-  tps: 15779.54802
+  dps: 22226.81094
+  tps: 15782.30714
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 21347.8023
-  tps: 15158.13622
+  dps: 21355.94084
+  tps: 15163.98937
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 21790.57887
-  tps: 15472.50759
+  dps: 21804.27768
+  tps: 15482.30853
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 21956.10417
-  tps: 15590.03055
+  dps: 21966.04741
+  tps: 15597.16504
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Defender'sCode-40257"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 22197.38556
-  tps: 15761.34034
+  dps: 22188.78412
+  tps: 15755.3081
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 22173.17181
-  tps: 15744.14857
+  dps: 22164.29631
+  tps: 15737.92175
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 21406.83184
-  tps: 15200.04719
+  dps: 21426.57073
+  tps: 15214.13659
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 21421.10506
-  tps: 15210.18118
+  dps: 21426.25302
+  tps: 15213.91102
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 22141.69808
-  tps: 15721.80223
+  dps: 22132.90478
+  tps: 15715.63377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 21250.94862
-  tps: 15119.61107
+  dps: 21256.24749
+  tps: 15123.39355
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 22141.69808
-  tps: 15721.80223
+  dps: 22132.90478
+  tps: 15715.63377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 22141.69808
-  tps: 15721.80223
+  dps: 22132.90478
+  tps: 15715.63377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 22197.38556
-  tps: 15761.34034
+  dps: 22188.78412
+  tps: 15755.3081
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 22170.70403
-  tps: 15742.39645
+  dps: 22161.82853
+  tps: 15736.16963
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 22161.06913
-  tps: 15735.55567
+  dps: 22152.19363
+  tps: 15729.32885
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 21352.88937
-  tps: 15161.74804
+  dps: 21361.29393
+  tps: 15167.79007
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 22734.28714
-  tps: 16142.54046
+  dps: 22749.92993
+  tps: 16153.72162
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 22964.60808
-  tps: 16306.06832
+  dps: 22944.50531
+  tps: 16291.87015
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 22141.69808
-  tps: 15721.80223
+  dps: 22132.90478
+  tps: 15715.63377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 22141.69808
-  tps: 15721.80223
+  dps: 22132.90478
+  tps: 15715.63377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 21403.16519
-  tps: 15197.44387
+  dps: 21395.33168
+  tps: 15191.95686
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 21357.73931
-  tps: 15165.1915
+  dps: 21349.9058
+  tps: 15159.70449
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-59500"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-65124"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 22955.959
-  tps: 16300.00227
+  dps: 22960.22703
+  tps: 16303.10735
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 21982.91805
-  tps: 15609.0684
+  dps: 21988.5468
+  tps: 15613.1396
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 22198.57147
-  tps: 15762.18233
+  dps: 22189.76092
+  tps: 15756.00163
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FluidDeath-58181"
  value: {
-  dps: 22758.36043
-  tps: 16159.78206
+  dps: 22751.60939
+  tps: 16155.06361
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForgeEmber-37660"
  value: {
-  dps: 21343.31376
-  tps: 15154.94936
+  dps: 21336.84695
+  tps: 15150.43271
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 22141.69808
-  tps: 15721.80223
+  dps: 22132.90478
+  tps: 15715.63377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 22141.69808
-  tps: 15721.80223
+  dps: 22132.90478
+  tps: 15715.63377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 22141.69808
-  tps: 15721.80223
+  dps: 22132.90478
+  tps: 15715.63377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 22093.4773
-  tps: 15687.56547
+  dps: 22078.83965
+  tps: 15677.24753
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 21635.3013
-  tps: 15362.26051
+  dps: 21640.51442
+  tps: 15366.03661
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuturesightRune-38763"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56138"
  value: {
-  dps: 21575.57679
-  tps: 15319.85611
+  dps: 21592.41205
+  tps: 15331.88393
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56462"
  value: {
-  dps: 21533.8153
-  tps: 15290.20545
+  dps: 21529.24639
+  tps: 15287.03631
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GearDetector-61462"
  value: {
-  dps: 22039.26976
-  tps: 15649.07812
+  dps: 22034.42912
+  tps: 15645.71605
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 21382.11352
-  tps: 15182.64676
+  dps: 21375.64671
+  tps: 15178.13011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 22051.23886
-  tps: 15657.57617
+  dps: 22045.45281
+  tps: 15653.54287
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 22394.87904
-  tps: 15901.5607
+  dps: 22406.27391
+  tps: 15909.72585
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HarmlightToken-63839"
  value: {
-  dps: 21256.4608
-  tps: 15093.28375
+  dps: 21261.75967
+  tps: 15097.12074
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 21757.23925
-  tps: 15448.83646
+  dps: 21763.60114
+  tps: 15453.42818
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-59224"
  value: {
-  dps: 22115.5443
-  tps: 15703.23304
+  dps: 22118.11768
+  tps: 15705.13492
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-65072"
  value: {
-  dps: 22307.85281
-  tps: 15839.77208
+  dps: 22319.45434
+  tps: 15848.08396
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-55868"
  value: {
-  dps: 21575.57679
-  tps: 15319.85611
+  dps: 21592.41205
+  tps: 15331.88393
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-56393"
  value: {
-  dps: 22013.53616
-  tps: 15630.80726
+  dps: 22009.29431
+  tps: 15627.87034
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-55845"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-56370"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 22158.91479
-  tps: 15734.02609
+  dps: 22165.95291
+  tps: 15739.09794
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-49982"
  value: {
-  dps: 23114.29608
-  tps: 16412.3468
+  dps: 23108.96276
+  tps: 16408.63493
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-50641"
  value: {
-  dps: 23174.09342
-  tps: 16454.80291
+  dps: 23172.1669
+  tps: 16453.50987
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 22197.38556
-  tps: 15761.34034
+  dps: 22188.78412
+  tps: 15755.3081
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 22170.70403
-  tps: 15742.39645
+  dps: 22161.82853
+  tps: 15736.16963
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 22161.06913
-  tps: 15735.55567
+  dps: 22152.19363
+  tps: 15729.32885
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 22076.27834
-  tps: 15675.35421
+  dps: 22081.95082
+  tps: 15679.45646
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 22076.27834
-  tps: 15675.35421
+  dps: 22081.95082
+  tps: 15679.45646
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 21508.38981
-  tps: 15272.15335
+  dps: 21514.00123
+  tps: 15276.21225
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 21542.10235
-  tps: 15296.08926
+  dps: 21547.75469
+  tps: 15300.17721
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IncisorFragment-37723"
  value: {
-  dps: 21626.73344
-  tps: 15356.17733
+  dps: 21631.71821
+  tps: 15359.7913
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 22141.69808
-  tps: 15721.80223
+  dps: 22132.90478
+  tps: 15715.63377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 21449.13748
-  tps: 15230.0842
+  dps: 21454.67696
+  tps: 15234.09201
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 22217.58895
-  tps: 15775.68474
+  dps: 22245.05551
+  tps: 15795.26079
   hps: 60.89842
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 22398.21696
-  tps: 15903.93063
+  dps: 22405.23571
+  tps: 15908.98873
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 22474.64625
-  tps: 15958.27021
+  dps: 22459.75416
+  tps: 15947.77162
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 22787.15535
-  tps: 16180.15167
+  dps: 22798.87404
+  tps: 16188.54673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 21655.2866
-  tps: 15376.45008
+  dps: 21676.77554
+  tps: 15391.78201
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 21655.2866
-  tps: 15376.45008
+  dps: 21676.77554
+  tps: 15391.78201
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 21408.29483
-  tps: 15201.08591
+  dps: 21412.76733
+  tps: 15204.33618
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50179"
  value: {
-  dps: 22831.71636
-  tps: 16211.7152
+  dps: 22822.4153
+  tps: 16205.18623
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50708"
  value: {
-  dps: 22851.36925
-  tps: 16225.66875
+  dps: 22842.03952
+  tps: 16219.11943
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-55816"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-56347"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 22531.23804
-  tps: 15998.37559
+  dps: 22539.17648
+  tps: 16004.08668
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 22671.22898
-  tps: 16097.76916
+  dps: 22678.72762
+  tps: 16103.16798
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 21970.16698
-  tps: 15600.16472
+  dps: 21988.62148
+  tps: 15613.3422
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 21808.35243
-  tps: 15485.12681
+  dps: 21827.02477
+  tps: 15498.45896
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 21921.78353
-  tps: 15565.66289
+  dps: 21928.3641
+  tps: 15570.40988
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 21930.7147
-  tps: 15572.00402
+  dps: 21938.41185
+  tps: 15577.54378
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 22020.55502
-  tps: 15635.79065
+  dps: 22028.57262
+  tps: 15641.55793
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 21459.93316
-  tps: 15237.74913
+  dps: 21464.59803
+  tps: 15241.13598
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 21673.90649
-  tps: 15389.74498
+  dps: 21696.73442
+  tps: 15406.0276
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 21943.81804
-  tps: 15581.38218
+  dps: 21962.70076
+  tps: 15594.8637
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 21578.87966
-  tps: 15322.20115
+  dps: 21584.57666
+  tps: 15326.3208
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 21578.87966
-  tps: 15322.20115
+  dps: 21584.57666
+  tps: 15326.3208
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 21673.09045
-  tps: 15389.09081
+  dps: 21678.92023
+  tps: 15393.30474
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 21398.43484
-  tps: 15194.08533
+  dps: 21399.84415
+  tps: 15195.16072
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 21767.65245
-  tps: 15456.22983
+  dps: 21768.69064
+  tps: 15457.04173
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 22161.06913
-  tps: 15735.55567
+  dps: 22152.19363
+  tps: 15729.32885
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 22170.70403
-  tps: 15742.39645
+  dps: 22161.82853
+  tps: 15736.16963
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 21458.82131
-  tps: 15236.95971
+  dps: 21462.70575
+  tps: 15239.79246
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 21613.31601
-  tps: 15346.65095
+  dps: 21621.73294
+  tps: 15352.70176
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 22141.69808
-  tps: 15721.80223
+  dps: 22132.90478
+  tps: 15715.63377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 22141.69808
-  tps: 15721.80223
+  dps: 22132.90478
+  tps: 15715.63377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 22141.69808
-  tps: 15721.80223
+  dps: 22132.90478
+  tps: 15715.63377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 22835.08431
-  tps: 16214.10645
+  dps: 22829.77494
+  tps: 16210.41158
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 22946.57218
-  tps: 16293.26284
+  dps: 22924.02811
+  tps: 16277.33133
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-55854"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-56377"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 22575.28799
-  tps: 16029.65106
+  dps: 22565.96993
+  tps: 16023.11002
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 22580.00968
-  tps: 16033.00346
+  dps: 22570.77056
+  tps: 16026.51847
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 22508.88825
-  tps: 15982.50724
+  dps: 22499.69487
+  tps: 15976.05473
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 22141.69808
-  tps: 15721.80223
+  dps: 22132.90478
+  tps: 15715.63377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 21885.66208
-  tps: 15540.09145
+  dps: 21903.20506
+  tps: 15552.62175
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 21934.8398
-  tps: 15575.00763
+  dps: 21955.61329
+  tps: 15589.83159
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 22255.00744
-  tps: 15802.25187
+  dps: 22249.05738
+  tps: 15798.10211
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-55256"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-56290"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShieldedSkyflareDiamond"
  value: {
-  dps: 22141.69808
-  tps: 15721.80223
+  dps: 22132.90478
+  tps: 15715.63377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 21858.7412
-  tps: 15520.90284
+  dps: 21848.15057
+  tps: 15513.45828
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 22424.70695
-  tps: 15922.73852
+  dps: 22417.15158
+  tps: 15917.449
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 22577.74166
-  tps: 16031.39316
+  dps: 22570.34806
+  tps: 16026.21849
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-55879"
  value: {
-  dps: 21508.38981
-  tps: 15272.15335
+  dps: 21514.00123
+  tps: 15276.21225
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-56400"
  value: {
-  dps: 21542.10235
-  tps: 15296.08926
+  dps: 21547.75469
+  tps: 15300.17721
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 21729.39106
-  tps: 15429.13903
+  dps: 21747.87707
+  tps: 15442.33888
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulCasket-58183"
  value: {
-  dps: 21578.87966
-  tps: 15322.20115
+  dps: 21584.57666
+  tps: 15326.3208
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulPreserver-37111"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SouloftheDead-40382"
  value: {
-  dps: 21361.89065
-  tps: 15168.13895
+  dps: 21354.05714
+  tps: 15162.65194
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SparkofLife-37657"
  value: {
-  dps: 21367.09596
-  tps: 15171.83472
+  dps: 21389.92277
+  tps: 15188.11654
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 21532.88571
-  tps: 15289.62022
+  dps: 21542.51564
+  tps: 15296.53226
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 21261.49787
-  tps: 15096.86007
+  dps: 21266.79674
+  tps: 15100.69706
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stormrider'sBattlegarb"
  value: {
-  dps: 21969.39234
-  tps: 15599.53994
+  dps: 21964.03757
+  tps: 15595.81284
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62465"
  value: {
-  dps: 21480.89388
-  tps: 15252.78082
+  dps: 21498.92006
+  tps: 15265.65419
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62470"
  value: {
-  dps: 21480.89388
-  tps: 15252.78082
+  dps: 21498.92006
+  tps: 15265.65419
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 22170.70403
-  tps: 15742.39645
+  dps: 22161.82853
+  tps: 15736.16963
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 22161.06913
-  tps: 15735.55567
+  dps: 22152.19363
+  tps: 15729.32885
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 22148.26506
-  tps: 15726.46478
+  dps: 22138.88901
+  tps: 15719.88257
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 21260.58291
-  tps: 15096.21045
+  dps: 21265.88178
+  tps: 15100.04744
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 21941.51964
-  tps: 15579.67553
+  dps: 21923.24248
+  tps: 15566.77354
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-55819"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-56351"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 21470.59091
-  tps: 15245.31613
+  dps: 21476.15643
+  tps: 15249.34244
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 21542.10235
-  tps: 15296.08926
+  dps: 21547.75469
+  tps: 15300.17721
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 21273.0961
-  tps: 15105.09482
+  dps: 21278.39497
+  tps: 15108.93181
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 22213.64669
-  tps: 15772.88573
+  dps: 22236.70449
+  tps: 15789.33156
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 22518.28357
-  tps: 15989.17792
+  dps: 22508.44238
+  tps: 15982.26546
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 21470.72093
-  tps: 15245.48323
+  dps: 21441.85318
+  tps: 15225.06191
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 21487.25827
-  tps: 15257.22474
+  dps: 21472.60057
+  tps: 15246.89256
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 22141.69808
-  tps: 15721.80223
+  dps: 22132.90478
+  tps: 15715.63377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 22141.69808
-  tps: 15721.80223
+  dps: 22132.90478
+  tps: 15715.63377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 21357.66271
-  tps: 15165.13711
+  dps: 21372.97579
+  tps: 15176.08418
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 22141.69808
-  tps: 15721.80223
+  dps: 22132.90478
+  tps: 15715.63377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 22141.69808
-  tps: 15721.80223
+  dps: 22132.90478
+  tps: 15715.63377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 21323.12416
-  tps: 15140.76431
+  dps: 21328.29866
+  tps: 15144.513
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 17367.96337
-  tps: 12332.45058
+  dps: 17381.6484
+  tps: 12342.24174
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 22935.03165
-  tps: 16285.06906
+  dps: 22935.73047
+  tps: 16285.64001
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 22935.03165
-  tps: 16285.06906
+  dps: 22935.73047
+  tps: 16285.64001
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 19189.1314
-  tps: 13625.47988
+  dps: 19197.82019
+  tps: 13631.72371
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 22586.63339
-  tps: 16037.70629
+  dps: 22586.9656
+  tps: 16038.01695
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 21740.31341
-  tps: 15436.81911
+  dps: 21745.56934
+  tps: 15440.6256
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 21480.89388
-  tps: 15252.78082
+  dps: 21498.92006
+  tps: 15265.65419
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 21581.11191
-  tps: 15323.78604
+  dps: 21575.00213
+  tps: 15319.52288
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 21566.34223
-  tps: 15313.29957
+  dps: 21555.38214
+  tps: 15305.59269
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 21630.55278
-  tps: 15358.88906
+  dps: 21640.64334
+  tps: 15366.12814
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 21598.28991
-  tps: 15335.98243
+  dps: 21604.01047
+  tps: 15340.11881
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 22479.5548
-  tps: 15961.6805
+  dps: 22470.32097
+  tps: 15955.19926
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 21717.96375
-  tps: 15420.95085
+  dps: 21721.61154
+  tps: 15423.61556
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WingedTalisman-37844"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 21250.94862
-  tps: 15089.37011
+  dps: 21256.24749
+  tps: 15093.20709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 21474.67728
-  tps: 15248.21745
+  dps: 21480.24776
+  tps: 15252.24729
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 21554.99874
-  tps: 15305.24569
+  dps: 21562.33102
+  tps: 15310.5264
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 21554.99874
-  tps: 15305.24569
+  dps: 21562.33102
+  tps: 15310.5264
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 22885.93711
-  tps: 16250.2961
+  dps: 22882.52867
+  tps: 16247.94784
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 57300.01993
-  tps: 40712.77925
+  dps: 57404.94179
+  tps: 40787.19898
  }
 }
 dps_results: {
@@ -1870,71 +1870,71 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-ExternalBleed-aoe-FullBuffs-5.0yards-LongMultiTarget"
  value: {
-  dps: 57766.29981
-  tps: 41043.83796
+  dps: 57916.43002
+  tps: 41150.43041
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-ExternalBleed-aoe-FullBuffs-5.0yards-LongSingleTarget"
  value: {
-  dps: 16327.7542
-  tps: 11593.97686
+  dps: 16339.73436
+  tps: 11602.55756
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-ExternalBleed-aoe-FullBuffs-5.0yards-ShortSingleTarget"
  value: {
-  dps: 18742.85769
-  tps: 13313.78582
+  dps: 18748.03791
+  tps: 13317.83771
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38815.03423
-  tps: 27589.78556
+  dps: 38729.55851
+  tps: 27529.02301
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 10472.48013
-  tps: 7438.228
+  dps: 10539.9596
+  tps: 7486.06364
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-ExternalBleed-aoe-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 10266.19499
-  tps: 7296.47711
+  dps: 10329.83115
+  tps: 7341.65878
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-ExternalBleed-aoe-NoBuffs-5.0yards-LongMultiTarget"
  value: {
-  dps: 39005.69389
-  tps: 27725.15391
+  dps: 38888.19446
+  tps: 27641.43018
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-ExternalBleed-aoe-NoBuffs-5.0yards-LongSingleTarget"
  value: {
-  dps: 10570.04305
-  tps: 7507.49767
+  dps: 10572.30027
+  tps: 7508.72637
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-ExternalBleed-aoe-NoBuffs-5.0yards-ShortSingleTarget"
  value: {
-  dps: 10560.16065
-  tps: 7505.19273
+  dps: 10559.50023
+  tps: 7504.72383
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 27523.56792
-  tps: 19541.73322
+  dps: 27318.55597
+  tps: 19425.79026
  }
 }
 dps_results: {
@@ -1954,71 +1954,71 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-ExternalBleed-default-FullBuffs-5.0yards-LongMultiTarget"
  value: {
-  dps: 27560.89923
-  tps: 19569.50983
+  dps: 27357.51558
+  tps: 19453.60115
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-ExternalBleed-default-FullBuffs-5.0yards-LongSingleTarget"
  value: {
-  dps: 27560.89923
-  tps: 19569.50983
+  dps: 27556.46647
+  tps: 19566.43735
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-ExternalBleed-default-FullBuffs-5.0yards-ShortSingleTarget"
  value: {
-  dps: 34168.51921
-  tps: 24266.00551
+  dps: 34190.0455
+  tps: 24281.6631
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 18024.09558
-  tps: 12799.87497
+  dps: 17945.36697
+  tps: 12772.24702
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 18024.09558
-  tps: 12799.87497
+  dps: 17986.91133
+  tps: 12773.39936
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 19248.09469
-  tps: 13673.6259
+  dps: 19595.13593
+  tps: 13920.02518
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-ExternalBleed-default-NoBuffs-5.0yards-LongMultiTarget"
  value: {
-  dps: 18095.12231
-  tps: 12850.30395
+  dps: 17935.5354
+  tps: 12765.04224
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-ExternalBleed-default-NoBuffs-5.0yards-LongSingleTarget"
  value: {
-  dps: 18095.12231
-  tps: 12850.30395
+  dps: 18094.88954
+  tps: 12849.98911
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-ExternalBleed-default-NoBuffs-5.0yards-ShortSingleTarget"
  value: {
-  dps: 19953.81228
-  tps: 14174.68538
+  dps: 19952.01828
+  tps: 14173.41165
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 45222.33729
-  tps: 32137.54978
+  dps: 45329.88383
+  tps: 32213.83304
  }
 }
 dps_results: {
@@ -2038,57 +2038,57 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-aoe-FullBuffs-5.0yards-LongMultiTarget"
  value: {
-  dps: 45875.7393
-  tps: 32601.46521
+  dps: 45479.18845
+  tps: 32319.91411
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-aoe-FullBuffs-5.0yards-LongSingleTarget"
  value: {
-  dps: 13065.89079
-  tps: 9277.97905
+  dps: 13068.72398
+  tps: 9280.0654
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-aoe-FullBuffs-5.0yards-ShortSingleTarget"
  value: {
-  dps: 14960.49952
-  tps: 10627.93759
+  dps: 14984.35301
+  tps: 10645.2475
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 29927.88258
-  tps: 21279.8331
+  dps: 29903.61053
+  tps: 21262.37558
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 8158.94768
-  tps: 5795.54517
+  dps: 8170.09556
+  tps: 5803.3106
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-aoe-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 7813.05644
-  tps: 5554.74874
+  dps: 7932.83234
+  tps: 5639.78963
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-aoe-NoBuffs-5.0yards-LongMultiTarget"
  value: {
-  dps: 30110.88515
-  tps: 21409.76493
+  dps: 29998.57568
+  tps: 21329.95041
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-aoe-NoBuffs-5.0yards-LongSingleTarget"
  value: {
-  dps: 8200.77619
-  tps: 5825.24341
+  dps: 8204.23261
+  tps: 5827.24875
  }
 }
 dps_results: {
@@ -2101,8 +2101,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 22744.6389
-  tps: 16148.69362
+  dps: 22497.21032
+  tps: 16002.41049
  }
 }
 dps_results: {
@@ -2122,70 +2122,70 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-default-FullBuffs-5.0yards-LongMultiTarget"
  value: {
-  dps: 22700.25886
-  tps: 16118.38038
+  dps: 22618.26301
+  tps: 16088.65705
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-default-FullBuffs-5.0yards-LongSingleTarget"
  value: {
-  dps: 22700.25886
-  tps: 16118.38038
+  dps: 22691.02705
+  tps: 16111.90058
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-default-FullBuffs-5.0yards-ShortSingleTarget"
  value: {
-  dps: 28172.59511
-  tps: 20008.52546
+  dps: 28162.12407
+  tps: 20001.46496
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 14590.76076
-  tps: 10362.13246
+  dps: 14507.9091
+  tps: 10331.57714
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 14590.76076
-  tps: 10362.13246
+  dps: 14540.56004
+  tps: 10326.26559
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 15569.78701
-  tps: 11062.02744
+  dps: 15681.73044
+  tps: 11141.50728
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-default-NoBuffs-5.0yards-LongMultiTarget"
  value: {
-  dps: 14629.37893
-  tps: 10389.55136
+  dps: 14539.62274
+  tps: 10353.57032
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-default-NoBuffs-5.0yards-LongSingleTarget"
  value: {
-  dps: 14629.37893
-  tps: 10389.55136
+  dps: 14637.71164
+  tps: 10395.09365
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-default-NoBuffs-5.0yards-ShortSingleTarget"
  value: {
-  dps: 16104.24909
-  tps: 11441.49552
+  dps: 16106.65588
+  tps: 11443.20434
  }
 }
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 19518.01667
-  tps: 13858.98842
+  dps: 19495.05197
+  tps: 13842.75827
  }
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -39,1811 +39,1811 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 22669.11689
-  tps: 16096.26958
+  dps: 22700.25886
+  tps: 16118.38038
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 21430.71609
-  tps: 15217.0798
+  dps: 21480.8507
+  tps: 15252.67537
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 21430.71609
-  tps: 15217.0798
+  dps: 21480.8507
+  tps: 15252.67537
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 22099.77907
-  tps: 15692.03973
+  dps: 22141.69808
+  tps: 15721.80223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 22099.77907
-  tps: 15692.03973
+  dps: 22141.69808
+  tps: 15721.80223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 21478.52511
-  tps: 15251.0242
+  dps: 21529.58877
+  tps: 15287.2794
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
   hps: 84.91645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
   hps: 84.91645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 22140.63713
-  tps: 15721.04895
+  dps: 22170.70403
+  tps: 15742.39645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 21542.54588
-  tps: 15296.40416
+  dps: 21555.62544
+  tps: 15305.69065
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 21559.04339
-  tps: 15308.11739
+  dps: 21574.42803
+  tps: 15319.04049
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BindingPromise-67037"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 16345.54782
-  tps: 11606.53554
+  dps: 16411.51056
+  tps: 11653.36909
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 22365.53141
-  tps: 15880.72389
+  dps: 22398.21696
+  tps: 15903.93063
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 21456.45376
-  tps: 15235.27875
+  dps: 21508.38981
+  tps: 15272.15335
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 21489.97189
-  tps: 15259.07663
+  dps: 21542.10235
+  tps: 15296.08926
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 22747.1512
-  tps: 16151.67394
+  dps: 22768.52843
+  tps: 16166.85177
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 21647.94314
-  tps: 15371.23621
+  dps: 21714.3969
+  tps: 15418.41838
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 21530.49165
-  tps: 15287.84566
+  dps: 21541.03323
+  tps: 15295.33018
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 22279.47368
-  tps: 15819.6229
+  dps: 22320.05701
+  tps: 15848.43707
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 21616.88383
-  tps: 15349.1841
+  dps: 21667.09126
+  tps: 15384.83138
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledLightning-66879"
  value: {
-  dps: 21331.71598
-  tps: 15146.71493
+  dps: 21374.16495
+  tps: 15176.8537
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 22099.77907
-  tps: 15378.19893
+  dps: 22141.69808
+  tps: 15407.36618
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 22099.77907
-  tps: 15378.19893
+  dps: 22141.69808
+  tps: 15407.36618
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 22465.62566
-  tps: 15951.7908
+  dps: 22508.88825
+  tps: 15982.50724
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 22542.18459
-  tps: 16006.14764
+  dps: 22567.56902
+  tps: 16024.17059
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 22508.37992
-  tps: 15982.14633
+  dps: 22539.2866
+  tps: 16004.09007
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
   hps: 64
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-59506"
  value: {
-  dps: 22031.10512
-  tps: 15643.28122
+  dps: 22074.99806
+  tps: 15674.44521
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-65118"
  value: {
-  dps: 22182.88642
-  tps: 15751.04594
+  dps: 22147.74146
+  tps: 15726.09303
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 21318.94179
-  tps: 15137.64525
+  dps: 21373.19321
+  tps: 15176.16376
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 21347.69177
-  tps: 15158.20732
+  dps: 21401.68608
+  tps: 15196.54328
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 21590.68717
-  tps: 15330.58448
+  dps: 21621.49698
+  tps: 15352.45944
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 21888.81057
-  tps: 15542.25209
+  dps: 21942.30776
+  tps: 15580.2351
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 22579.43835
-  tps: 16032.59782
+  dps: 22621.39329
+  tps: 16062.38582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 21527.5878
-  tps: 15288.08689
+  dps: 21579.93035
+  tps: 15325.2501
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Death'sChoice-47464"
  value: {
-  dps: 22183.82233
-  tps: 15751.71044
+  dps: 22223.03018
+  tps: 15779.54802
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 21302.10219
-  tps: 15125.68914
+  dps: 21347.8023
+  tps: 15158.13622
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 21753.67937
-  tps: 15446.30894
+  dps: 21790.57887
+  tps: 15472.50759
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 21937.26435
-  tps: 15576.65427
+  dps: 21956.10417
+  tps: 15590.03055
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Defender'sCode-40257"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 22172.52832
-  tps: 15743.69169
+  dps: 22197.38556
+  tps: 15761.34034
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 22143.1049
-  tps: 15722.80107
+  dps: 22173.17181
+  tps: 15744.14857
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 21392.51195
-  tps: 15189.88007
+  dps: 21406.83184
+  tps: 15200.04719
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 21428.28012
-  tps: 15215.27547
+  dps: 21421.10506
+  tps: 15210.18118
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 22099.77907
-  tps: 15692.03973
+  dps: 22141.69808
+  tps: 15721.80223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 21200.49713
-  tps: 15083.74569
+  dps: 21250.94862
+  tps: 15119.61107
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 22099.77907
-  tps: 15692.03973
+  dps: 22141.69808
+  tps: 15721.80223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 22099.77907
-  tps: 15692.03973
+  dps: 22141.69808
+  tps: 15721.80223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 22172.52832
-  tps: 15743.69169
+  dps: 22197.38556
+  tps: 15761.34034
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 22140.63713
-  tps: 15721.04895
+  dps: 22170.70403
+  tps: 15742.39645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 22135.85108
-  tps: 15717.65085
+  dps: 22161.06913
+  tps: 15735.55567
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 21308.12054
-  tps: 15129.96217
+  dps: 21352.88937
+  tps: 15161.74804
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 22721.5011
-  tps: 16133.46237
+  dps: 22734.28714
+  tps: 16142.54046
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 22967.40466
-  tps: 16308.0539
+  dps: 22964.60808
+  tps: 16306.06832
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 22099.77907
-  tps: 15692.03973
+  dps: 22141.69808
+  tps: 15721.80223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 22099.77907
-  tps: 15692.03973
+  dps: 22141.69808
+  tps: 15721.80223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 21348.99629
-  tps: 15158.98396
+  dps: 21403.16519
+  tps: 15197.44387
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 21303.745
-  tps: 15126.85553
+  dps: 21357.73931
+  tps: 15165.1915
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-59500"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-65124"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 22876.56806
-  tps: 16243.6347
+  dps: 22955.959
+  tps: 16300.00227
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 21915.19472
-  tps: 15560.98484
+  dps: 21982.91805
+  tps: 15609.0684
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 22156.30459
-  tps: 15732.17285
+  dps: 22198.57147
+  tps: 15762.18233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FluidDeath-58181"
  value: {
-  dps: 22692.51868
-  tps: 16113.03443
+  dps: 22758.36043
+  tps: 16159.78206
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForgeEmber-37660"
  value: {
-  dps: 21289.31945
-  tps: 15116.61339
+  dps: 21343.31376
+  tps: 15154.94936
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 22099.77907
-  tps: 15692.03973
+  dps: 22141.69808
+  tps: 15721.80223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 22099.77907
-  tps: 15692.03973
+  dps: 22141.69808
+  tps: 15721.80223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 22099.77907
-  tps: 15692.03973
+  dps: 22141.69808
+  tps: 15721.80223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 22087.1924
-  tps: 15683.10319
+  dps: 22093.4773
+  tps: 15687.56547
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 21583.81878
-  tps: 15325.70792
+  dps: 21635.3013
+  tps: 15362.26051
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuturesightRune-38763"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56138"
  value: {
-  dps: 21451.35059
-  tps: 15231.65551
+  dps: 21575.57679
+  tps: 15319.85611
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56462"
  value: {
-  dps: 21532.77945
-  tps: 15289.47
+  dps: 21533.8153
+  tps: 15290.20545
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GearDetector-61462"
  value: {
-  dps: 22030.36863
-  tps: 15642.75831
+  dps: 22039.26976
+  tps: 15649.07812
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 21328.11921
-  tps: 15144.3108
+  dps: 21382.11352
+  tps: 15182.64676
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 22022.67551
-  tps: 15637.2962
+  dps: 22051.23886
+  tps: 15657.57617
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 22346.92483
-  tps: 15867.51321
+  dps: 22394.87904
+  tps: 15901.5607
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HarmlightToken-63839"
  value: {
-  dps: 21206.78161
-  tps: 15058.01153
+  dps: 21256.4608
+  tps: 15093.28375
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 21708.31558
-  tps: 15414.10065
+  dps: 21757.23925
+  tps: 15448.83646
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-59224"
  value: {
-  dps: 22066.95971
-  tps: 15668.73798
+  dps: 22115.5443
+  tps: 15703.23304
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-65072"
  value: {
-  dps: 22218.45741
-  tps: 15776.30135
+  dps: 22307.85281
+  tps: 15839.77208
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-55868"
  value: {
-  dps: 21451.35059
-  tps: 15231.65551
+  dps: 21575.57679
+  tps: 15319.85611
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-56393"
  value: {
-  dps: 22010.54627
-  tps: 15628.68444
+  dps: 22013.53616
+  tps: 15630.80726
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-55845"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-56370"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 22116.50048
-  tps: 15703.91193
+  dps: 22158.91479
+  tps: 15734.02609
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-49982"
  value: {
-  dps: 23086.59352
-  tps: 16392.67799
+  dps: 23114.29608
+  tps: 16412.3468
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-50641"
  value: {
-  dps: 23159.6338
-  tps: 16444.53658
+  dps: 23174.09342
+  tps: 16454.80291
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 22172.52832
-  tps: 15743.69169
+  dps: 22197.38556
+  tps: 15761.34034
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 22140.63713
-  tps: 15721.04895
+  dps: 22170.70403
+  tps: 15742.39645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 22135.85108
-  tps: 15717.65085
+  dps: 22161.06913
+  tps: 15735.55567
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 22006.28927
-  tps: 15625.66197
+  dps: 22076.27834
+  tps: 15675.35421
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 22006.28927
-  tps: 15625.66197
+  dps: 22076.27834
+  tps: 15675.35421
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 21456.45376
-  tps: 15235.27875
+  dps: 21508.38981
+  tps: 15272.15335
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 21489.97189
-  tps: 15259.07663
+  dps: 21542.10235
+  tps: 15296.08926
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IncisorFragment-37723"
  value: {
-  dps: 21578.66987
-  tps: 15322.0522
+  dps: 21626.73344
+  tps: 15356.17733
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 22099.77907
-  tps: 15692.03973
+  dps: 22141.69808
+  tps: 15721.80223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 21397.5431
-  tps: 15193.45219
+  dps: 21449.13748
+  tps: 15230.0842
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 22185.35706
-  tps: 15752.8001
+  dps: 22217.58895
+  tps: 15775.68474
   hps: 60.89842
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 22365.53141
-  tps: 15880.72389
+  dps: 22398.21696
+  tps: 15903.93063
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 22365.26611
-  tps: 15880.61031
+  dps: 22474.64625
+  tps: 15958.27021
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 22741.35397
-  tps: 16147.6327
+  dps: 22787.15535
+  tps: 16180.15167
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 21563.00503
-  tps: 15310.93016
+  dps: 21655.2866
+  tps: 15376.45008
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 21563.00503
-  tps: 15310.93016
+  dps: 21655.2866
+  tps: 15376.45008
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 21395.15939
-  tps: 15191.75976
+  dps: 21408.29483
+  tps: 15201.08591
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50179"
  value: {
-  dps: 22800.29578
-  tps: 16189.40659
+  dps: 22831.71636
+  tps: 16211.7152
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50708"
  value: {
-  dps: 22819.98865
-  tps: 16203.38853
+  dps: 22851.36925
+  tps: 16225.66875
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-55816"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-56347"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 22518.03737
-  tps: 15989.00312
+  dps: 22531.23804
+  tps: 15998.37559
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 22683.92326
-  tps: 16106.7821
+  dps: 22671.22898
+  tps: 16097.76916
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 21918.99005
-  tps: 15563.8291
+  dps: 21970.16698
+  tps: 15600.16472
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 21743.06403
-  tps: 15438.77205
+  dps: 21808.35243
+  tps: 15485.12681
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 21910.19402
-  tps: 15557.43434
+  dps: 21921.78353
+  tps: 15565.66289
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 21871.71531
-  tps: 15530.11445
+  dps: 21930.7147
+  tps: 15572.00402
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 21960.40597
-  tps: 15593.08483
+  dps: 22020.55502
+  tps: 15635.79065
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 21433.85629
-  tps: 15219.23455
+  dps: 21459.93316
+  tps: 15237.74913
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 21593.80591
-  tps: 15332.87357
+  dps: 21673.90649
+  tps: 15389.74498
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 21884.2446
-  tps: 15539.08504
+  dps: 21943.81804
+  tps: 15581.38218
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 21526.53712
-  tps: 15285.03794
+  dps: 21578.87966
+  tps: 15322.20115
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 21526.53712
-  tps: 15285.03794
+  dps: 21578.87966
+  tps: 15322.20115
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 21591.92176
-  tps: 15331.46103
+  dps: 21673.09045
+  tps: 15389.09081
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 21382.10457
-  tps: 15182.49083
+  dps: 21398.43484
+  tps: 15194.08533
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 21746.52704
-  tps: 15441.23078
+  dps: 21767.65245
+  tps: 15456.22983
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 22135.85108
-  tps: 15717.65085
+  dps: 22161.06913
+  tps: 15735.55567
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 22140.63713
-  tps: 15721.04895
+  dps: 22170.70403
+  tps: 15742.39645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 21406.58768
-  tps: 15199.87384
+  dps: 21458.82131
+  tps: 15236.95971
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 21566.60773
-  tps: 15313.48808
+  dps: 21613.31601
+  tps: 15346.65095
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 22099.77907
-  tps: 15692.03973
+  dps: 22141.69808
+  tps: 15721.80223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 22099.77907
-  tps: 15692.03973
+  dps: 22141.69808
+  tps: 15721.80223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 22099.77907
-  tps: 15692.03973
+  dps: 22141.69808
+  tps: 15721.80223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 22763.27884
-  tps: 16163.12457
+  dps: 22835.08431
+  tps: 16214.10645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 22925.79113
-  tps: 16278.50829
+  dps: 22946.57218
+  tps: 16293.26284
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-55854"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-56377"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 22549.26416
-  tps: 16011.17414
+  dps: 22575.28799
+  tps: 16029.65106
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 22536.58155
-  tps: 16002.16949
+  dps: 22580.00968
+  tps: 16033.00346
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 22465.62566
-  tps: 15951.7908
+  dps: 22508.88825
+  tps: 15982.50724
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 22099.77907
-  tps: 15692.03973
+  dps: 22141.69808
+  tps: 15721.80223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 21833.692
-  tps: 15503.1927
+  dps: 21885.66208
+  tps: 15540.09145
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 21879.80573
-  tps: 15535.93344
+  dps: 21934.8398
+  tps: 15575.00763
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 22212.93589
-  tps: 15772.38107
+  dps: 22255.00744
+  tps: 15802.25187
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-55256"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-56290"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShieldedSkyflareDiamond"
  value: {
-  dps: 22099.77907
-  tps: 15692.03973
+  dps: 22141.69808
+  tps: 15721.80223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 21839.77505
-  tps: 15507.43687
+  dps: 21858.7412
+  tps: 15520.90284
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 22356.33958
-  tps: 15874.19769
+  dps: 22424.70695
+  tps: 15922.73852
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 22510.11717
-  tps: 15983.37978
+  dps: 22577.74166
+  tps: 16031.39316
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-55879"
  value: {
-  dps: 21456.45376
-  tps: 15235.27875
+  dps: 21508.38981
+  tps: 15272.15335
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-56400"
  value: {
-  dps: 21489.97189
-  tps: 15259.07663
+  dps: 21542.10235
+  tps: 15296.08926
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 21674.18929
-  tps: 15389.94577
+  dps: 21729.39106
+  tps: 15429.13903
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulCasket-58183"
  value: {
-  dps: 21526.53712
-  tps: 15285.03794
+  dps: 21578.87966
+  tps: 15322.20115
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulPreserver-37111"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SouloftheDead-40382"
  value: {
-  dps: 21307.72176
-  tps: 15129.67903
+  dps: 21361.89065
+  tps: 15168.13895
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SparkofLife-37657"
  value: {
-  dps: 21348.3543
-  tps: 15158.52814
+  dps: 21367.09596
+  tps: 15171.83472
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 21492.10803
-  tps: 15260.66808
+  dps: 21532.88571
+  tps: 15289.62022
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 21211.04638
-  tps: 15061.03951
+  dps: 21261.49787
+  tps: 15096.86007
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stormrider'sBattlegarb"
  value: {
-  dps: 21944.9741
-  tps: 15582.20298
+  dps: 21969.39234
+  tps: 15599.53994
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62465"
  value: {
-  dps: 21430.75927
-  tps: 15217.18524
+  dps: 21480.89388
+  tps: 15252.78082
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62470"
  value: {
-  dps: 21430.75927
-  tps: 15217.18524
+  dps: 21480.89388
+  tps: 15252.78082
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 22140.63713
-  tps: 15721.04895
+  dps: 22170.70403
+  tps: 15742.39645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 22135.85108
-  tps: 15717.65085
+  dps: 22161.06913
+  tps: 15735.55567
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 22123.0151
-  tps: 15708.53731
+  dps: 22148.26506
+  tps: 15726.46478
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 21210.13142
-  tps: 15060.38989
+  dps: 21260.58291
+  tps: 15096.21045
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 21894.44141
-  tps: 15546.24999
+  dps: 21941.51964
+  tps: 15579.67553
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-55819"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-56351"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 21418.87282
-  tps: 15208.59629
+  dps: 21470.59091
+  tps: 15245.31613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 21489.97189
-  tps: 15259.07663
+  dps: 21542.10235
+  tps: 15296.08926
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 21222.64461
-  tps: 15069.27426
+  dps: 21273.0961
+  tps: 15105.09482
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 22179.25429
-  tps: 15748.46713
+  dps: 22213.64669
+  tps: 15772.88573
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 22478.58416
-  tps: 15960.99134
+  dps: 22518.28357
+  tps: 15989.17792
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 21457.97024
-  tps: 15236.43025
+  dps: 21470.72093
+  tps: 15245.48323
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 21447.83312
-  tps: 15229.23289
+  dps: 21487.25827
+  tps: 15257.22474
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 22099.77907
-  tps: 15692.03973
+  dps: 22141.69808
+  tps: 15721.80223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 22099.77907
-  tps: 15692.03973
+  dps: 22141.69808
+  tps: 15721.80223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 21320.02504
-  tps: 15138.41437
+  dps: 21357.66271
+  tps: 15165.13711
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 22099.77907
-  tps: 15692.03973
+  dps: 22141.69808
+  tps: 15721.80223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 22099.77907
-  tps: 15692.03973
+  dps: 22141.69808
+  tps: 15721.80223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 21272.72198
-  tps: 15104.97876
+  dps: 21323.12416
+  tps: 15140.76431
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 17338.46581
-  tps: 12311.50731
+  dps: 17367.96337
+  tps: 12332.45058
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 22876.85896
-  tps: 16243.76645
+  dps: 22935.03165
+  tps: 16285.06906
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 22876.85896
-  tps: 16243.76645
+  dps: 22935.03165
+  tps: 16285.06906
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 19187.12474
-  tps: 13624.05515
+  dps: 19189.1314
+  tps: 13625.47988
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 22532.32349
-  tps: 15999.14627
+  dps: 22586.63339
+  tps: 16037.70629
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 21672.96479
-  tps: 15389.00159
+  dps: 21740.31341
+  tps: 15436.81911
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 21430.75927
-  tps: 15217.18524
+  dps: 21480.89388
+  tps: 15252.78082
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 21537.41064
-  tps: 15292.75814
+  dps: 21581.11191
+  tps: 15323.78604
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 21554.94852
-  tps: 15305.21004
+  dps: 21566.34223
+  tps: 15313.29957
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 21546.03342
-  tps: 15298.88032
+  dps: 21630.55278
+  tps: 15358.88906
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 21545.83543
-  tps: 15298.73975
+  dps: 21598.28991
+  tps: 15335.98243
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 22440.67675
-  tps: 15934.07708
+  dps: 22479.5548
+  tps: 15961.6805
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 21664.31424
-  tps: 15382.8597
+  dps: 21717.96375
+  tps: 15420.95085
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WingedTalisman-37844"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 21200.49713
-  tps: 15053.54955
+  dps: 21250.94862
+  tps: 15089.37011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 21422.93563
-  tps: 15211.48088
+  dps: 21474.67728
+  tps: 15248.21745
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 21498.03731
-  tps: 15264.80308
+  dps: 21554.99874
+  tps: 15305.24569
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 21498.03731
-  tps: 15264.80308
+  dps: 21554.99874
+  tps: 15305.24569
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 22853.26523
-  tps: 16227.09907
+  dps: 22885.93711
+  tps: 16250.2961
  }
 }
 dps_results: {
@@ -1891,15 +1891,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 27519.54073
-  tps: 19540.14529
+  dps: 27559.9831
+  tps: 19568.85937
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 27519.54073
-  tps: 19540.14529
+  dps: 27559.9831
+  tps: 19568.85937
  }
 }
 dps_results: {
@@ -1912,22 +1912,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 18054.97164
-  tps: 12821.79697
+  dps: 18097.19863
+  tps: 12851.77813
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 18054.97164
-  tps: 12821.79697
+  dps: 18097.19863
+  tps: 12851.77813
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 19863.14866
-  tps: 14110.31421
+  dps: 19938.79393
+  tps: 14164.02235
  }
 }
 dps_results: {
@@ -1975,15 +1975,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-Default-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 27519.54073
-  tps: 19540.14529
+  dps: 27560.89923
+  tps: 19569.50983
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-Default-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 27519.54073
-  tps: 19540.14529
+  dps: 27560.89923
+  tps: 19569.50983
  }
 }
 dps_results: {
@@ -1996,22 +1996,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-Default-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 18054.97164
-  tps: 12821.79697
+  dps: 18095.12231
+  tps: 12850.30395
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-Default-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 18054.97164
-  tps: 12821.79697
+  dps: 18095.12231
+  tps: 12850.30395
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-Default-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 19863.14866
-  tps: 14110.31421
+  dps: 19953.81228
+  tps: 14174.68538
  }
 }
 dps_results: {
@@ -2059,15 +2059,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 22669.11689
-  tps: 16096.26958
+  dps: 22698.67081
+  tps: 16117.25286
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 22669.11689
-  tps: 16096.26958
+  dps: 22698.67081
+  tps: 16117.25286
  }
 }
 dps_results: {
@@ -2080,22 +2080,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14685.96237
-  tps: 10429.7256
+  dps: 14614.64832
+  tps: 10379.09263
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 14685.96237
-  tps: 10429.7256
+  dps: 14614.64832
+  tps: 10379.09263
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 16123.28911
-  tps: 11455.01393
+  dps: 16049.09507
+  tps: 11402.33617
  }
 }
 dps_results: {
@@ -2143,15 +2143,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-FullBuffs-LongMultiTarget"
  value: {
-  dps: 22669.11689
-  tps: 16096.26958
+  dps: 22700.25886
+  tps: 16118.38038
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-FullBuffs-LongSingleTarget"
  value: {
-  dps: 22669.11689
-  tps: 16096.26958
+  dps: 22700.25886
+  tps: 16118.38038
  }
 }
 dps_results: {
@@ -2164,28 +2164,28 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-LongMultiTarget"
  value: {
-  dps: 14685.96237
-  tps: 10429.7256
+  dps: 14629.37893
+  tps: 10389.55136
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-LongSingleTarget"
  value: {
-  dps: 14685.96237
-  tps: 10429.7256
+  dps: 14629.37893
+  tps: 10389.55136
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-ShortSingleTarget"
  value: {
-  dps: 16123.28911
-  tps: 11455.01393
+  dps: 16104.24909
+  tps: 11441.49552
  }
 }
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 19462.02901
-  tps: 13819.23718
+  dps: 19518.01667
+  tps: 13858.98842
  }
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -1847,336 +1847,336 @@ dps_results: {
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-aoe-FullBuffs-LongMultiTarget"
+ key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-aoe-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 57766.29981
   tps: 41043.83796
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-aoe-FullBuffs-LongSingleTarget"
+ key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-aoe-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 16327.7542
   tps: 11593.97686
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-aoe-FullBuffs-ShortSingleTarget"
+ key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-aoe-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 18742.85769
   tps: 13313.78582
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-aoe-NoBuffs-LongMultiTarget"
+ key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-aoe-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 39005.69389
   tps: 27725.15391
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-aoe-NoBuffs-LongSingleTarget"
+ key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-aoe-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 10570.04305
   tps: 7507.49767
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-aoe-NoBuffs-ShortSingleTarget"
+ key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-aoe-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 10560.16065
   tps: 7505.19273
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-default-FullBuffs-LongMultiTarget"
+ key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 27559.9831
   tps: 19568.85937
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-default-FullBuffs-LongSingleTarget"
+ key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 27559.9831
   tps: 19568.85937
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-default-FullBuffs-ShortSingleTarget"
+ key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 34168.51921
   tps: 24266.00551
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-default-NoBuffs-LongMultiTarget"
+ key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 18097.19863
   tps: 12851.77813
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-default-NoBuffs-LongSingleTarget"
+ key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 18097.19863
   tps: 12851.77813
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-default-NoBuffs-ShortSingleTarget"
+ key: "TestFeral-Settings-Tauren-p1-Default-NoBleed-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 19938.79393
   tps: 14164.02235
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-aoe-FullBuffs-LongMultiTarget"
+ key: "TestFeral-Settings-Tauren-p1-Default-aoe-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 57766.29981
   tps: 41043.83796
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-aoe-FullBuffs-LongSingleTarget"
+ key: "TestFeral-Settings-Tauren-p1-Default-aoe-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 16327.7542
   tps: 11593.97686
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-aoe-FullBuffs-ShortSingleTarget"
+ key: "TestFeral-Settings-Tauren-p1-Default-aoe-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 18742.85769
   tps: 13313.78582
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-aoe-NoBuffs-LongMultiTarget"
+ key: "TestFeral-Settings-Tauren-p1-Default-aoe-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 39005.69389
   tps: 27725.15391
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-aoe-NoBuffs-LongSingleTarget"
+ key: "TestFeral-Settings-Tauren-p1-Default-aoe-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 10570.04305
   tps: 7507.49767
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-aoe-NoBuffs-ShortSingleTarget"
+ key: "TestFeral-Settings-Tauren-p1-Default-aoe-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 10560.16065
   tps: 7505.19273
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-default-FullBuffs-LongMultiTarget"
+ key: "TestFeral-Settings-Tauren-p1-Default-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 27560.89923
   tps: 19569.50983
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-default-FullBuffs-LongSingleTarget"
+ key: "TestFeral-Settings-Tauren-p1-Default-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 27560.89923
   tps: 19569.50983
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-default-FullBuffs-ShortSingleTarget"
+ key: "TestFeral-Settings-Tauren-p1-Default-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 34168.51921
   tps: 24266.00551
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-default-NoBuffs-LongMultiTarget"
+ key: "TestFeral-Settings-Tauren-p1-Default-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 18095.12231
   tps: 12850.30395
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-default-NoBuffs-LongSingleTarget"
+ key: "TestFeral-Settings-Tauren-p1-Default-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 18095.12231
   tps: 12850.30395
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-p1-Default-default-NoBuffs-ShortSingleTarget"
+ key: "TestFeral-Settings-Tauren-p1-Default-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 19953.81228
   tps: 14174.68538
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-aoe-FullBuffs-LongMultiTarget"
+ key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-aoe-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 45875.7393
   tps: 32601.46521
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-aoe-FullBuffs-LongSingleTarget"
+ key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-aoe-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 13065.89079
   tps: 9277.97905
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-aoe-FullBuffs-ShortSingleTarget"
+ key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-aoe-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 14960.49952
   tps: 10627.93759
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-aoe-NoBuffs-LongMultiTarget"
+ key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-aoe-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 30110.88515
   tps: 21409.76493
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-aoe-NoBuffs-LongSingleTarget"
+ key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-aoe-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 8200.77619
   tps: 5825.24341
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-aoe-NoBuffs-ShortSingleTarget"
+ key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-aoe-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 8118.4119
   tps: 5771.55111
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-FullBuffs-LongMultiTarget"
+ key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 22698.67081
   tps: 16117.25286
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-FullBuffs-LongSingleTarget"
+ key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 22698.67081
   tps: 16117.25286
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-FullBuffs-ShortSingleTarget"
+ key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 28172.59511
   tps: 20008.52546
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-LongMultiTarget"
+ key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 14614.64832
   tps: 10379.09263
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-LongSingleTarget"
+ key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 14614.64832
   tps: 10379.09263
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-ShortSingleTarget"
+ key: "TestFeral-Settings-Tauren-preraid-Default-NoBleed-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 16049.09507
   tps: 11402.33617
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-aoe-FullBuffs-LongMultiTarget"
+ key: "TestFeral-Settings-Tauren-preraid-Default-aoe-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 45875.7393
   tps: 32601.46521
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-aoe-FullBuffs-LongSingleTarget"
+ key: "TestFeral-Settings-Tauren-preraid-Default-aoe-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 13065.89079
   tps: 9277.97905
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-aoe-FullBuffs-ShortSingleTarget"
+ key: "TestFeral-Settings-Tauren-preraid-Default-aoe-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 14960.49952
   tps: 10627.93759
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-aoe-NoBuffs-LongMultiTarget"
+ key: "TestFeral-Settings-Tauren-preraid-Default-aoe-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 30110.88515
   tps: 21409.76493
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-aoe-NoBuffs-LongSingleTarget"
+ key: "TestFeral-Settings-Tauren-preraid-Default-aoe-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 8200.77619
   tps: 5825.24341
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-aoe-NoBuffs-ShortSingleTarget"
+ key: "TestFeral-Settings-Tauren-preraid-Default-aoe-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 8118.4119
   tps: 5771.55111
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-default-FullBuffs-LongMultiTarget"
+ key: "TestFeral-Settings-Tauren-preraid-Default-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 22700.25886
   tps: 16118.38038
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-default-FullBuffs-LongSingleTarget"
+ key: "TestFeral-Settings-Tauren-preraid-Default-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 22700.25886
   tps: 16118.38038
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-default-FullBuffs-ShortSingleTarget"
+ key: "TestFeral-Settings-Tauren-preraid-Default-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 28172.59511
   tps: 20008.52546
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-LongMultiTarget"
+ key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 14629.37893
   tps: 10389.55136
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-LongSingleTarget"
+ key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 14629.37893
   tps: 10389.55136
  }
 }
 dps_results: {
- key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-ShortSingleTarget"
+ key: "TestFeral-Settings-Tauren-preraid-Default-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 16104.24909
   tps: 11441.49552

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -1849,22 +1849,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 57314.19582
-  tps: 40722.84412
+  dps: 57300.01993
+  tps: 40712.77925
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 16127.696
-  tps: 11450.66416
+  dps: 16241.73405
+  tps: 11531.63118
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 18127.72084
-  tps: 12870.6818
+  dps: 18431.28546
+  tps: 13086.21267
  }
 }
 dps_results: {
@@ -1891,22 +1891,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38626.9845
-  tps: 27456.19546
+  dps: 38815.03423
+  tps: 27589.78556
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 10468.67731
-  tps: 7435.30364
+  dps: 10472.48013
+  tps: 7438.228
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-ExternalBleed-aoe-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 10108.60278
-  tps: 7184.58664
+  dps: 10266.19499
+  tps: 7296.47711
  }
 }
 dps_results: {
@@ -1933,22 +1933,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 27447.39378
-  tps: 19487.64958
+  dps: 27523.56792
+  tps: 19541.73322
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 27447.39378
-  tps: 19487.64958
+  dps: 27523.56792
+  tps: 19541.73322
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 33389.85097
-  tps: 23706.79419
+  dps: 33552.46263
+  tps: 23822.24846
  }
 }
 dps_results: {
@@ -1975,22 +1975,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 17954.59836
-  tps: 12750.53194
+  dps: 18024.09558
+  tps: 12799.87497
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 17954.59836
-  tps: 12750.53194
+  dps: 18024.09558
+  tps: 12799.87497
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 18971.72991
-  tps: 13477.4069
+  dps: 19248.09469
+  tps: 13673.6259
  }
 }
 dps_results: {
@@ -2017,22 +2017,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 45148.00802
-  tps: 32084.70121
+  dps: 45222.33729
+  tps: 32137.54978
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 12954.75127
-  tps: 9197.8734
+  dps: 13025.94915
+  tps: 9248.4239
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 14519.37996
-  tps: 10308.75977
+  dps: 14646.05559
+  tps: 10398.69947
  }
 }
 dps_results: {
@@ -2059,22 +2059,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 29820.07555
-  tps: 21203.2901
+  dps: 29927.88258
+  tps: 21279.8331
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 8126.97617
-  tps: 5772.8454
+  dps: 8158.94768
+  tps: 5795.54517
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-aoe-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 7761.622
-  tps: 5518.23029
+  dps: 7813.05644
+  tps: 5554.74874
  }
 }
 dps_results: {
@@ -2101,22 +2101,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 22654.03814
-  tps: 16084.36708
+  dps: 22744.6389
+  tps: 16148.69362
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 22654.03814
-  tps: 16084.36708
+  dps: 22744.6389
+  tps: 16148.69362
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27360.59883
-  tps: 19426.02517
+  dps: 27699.39426
+  tps: 19666.56992
  }
 }
 dps_results: {
@@ -2143,22 +2143,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 14516.28075
-  tps: 10309.25165
+  dps: 14590.76076
+  tps: 10362.13246
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 14516.28075
-  tps: 10309.25165
+  dps: 14590.76076
+  tps: 10362.13246
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 15399.25116
-  tps: 10940.94699
+  dps: 15569.78701
+  tps: 11062.02744
  }
 }
 dps_results: {

--- a/sim/druid/feral/apl_values.go
+++ b/sim/druid/feral/apl_values.go
@@ -148,6 +148,16 @@ func (action *APLActionCatOptimalRotationAction) Execute(sim *core.Simulation) {
 
 	action.lastAction = sim.CurrentTime
 
+	// Keep up Sunder debuff if not provided externally. Do this here since FF can be
+	// cast while moving.
+	if cat.Rotation.MaintainFaerieFire {
+		for _, aoeTarget := range sim.Encounter.TargetUnits {
+			if cat.ShouldFaerieFire(sim, aoeTarget) {
+				cat.FaerieFire.Cast(sim, aoeTarget)
+			}
+		}
+	}
+
 	// Handle movement before any rotation logic
 	if cat.Moving {
 		return

--- a/sim/druid/feral/apl_values.go
+++ b/sim/druid/feral/apl_values.go
@@ -148,6 +148,16 @@ func (action *APLActionCatOptimalRotationAction) Execute(sim *core.Simulation) {
 
 	action.lastAction = sim.CurrentTime
 
+	// Handle movement before any rotation logic
+	if cat.Moving {
+		return
+	}
+	if cat.DistanceFromTarget > 5 {
+		// Charge logic will go here before defaulting to manual movement
+		cat.MoveTo(4, sim) // movement aura is discretized in 1 yard intervals, so need to overshoot to guarantee melee range
+		return
+	}
+
 	if !cat.GCD.IsReady(sim) {
 		cat.WaitUntil(sim, cat.NextGCDAt())
 		return

--- a/sim/druid/feral/apl_values.go
+++ b/sim/druid/feral/apl_values.go
@@ -152,9 +152,9 @@ func (action *APLActionCatOptimalRotationAction) Execute(sim *core.Simulation) {
 	if cat.Moving {
 		return
 	}
-	if cat.DistanceFromTarget > 5 {
+	if cat.DistanceFromTarget > core.MaxMeleeRange {
 		// Charge logic will go here before defaulting to manual movement
-		cat.MoveTo(4, sim) // movement aura is discretized in 1 yard intervals, so need to overshoot to guarantee melee range
+		cat.MoveTo(core.MaxMeleeRange - 1, sim) // movement aura is discretized in 1 yard intervals, so need to overshoot to guarantee melee range
 		return
 	}
 

--- a/sim/druid/feral/feral_test.go
+++ b/sim/druid/feral/feral_test.go
@@ -38,14 +38,13 @@ func TestFeral(t *testing.T) {
 		Talents:     StandardTalents,
 		Glyphs:      StandardGlyphs,
 		Consumes:    FullConsumes,
-		SpecOptions: core.SpecOptionsCombo{Label: "Default", SpecOptions: PlayerOptionsMonoCat},
-		OtherSpecOptions: []core.SpecOptionsCombo{
-			{Label: "Default-NoBleed", SpecOptions: PlayerOptionsMonoCatNoBleed},
-		},
+		SpecOptions: core.SpecOptionsCombo{Label: "ExternalBleed", SpecOptions: PlayerOptionsMonoCat},
 		Rotation: core.GetAplRotation("../../../ui/druid/feral/apls", "default"),
 		OtherRotations: []core.RotationCombo{
 			core.GetAplRotation("../../../ui/druid/feral/apls", "aoe"),
 		},
+		StartingDistance: core.MaxMeleeRange,
+		OtherStartingDistances: []float64{25},
 		ItemFilter: FeralItemFilter,
 	}))
 }

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -472,9 +472,6 @@ func (cat *FeralDruid) doRotation(sim *core.Simulation) (bool, time.Duration) {
 
 	roarNow := curCp >= 1 && (!cat.SavageRoarAura.IsActive() || cat.clipRoar(sim, isExecutePhase))
 
-	// Keep up Sunder debuff if not provided externally
-	ffNow := rotation.MaintainFaerieFire && cat.ShouldFaerieFire(sim, cat.CurrentTarget)
-
 	// Pooling calcs
 	ripRefreshPending := ripDot.IsActive() && (ripDot.RemainingDuration(sim) < simTimeRemain-baseEndThresh) && (curCp >= core.TernaryInt32(isExecutePhase, 1, rotation.MinCombosForRip))
 	rakeRefreshPending := rakeDot.IsActive() && (rakeDot.RemainingDuration(sim) < simTimeRemain-rakeDot.TickLength)
@@ -635,9 +632,6 @@ func (cat *FeralDruid) doRotation(sim *core.Simulation) (bool, time.Duration) {
 			return false, 0
 		}
 		timeToNextAction = core.DurationFromSeconds((cat.CurrentMangleCatCost() - curEnergy) / regenRate)
-	} else if ffNow {
-		cat.FaerieFire.Cast(sim, cat.CurrentTarget)
-		return false, 0
 	} else if ripNow {
 		if cat.Rip.CanCast(sim, cat.CurrentTarget) {
 			cat.Rip.Cast(sim, cat.CurrentTarget)

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -417,7 +417,7 @@ func (cat *FeralDruid) doRotation(sim *core.Simulation) (bool, time.Duration) {
 	if mangleRefreshPending && !t11Active {
 		numManglesRemaining := 1 + int32((sim.Duration-time.Second-cat.bleedAura.ExpiresAt())/time.Minute)
 		earliestMangle := sim.Duration - time.Duration(numManglesRemaining)*time.Minute
-		clipMangle = sim.CurrentTime >= earliestMangle
+		clipMangle = (sim.CurrentTime >= earliestMangle) && !isClearcast
 	}
 
 	mangleNow := cat.MangleCat != nil && (mangleRefreshNow || clipMangle)

--- a/sim/druid/feral/rotation_aoe.go
+++ b/sim/druid/feral/rotation_aoe.go
@@ -17,22 +17,11 @@ func (cat *FeralDruid) calcExpectedSwipeDamage(sim *core.Simulation) (float64, f
 
 func (cat *FeralDruid) doAoeRotation(sim *core.Simulation) (bool, time.Duration) {
 	// Store state variables for re-use
-	rotation := &cat.Rotation
 	curEnergy := cat.CurrentEnergy()
 	curCp := cat.ComboPoints()
 	isClearcast := cat.ClearcastingAura.IsActive()
 	simTimeRemain := sim.GetRemainingDuration()
 	regenRate := cat.EnergyRegenPerSecond()
-
-	// Keep up Sunder debuff if not provided externally
-	if rotation.MaintainFaerieFire {
-		for _, aoeTarget := range sim.Encounter.TargetUnits {
-			if cat.ShouldFaerieFire(sim, aoeTarget) {
-				cat.FaerieFire.Cast(sim, aoeTarget)
-				return false, 0
-			}
-		}
-	}
 
 	// Roar check
 	roarNow := (curCp >= 1) && !cat.SavageRoarAura.IsActive()

--- a/sim/druid/ferocious_bite.go
+++ b/sim/druid/ferocious_bite.go
@@ -44,6 +44,7 @@ func (druid *Druid) registerFerociousBiteSpell() {
 		DamageMultiplier: 1 + 0.05*float64(druid.Talents.FeralAggression),
 		CritMultiplier:   druid.DefaultMeleeCritMultiplier(),
 		ThreatMultiplier: 1,
+		MaxRange:         5,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			comboPoints := float64(druid.ComboPoints())

--- a/sim/druid/ferocious_bite.go
+++ b/sim/druid/ferocious_bite.go
@@ -44,7 +44,7 @@ func (druid *Druid) registerFerociousBiteSpell() {
 		DamageMultiplier: 1 + 0.05*float64(druid.Talents.FeralAggression),
 		CritMultiplier:   druid.DefaultMeleeCritMultiplier(),
 		ThreatMultiplier: 1,
-		MaxRange:         5,
+		MaxRange:         core.MaxMeleeRange,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			comboPoints := float64(druid.ComboPoints())

--- a/sim/druid/forms.go
+++ b/sim/druid/forms.go
@@ -55,6 +55,7 @@ func (druid *Druid) GetCatWeapon() core.Weapon {
 		NormalizedSwingSpeed: 1.0,
 		CritMultiplier:       druid.DefaultMeleeCritMultiplier(),
 		AttackPowerPerDPS:    core.DefaultAttackPowerPerDPS,
+		MaxRange:             5.0,
 	}
 }
 
@@ -67,6 +68,7 @@ func (druid *Druid) GetBearWeapon() core.Weapon {
 		NormalizedSwingSpeed: 2.5,
 		CritMultiplier:       druid.DefaultMeleeCritMultiplier(),
 		AttackPowerPerDPS:    core.DefaultAttackPowerPerDPS,
+		MaxRange:             5.0,
 	}
 }
 

--- a/sim/druid/forms.go
+++ b/sim/druid/forms.go
@@ -55,7 +55,7 @@ func (druid *Druid) GetCatWeapon() core.Weapon {
 		NormalizedSwingSpeed: 1.0,
 		CritMultiplier:       druid.DefaultMeleeCritMultiplier(),
 		AttackPowerPerDPS:    core.DefaultAttackPowerPerDPS,
-		MaxRange:             5.0,
+		MaxRange:             core.MaxMeleeRange,
 	}
 }
 
@@ -68,7 +68,7 @@ func (druid *Druid) GetBearWeapon() core.Weapon {
 		NormalizedSwingSpeed: 2.5,
 		CritMultiplier:       druid.DefaultMeleeCritMultiplier(),
 		AttackPowerPerDPS:    core.DefaultAttackPowerPerDPS,
-		MaxRange:             5.0,
+		MaxRange:             core.MaxMeleeRange,
 	}
 }
 

--- a/sim/druid/forms.go
+++ b/sim/druid/forms.go
@@ -113,6 +113,7 @@ func (druid *Druid) registerCatFormSpell() {
 			druid.PseudoStats.ThreatMultiplier *= 0.71
 			druid.PseudoStats.SpiritRegenMultiplier *= AnimalSpiritRegenSuppression
 			druid.PseudoStats.BaseDodge += 0.02 * float64(druid.Talents.FeralSwiftness)
+			druid.PseudoStats.MovementSpeedMultiplier *= 1.0 + 0.15 * float64(druid.Talents.FeralSwiftness)
 
 			druid.AddStatsDynamic(sim, statBonus)
 			druid.EnableDynamicStatDep(sim, agiApDep)
@@ -146,6 +147,7 @@ func (druid *Druid) registerCatFormSpell() {
 			druid.PseudoStats.ThreatMultiplier /= 0.71
 			druid.PseudoStats.SpiritRegenMultiplier /= AnimalSpiritRegenSuppression
 			druid.PseudoStats.BaseDodge -= 0.02 * float64(druid.Talents.FeralSwiftness)
+			druid.PseudoStats.MovementSpeedMultiplier /= 1.0 + 0.15 * float64(druid.Talents.FeralSwiftness)
 
 			druid.AddStatsDynamic(sim, statBonus.Invert())
 			druid.DisableDynamicStatDep(sim, agiApDep)

--- a/sim/druid/lacerate.go
+++ b/sim/druid/lacerate.go
@@ -39,6 +39,7 @@ func (druid *Druid) registerLacerateSpell() {
 		DamageMultiplier: initialDamageMul,
 		CritMultiplier:   druid.DefaultMeleeCritMultiplier(),
 		ThreatMultiplier: 0.5,
+		MaxRange:         5,
 		// FlatThreatBonus:  515.5, // Handled below
 
 		Dot: core.DotConfig{

--- a/sim/druid/lacerate.go
+++ b/sim/druid/lacerate.go
@@ -39,7 +39,7 @@ func (druid *Druid) registerLacerateSpell() {
 		DamageMultiplier: initialDamageMul,
 		CritMultiplier:   druid.DefaultMeleeCritMultiplier(),
 		ThreatMultiplier: 0.5,
-		MaxRange:         5,
+		MaxRange:         core.MaxMeleeRange,
 		// FlatThreatBonus:  515.5, // Handled below
 
 		Dot: core.DotConfig{

--- a/sim/druid/mangle.go
+++ b/sim/druid/mangle.go
@@ -36,6 +36,7 @@ func (druid *Druid) registerMangleBearSpell() {
 		CritMultiplier:   druid.DefaultMeleeCritMultiplier(),
 		ThreatMultiplier: 1,
 		BonusCoefficient: 1,
+		MaxRange:         5,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			baseDamage := 3306.0/1.9 +
@@ -91,6 +92,7 @@ func (druid *Druid) registerMangleCatSpell() {
 		CritMultiplier:   druid.DefaultMeleeCritMultiplier(),
 		ThreatMultiplier: 1,
 		BonusCoefficient: 1,
+		MaxRange:         5,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			baseDamage := 302.0/5.4 +

--- a/sim/druid/mangle.go
+++ b/sim/druid/mangle.go
@@ -36,7 +36,7 @@ func (druid *Druid) registerMangleBearSpell() {
 		CritMultiplier:   druid.DefaultMeleeCritMultiplier(),
 		ThreatMultiplier: 1,
 		BonusCoefficient: 1,
-		MaxRange:         5,
+		MaxRange:         core.MaxMeleeRange,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			baseDamage := 3306.0/1.9 +
@@ -92,7 +92,7 @@ func (druid *Druid) registerMangleCatSpell() {
 		CritMultiplier:   druid.DefaultMeleeCritMultiplier(),
 		ThreatMultiplier: 1,
 		BonusCoefficient: 1,
-		MaxRange:         5,
+		MaxRange:         core.MaxMeleeRange,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			baseDamage := 302.0/5.4 +

--- a/sim/druid/maul.go
+++ b/sim/druid/maul.go
@@ -32,7 +32,7 @@ func (druid *Druid) registerMaulSpell() {
 		ThreatMultiplier: 1,
 		FlatThreatBonus:  424,
 		BonusCoefficient: 1,
-		MaxRange:         5,
+		MaxRange:         core.MaxMeleeRange,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			// Need to specially deactivate CC here in case maul is cast simultaneously with another spell.

--- a/sim/druid/maul.go
+++ b/sim/druid/maul.go
@@ -32,6 +32,7 @@ func (druid *Druid) registerMaulSpell() {
 		ThreatMultiplier: 1,
 		FlatThreatBonus:  424,
 		BonusCoefficient: 1,
+		MaxRange:         5,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			// Need to specially deactivate CC here in case maul is cast simultaneously with another spell.

--- a/sim/druid/pulverize.go
+++ b/sim/druid/pulverize.go
@@ -44,7 +44,7 @@ func (druid *Druid) registerPulverizeSpell() {
 		CritMultiplier:   druid.DefaultMeleeCritMultiplier(),
 		ThreatMultiplier: 1,
 		BonusCoefficient: 1,
-		MaxRange:         5,
+		MaxRange:         core.MaxMeleeRange,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			lacerateDot := druid.Lacerate.Dot(target)

--- a/sim/druid/pulverize.go
+++ b/sim/druid/pulverize.go
@@ -44,6 +44,7 @@ func (druid *Druid) registerPulverizeSpell() {
 		CritMultiplier:   druid.DefaultMeleeCritMultiplier(),
 		ThreatMultiplier: 1,
 		BonusCoefficient: 1,
+		MaxRange:         5,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			lacerateDot := druid.Lacerate.Dot(target)

--- a/sim/druid/rake.go
+++ b/sim/druid/rake.go
@@ -37,6 +37,7 @@ func (druid *Druid) registerRakeSpell() {
 		DamageMultiplier: druid.RazorClawsMultiplier(druid.GetStat(stats.Mastery)),
 		CritMultiplier:   druid.DefaultMeleeCritMultiplier(),
 		ThreatMultiplier: 1,
+		MaxRange:         5,
 
 		Dot: core.DotConfig{
 			Aura: druid.applyRendAndTear(core.Aura{

--- a/sim/druid/rake.go
+++ b/sim/druid/rake.go
@@ -37,7 +37,7 @@ func (druid *Druid) registerRakeSpell() {
 		DamageMultiplier: druid.RazorClawsMultiplier(druid.GetStat(stats.Mastery)),
 		CritMultiplier:   druid.DefaultMeleeCritMultiplier(),
 		ThreatMultiplier: 1,
-		MaxRange:         5,
+		MaxRange:         core.MaxMeleeRange,
 
 		Dot: core.DotConfig{
 			Aura: druid.applyRendAndTear(core.Aura{

--- a/sim/druid/rip.go
+++ b/sim/druid/rip.go
@@ -43,7 +43,7 @@ func (druid *Druid) registerRipSpell() {
 		DamageMultiplier: glyphMulti * druid.RazorClawsMultiplier(druid.GetStat(stats.Mastery)),
 		CritMultiplier:   druid.DefaultMeleeCritMultiplier(),
 		ThreatMultiplier: 1,
-		MaxRange:         5,
+		MaxRange:         core.MaxMeleeRange,
 
 		Dot: core.DotConfig{
 			Aura: druid.applyRendAndTear(core.Aura{

--- a/sim/druid/rip.go
+++ b/sim/druid/rip.go
@@ -43,6 +43,7 @@ func (druid *Druid) registerRipSpell() {
 		DamageMultiplier: glyphMulti * druid.RazorClawsMultiplier(druid.GetStat(stats.Mastery)),
 		CritMultiplier:   druid.DefaultMeleeCritMultiplier(),
 		ThreatMultiplier: 1,
+		MaxRange:         5,
 
 		Dot: core.DotConfig{
 			Aura: druid.applyRendAndTear(core.Aura{

--- a/sim/druid/shred.go
+++ b/sim/druid/shred.go
@@ -36,6 +36,7 @@ func (druid *Druid) registerShredSpell() {
 		CritMultiplier:   druid.DefaultMeleeCritMultiplier(),
 		ThreatMultiplier: 1,
 		BonusCoefficient: 1,
+		MaxRange:         5,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			baseDamage := flatDamageBonus +

--- a/sim/druid/shred.go
+++ b/sim/druid/shred.go
@@ -36,7 +36,7 @@ func (druid *Druid) registerShredSpell() {
 		CritMultiplier:   druid.DefaultMeleeCritMultiplier(),
 		ThreatMultiplier: 1,
 		BonusCoefficient: 1,
-		MaxRange:         5,
+		MaxRange:         core.MaxMeleeRange,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			baseDamage := flatDamageBonus +

--- a/sim/hunter/beast_mastery/TestBM.results
+++ b/sim/hunter/beast_mastery/TestBM.results
@@ -1938,168 +1938,168 @@ dps_results: {
  }
 }
 dps_results: {
- key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm-FullBuffs-LongMultiTarget"
+ key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm-FullBuffs-5.1yards-LongMultiTarget"
  value: {
   dps: 19954.49503
   tps: 16942.75481
  }
 }
 dps_results: {
- key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm-FullBuffs-LongSingleTarget"
+ key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm-FullBuffs-5.1yards-LongSingleTarget"
  value: {
   dps: 19954.49503
   tps: 16942.75481
  }
 }
 dps_results: {
- key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm-FullBuffs-ShortSingleTarget"
+ key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
   dps: 23788.31077
   tps: 20021.92092
  }
 }
 dps_results: {
- key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm-NoBuffs-LongMultiTarget"
+ key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm-NoBuffs-5.1yards-LongMultiTarget"
  value: {
   dps: 13538.96709
   tps: 11518.83237
  }
 }
 dps_results: {
- key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm-NoBuffs-LongSingleTarget"
+ key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm-NoBuffs-5.1yards-LongSingleTarget"
  value: {
   dps: 13538.96709
   tps: 11518.83237
  }
 }
 dps_results: {
- key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm-NoBuffs-ShortSingleTarget"
+ key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm-NoBuffs-5.1yards-ShortSingleTarget"
  value: {
   dps: 14186.89388
   tps: 12088.11873
  }
 }
 dps_results: {
- key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm_advanced-FullBuffs-LongMultiTarget"
+ key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm_advanced-FullBuffs-5.1yards-LongMultiTarget"
  value: {
   dps: 19954.49503
   tps: 16942.75481
  }
 }
 dps_results: {
- key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm_advanced-FullBuffs-LongSingleTarget"
+ key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm_advanced-FullBuffs-5.1yards-LongSingleTarget"
  value: {
   dps: 19954.49503
   tps: 16942.75481
  }
 }
 dps_results: {
- key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm_advanced-FullBuffs-ShortSingleTarget"
+ key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm_advanced-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
   dps: 23788.31077
   tps: 20021.92092
  }
 }
 dps_results: {
- key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm_advanced-NoBuffs-LongMultiTarget"
+ key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm_advanced-NoBuffs-5.1yards-LongMultiTarget"
  value: {
   dps: 13538.96709
   tps: 11518.83237
  }
 }
 dps_results: {
- key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm_advanced-NoBuffs-LongSingleTarget"
+ key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm_advanced-NoBuffs-5.1yards-LongSingleTarget"
  value: {
   dps: 13538.96709
   tps: 11518.83237
  }
 }
 dps_results: {
- key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm_advanced-NoBuffs-ShortSingleTarget"
+ key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm_advanced-NoBuffs-5.1yards-ShortSingleTarget"
  value: {
   dps: 14186.89388
   tps: 12088.11873
  }
 }
 dps_results: {
- key: "TestBM-Settings-Orc-preraid_bm-Basic-bm-FullBuffs-LongMultiTarget"
+ key: "TestBM-Settings-Orc-preraid_bm-Basic-bm-FullBuffs-5.1yards-LongMultiTarget"
  value: {
   dps: 20287.29846
   tps: 17093.18035
  }
 }
 dps_results: {
- key: "TestBM-Settings-Orc-preraid_bm-Basic-bm-FullBuffs-LongSingleTarget"
+ key: "TestBM-Settings-Orc-preraid_bm-Basic-bm-FullBuffs-5.1yards-LongSingleTarget"
  value: {
   dps: 20287.29846
   tps: 17093.18035
  }
 }
 dps_results: {
- key: "TestBM-Settings-Orc-preraid_bm-Basic-bm-FullBuffs-ShortSingleTarget"
+ key: "TestBM-Settings-Orc-preraid_bm-Basic-bm-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
   dps: 24360.12007
   tps: 20328.57259
  }
 }
 dps_results: {
- key: "TestBM-Settings-Orc-preraid_bm-Basic-bm-NoBuffs-LongMultiTarget"
+ key: "TestBM-Settings-Orc-preraid_bm-Basic-bm-NoBuffs-5.1yards-LongMultiTarget"
  value: {
   dps: 13774.40658
   tps: 11631.59639
  }
 }
 dps_results: {
- key: "TestBM-Settings-Orc-preraid_bm-Basic-bm-NoBuffs-LongSingleTarget"
+ key: "TestBM-Settings-Orc-preraid_bm-Basic-bm-NoBuffs-5.1yards-LongSingleTarget"
  value: {
   dps: 13774.40658
   tps: 11631.59639
  }
 }
 dps_results: {
- key: "TestBM-Settings-Orc-preraid_bm-Basic-bm-NoBuffs-ShortSingleTarget"
+ key: "TestBM-Settings-Orc-preraid_bm-Basic-bm-NoBuffs-5.1yards-ShortSingleTarget"
  value: {
   dps: 14538.33171
   tps: 12291.1326
  }
 }
 dps_results: {
- key: "TestBM-Settings-Orc-preraid_bm-Basic-bm_advanced-FullBuffs-LongMultiTarget"
+ key: "TestBM-Settings-Orc-preraid_bm-Basic-bm_advanced-FullBuffs-5.1yards-LongMultiTarget"
  value: {
   dps: 20287.29846
   tps: 17093.18035
  }
 }
 dps_results: {
- key: "TestBM-Settings-Orc-preraid_bm-Basic-bm_advanced-FullBuffs-LongSingleTarget"
+ key: "TestBM-Settings-Orc-preraid_bm-Basic-bm_advanced-FullBuffs-5.1yards-LongSingleTarget"
  value: {
   dps: 20287.29846
   tps: 17093.18035
  }
 }
 dps_results: {
- key: "TestBM-Settings-Orc-preraid_bm-Basic-bm_advanced-FullBuffs-ShortSingleTarget"
+ key: "TestBM-Settings-Orc-preraid_bm-Basic-bm_advanced-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
   dps: 24360.12007
   tps: 20328.57259
  }
 }
 dps_results: {
- key: "TestBM-Settings-Orc-preraid_bm-Basic-bm_advanced-NoBuffs-LongMultiTarget"
+ key: "TestBM-Settings-Orc-preraid_bm-Basic-bm_advanced-NoBuffs-5.1yards-LongMultiTarget"
  value: {
   dps: 13774.40658
   tps: 11631.59639
  }
 }
 dps_results: {
- key: "TestBM-Settings-Orc-preraid_bm-Basic-bm_advanced-NoBuffs-LongSingleTarget"
+ key: "TestBM-Settings-Orc-preraid_bm-Basic-bm_advanced-NoBuffs-5.1yards-LongSingleTarget"
  value: {
   dps: 13774.40658
   tps: 11631.59639
  }
 }
 dps_results: {
- key: "TestBM-Settings-Orc-preraid_bm-Basic-bm_advanced-NoBuffs-ShortSingleTarget"
+ key: "TestBM-Settings-Orc-preraid_bm-Basic-bm_advanced-NoBuffs-5.1yards-ShortSingleTarget"
  value: {
   dps: 14538.33171
   tps: 12291.1326

--- a/sim/hunter/beast_mastery/beast_mastery_test.go
+++ b/sim/hunter/beast_mastery/beast_mastery_test.go
@@ -29,7 +29,7 @@ func TestBM(t *testing.T) {
 		},
 
 		ItemFilter:         ItemFilter,
-		DistanceFromTarget: 5.1,
+		StartingDistance:   5.1,
 	}))
 }
 

--- a/sim/hunter/marksmanship/TestMM.results
+++ b/sim/hunter/marksmanship/TestMM.results
@@ -1938,168 +1938,168 @@ dps_results: {
  }
 }
 dps_results: {
- key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-FullBuffs-LongMultiTarget"
+ key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-FullBuffs-5.1yards-LongMultiTarget"
  value: {
   dps: 22231.41236
   tps: 20246.90593
  }
 }
 dps_results: {
- key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-FullBuffs-LongSingleTarget"
+ key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-FullBuffs-5.1yards-LongSingleTarget"
  value: {
   dps: 21245.07879
   tps: 19286.01109
  }
 }
 dps_results: {
- key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-FullBuffs-ShortSingleTarget"
+ key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
   dps: 26157.18103
   tps: 23611.59966
  }
 }
 dps_results: {
- key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-NoBuffs-LongMultiTarget"
+ key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-NoBuffs-5.1yards-LongMultiTarget"
  value: {
   dps: 14913.89494
   tps: 13499.02536
  }
 }
 dps_results: {
- key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-NoBuffs-LongSingleTarget"
+ key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-NoBuffs-5.1yards-LongSingleTarget"
  value: {
   dps: 14161.39758
   tps: 12735.75514
  }
 }
 dps_results: {
- key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-NoBuffs-ShortSingleTarget"
+ key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-NoBuffs-5.1yards-ShortSingleTarget"
  value: {
   dps: 15180.89042
   tps: 13690.15891
  }
 }
 dps_results: {
- key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm_advanced-FullBuffs-LongMultiTarget"
+ key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm_advanced-FullBuffs-5.1yards-LongMultiTarget"
  value: {
   dps: 22231.41236
   tps: 20246.90593
  }
 }
 dps_results: {
- key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm_advanced-FullBuffs-LongSingleTarget"
+ key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm_advanced-FullBuffs-5.1yards-LongSingleTarget"
  value: {
   dps: 21245.07879
   tps: 19286.01109
  }
 }
 dps_results: {
- key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm_advanced-FullBuffs-ShortSingleTarget"
+ key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm_advanced-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
   dps: 26157.18103
   tps: 23611.59966
  }
 }
 dps_results: {
- key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm_advanced-NoBuffs-LongMultiTarget"
+ key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm_advanced-NoBuffs-5.1yards-LongMultiTarget"
  value: {
   dps: 14913.89494
   tps: 13499.02536
  }
 }
 dps_results: {
- key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm_advanced-NoBuffs-LongSingleTarget"
+ key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm_advanced-NoBuffs-5.1yards-LongSingleTarget"
  value: {
   dps: 14161.39758
   tps: 12735.75514
  }
 }
 dps_results: {
- key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm_advanced-NoBuffs-ShortSingleTarget"
+ key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm_advanced-NoBuffs-5.1yards-ShortSingleTarget"
  value: {
   dps: 15180.89042
   tps: 13690.15891
  }
 }
 dps_results: {
- key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-FullBuffs-LongMultiTarget"
+ key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-FullBuffs-5.1yards-LongMultiTarget"
  value: {
   dps: 22578.01939
   tps: 20471.53764
  }
 }
 dps_results: {
- key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-FullBuffs-LongSingleTarget"
+ key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-FullBuffs-5.1yards-LongSingleTarget"
  value: {
   dps: 21546.5687
   tps: 19466.89583
  }
 }
 dps_results: {
- key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-FullBuffs-ShortSingleTarget"
+ key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
   dps: 26712.80221
   tps: 23986.31342
  }
 }
 dps_results: {
- key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-NoBuffs-LongMultiTarget"
+ key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-NoBuffs-5.1yards-LongMultiTarget"
  value: {
   dps: 15171.66811
   tps: 13669.01745
  }
 }
 dps_results: {
- key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-NoBuffs-LongSingleTarget"
+ key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-NoBuffs-5.1yards-LongSingleTarget"
  value: {
   dps: 14374.93329
   tps: 12860.75372
  }
 }
 dps_results: {
- key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-NoBuffs-ShortSingleTarget"
+ key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-NoBuffs-5.1yards-ShortSingleTarget"
  value: {
   dps: 15509.94062
   tps: 13913.02786
  }
 }
 dps_results: {
- key: "TestMM-Settings-Orc-preraid_mm-Basic-mm_advanced-FullBuffs-LongMultiTarget"
+ key: "TestMM-Settings-Orc-preraid_mm-Basic-mm_advanced-FullBuffs-5.1yards-LongMultiTarget"
  value: {
   dps: 22578.01939
   tps: 20471.53764
  }
 }
 dps_results: {
- key: "TestMM-Settings-Orc-preraid_mm-Basic-mm_advanced-FullBuffs-LongSingleTarget"
+ key: "TestMM-Settings-Orc-preraid_mm-Basic-mm_advanced-FullBuffs-5.1yards-LongSingleTarget"
  value: {
   dps: 21546.5687
   tps: 19466.89583
  }
 }
 dps_results: {
- key: "TestMM-Settings-Orc-preraid_mm-Basic-mm_advanced-FullBuffs-ShortSingleTarget"
+ key: "TestMM-Settings-Orc-preraid_mm-Basic-mm_advanced-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
   dps: 26712.80221
   tps: 23986.31342
  }
 }
 dps_results: {
- key: "TestMM-Settings-Orc-preraid_mm-Basic-mm_advanced-NoBuffs-LongMultiTarget"
+ key: "TestMM-Settings-Orc-preraid_mm-Basic-mm_advanced-NoBuffs-5.1yards-LongMultiTarget"
  value: {
   dps: 15171.66811
   tps: 13669.01745
  }
 }
 dps_results: {
- key: "TestMM-Settings-Orc-preraid_mm-Basic-mm_advanced-NoBuffs-LongSingleTarget"
+ key: "TestMM-Settings-Orc-preraid_mm-Basic-mm_advanced-NoBuffs-5.1yards-LongSingleTarget"
  value: {
   dps: 14374.93329
   tps: 12860.75372
  }
 }
 dps_results: {
- key: "TestMM-Settings-Orc-preraid_mm-Basic-mm_advanced-NoBuffs-ShortSingleTarget"
+ key: "TestMM-Settings-Orc-preraid_mm-Basic-mm_advanced-NoBuffs-5.1yards-ShortSingleTarget"
  value: {
   dps: 15509.94062
   tps: 13913.02786

--- a/sim/hunter/marksmanship/marksmanship_test.go
+++ b/sim/hunter/marksmanship/marksmanship_test.go
@@ -29,7 +29,7 @@ func TestMM(t *testing.T) {
 		},
 
 		ItemFilter:         ItemFilter,
-		DistanceFromTarget: 5.1,
+		StartingDistance:   5.1,
 	}))
 }
 

--- a/sim/hunter/survival/TestSV.results
+++ b/sim/hunter/survival/TestSV.results
@@ -1938,252 +1938,252 @@ dps_results: {
  }
 }
 dps_results: {
- key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-FullBuffs-LongMultiTarget"
+ key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-FullBuffs-5.1yards-LongMultiTarget"
  value: {
   dps: 58436.74814
   tps: 56655.99301
  }
 }
 dps_results: {
- key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-FullBuffs-LongSingleTarget"
+ key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-FullBuffs-5.1yards-LongSingleTarget"
  value: {
   dps: 18318.37691
   tps: 16540.86603
  }
 }
 dps_results: {
- key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-FullBuffs-ShortSingleTarget"
+ key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
   dps: 22282.7691
   tps: 20038.35786
  }
 }
 dps_results: {
- key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-NoBuffs-LongMultiTarget"
+ key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-NoBuffs-5.1yards-LongMultiTarget"
  value: {
   dps: 38278.89407
   tps: 37080.93424
  }
 }
 dps_results: {
- key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-NoBuffs-LongSingleTarget"
+ key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-NoBuffs-5.1yards-LongSingleTarget"
  value: {
   dps: 11944.70035
   tps: 10743.90271
  }
 }
 dps_results: {
- key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-NoBuffs-ShortSingleTarget"
+ key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-NoBuffs-5.1yards-ShortSingleTarget"
  value: {
   dps: 12618.90763
   tps: 11332.43433
  }
 }
 dps_results: {
- key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-FullBuffs-LongMultiTarget"
+ key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-FullBuffs-5.1yards-LongMultiTarget"
  value: {
   dps: 26923.23849
   tps: 24798.50723
  }
 }
 dps_results: {
- key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-FullBuffs-LongSingleTarget"
+ key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-FullBuffs-5.1yards-LongSingleTarget"
  value: {
   dps: 24534.1148
   tps: 22407.24129
  }
 }
 dps_results: {
- key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-FullBuffs-ShortSingleTarget"
+ key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
   dps: 30410.71139
   tps: 27735.62343
  }
 }
 dps_results: {
- key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-NoBuffs-LongMultiTarget"
+ key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-NoBuffs-5.1yards-LongMultiTarget"
  value: {
   dps: 17856.05198
   tps: 16384.86575
  }
 }
 dps_results: {
- key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-NoBuffs-LongSingleTarget"
+ key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-NoBuffs-5.1yards-LongSingleTarget"
  value: {
   dps: 16540.114
   tps: 15066.48922
  }
 }
 dps_results: {
- key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-NoBuffs-ShortSingleTarget"
+ key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-NoBuffs-5.1yards-ShortSingleTarget"
  value: {
   dps: 18159.65391
   tps: 16576.77941
  }
 }
 dps_results: {
- key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv_advanced-FullBuffs-LongMultiTarget"
+ key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv_advanced-FullBuffs-5.1yards-LongMultiTarget"
  value: {
   dps: 26923.23849
   tps: 24798.50723
  }
 }
 dps_results: {
- key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv_advanced-FullBuffs-LongSingleTarget"
+ key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv_advanced-FullBuffs-5.1yards-LongSingleTarget"
  value: {
   dps: 24534.1148
   tps: 22407.24129
  }
 }
 dps_results: {
- key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv_advanced-FullBuffs-ShortSingleTarget"
+ key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv_advanced-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
   dps: 30410.71139
   tps: 27735.62343
  }
 }
 dps_results: {
- key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv_advanced-NoBuffs-LongMultiTarget"
+ key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv_advanced-NoBuffs-5.1yards-LongMultiTarget"
  value: {
   dps: 17856.05198
   tps: 16384.86575
  }
 }
 dps_results: {
- key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv_advanced-NoBuffs-LongSingleTarget"
+ key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv_advanced-NoBuffs-5.1yards-LongSingleTarget"
  value: {
   dps: 16540.114
   tps: 15066.48922
  }
 }
 dps_results: {
- key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv_advanced-NoBuffs-ShortSingleTarget"
+ key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv_advanced-NoBuffs-5.1yards-ShortSingleTarget"
  value: {
   dps: 18159.65391
   tps: 16576.77941
  }
 }
 dps_results: {
- key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-FullBuffs-LongMultiTarget"
+ key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-FullBuffs-5.1yards-LongMultiTarget"
  value: {
   dps: 59130.62831
   tps: 57238.40623
  }
 }
 dps_results: {
- key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-FullBuffs-LongSingleTarget"
+ key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-FullBuffs-5.1yards-LongSingleTarget"
  value: {
   dps: 18610.42481
   tps: 16721.482
  }
 }
 dps_results: {
- key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-FullBuffs-ShortSingleTarget"
+ key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
   dps: 22816.58218
   tps: 20411.68645
  }
 }
 dps_results: {
- key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-NoBuffs-LongMultiTarget"
+ key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-NoBuffs-5.1yards-LongMultiTarget"
  value: {
   dps: 38795.11531
   tps: 37522.12462
  }
 }
 dps_results: {
- key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-NoBuffs-LongSingleTarget"
+ key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-NoBuffs-5.1yards-LongSingleTarget"
  value: {
   dps: 12154.05737
   tps: 10877.07803
  }
 }
 dps_results: {
- key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-NoBuffs-ShortSingleTarget"
+ key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-NoBuffs-5.1yards-ShortSingleTarget"
  value: {
   dps: 12962.23931
   tps: 11582.10531
  }
 }
 dps_results: {
- key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-FullBuffs-LongMultiTarget"
+ key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-FullBuffs-5.1yards-LongMultiTarget"
  value: {
   dps: 27353.06649
   tps: 25099.36127
  }
 }
 dps_results: {
- key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-FullBuffs-LongSingleTarget"
+ key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-FullBuffs-5.1yards-LongSingleTarget"
  value: {
   dps: 24856.93533
   tps: 22601.52631
  }
 }
 dps_results: {
- key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-FullBuffs-ShortSingleTarget"
+ key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
   dps: 31008.16343
   tps: 28151.97942
  }
 }
 dps_results: {
- key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-NoBuffs-LongMultiTarget"
+ key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-NoBuffs-5.1yards-LongMultiTarget"
  value: {
   dps: 18167.59818
   tps: 16605.95072
  }
 }
 dps_results: {
- key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-NoBuffs-LongSingleTarget"
+ key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-NoBuffs-5.1yards-LongSingleTarget"
  value: {
   dps: 16773.47332
   tps: 15209.39797
  }
 }
 dps_results: {
- key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-NoBuffs-ShortSingleTarget"
+ key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-NoBuffs-5.1yards-ShortSingleTarget"
  value: {
   dps: 18547.95851
   tps: 16853.78744
  }
 }
 dps_results: {
- key: "TestSV-Settings-Orc-preraid_sv-Basic-sv_advanced-FullBuffs-LongMultiTarget"
+ key: "TestSV-Settings-Orc-preraid_sv-Basic-sv_advanced-FullBuffs-5.1yards-LongMultiTarget"
  value: {
   dps: 27353.06649
   tps: 25099.36127
  }
 }
 dps_results: {
- key: "TestSV-Settings-Orc-preraid_sv-Basic-sv_advanced-FullBuffs-LongSingleTarget"
+ key: "TestSV-Settings-Orc-preraid_sv-Basic-sv_advanced-FullBuffs-5.1yards-LongSingleTarget"
  value: {
   dps: 24856.93533
   tps: 22601.52631
  }
 }
 dps_results: {
- key: "TestSV-Settings-Orc-preraid_sv-Basic-sv_advanced-FullBuffs-ShortSingleTarget"
+ key: "TestSV-Settings-Orc-preraid_sv-Basic-sv_advanced-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
   dps: 31008.16343
   tps: 28151.97942
  }
 }
 dps_results: {
- key: "TestSV-Settings-Orc-preraid_sv-Basic-sv_advanced-NoBuffs-LongMultiTarget"
+ key: "TestSV-Settings-Orc-preraid_sv-Basic-sv_advanced-NoBuffs-5.1yards-LongMultiTarget"
  value: {
   dps: 18167.59818
   tps: 16605.95072
  }
 }
 dps_results: {
- key: "TestSV-Settings-Orc-preraid_sv-Basic-sv_advanced-NoBuffs-LongSingleTarget"
+ key: "TestSV-Settings-Orc-preraid_sv-Basic-sv_advanced-NoBuffs-5.1yards-LongSingleTarget"
  value: {
   dps: 16773.47332
   tps: 15209.39797
  }
 }
 dps_results: {
- key: "TestSV-Settings-Orc-preraid_sv-Basic-sv_advanced-NoBuffs-ShortSingleTarget"
+ key: "TestSV-Settings-Orc-preraid_sv-Basic-sv_advanced-NoBuffs-5.1yards-ShortSingleTarget"
  value: {
   dps: 18547.95851
   tps: 16853.78744

--- a/sim/hunter/survival/survival_test.go
+++ b/sim/hunter/survival/survival_test.go
@@ -28,7 +28,7 @@ func TestSV(t *testing.T) {
 			core.GetAplRotation("../../../ui/hunter/survival/apls", "sv_advanced"),
 			core.GetAplRotation("../../../ui/hunter/survival/apls", "aoe"),
 		},
-		DistanceFromTarget: 5.1,
+		StartingDistance:   5.1,
 		ItemFilter:         ItemFilter,
 	}))
 }

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -1916,126 +1916,126 @@ dps_results: {
  }
 }
 dps_results: {
- key: "TestShadow-Settings-Draenei-p1-Basic-default-FullBuffs-LongMultiTarget"
+ key: "TestShadow-Settings-Draenei-p1-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 28402.43415
   tps: 37973.1976
  }
 }
 dps_results: {
- key: "TestShadow-Settings-Draenei-p1-Basic-default-FullBuffs-LongSingleTarget"
+ key: "TestShadow-Settings-Draenei-p1-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 28402.43415
   tps: 26875.42163
  }
 }
 dps_results: {
- key: "TestShadow-Settings-Draenei-p1-Basic-default-FullBuffs-ShortSingleTarget"
+ key: "TestShadow-Settings-Draenei-p1-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 37065.97157
   tps: 33906.41477
  }
 }
 dps_results: {
- key: "TestShadow-Settings-Draenei-p1-Basic-default-NoBuffs-LongMultiTarget"
+ key: "TestShadow-Settings-Draenei-p1-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 15796.89364
   tps: 24469.74081
  }
 }
 dps_results: {
- key: "TestShadow-Settings-Draenei-p1-Basic-default-NoBuffs-LongSingleTarget"
+ key: "TestShadow-Settings-Draenei-p1-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 15796.89364
   tps: 15335.82751
  }
 }
 dps_results: {
- key: "TestShadow-Settings-Draenei-p1-Basic-default-NoBuffs-ShortSingleTarget"
+ key: "TestShadow-Settings-Draenei-p1-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 18577.77571
   tps: 17434.04893
  }
 }
 dps_results: {
- key: "TestShadow-Settings-NightElf-p1-Basic-default-FullBuffs-LongMultiTarget"
+ key: "TestShadow-Settings-NightElf-p1-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 28402.43415
   tps: 37973.1976
  }
 }
 dps_results: {
- key: "TestShadow-Settings-NightElf-p1-Basic-default-FullBuffs-LongSingleTarget"
+ key: "TestShadow-Settings-NightElf-p1-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 28402.43415
   tps: 26875.42163
  }
 }
 dps_results: {
- key: "TestShadow-Settings-NightElf-p1-Basic-default-FullBuffs-ShortSingleTarget"
+ key: "TestShadow-Settings-NightElf-p1-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 37065.97157
   tps: 33906.41477
  }
 }
 dps_results: {
- key: "TestShadow-Settings-NightElf-p1-Basic-default-NoBuffs-LongMultiTarget"
+ key: "TestShadow-Settings-NightElf-p1-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 15796.89364
   tps: 24469.74081
  }
 }
 dps_results: {
- key: "TestShadow-Settings-NightElf-p1-Basic-default-NoBuffs-LongSingleTarget"
+ key: "TestShadow-Settings-NightElf-p1-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 15796.89364
   tps: 15335.82751
  }
 }
 dps_results: {
- key: "TestShadow-Settings-NightElf-p1-Basic-default-NoBuffs-ShortSingleTarget"
+ key: "TestShadow-Settings-NightElf-p1-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 18577.77571
   tps: 17434.04893
  }
 }
 dps_results: {
- key: "TestShadow-Settings-Troll-p1-Basic-default-FullBuffs-LongMultiTarget"
+ key: "TestShadow-Settings-Troll-p1-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 28829.53967
   tps: 38503.10664
  }
 }
 dps_results: {
- key: "TestShadow-Settings-Troll-p1-Basic-default-FullBuffs-LongSingleTarget"
+ key: "TestShadow-Settings-Troll-p1-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 28829.53967
   tps: 27341.98845
  }
 }
 dps_results: {
- key: "TestShadow-Settings-Troll-p1-Basic-default-FullBuffs-ShortSingleTarget"
+ key: "TestShadow-Settings-Troll-p1-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 38250.08752
   tps: 35041.99797
  }
 }
 dps_results: {
- key: "TestShadow-Settings-Troll-p1-Basic-default-NoBuffs-LongMultiTarget"
+ key: "TestShadow-Settings-Troll-p1-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 16749.4559
   tps: 25641.7068
  }
 }
 dps_results: {
- key: "TestShadow-Settings-Troll-p1-Basic-default-NoBuffs-LongSingleTarget"
+ key: "TestShadow-Settings-Troll-p1-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 16749.4559
   tps: 16243.82207
  }
 }
 dps_results: {
- key: "TestShadow-Settings-Troll-p1-Basic-default-NoBuffs-ShortSingleTarget"
+ key: "TestShadow-Settings-Troll-p1-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 19495.01037
   tps: 18280.78784

--- a/sim/rogue/assassination/TestAssassination.results
+++ b/sim/rogue/assassination/TestAssassination.results
@@ -1875,336 +1875,336 @@ dps_results: {
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Human-p1_assassination_test-Assassination-mutilate-FullBuffs-LongMultiTarget"
+ key: "TestAssassination-Settings-Human-p1_assassination_test-Assassination-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 29507.29321
   tps: 20950.17818
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Human-p1_assassination_test-Assassination-mutilate-FullBuffs-LongSingleTarget"
+ key: "TestAssassination-Settings-Human-p1_assassination_test-Assassination-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 29507.29321
   tps: 20950.17818
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Human-p1_assassination_test-Assassination-mutilate-FullBuffs-ShortSingleTarget"
+ key: "TestAssassination-Settings-Human-p1_assassination_test-Assassination-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 39000.60063
   tps: 27690.42645
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Human-p1_assassination_test-Assassination-mutilate-NoBuffs-LongMultiTarget"
+ key: "TestAssassination-Settings-Human-p1_assassination_test-Assassination-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 17877.91912
   tps: 12693.32258
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Human-p1_assassination_test-Assassination-mutilate-NoBuffs-LongSingleTarget"
+ key: "TestAssassination-Settings-Human-p1_assassination_test-Assassination-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 17877.91912
   tps: 12693.32258
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Human-p1_assassination_test-Assassination-mutilate-NoBuffs-ShortSingleTarget"
+ key: "TestAssassination-Settings-Human-p1_assassination_test-Assassination-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 20004.51898
   tps: 14203.20848
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Human-p1_assassination_test-MH Deadly OH Deadly-mutilate-FullBuffs-LongMultiTarget"
+ key: "TestAssassination-Settings-Human-p1_assassination_test-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 21441.55312
   tps: 15223.50272
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Human-p1_assassination_test-MH Deadly OH Deadly-mutilate-FullBuffs-LongSingleTarget"
+ key: "TestAssassination-Settings-Human-p1_assassination_test-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 21441.55312
   tps: 15223.50272
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Human-p1_assassination_test-MH Deadly OH Deadly-mutilate-FullBuffs-ShortSingleTarget"
+ key: "TestAssassination-Settings-Human-p1_assassination_test-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 28479.35188
   tps: 20220.33984
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Human-p1_assassination_test-MH Deadly OH Deadly-mutilate-NoBuffs-LongMultiTarget"
+ key: "TestAssassination-Settings-Human-p1_assassination_test-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 13118.48119
   tps: 9314.12164
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Human-p1_assassination_test-MH Deadly OH Deadly-mutilate-NoBuffs-LongSingleTarget"
+ key: "TestAssassination-Settings-Human-p1_assassination_test-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 13118.48119
   tps: 9314.12164
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Human-p1_assassination_test-MH Deadly OH Deadly-mutilate-NoBuffs-ShortSingleTarget"
+ key: "TestAssassination-Settings-Human-p1_assassination_test-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 15087.97851
   tps: 10712.46474
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Deadly-mutilate-FullBuffs-LongMultiTarget"
+ key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 28035.17445
   tps: 19904.97386
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Deadly-mutilate-FullBuffs-LongSingleTarget"
+ key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 28035.17445
   tps: 19904.97386
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Deadly-mutilate-FullBuffs-ShortSingleTarget"
+ key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 36966.82693
   tps: 26246.44712
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Deadly-mutilate-NoBuffs-LongMultiTarget"
+ key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 16964.31602
   tps: 12044.66437
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Deadly-mutilate-NoBuffs-LongSingleTarget"
+ key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 16964.31602
   tps: 12044.66437
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Deadly-mutilate-NoBuffs-ShortSingleTarget"
+ key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 18920.77558
   tps: 13433.75066
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Instant-mutilate-FullBuffs-LongMultiTarget"
+ key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 16420.04242
   tps: 11658.23012
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Instant-mutilate-FullBuffs-LongSingleTarget"
+ key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 16420.04242
   tps: 11658.23012
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Instant-mutilate-FullBuffs-ShortSingleTarget"
+ key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 20554.6667
   tps: 14593.81336
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Instant-mutilate-NoBuffs-LongMultiTarget"
+ key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 9588.93166
   tps: 6808.14148
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Instant-mutilate-NoBuffs-LongSingleTarget"
+ key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 9588.93166
   tps: 6808.14148
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Instant-mutilate-NoBuffs-ShortSingleTarget"
+ key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 10560.35602
   tps: 7497.85277
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Orc-p1_assassination_test-Assassination-mutilate-FullBuffs-LongMultiTarget"
+ key: "TestAssassination-Settings-Orc-p1_assassination_test-Assassination-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 29800.67994
   tps: 21158.48276
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Orc-p1_assassination_test-Assassination-mutilate-FullBuffs-LongSingleTarget"
+ key: "TestAssassination-Settings-Orc-p1_assassination_test-Assassination-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 29800.67994
   tps: 21158.48276
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Orc-p1_assassination_test-Assassination-mutilate-FullBuffs-ShortSingleTarget"
+ key: "TestAssassination-Settings-Orc-p1_assassination_test-Assassination-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 39634.5715
   tps: 28140.54576
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Orc-p1_assassination_test-Assassination-mutilate-NoBuffs-LongMultiTarget"
+ key: "TestAssassination-Settings-Orc-p1_assassination_test-Assassination-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 18071.95177
   tps: 12831.08576
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Orc-p1_assassination_test-Assassination-mutilate-NoBuffs-LongSingleTarget"
+ key: "TestAssassination-Settings-Orc-p1_assassination_test-Assassination-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 18071.95177
   tps: 12831.08576
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Orc-p1_assassination_test-Assassination-mutilate-NoBuffs-ShortSingleTarget"
+ key: "TestAssassination-Settings-Orc-p1_assassination_test-Assassination-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 20362.37998
   tps: 14457.28979
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Deadly OH Deadly-mutilate-FullBuffs-LongMultiTarget"
+ key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 21659.88303
   tps: 15378.51695
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Deadly OH Deadly-mutilate-FullBuffs-LongSingleTarget"
+ key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 21659.88303
   tps: 15378.51695
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Deadly OH Deadly-mutilate-FullBuffs-ShortSingleTarget"
+ key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 28948.64779
   tps: 20553.53993
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Deadly OH Deadly-mutilate-NoBuffs-LongMultiTarget"
+ key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 13259.37101
   tps: 9414.15342
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Deadly OH Deadly-mutilate-NoBuffs-LongSingleTarget"
+ key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 13259.37101
   tps: 9414.15342
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Deadly OH Deadly-mutilate-NoBuffs-ShortSingleTarget"
+ key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 15361.28487
   tps: 10906.51226
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Deadly-mutilate-FullBuffs-LongMultiTarget"
+ key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 28309.44313
   tps: 20099.70462
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Deadly-mutilate-FullBuffs-LongSingleTarget"
+ key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 28309.44313
   tps: 20099.70462
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Deadly-mutilate-FullBuffs-ShortSingleTarget"
+ key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 37559.75133
   tps: 26667.42344
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Deadly-mutilate-NoBuffs-LongMultiTarget"
+ key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 17144.38805
   tps: 12172.51552
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Deadly-mutilate-NoBuffs-LongSingleTarget"
+ key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 17144.38805
   tps: 12172.51552
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Deadly-mutilate-NoBuffs-ShortSingleTarget"
+ key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 19252.17115
   tps: 13669.04152
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Instant-mutilate-FullBuffs-LongMultiTarget"
+ key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 16585.01231
   tps: 11775.35874
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Instant-mutilate-FullBuffs-LongSingleTarget"
+ key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 16585.01231
   tps: 11775.35874
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Instant-mutilate-FullBuffs-ShortSingleTarget"
+ key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 20918.84389
   tps: 14852.37916
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Instant-mutilate-NoBuffs-LongMultiTarget"
+ key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 9697.82333
   tps: 6885.45456
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Instant-mutilate-NoBuffs-LongSingleTarget"
+ key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 9697.82333
   tps: 6885.45456
  }
 }
 dps_results: {
- key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Instant-mutilate-NoBuffs-ShortSingleTarget"
+ key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 10773.65806
   tps: 7649.29722

--- a/sim/rogue/combat/TestCombat.results
+++ b/sim/rogue/combat/TestCombat.results
@@ -1931,336 +1931,336 @@ dps_results: {
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Human-p1_combat_test-Combat-combat-FullBuffs-LongMultiTarget"
+ key: "TestCombat-Settings-Human-p1_combat_test-Combat-combat-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 28717.07122
   tps: 20389.12057
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Human-p1_combat_test-Combat-combat-FullBuffs-LongSingleTarget"
+ key: "TestCombat-Settings-Human-p1_combat_test-Combat-combat-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 29061.38697
   tps: 20633.58475
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Human-p1_combat_test-Combat-combat-FullBuffs-ShortSingleTarget"
+ key: "TestCombat-Settings-Human-p1_combat_test-Combat-combat-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 34888.61389
   tps: 24770.91586
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Human-p1_combat_test-Combat-combat-NoBuffs-LongMultiTarget"
+ key: "TestCombat-Settings-Human-p1_combat_test-Combat-combat-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 16716.16191
   tps: 11868.47496
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Human-p1_combat_test-Combat-combat-NoBuffs-LongSingleTarget"
+ key: "TestCombat-Settings-Human-p1_combat_test-Combat-combat-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 16903.38028
   tps: 12001.4
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Human-p1_combat_test-Combat-combat-NoBuffs-ShortSingleTarget"
+ key: "TestCombat-Settings-Human-p1_combat_test-Combat-combat-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 16965.24175
   tps: 12045.32164
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Deadly-combat-FullBuffs-LongMultiTarget"
+ key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Deadly-combat-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 25012.56228
   tps: 17758.91922
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Deadly-combat-FullBuffs-LongSingleTarget"
+ key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Deadly-combat-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 24931.75423
   tps: 17701.54551
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Deadly-combat-FullBuffs-ShortSingleTarget"
+ key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Deadly-combat-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 29998.58782
   tps: 21298.99736
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Deadly-combat-NoBuffs-LongMultiTarget"
+ key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Deadly-combat-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 14714.14439
   tps: 10447.04252
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Deadly-combat-NoBuffs-LongSingleTarget"
+ key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Deadly-combat-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 14657.78314
   tps: 10407.02603
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Deadly-combat-NoBuffs-ShortSingleTarget"
+ key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Deadly-combat-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 14753.14045
   tps: 10474.72972
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Instant-combat-FullBuffs-LongMultiTarget"
+ key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Instant-combat-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 27727.59051
   tps: 19686.58927
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Instant-combat-FullBuffs-LongSingleTarget"
+ key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Instant-combat-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 27989.77659
   tps: 19872.74138
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Instant-combat-FullBuffs-ShortSingleTarget"
+ key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Instant-combat-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 33653.97424
   tps: 23894.32171
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Instant-combat-NoBuffs-LongMultiTarget"
+ key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Instant-combat-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 16309.49904
   tps: 11579.74432
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Instant-combat-NoBuffs-LongSingleTarget"
+ key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Instant-combat-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 16415.89679
   tps: 11655.28672
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Instant-combat-NoBuffs-ShortSingleTarget"
+ key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Instant-combat-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 16327.58798
   tps: 11592.58747
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Human-p1_combat_test-MH Instant OH Instant-combat-FullBuffs-LongMultiTarget"
+ key: "TestCombat-Settings-Human-p1_combat_test-MH Instant OH Instant-combat-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 25301.07933
   tps: 17963.76632
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Human-p1_combat_test-MH Instant OH Instant-combat-FullBuffs-LongSingleTarget"
+ key: "TestCombat-Settings-Human-p1_combat_test-MH Instant OH Instant-combat-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 25578.44086
   tps: 18160.69301
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Human-p1_combat_test-MH Instant OH Instant-combat-FullBuffs-ShortSingleTarget"
+ key: "TestCombat-Settings-Human-p1_combat_test-MH Instant OH Instant-combat-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 31299.74546
   tps: 22222.81927
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Human-p1_combat_test-MH Instant OH Instant-combat-NoBuffs-LongMultiTarget"
+ key: "TestCombat-Settings-Human-p1_combat_test-MH Instant OH Instant-combat-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 14652.65239
   tps: 10403.38319
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Human-p1_combat_test-MH Instant OH Instant-combat-NoBuffs-LongSingleTarget"
+ key: "TestCombat-Settings-Human-p1_combat_test-MH Instant OH Instant-combat-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 14796.93252
   tps: 10505.82209
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Human-p1_combat_test-MH Instant OH Instant-combat-NoBuffs-ShortSingleTarget"
+ key: "TestCombat-Settings-Human-p1_combat_test-MH Instant OH Instant-combat-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 15015.85709
   tps: 10661.25853
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Orc-p1_combat_test-Combat-combat-FullBuffs-LongMultiTarget"
+ key: "TestCombat-Settings-Orc-p1_combat_test-Combat-combat-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 28982.76253
   tps: 20577.76139
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Orc-p1_combat_test-Combat-combat-FullBuffs-LongSingleTarget"
+ key: "TestCombat-Settings-Orc-p1_combat_test-Combat-combat-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 29332.74836
   tps: 20826.25133
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Orc-p1_combat_test-Combat-combat-FullBuffs-ShortSingleTarget"
+ key: "TestCombat-Settings-Orc-p1_combat_test-Combat-combat-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 35434.5723
   tps: 25158.54633
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Orc-p1_combat_test-Combat-combat-NoBuffs-LongMultiTarget"
+ key: "TestCombat-Settings-Orc-p1_combat_test-Combat-combat-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 16887.91795
   tps: 11990.42175
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Orc-p1_combat_test-Combat-combat-NoBuffs-LongSingleTarget"
+ key: "TestCombat-Settings-Orc-p1_combat_test-Combat-combat-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 17078.7984
   tps: 12125.94687
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Orc-p1_combat_test-Combat-combat-NoBuffs-ShortSingleTarget"
+ key: "TestCombat-Settings-Orc-p1_combat_test-Combat-combat-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 17320.91879
   tps: 12297.85234
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Deadly-combat-FullBuffs-LongMultiTarget"
+ key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Deadly-combat-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 25240.4519
   tps: 17920.72085
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Deadly-combat-FullBuffs-LongSingleTarget"
+ key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Deadly-combat-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 25159.41908
   tps: 17863.18755
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Deadly-combat-FullBuffs-ShortSingleTarget"
+ key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Deadly-combat-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 30471.68446
   tps: 21634.89597
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Deadly-combat-NoBuffs-LongMultiTarget"
+ key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Deadly-combat-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 14865.0659
   tps: 10554.19679
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Deadly-combat-NoBuffs-LongSingleTarget"
+ key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Deadly-combat-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 14807.58886
   tps: 10513.38809
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Deadly-combat-NoBuffs-ShortSingleTarget"
+ key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Deadly-combat-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 15064.00997
   tps: 10695.44708
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Instant-combat-FullBuffs-LongMultiTarget"
+ key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Instant-combat-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 27978.57571
   tps: 19864.78875
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Instant-combat-FullBuffs-LongSingleTarget"
+ key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Instant-combat-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 28244.24113
   tps: 20053.4112
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Instant-combat-FullBuffs-ShortSingleTarget"
+ key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Instant-combat-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 34182.04031
   tps: 24269.24862
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Instant-combat-NoBuffs-LongMultiTarget"
+ key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Instant-combat-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 16477.09613
   tps: 11698.73825
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Instant-combat-NoBuffs-LongSingleTarget"
+ key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Instant-combat-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 16584.88152
   tps: 11775.26588
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Instant-combat-NoBuffs-ShortSingleTarget"
+ key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Instant-combat-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 16671.51857
   tps: 11836.77819
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Orc-p1_combat_test-MH Instant OH Instant-combat-FullBuffs-LongMultiTarget"
+ key: "TestCombat-Settings-Orc-p1_combat_test-MH Instant OH Instant-combat-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 25534.77299
   tps: 18129.68882
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Orc-p1_combat_test-MH Instant OH Instant-combat-FullBuffs-LongSingleTarget"
+ key: "TestCombat-Settings-Orc-p1_combat_test-MH Instant OH Instant-combat-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 25815.7635
   tps: 18329.19208
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Orc-p1_combat_test-MH Instant OH Instant-combat-FullBuffs-ShortSingleTarget"
+ key: "TestCombat-Settings-Orc-p1_combat_test-MH Instant OH Instant-combat-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 31808.45814
   tps: 22584.00528
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Orc-p1_combat_test-MH Instant OH Instant-combat-NoBuffs-LongMultiTarget"
+ key: "TestCombat-Settings-Orc-p1_combat_test-MH Instant OH Instant-combat-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 14804.34729
   tps: 10511.08658
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Orc-p1_combat_test-MH Instant OH Instant-combat-NoBuffs-LongSingleTarget"
+ key: "TestCombat-Settings-Orc-p1_combat_test-MH Instant OH Instant-combat-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 14950.74311
   tps: 10615.02761
  }
 }
 dps_results: {
- key: "TestCombat-Settings-Orc-p1_combat_test-MH Instant OH Instant-combat-NoBuffs-ShortSingleTarget"
+ key: "TestCombat-Settings-Orc-p1_combat_test-MH Instant OH Instant-combat-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 15345.10815
   tps: 10895.02679

--- a/sim/rogue/subtlety/TestSubtlety.results
+++ b/sim/rogue/subtlety/TestSubtlety.results
@@ -1879,336 +1879,336 @@ dps_results: {
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Deadly-subtlety-FullBuffs-LongMultiTarget"
+ key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Deadly-subtlety-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 20428.72734
   tps: 14504.39641
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Deadly-subtlety-FullBuffs-LongSingleTarget"
+ key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Deadly-subtlety-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 20428.72734
   tps: 14504.39641
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Deadly-subtlety-FullBuffs-ShortSingleTarget"
+ key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Deadly-subtlety-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 26388.81494
   tps: 18736.05861
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Deadly-subtlety-NoBuffs-LongMultiTarget"
+ key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Deadly-subtlety-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 11742.39569
   tps: 8337.10094
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Deadly-subtlety-NoBuffs-LongSingleTarget"
+ key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Deadly-subtlety-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 11742.39569
   tps: 8337.10094
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Deadly-subtlety-NoBuffs-ShortSingleTarget"
+ key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Deadly-subtlety-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 12654.6946
   tps: 8984.83317
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Instant-subtlety-FullBuffs-LongMultiTarget"
+ key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Instant-subtlety-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 22733.20511
   tps: 16140.57563
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Instant-subtlety-FullBuffs-LongSingleTarget"
+ key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Instant-subtlety-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 22733.20511
   tps: 16140.57563
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Instant-subtlety-FullBuffs-ShortSingleTarget"
+ key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Instant-subtlety-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 28874.99765
   tps: 20501.24833
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Instant-subtlety-NoBuffs-LongMultiTarget"
+ key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Instant-subtlety-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 12921.20541
   tps: 9174.05584
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Instant-subtlety-NoBuffs-LongSingleTarget"
+ key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Instant-subtlety-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 12921.20541
   tps: 9174.05584
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Instant-subtlety-NoBuffs-ShortSingleTarget"
+ key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Instant-subtlety-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 14056.5982
   tps: 9980.18472
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Instant OH Instant-subtlety-FullBuffs-LongMultiTarget"
+ key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Instant OH Instant-subtlety-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 20437.81147
   tps: 14510.84614
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Instant OH Instant-subtlety-FullBuffs-LongSingleTarget"
+ key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Instant OH Instant-subtlety-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 20437.81147
   tps: 14510.84614
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Instant OH Instant-subtlety-FullBuffs-ShortSingleTarget"
+ key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Instant OH Instant-subtlety-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 27125.43382
   tps: 19259.05801
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Instant OH Instant-subtlety-NoBuffs-LongMultiTarget"
+ key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Instant OH Instant-subtlety-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 11516.52761
   tps: 8176.7346
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Instant OH Instant-subtlety-NoBuffs-LongSingleTarget"
+ key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Instant OH Instant-subtlety-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 11516.52761
   tps: 8176.7346
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Instant OH Instant-subtlety-NoBuffs-ShortSingleTarget"
+ key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Instant OH Instant-subtlety-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 12551.71493
   tps: 8911.7176
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Human-p1_subtlety_test-Subtlety-subtlety-FullBuffs-LongMultiTarget"
+ key: "TestSubtlety-Settings-Human-p1_subtlety_test-Subtlety-subtlety-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 22742.85812
   tps: 16147.42927
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Human-p1_subtlety_test-Subtlety-subtlety-FullBuffs-LongSingleTarget"
+ key: "TestSubtlety-Settings-Human-p1_subtlety_test-Subtlety-subtlety-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 22742.85812
   tps: 16147.42927
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Human-p1_subtlety_test-Subtlety-subtlety-FullBuffs-ShortSingleTarget"
+ key: "TestSubtlety-Settings-Human-p1_subtlety_test-Subtlety-subtlety-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 29265.73874
   tps: 20778.67451
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Human-p1_subtlety_test-Subtlety-subtlety-NoBuffs-LongMultiTarget"
+ key: "TestSubtlety-Settings-Human-p1_subtlety_test-Subtlety-subtlety-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 12872.27727
   tps: 9139.31686
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Human-p1_subtlety_test-Subtlety-subtlety-NoBuffs-LongSingleTarget"
+ key: "TestSubtlety-Settings-Human-p1_subtlety_test-Subtlety-subtlety-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 12872.27727
   tps: 9139.31686
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Human-p1_subtlety_test-Subtlety-subtlety-NoBuffs-ShortSingleTarget"
+ key: "TestSubtlety-Settings-Human-p1_subtlety_test-Subtlety-subtlety-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 13735.44755
   tps: 9752.16776
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Deadly-subtlety-FullBuffs-LongMultiTarget"
+ key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Deadly-subtlety-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 20621.61664
   tps: 14641.34781
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Deadly-subtlety-FullBuffs-LongSingleTarget"
+ key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Deadly-subtlety-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 20621.61664
   tps: 14641.34781
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Deadly-subtlety-FullBuffs-ShortSingleTarget"
+ key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Deadly-subtlety-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 26792.44689
   tps: 19022.63729
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Deadly-subtlety-NoBuffs-LongMultiTarget"
+ key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Deadly-subtlety-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 11841.04574
   tps: 8407.14248
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Deadly-subtlety-NoBuffs-LongSingleTarget"
+ key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Deadly-subtlety-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 11841.04574
   tps: 8407.14248
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Deadly-subtlety-NoBuffs-ShortSingleTarget"
+ key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Deadly-subtlety-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 12869.581
   tps: 9137.40251
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Instant-subtlety-FullBuffs-LongMultiTarget"
+ key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Instant-subtlety-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 22951.68576
   tps: 16295.69689
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Instant-subtlety-FullBuffs-LongSingleTarget"
+ key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Instant-subtlety-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 22951.68576
   tps: 16295.69689
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Instant-subtlety-FullBuffs-ShortSingleTarget"
+ key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Instant-subtlety-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 29308.15027
   tps: 20808.78669
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Instant-subtlety-NoBuffs-LongMultiTarget"
+ key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Instant-subtlety-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 13026.79759
   tps: 9249.02629
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Instant-subtlety-NoBuffs-LongSingleTarget"
+ key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Instant-subtlety-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 13026.79759
   tps: 9249.02629
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Instant-subtlety-NoBuffs-ShortSingleTarget"
+ key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Instant-subtlety-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 14277.62702
   tps: 10137.11519
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Instant OH Instant-subtlety-FullBuffs-LongMultiTarget"
+ key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Instant OH Instant-subtlety-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 20623.11457
   tps: 14642.41134
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Instant OH Instant-subtlety-FullBuffs-LongSingleTarget"
+ key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Instant OH Instant-subtlety-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 20623.11457
   tps: 14642.41134
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Instant OH Instant-subtlety-FullBuffs-ShortSingleTarget"
+ key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Instant OH Instant-subtlety-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 27540.12914
   tps: 19553.49169
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Instant OH Instant-subtlety-NoBuffs-LongMultiTarget"
+ key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Instant OH Instant-subtlety-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 11596.24413
   tps: 8233.33333
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Instant OH Instant-subtlety-NoBuffs-LongSingleTarget"
+ key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Instant OH Instant-subtlety-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 11596.24413
   tps: 8233.33333
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Instant OH Instant-subtlety-NoBuffs-ShortSingleTarget"
+ key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Instant OH Instant-subtlety-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 12758.43114
   tps: 9058.48611
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Orc-p1_subtlety_test-Subtlety-subtlety-FullBuffs-LongMultiTarget"
+ key: "TestSubtlety-Settings-Orc-p1_subtlety_test-Subtlety-subtlety-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 22955.55172
   tps: 16298.44172
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Orc-p1_subtlety_test-Subtlety-subtlety-FullBuffs-LongSingleTarget"
+ key: "TestSubtlety-Settings-Orc-p1_subtlety_test-Subtlety-subtlety-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 22955.55172
   tps: 16298.44172
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Orc-p1_subtlety_test-Subtlety-subtlety-FullBuffs-ShortSingleTarget"
+ key: "TestSubtlety-Settings-Orc-p1_subtlety_test-Subtlety-subtlety-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 29696.7014
   tps: 21084.658
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Orc-p1_subtlety_test-Subtlety-subtlety-NoBuffs-LongMultiTarget"
+ key: "TestSubtlety-Settings-Orc-p1_subtlety_test-Subtlety-subtlety-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 12983.01428
   tps: 9217.94014
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Orc-p1_subtlety_test-Subtlety-subtlety-NoBuffs-LongSingleTarget"
+ key: "TestSubtlety-Settings-Orc-p1_subtlety_test-Subtlety-subtlety-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 12983.01428
   tps: 9217.94014
  }
 }
 dps_results: {
- key: "TestSubtlety-Settings-Orc-p1_subtlety_test-Subtlety-subtlety-NoBuffs-ShortSingleTarget"
+ key: "TestSubtlety-Settings-Orc-p1_subtlety_test-Subtlety-subtlety-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 13954.16219
   tps: 9907.45516

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -1993,84 +1993,84 @@ dps_results: {
  }
 }
 dps_results: {
- key: "TestElemental-Settings-Orc-p1-Standard-default-FullBuffs-LongMultiTarget"
+ key: "TestElemental-Settings-Orc-p1-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 28897.31473
   tps: 9473.02258
  }
 }
 dps_results: {
- key: "TestElemental-Settings-Orc-p1-Standard-default-FullBuffs-LongSingleTarget"
+ key: "TestElemental-Settings-Orc-p1-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 27399.41346
   tps: 555.44594
  }
 }
 dps_results: {
- key: "TestElemental-Settings-Orc-p1-Standard-default-FullBuffs-ShortSingleTarget"
+ key: "TestElemental-Settings-Orc-p1-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 33289.92656
   tps: 724.35308
  }
 }
 dps_results: {
- key: "TestElemental-Settings-Orc-p1-Standard-default-NoBuffs-LongMultiTarget"
+ key: "TestElemental-Settings-Orc-p1-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 22511.38552
   tps: 9026.38845
  }
 }
 dps_results: {
- key: "TestElemental-Settings-Orc-p1-Standard-default-NoBuffs-LongSingleTarget"
+ key: "TestElemental-Settings-Orc-p1-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 20958.06059
   tps: 515.68076
  }
 }
 dps_results: {
- key: "TestElemental-Settings-Orc-p1-Standard-default-NoBuffs-ShortSingleTarget"
+ key: "TestElemental-Settings-Orc-p1-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 24556.30238
   tps: 595.65149
  }
 }
 dps_results: {
- key: "TestElemental-Settings-Troll-p1-Standard-default-FullBuffs-LongMultiTarget"
+ key: "TestElemental-Settings-Troll-p1-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 28870.65079
   tps: 9472.19825
  }
 }
 dps_results: {
- key: "TestElemental-Settings-Troll-p1-Standard-default-FullBuffs-LongSingleTarget"
+ key: "TestElemental-Settings-Troll-p1-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 27259.31856
   tps: 555.14734
  }
 }
 dps_results: {
- key: "TestElemental-Settings-Troll-p1-Standard-default-FullBuffs-ShortSingleTarget"
+ key: "TestElemental-Settings-Troll-p1-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 32800.58152
   tps: 709.67352
  }
 }
 dps_results: {
- key: "TestElemental-Settings-Troll-p1-Standard-default-NoBuffs-LongMultiTarget"
+ key: "TestElemental-Settings-Troll-p1-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 22404.03618
   tps: 9080.77864
  }
 }
 dps_results: {
- key: "TestElemental-Settings-Troll-p1-Standard-default-NoBuffs-LongSingleTarget"
+ key: "TestElemental-Settings-Troll-p1-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 20897.57999
   tps: 513.36927
  }
 }
 dps_results: {
- key: "TestElemental-Settings-Troll-p1-Standard-default-NoBuffs-ShortSingleTarget"
+ key: "TestElemental-Settings-Troll-p1-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 23878.01773
   tps: 581.42533

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -1994,126 +1994,126 @@ dps_results: {
  }
 }
 dps_results: {
- key: "TestEnhancement-Settings-Draenei-p1-Standard-default-FullBuffs-LongMultiTarget"
+ key: "TestEnhancement-Settings-Draenei-p1-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 31139.82792
   tps: 25204.73346
  }
 }
 dps_results: {
- key: "TestEnhancement-Settings-Draenei-p1-Standard-default-FullBuffs-LongSingleTarget"
+ key: "TestEnhancement-Settings-Draenei-p1-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 30579.34207
   tps: 20765.29665
  }
 }
 dps_results: {
- key: "TestEnhancement-Settings-Draenei-p1-Standard-default-FullBuffs-ShortSingleTarget"
+ key: "TestEnhancement-Settings-Draenei-p1-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 34589.49576
   tps: 23049.62408
  }
 }
 dps_results: {
- key: "TestEnhancement-Settings-Draenei-p1-Standard-default-NoBuffs-LongMultiTarget"
+ key: "TestEnhancement-Settings-Draenei-p1-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 23979.22664
   tps: 20646.07194
  }
 }
 dps_results: {
- key: "TestEnhancement-Settings-Draenei-p1-Standard-default-NoBuffs-LongSingleTarget"
+ key: "TestEnhancement-Settings-Draenei-p1-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 23475.84573
   tps: 16129.98701
  }
 }
 dps_results: {
- key: "TestEnhancement-Settings-Draenei-p1-Standard-default-NoBuffs-ShortSingleTarget"
+ key: "TestEnhancement-Settings-Draenei-p1-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 25811.64685
   tps: 17435.10942
  }
 }
 dps_results: {
- key: "TestEnhancement-Settings-Orc-p1-Standard-default-FullBuffs-LongMultiTarget"
+ key: "TestEnhancement-Settings-Orc-p1-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 31655.99582
   tps: 25615.46353
  }
 }
 dps_results: {
- key: "TestEnhancement-Settings-Orc-p1-Standard-default-FullBuffs-LongSingleTarget"
+ key: "TestEnhancement-Settings-Orc-p1-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 31131.1334
   tps: 21084.57221
  }
 }
 dps_results: {
- key: "TestEnhancement-Settings-Orc-p1-Standard-default-FullBuffs-ShortSingleTarget"
+ key: "TestEnhancement-Settings-Orc-p1-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 35591.03696
   tps: 23732.79037
  }
 }
 dps_results: {
- key: "TestEnhancement-Settings-Orc-p1-Standard-default-NoBuffs-LongMultiTarget"
+ key: "TestEnhancement-Settings-Orc-p1-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 24477.63757
   tps: 21013.7196
  }
 }
 dps_results: {
- key: "TestEnhancement-Settings-Orc-p1-Standard-default-NoBuffs-LongSingleTarget"
+ key: "TestEnhancement-Settings-Orc-p1-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 23962.12773
   tps: 16482.26574
  }
 }
 dps_results: {
- key: "TestEnhancement-Settings-Orc-p1-Standard-default-NoBuffs-ShortSingleTarget"
+ key: "TestEnhancement-Settings-Orc-p1-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 26344.33298
   tps: 17779.68351
  }
 }
 dps_results: {
- key: "TestEnhancement-Settings-Troll-p1-Standard-default-FullBuffs-LongMultiTarget"
+ key: "TestEnhancement-Settings-Troll-p1-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 31298.30053
   tps: 25277.1922
  }
 }
 dps_results: {
- key: "TestEnhancement-Settings-Troll-p1-Standard-default-FullBuffs-LongSingleTarget"
+ key: "TestEnhancement-Settings-Troll-p1-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 30660.98194
   tps: 20766.82856
  }
 }
 dps_results: {
- key: "TestEnhancement-Settings-Troll-p1-Standard-default-FullBuffs-ShortSingleTarget"
+ key: "TestEnhancement-Settings-Troll-p1-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 35079.62202
   tps: 23349.25582
  }
 }
 dps_results: {
- key: "TestEnhancement-Settings-Troll-p1-Standard-default-NoBuffs-LongMultiTarget"
+ key: "TestEnhancement-Settings-Troll-p1-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 24153.7303
   tps: 20796.86482
  }
 }
 dps_results: {
- key: "TestEnhancement-Settings-Troll-p1-Standard-default-NoBuffs-LongSingleTarget"
+ key: "TestEnhancement-Settings-Troll-p1-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 23509.79159
   tps: 16112.38012
  }
 }
 dps_results: {
- key: "TestEnhancement-Settings-Troll-p1-Standard-default-NoBuffs-ShortSingleTarget"
+ key: "TestEnhancement-Settings-Troll-p1-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 25756.87684
   tps: 17386.59878

--- a/sim/warrior/arms/TestArms.results
+++ b/sim/warrior/arms/TestArms.results
@@ -1896,84 +1896,84 @@ dps_results: {
  }
 }
 dps_results: {
- key: "TestArms-Settings-Orc-preraid_arms-Basic-arms-FullBuffs-LongMultiTarget"
+ key: "TestArms-Settings-Orc-preraid_arms-Basic-arms-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 55219.1154
   tps: 29681.00394
  }
 }
 dps_results: {
- key: "TestArms-Settings-Orc-preraid_arms-Basic-arms-FullBuffs-LongSingleTarget"
+ key: "TestArms-Settings-Orc-preraid_arms-Basic-arms-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 26334.02238
   tps: 18128.47647
  }
 }
 dps_results: {
- key: "TestArms-Settings-Orc-preraid_arms-Basic-arms-FullBuffs-ShortSingleTarget"
+ key: "TestArms-Settings-Orc-preraid_arms-Basic-arms-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 30882.05336
   tps: 21479.73889
  }
 }
 dps_results: {
- key: "TestArms-Settings-Orc-preraid_arms-Basic-arms-NoBuffs-LongMultiTarget"
+ key: "TestArms-Settings-Orc-preraid_arms-Basic-arms-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 35674.46206
   tps: 18190.8899
  }
 }
 dps_results: {
- key: "TestArms-Settings-Orc-preraid_arms-Basic-arms-NoBuffs-LongSingleTarget"
+ key: "TestArms-Settings-Orc-preraid_arms-Basic-arms-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 16640.26476
   tps: 11259.47337
  }
 }
 dps_results: {
- key: "TestArms-Settings-Orc-preraid_arms-Basic-arms-NoBuffs-ShortSingleTarget"
+ key: "TestArms-Settings-Orc-preraid_arms-Basic-arms-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 18115.34356
   tps: 12286.12569
  }
 }
 dps_results: {
- key: "TestArms-Settings-Worgen-preraid_arms-Basic-arms-FullBuffs-LongMultiTarget"
+ key: "TestArms-Settings-Worgen-preraid_arms-Basic-arms-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 55106.92249
   tps: 29476.13744
  }
 }
 dps_results: {
- key: "TestArms-Settings-Worgen-preraid_arms-Basic-arms-FullBuffs-LongSingleTarget"
+ key: "TestArms-Settings-Worgen-preraid_arms-Basic-arms-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 26321.61982
   tps: 18055.72057
  }
 }
 dps_results: {
- key: "TestArms-Settings-Worgen-preraid_arms-Basic-arms-FullBuffs-ShortSingleTarget"
+ key: "TestArms-Settings-Worgen-preraid_arms-Basic-arms-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 30462.12134
   tps: 21124.78586
  }
 }
 dps_results: {
- key: "TestArms-Settings-Worgen-preraid_arms-Basic-arms-NoBuffs-LongMultiTarget"
+ key: "TestArms-Settings-Worgen-preraid_arms-Basic-arms-NoBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 35636.63961
   tps: 17991.91728
  }
 }
 dps_results: {
- key: "TestArms-Settings-Worgen-preraid_arms-Basic-arms-NoBuffs-LongSingleTarget"
+ key: "TestArms-Settings-Worgen-preraid_arms-Basic-arms-NoBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 16554.68901
   tps: 11178.36328
  }
 }
 dps_results: {
- key: "TestArms-Settings-Worgen-preraid_arms-Basic-arms-NoBuffs-ShortSingleTarget"
+ key: "TestArms-Settings-Worgen-preraid_arms-Basic-arms-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 17966.62751
   tps: 12154.12515

--- a/ui/druid/feral/sim.ts
+++ b/ui/druid/feral/sim.ts
@@ -93,7 +93,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFeralDruid, {
 		individualBuffs: IndividualBuffs.create({
 		}),
 		debuffs: Debuffs.create({
-			savageCombat: true,
+			bloodFrenzy: true,
 		}),
 	},
 

--- a/ui/druid/feral/sim.ts
+++ b/ui/druid/feral/sim.ts
@@ -106,7 +106,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFeralDruid, {
 	excludeBuffDebuffInputs: [],
 	// Inputs to include in the 'Other' section on the settings tab.
 	otherInputs: {
-		inputs: [FeralInputs.AssumeBleedActive, OtherInputs.InputDelay, OtherInputs.TankAssignment, OtherInputs.InFrontOfTarget, OtherInputs.DarkIntentUptime],
+		inputs: [FeralInputs.AssumeBleedActive, OtherInputs.InputDelay, OtherInputs.DistanceFromTarget, OtherInputs.TankAssignment, OtherInputs.InFrontOfTarget, OtherInputs.DarkIntentUptime],
 	},
 	encounterPicker: {
 		// Whether to include 'Execute Duration (%)' in the 'Encounter' section of the settings tab.


### PR DESCRIPTION
- Adjusted rotation logic to not burn Omen procs on clipped Mangles.
- Made Blood Frenzy a default debuff due to prevalence of Arms Warriors in Cata.
- Implemented TF Rake delay logic using the same algorithm as for Rip delays.
- Added support for `MinRange` and `MaxRange` configuration for spells.
- Added `DistanceFromTarget` input to Feral sim, and adjusted rotation logic to run into melee range if necessary.
- Fixed a bug where `DistanceFromTarget` was not being reset between iterations.
- Added constant for `MaxMeleeRange` to replace the hardcoded value of 5 that was used in various places in the code.
- Added support for testing multiple starting distances from target in unit tests.
- Added 25-yard starting distance option to Feral tests, and removed the "no bleed" option that does not produce different behavior for Cata rotation.
- Implemented movement speed increase from Feral Swiftness talent.
- Allowed Faerie Fire usage while moving.