### PR TITLE
Make Stormstrike trigger spells

### DIFF
--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -39,2090 +39,2090 @@ character_stats_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 30578.5899
-  tps: 20764.84874
+  dps: 29153.4987
+  tps: 19414.07258
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Althor'sAbacus-50359"
  value: {
-  dps: 28804.88752
-  tps: 19532.1484
+  dps: 27472.8578
+  tps: 18251.30168
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 28805.7223
-  tps: 19532.37374
+  dps: 27473.1099
+  tps: 18251.46435
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 28934.72809
-  tps: 19566.42934
+  dps: 27483.95294
+  tps: 18349.36201
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 28901.25577
-  tps: 19549.25453
+  dps: 27627.12207
+  tps: 18434.74589
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AustereEarthsiegeDiamond"
  value: {
-  dps: 29946.48184
-  tps: 20323.3163
+  dps: 28532.51989
+  tps: 18991.71982
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 29946.48184
-  tps: 20323.3163
+  dps: 28532.51989
+  tps: 18991.71982
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bandit'sInsignia-40371"
  value: {
-  dps: 29146.56372
-  tps: 19758.58977
+  dps: 27877.81872
+  tps: 18515.73931
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BattlegearoftheRagingElements"
  value: {
-  dps: 27528.5256
-  tps: 18694.34823
+  dps: 26413.195
+  tps: 17643.23885
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BaubleofTrueBlood-50354"
  value: {
-  dps: 28801.53731
-  tps: 19551.01048
+  dps: 27448.36916
+  tps: 18241.88425
   hps: 86.32308
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 28801.53731
-  tps: 19551.00583
+  dps: 27448.36916
+  tps: 18241.87987
   hps: 86.32308
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BeamingEarthsiegeDiamond"
  value: {
-  dps: 29958.15691
-  tps: 20317.91768
+  dps: 28549.15123
+  tps: 19002.54724
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 28801.53731
-  tps: 19551.04672
+  dps: 27448.36916
+  tps: 18241.91879
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 29081.39809
-  tps: 19748.81693
+  dps: 27749.41184
+  tps: 18469.72868
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 29141.64528
-  tps: 19794.21736
+  dps: 27809.33443
+  tps: 18517.28768
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BindingPromise-67037"
  value: {
-  dps: 28801.53731
-  tps: 19551.04672
+  dps: 27448.36916
+  tps: 18241.91879
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlackBruise-50035"
  value: {
-  dps: 28410.2914
-  tps: 19135.36679
+  dps: 27019.06681
+  tps: 17869.11901
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlackBruise-50692"
  value: {
-  dps: 28561.28862
-  tps: 19291.61571
+  dps: 27155.07198
+  tps: 18010.27426
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlessedGarboftheUndeadSlayer"
  value: {
-  dps: 21802.21728
-  tps: 14936.25772
+  dps: 20782.36741
+  tps: 13957.49898
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlessedRegaliaofUndeadCleansing"
  value: {
-  dps: 20811.39259
-  tps: 14183.15594
+  dps: 19819.52111
+  tps: 13273.65211
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 30077.96212
-  tps: 20346.47726
+  dps: 28657.63064
+  tps: 18984.36155
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 29254.67912
-  tps: 19801.43878
+  dps: 27871.09461
+  tps: 18463.57759
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 29314.10119
-  tps: 19834.31028
+  dps: 27926.53333
+  tps: 18492.68616
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 30426.3342
-  tps: 20604.09023
+  dps: 28995.2691
+  tps: 19287.37006
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 28801.53731
-  tps: 19551.04672
+  dps: 27448.36916
+  tps: 18241.91879
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 29335.08657
-  tps: 19890.17773
+  dps: 27957.64207
+  tps: 18553.40384
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 29071.70481
-  tps: 19741.31682
+  dps: 27736.86562
+  tps: 18461.96397
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 28801.53731
-  tps: 19550.97399
+  dps: 27448.36916
+  tps: 18241.8499
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 28801.53731
-  tps: 19551.04672
+  dps: 27448.36916
+  tps: 18241.91879
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 30115.2771
-  tps: 20393.26542
+  dps: 28685.11531
+  tps: 19047.9879
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 28801.53731
-  tps: 19551.04672
+  dps: 27448.36916
+  tps: 18241.91879
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 29312.24603
-  tps: 19870.57242
+  dps: 27934.65379
+  tps: 18535.91923
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BottledLightning-66879"
  value: {
-  dps: 28937.5793
-  tps: 19600.78764
+  dps: 27615.1523
+  tps: 18364.21489
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BracingEarthsiegeDiamond"
  value: {
-  dps: 29948.3504
-  tps: 19922.31644
+  dps: 28534.90844
+  tps: 18616.95606
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 29950.45034
-  tps: 19923.10608
+  dps: 28538.96941
+  tps: 18618.66421
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bryntroll,theBoneArbiter-50415"
  value: {
-  dps: 30578.5899
-  tps: 20764.84874
+  dps: 29153.4987
+  tps: 19414.07258
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 30578.5899
-  tps: 20764.84874
+  dps: 29153.4987
+  tps: 19414.07258
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 30377.10404
-  tps: 20628.40682
+  dps: 28942.10243
+  tps: 19275.20318
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 30428.83541
-  tps: 20657.60423
+  dps: 29011.22981
+  tps: 19324.06141
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ChaoticSkyflareDiamond"
  value: {
-  dps: 30386.43242
-  tps: 20621.45478
+  dps: 28953.07052
+  tps: 19283.98899
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 28820.55087
-  tps: 19538.07851
+  dps: 27484.7556
+  tps: 18256.05794
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 28801.53731
-  tps: 19551.04672
+  dps: 27448.36916
+  tps: 18241.91879
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CorpseTongueCoin-50352"
  value: {
-  dps: 28801.53731
-  tps: 19551.04672
+  dps: 27448.36916
+  tps: 18241.91879
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CorrodedSkeletonKey-50356"
  value: {
-  dps: 28801.53731
-  tps: 19551.04672
+  dps: 27448.36916
+  tps: 18241.91879
   hps: 64
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CrushingWeight-59506"
  value: {
-  dps: 29607.61893
-  tps: 20039.83403
+  dps: 28338.94675
+  tps: 18821.15815
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CrushingWeight-65118"
  value: {
-  dps: 29778.64831
-  tps: 20186.29355
+  dps: 28300.22352
+  tps: 18764.17804
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Berserker!-42989"
  value: {
-  dps: 28862.34147
-  tps: 19575.81931
+  dps: 27524.94268
+  tps: 18315.77
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Death-42990"
  value: {
-  dps: 28919.48194
-  tps: 19616.50768
+  dps: 27715.94083
+  tps: 18411.76013
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 28801.53731
-  tps: 19551.04672
+  dps: 27448.36916
+  tps: 18241.91879
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Greatness-44255"
  value: {
-  dps: 29155.82029
-  tps: 19780.01303
+  dps: 27836.68221
+  tps: 18515.04868
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 29886.45473
-  tps: 20422.53391
+  dps: 28424.5553
+  tps: 19143.95011
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 30554.46879
-  tps: 20904.21904
+  dps: 29125.20162
+  tps: 19632.75564
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 28820.55087
-  tps: 19538.07851
+  dps: 27484.7556
+  tps: 18256.05794
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 29553.84502
-  tps: 20056.78071
+  dps: 28248.02376
+  tps: 18774.17091
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DeadlyGladiator'sTotemofSurvival-42602"
  value: {
-  dps: 29863.41503
-  tps: 20267.00842
+  dps: 28412.38209
+  tps: 18931.11681
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Death'sChoice-47464"
  value: {
-  dps: 29889.8246
-  tps: 20263.90269
+  dps: 28499.73351
+  tps: 18924.69891
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DeathKnight'sAnguish-38212"
  value: {
-  dps: 28871.00244
-  tps: 19598.9667
+  dps: 27517.98197
+  tps: 18294.80492
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Deathbringer'sWill-50362"
  value: {
-  dps: 29390.73052
-  tps: 19899.94637
+  dps: 28035.75282
+  tps: 18650.32235
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 29546.67697
-  tps: 19983.90762
+  dps: 28269.56259
+  tps: 18824.29337
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Defender'sCode-40257"
  value: {
-  dps: 28801.53731
-  tps: 19551.04672
+  dps: 27448.36916
+  tps: 18241.91879
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 29998.13346
-  tps: 20351.90565
+  dps: 28603.02449
+  tps: 19038.83398
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DestructiveSkyflareDiamond"
  value: {
-  dps: 29963.89602
-  tps: 20320.73385
+  dps: 28551.54297
+  tps: 19004.33989
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 28959.721
-  tps: 19563.6908
+  dps: 27600.90275
+  tps: 18329.70728
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DislodgedForeignObject-50353"
  value: {
-  dps: 28917.95473
-  tps: 19543.53815
+  dps: 27558.40325
+  tps: 18318.15402
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 29946.48184
-  tps: 20323.3163
+  dps: 28532.51989
+  tps: 18991.71982
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 28817.65938
-  tps: 19588.33393
+  dps: 27458.02146
+  tps: 18276.51291
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 29950.45034
-  tps: 20325.27809
+  dps: 28538.96941
+  tps: 18994.36924
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EmberSkyflareDiamond"
  value: {
-  dps: 29948.65486
-  tps: 20324.61691
+  dps: 28535.13512
+  tps: 18993.00881
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 29998.13346
-  tps: 20351.90565
+  dps: 28603.02449
+  tps: 19038.83398
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnigmaticSkyflareDiamond"
  value: {
-  dps: 29958.15691
-  tps: 20318.07948
+  dps: 28549.15123
+  tps: 19002.72213
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnigmaticStarflareDiamond"
  value: {
-  dps: 29959.00806
-  tps: 20331.93792
+  dps: 28545.21732
+  tps: 19000.08287
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EphemeralSnowflake-50260"
  value: {
-  dps: 28889.64385
-  tps: 19521.64306
+  dps: 27493.75575
+  tps: 18281.80861
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EssenceofGossamer-37220"
  value: {
-  dps: 28801.53731
-  tps: 19551.04672
+  dps: 27448.36916
+  tps: 18241.91879
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 30341.52009
-  tps: 20603.30142
+  dps: 29069.29961
+  tps: 19323.86989
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EternalEarthsiegeDiamond"
  value: {
-  dps: 29946.48184
-  tps: 20323.3163
+  dps: 28532.51989
+  tps: 18991.71982
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 29946.48184
-  tps: 20323.3163
+  dps: 28532.51989
+  tps: 18991.71982
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ExtractofNecromanticPower-40373"
  value: {
-  dps: 28915.39942
-  tps: 19631.71746
+  dps: 27582.3965
+  tps: 18381.36889
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EyeoftheBroodmother-45308"
  value: {
-  dps: 28833.92522
-  tps: 19556.9664
+  dps: 27523.23738
+  tps: 18312.3049
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FallofMortality-59500"
  value: {
-  dps: 28820.55087
-  tps: 19538.07851
+  dps: 27484.7556
+  tps: 18256.05794
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FallofMortality-65124"
  value: {
-  dps: 28824.98773
-  tps: 19539.90974
+  dps: 27486.90043
+  tps: 18256.61658
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 30403.4764
-  tps: 20598.86988
+  dps: 29093.07528
+  tps: 19396.5344
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 28817.61207
-  tps: 19536.93578
+  dps: 27481.85643
+  tps: 18255.64541
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 28801.53731
-  tps: 19551.04672
+  dps: 27448.36916
+  tps: 18241.91879
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 28817.61207
-  tps: 19536.93578
+  dps: 27481.85643
+  tps: 18255.64541
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 29823.42672
-  tps: 20157.26998
+  dps: 28412.53943
+  tps: 18789.10731
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-SapphireOwl-42413"
  value: {
-  dps: 28805.64443
-  tps: 19553.40421
+  dps: 27453.68692
+  tps: 18243.92249
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 30047.3045
-  tps: 20378.9691
+  dps: 28626.5552
+  tps: 19041.11546
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForethoughtTalisman-40258"
  value: {
-  dps: 28801.08256
-  tps: 19530.1026
+  dps: 27465.3832
+  tps: 18248.9303
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForgeEmber-37660"
  value: {
-  dps: 28823.52435
-  tps: 19548.40603
+  dps: 27506.71611
+  tps: 18291.86284
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 29950.45034
-  tps: 20325.44282
+  dps: 28538.96941
+  tps: 18994.54689
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForlornSkyflareDiamond"
  value: {
-  dps: 29948.3504
-  tps: 20324.6339
+  dps: 28534.90844
+  tps: 18992.80046
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForlornStarflareDiamond"
  value: {
-  dps: 29948.10928
-  tps: 20324.41147
+  dps: 28534.26423
+  tps: 18992.43713
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuriousGladiator'sTotemofSurvival-42603"
  value: {
-  dps: 29863.87372
-  tps: 20267.23848
+  dps: 28414.74603
+  tps: 18932.40062
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 29727.83667
-  tps: 20157.69772
+  dps: 28366.74013
+  tps: 18850.70885
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuryoftheFiveFlights-40431"
  value: {
-  dps: 29284.40042
-  tps: 19858.4171
+  dps: 27907.35401
+  tps: 18526.00755
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuturesightRune-38763"
  value: {
-  dps: 28806.57561
-  tps: 19553.37767
+  dps: 27456.0377
+  tps: 18244.94778
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GaleofShadows-56138"
  value: {
-  dps: 28921.33085
-  tps: 19506.91165
+  dps: 27684.99233
+  tps: 18412.01269
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GaleofShadows-56462"
  value: {
-  dps: 28918.8246
-  tps: 19536.3607
+  dps: 27708.5457
+  tps: 18412.2943
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GearDetector-61462"
  value: {
-  dps: 29538.38893
-  tps: 20029.71801
+  dps: 28139.00358
+  tps: 18679.89222
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GlowingTwilightScale-54573"
  value: {
-  dps: 28805.7223
-  tps: 19532.41354
+  dps: 27473.1099
+  tps: 18251.50666
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 28807.8773
-  tps: 19533.7824
+  dps: 27474.81266
+  tps: 18252.83902
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GnomishLightningGenerator-41121"
  value: {
-  dps: 28893.00273
-  tps: 19583.61528
+  dps: 27710.48944
+  tps: 18425.78043
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 29605.42061
-  tps: 20089.60336
+  dps: 28272.30064
+  tps: 18813.86842
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 30020.9946
-  tps: 20348.37707
+  dps: 28747.99422
+  tps: 19135.23928
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HarmlightToken-63839"
  value: {
-  dps: 28999.27906
-  tps: 19723.11576
+  dps: 27670.02421
+  tps: 18446.41448
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 29522.49636
-  tps: 19979.29395
+  dps: 28132.04919
+  tps: 18634.6552
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HatefulGladiator'sTotemofSurvival-42601"
  value: {
-  dps: 29859.38021
-  tps: 20264.42885
+  dps: 28406.67955
+  tps: 18928.72443
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 29001.31275
-  tps: 19611.50038
+  dps: 27726.15073
+  tps: 18418.60834
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 29107.95198
-  tps: 19635.08
+  dps: 27818.08715
+  tps: 18506.54792
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartofRage-59224"
  value: {
-  dps: 29632.68037
-  tps: 20105.96276
+  dps: 28393.40598
+  tps: 18919.84187
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartofRage-65072"
  value: {
-  dps: 29722.0229
-  tps: 20161.72135
+  dps: 28475.41924
+  tps: 18967.96262
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartofSolace-55868"
  value: {
-  dps: 28921.33085
-  tps: 19506.91165
+  dps: 27684.99233
+  tps: 18412.01269
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartofSolace-56393"
  value: {
-  dps: 29480.84421
-  tps: 19887.48929
+  dps: 28241.01477
+  tps: 18734.85653
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartofThunder-55845"
  value: {
-  dps: 28801.53731
-  tps: 19551.04672
+  dps: 27448.36916
+  tps: 18241.91879
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartofThunder-56370"
  value: {
-  dps: 28801.53731
-  tps: 19551.04672
+  dps: 27448.36916
+  tps: 18241.91879
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 29736.22711
-  tps: 20201.22406
+  dps: 28393.47353
+  tps: 18876.5221
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Heartpierce-49982"
  value: {
-  dps: 30578.5899
-  tps: 20764.84874
+  dps: 29153.4987
+  tps: 19414.07258
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Heartpierce-50641"
  value: {
-  dps: 30578.5899
-  tps: 20764.84874
+  dps: 29153.4987
+  tps: 19414.07258
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IllustrationoftheDragonSoul-40432"
  value: {
-  dps: 28801.53731
-  tps: 19551.04672
+  dps: 27448.36916
+  tps: 18241.91879
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 29998.13346
-  tps: 20351.90565
+  dps: 28603.02449
+  tps: 19038.83398
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpassiveSkyflareDiamond"
  value: {
-  dps: 29958.15691
-  tps: 20318.07948
+  dps: 28549.15123
+  tps: 19002.72213
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpassiveStarflareDiamond"
  value: {
-  dps: 29959.00806
-  tps: 20331.93792
+  dps: 28545.21732
+  tps: 19000.08287
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 29953.90849
-  tps: 20234.66342
+  dps: 28535.65031
+  tps: 18858.95513
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 29953.90849
-  tps: 20234.66342
+  dps: 28535.65031
+  tps: 18858.95513
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 29254.67912
-  tps: 19801.43878
+  dps: 27871.09461
+  tps: 18463.57759
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 29314.10119
-  tps: 19834.31028
+  dps: 27926.53333
+  tps: 18492.68616
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-IncisorFragment-37723"
  value: {
-  dps: 29180.42713
-  tps: 19841.7236
+  dps: 27813.40605
+  tps: 18518.19254
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InsightfulEarthsiegeDiamond"
  value: {
-  dps: 29948.3504
-  tps: 20325.9963
+  dps: 28534.90844
+  tps: 18994.56216
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 28801.53731
-  tps: 19551.04672
+  dps: 27448.36916
+  tps: 18241.91879
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 29150.28639
-  tps: 19743.71067
+  dps: 27773.70277
+  tps: 18412.463
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InvigoratingEarthsiegeDiamond"
  value: {
-  dps: 29876.36732
-  tps: 20293.56127
-  hps: 65.52519
+  dps: 28701.83629
+  tps: 19105.51075
+  hps: 64.85883
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 28801.53731
-  tps: 19555.80521
+  dps: 27448.36916
+  tps: 18246.65458
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 28801.53731
-  tps: 19555.882
+  dps: 27448.36916
+  tps: 18246.73137
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 30077.96212
-  tps: 20346.47726
+  dps: 28657.63064
+  tps: 18984.36155
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 30005.64086
-  tps: 20297.52871
+  dps: 28465.66325
+  tps: 18953.58711
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 30253.94701
-  tps: 20445.64567
+  dps: 28903.83884
+  tps: 19279.19901
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 29179.16931
-  tps: 19707.50556
+  dps: 27848.48021
+  tps: 18496.2307
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 29179.16931
-  tps: 19707.50556
+  dps: 27848.48021
+  tps: 18496.2307
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 28822.38702
-  tps: 19528.97672
+  dps: 27543.51776
+  tps: 18347.60186
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LastWord-50179"
  value: {
-  dps: 30578.5899
-  tps: 20764.84874
+  dps: 29153.4987
+  tps: 19414.07258
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LastWord-50708"
  value: {
-  dps: 30578.5899
-  tps: 20764.84874
+  dps: 29153.4987
+  tps: 19414.07258
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Lavanthor'sTalisman-37872"
  value: {
-  dps: 28801.53731
-  tps: 19551.04672
+  dps: 27448.36916
+  tps: 18241.91879
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LeadenDespair-55816"
  value: {
-  dps: 28801.53731
-  tps: 19551.04672
+  dps: 27448.36916
+  tps: 18241.91879
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LeadenDespair-56347"
  value: {
-  dps: 28801.53731
-  tps: 19551.04672
+  dps: 27448.36916
+  tps: 18241.91879
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 30155.43091
-  tps: 20487.17882
+  dps: 28874.50112
+  tps: 19278.28145
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 30309.11025
-  tps: 20590.95674
+  dps: 29005.03611
+  tps: 19385.4457
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 29584.54135
-  tps: 19988.47109
+  dps: 28223.34158
+  tps: 18790.73258
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 29375.07349
-  tps: 19950.81025
+  dps: 28134.83123
+  tps: 18763.85538
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 29495.01779
-  tps: 20027.66268
+  dps: 28248.63866
+  tps: 18834.85287
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MajesticDragonFigurine-40430"
  value: {
-  dps: 28801.53731
-  tps: 19551.01906
+  dps: 27448.36916
+  tps: 18241.89231
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 28801.53731
-  tps: 19550.96909
+  dps: 27448.36916
+  tps: 18241.84529
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 28801.53731
-  tps: 19550.96909
+  dps: 27448.36916
+  tps: 18241.84529
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 29713.23417
-  tps: 20094.48181
+  dps: 28290.15269
+  tps: 18724.47358
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 29834.11795
-  tps: 20166.63895
+  dps: 28401.81753
+  tps: 18788.61117
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MeteoriteWhetstone-37390"
  value: {
-  dps: 28823.85624
-  tps: 19487.7188
+  dps: 27673.67628
+  tps: 18360.33475
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 29191.67531
-  tps: 19768.55027
+  dps: 27786.46414
+  tps: 18486.83406
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 29394.98568
-  tps: 19866.55359
+  dps: 28086.22607
+  tps: 18720.84205
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 29378.94693
-  tps: 19870.19178
+  dps: 27987.03355
+  tps: 18524.46256
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 29378.94693
-  tps: 19870.19178
+  dps: 27987.03355
+  tps: 18524.46256
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 29485.70928
-  tps: 19917.11643
+  dps: 28109.71104
+  tps: 18592.3339
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-NevermeltingIceCrystal-50259"
  value: {
-  dps: 28845.18224
-  tps: 19546.40443
+  dps: 27523.23288
+  tps: 18281.24539
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-OfferingofSacrifice-37638"
  value: {
-  dps: 28801.53731
-  tps: 19551.04672
+  dps: 27448.36916
+  tps: 18241.91879
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 29416.78563
-  tps: 19952.19904
+  dps: 28015.44891
+  tps: 18646.51761
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PersistentEarthshatterDiamond"
  value: {
-  dps: 29959.00806
-  tps: 20331.93792
+  dps: 28545.21732
+  tps: 19000.08287
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PersistentEarthsiegeDiamond"
  value: {
-  dps: 29958.15691
-  tps: 20318.07948
+  dps: 28549.15123
+  tps: 19002.72213
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PetrifiedScarab-21685"
  value: {
-  dps: 28801.53731
-  tps: 19551.04672
+  dps: 27448.36916
+  tps: 18241.91879
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PetrifiedTwilightScale-54571"
  value: {
-  dps: 28801.53731
-  tps: 19551.04672
+  dps: 27448.36916
+  tps: 18241.91879
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 28801.53731
-  tps: 19551.04672
+  dps: 27448.36916
+  tps: 18241.91879
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 29141.4896
-  tps: 19740.68382
+  dps: 27772.266
+  tps: 18414.35829
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 29432.87842
-  tps: 19899.04802
+  dps: 28045.97844
+  tps: 18554.14018
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulEarthshatterDiamond"
  value: {
-  dps: 29946.48184
-  tps: 20323.3163
+  dps: 28532.51989
+  tps: 18991.71982
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulEarthsiegeDiamond"
  value: {
-  dps: 29946.48184
-  tps: 20323.3163
+  dps: 28532.51989
+  tps: 18991.71982
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 29946.48184
-  tps: 20323.3163
+  dps: 28532.51989
+  tps: 18991.71982
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 30473.57277
-  tps: 20672.04857
+  dps: 28940.98407
+  tps: 19215.70612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 30525.86503
-  tps: 20639.1774
+  dps: 29047.37179
+  tps: 19335.2614
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PurifiedShardoftheGods"
  value: {
-  dps: 28801.53731
-  tps: 19551.04672
+  dps: 27448.36916
+  tps: 18241.91879
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Rainsong-55854"
  value: {
-  dps: 28801.53731
-  tps: 19550.99505
+  dps: 27448.36916
+  tps: 18241.86972
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Rainsong-56377"
  value: {
-  dps: 28801.53731
-  tps: 19550.97791
+  dps: 27448.36916
+  tps: 18241.85359
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RegaliaoftheRagingElements"
  value: {
-  dps: 20764.61578
-  tps: 14069.15539
+  dps: 19841.66506
+  tps: 13231.9362
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ReignoftheDead-47316"
  value: {
-  dps: 29119.25975
-  tps: 19800.15012
+  dps: 27789.31073
+  tps: 18523.38299
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ReignoftheDead-47477"
  value: {
-  dps: 29131.06443
-  tps: 19813.0368
+  dps: 27820.74004
+  tps: 18553.36874
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RelentlessEarthsiegeDiamond"
  value: {
-  dps: 30450.27133
-  tps: 20676.20561
+  dps: 29010.47301
+  tps: 19320.49189
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RelentlessGladiator'sTotemofSurvival-42604"
  value: {
-  dps: 29868.10731
-  tps: 20269.72825
+  dps: 28417.50741
+  tps: 18934.64738
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 30461.26432
-  tps: 20682.52652
+  dps: 29019.14417
+  tps: 19324.38352
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 30372.77838
-  tps: 20626.05306
+  dps: 28935.08105
+  tps: 19272.09362
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RevitalizingSkyflareDiamond"
  value: {
-  dps: 29946.48184
-  tps: 20323.31123
+  dps: 28532.51989
+  tps: 18991.71506
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 29424.30192
-  tps: 19879.43286
+  dps: 27945.47475
+  tps: 18639.34704
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 29454.16937
-  tps: 19905.10747
+  dps: 28141.80086
+  tps: 18761.77976
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RuneofRepulsion-40372"
  value: {
-  dps: 28801.53731
-  tps: 19551.04672
+  dps: 27448.36916
+  tps: 18241.91879
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SavageGladiator'sTotemofSurvival-42594"
  value: {
-  dps: 29856.5573
-  tps: 20263.03009
+  dps: 28404.54525
+  tps: 18927.48533
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 29987.7173
-  tps: 20308.9586
+  dps: 28608.05691
+  tps: 18965.52547
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SeaStar-55256"
  value: {
-  dps: 28801.53731
-  tps: 19550.99873
+  dps: 27448.36916
+  tps: 18241.87318
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SeaStar-56290"
  value: {
-  dps: 28801.53731
-  tps: 19550.97791
+  dps: 27448.36916
+  tps: 18241.85359
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SealofthePantheon-36993"
  value: {
-  dps: 28801.53731
-  tps: 19551.04672
+  dps: 27448.36916
+  tps: 18241.91879
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Shadowmourne-49623"
  value: {
-  dps: 30578.5899
-  tps: 20764.84874
+  dps: 29153.4987
+  tps: 19414.07258
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ShieldedSkyflareDiamond"
  value: {
-  dps: 29946.48184
-  tps: 20323.3163
+  dps: 28532.51989
+  tps: 18991.71982
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ShinyShardoftheGods"
  value: {
-  dps: 28801.53731
-  tps: 19551.00069
+  dps: 27448.36916
+  tps: 18241.87503
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 29350.94286
-  tps: 19811.60439
+  dps: 28101.46745
+  tps: 18701.95949
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Sindragosa'sFlawlessFang-50361"
  value: {
-  dps: 28801.53731
-  tps: 19551.04672
+  dps: 27448.36916
+  tps: 18241.91879
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 30250.13952
-  tps: 20477.97312
+  dps: 28815.51559
+  tps: 19101.54024
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 30464.40779
-  tps: 20592.93355
+  dps: 29062.2005
+  tps: 19246.51754
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkycallTotem-33506"
  value: {
-  dps: 29905.54337
-  tps: 20370.67994
+  dps: 28441.28093
+  tps: 18923.72855
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkyshatterHarness"
  value: {
-  dps: 16340.97416
-  tps: 11384.43067
+  dps: 15678.66836
+  tps: 10739.46549
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SkyshatterRegalia"
  value: {
-  dps: 15263.93349
-  tps: 10655.03689
+  dps: 14584.83965
+  tps: 10030.25431
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SliverofPureIce-50339"
  value: {
-  dps: 28802.56378
-  tps: 19532.89028
+  dps: 27468.64901
+  tps: 18251.22822
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SliverofPureIce-50346"
  value: {
-  dps: 28804.88752
-  tps: 19534.60115
+  dps: 27472.8578
+  tps: 18253.79294
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Sorrowsong-55879"
  value: {
-  dps: 29254.67912
-  tps: 19801.43878
+  dps: 27871.09461
+  tps: 18463.57759
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Sorrowsong-56400"
  value: {
-  dps: 29314.10119
-  tps: 19834.31028
+  dps: 27926.53333
+  tps: 18492.68616
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 29197.7186
-  tps: 19734.25345
+  dps: 27729.53872
+  tps: 18503.72793
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SoulCasket-58183"
  value: {
-  dps: 29378.94693
-  tps: 19870.19178
+  dps: 27987.03355
+  tps: 18524.46256
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SoulPreserver-37111"
  value: {
-  dps: 28807.27755
-  tps: 19553.81558
+  dps: 27456.25117
+  tps: 18244.89441
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SouloftheDead-40382"
  value: {
-  dps: 28836.60901
-  tps: 19559.03158
+  dps: 27523.69232
+  tps: 18313.70776
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SparkofLife-37657"
  value: {
-  dps: 28843.56549
-  tps: 19544.62847
+  dps: 27603.95356
+  tps: 18399.29439
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SphereofRedDragon'sBlood-37166"
  value: {
-  dps: 29047.8831
-  tps: 19678.39245
+  dps: 27755.5693
+  tps: 18443.92482
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Spiritwalker'sRegalia"
  value: {
-  dps: 21040.37236
-  tps: 14066.89985
+  dps: 20101.06223
+  tps: 13234.59539
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Stonebreaker'sTotem-33507"
  value: {
-  dps: 29998.6481
-  tps: 20349.82754
+  dps: 28592.08115
+  tps: 19059.36236
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 28997.57722
-  tps: 19676.26501
+  dps: 27716.01649
+  tps: 18458.7392
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-StumpofTime-62465"
  value: {
-  dps: 28973.16903
-  tps: 19600.48391
+  dps: 27642.53276
+  tps: 18429.84181
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-StumpofTime-62470"
  value: {
-  dps: 28973.16903
-  tps: 19600.48391
+  dps: 27642.53276
+  tps: 18429.84181
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftSkyflareDiamond"
  value: {
-  dps: 29958.15691
-  tps: 20318.07948
+  dps: 28549.15123
+  tps: 19002.72213
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftStarflareDiamond"
  value: {
-  dps: 29959.00806
-  tps: 20331.93792
+  dps: 28545.21732
+  tps: 19000.08287
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SwiftWindfireDiamond"
  value: {
-  dps: 29954.30131
-  tps: 20329.24924
+  dps: 28542.83822
+  tps: 18998.33613
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 28801.53731
-  tps: 19551.04672
+  dps: 27448.36916
+  tps: 18241.91879
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 28801.53731
-  tps: 19551.04672
+  dps: 27448.36916
+  tps: 18241.91879
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 29153.29259
-  tps: 19722.89938
+  dps: 27796.92252
+  tps: 18420.49643
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TalismanofTrollDivinity-37734"
  value: {
-  dps: 28801.53731
-  tps: 19551.02983
+  dps: 27448.36916
+  tps: 18241.90246
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 29416.47907
-  tps: 19900.47017
+  dps: 28087.07356
+  tps: 18610.73195
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TearofBlood-55819"
  value: {
-  dps: 28811.50243
-  tps: 19533.93951
+  dps: 27478.95256
+  tps: 18253.52471
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TearofBlood-56351"
  value: {
-  dps: 28817.61207
-  tps: 19536.93578
+  dps: 27481.85643
+  tps: 18255.64541
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TearsoftheVanquished-47215"
  value: {
-  dps: 28801.08256
-  tps: 19530.1514
+  dps: 27464.5485
+  tps: 18248.8329
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 29188.07698
-  tps: 19764.60545
+  dps: 27808.95857
+  tps: 18430.96324
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 29314.10119
-  tps: 19834.31028
+  dps: 27926.53333
+  tps: 18492.68616
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheGeneral'sHeart-45507"
  value: {
-  dps: 28801.53731
-  tps: 19551.04672
+  dps: 27448.36916
+  tps: 18241.91879
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 29473.97763
-  tps: 19909.05221
+  dps: 28096.03383
+  tps: 18585.99525
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 29586.85114
-  tps: 19966.46847
+  dps: 28187.72006
+  tps: 18631.17871
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 28801.53731
-  tps: 19551.04672
+  dps: 27448.36916
+  tps: 18241.91879
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 28801.53731
-  tps: 19551.04672
+  dps: 27448.36916
+  tps: 18241.91879
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ThunderingSkyflareDiamond"
  value: {
-  dps: 30062.22234
-  tps: 20371.02302
+  dps: 28636.0855
+  tps: 19028.21557
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 30392.3221
-  tps: 20563.33727
+  dps: 28968.2645
+  tps: 19205.07133
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 30606.16686
-  tps: 20696.20057
+  dps: 29185.60038
+  tps: 19341.12667
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TidefuryRaiment"
  value: {
-  dps: 18769.31616
-  tps: 12929.86995
+  dps: 17798.23254
+  tps: 12050.91694
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TinyAbominationinaJar-50351"
  value: {
-  dps: 29513.11443
-  tps: 20137.43607
+  dps: 28263.08348
+  tps: 18892.44784
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 29509.74293
-  tps: 20132.97718
+  dps: 28261.99673
+  tps: 18927.71392
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TirelessSkyflareDiamond"
  value: {
-  dps: 29948.3504
-  tps: 20324.6339
+  dps: 28534.90844
+  tps: 18992.80046
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TirelessStarflareDiamond"
  value: {
-  dps: 29948.10928
-  tps: 20324.41147
+  dps: 28534.26423
+  tps: 18992.43713
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TomeofArcanePhenomena-36972"
  value: {
-  dps: 28828.7285
-  tps: 19498.47974
+  dps: 27524.07367
+  tps: 18288.39109
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TotemofQuakingEarth-47667"
  value: {
-  dps: 30467.32237
-  tps: 20643.33877
+  dps: 29113.18229
+  tps: 19402.99
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TrenchantEarthshatterDiamond"
  value: {
-  dps: 29948.10928
-  tps: 20324.41147
+  dps: 28534.26423
+  tps: 18992.43713
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TrenchantEarthsiegeDiamond"
  value: {
-  dps: 29948.3504
-  tps: 20324.6339
+  dps: 28534.90844
+  tps: 18992.80046
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 28981.08359
-  tps: 19619.68602
+  dps: 27709.4155
+  tps: 18437.72672
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-UndeadSlayer'sBlessedArmor"
  value: {
-  dps: 21064.23733
-  tps: 14376.59624
+  dps: 20101.03835
+  tps: 13536.85579
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-UnheededWarning-59520"
  value: {
-  dps: 30572.84411
-  tps: 20716.8063
+  dps: 29188.80331
+  tps: 19387.172
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 28801.53731
-  tps: 19551.00558
+  dps: 27448.36916
+  tps: 18241.87964
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 30821.45014
-  tps: 20818.24103
+  dps: 29351.85942
+  tps: 19428.04175
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 30821.45014
-  tps: 20818.24103
+  dps: 29351.85942
+  tps: 19428.04175
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 26235.13737
-  tps: 17635.43009
+  dps: 24899.54699
+  tps: 16362.35521
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 28801.53731
-  tps: 19551.04672
+  dps: 27448.36916
+  tps: 18241.91879
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 28801.53731
-  tps: 19551.04672
+  dps: 27448.36916
+  tps: 18241.91879
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 30217.38887
-  tps: 20484.33017
+  dps: 28787.66498
+  tps: 19131.66656
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 28801.53731
-  tps: 19551.04672
+  dps: 27448.36916
+  tps: 18241.91879
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 29364.9232
-  tps: 19909.1423
+  dps: 27986.12114
+  tps: 18570.82241
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 28934.24915
-  tps: 19592.70728
+  dps: 27615.43059
+  tps: 18406.79416
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 29092.97396
-  tps: 19699.64174
+  dps: 27792.84282
+  tps: 18425.15867
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 29080.23289
-  tps: 19750.76624
+  dps: 27768.81514
+  tps: 18491.69455
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 29006.67313
-  tps: 19714.76351
+  dps: 27785.27983
+  tps: 18545.79165
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 29413.1802
-  tps: 19889.13836
+  dps: 28018.97331
+  tps: 18541.24254
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 28801.53731
-  tps: 19551.04672
+  dps: 27448.36916
+  tps: 18241.91879
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 30239.11108
-  tps: 20486.4448
+  dps: 28790.11762
+  tps: 19128.78427
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 28801.53731
-  tps: 19551.04672
+  dps: 27448.36916
+  tps: 18241.91879
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 29363.57257
-  tps: 19908.49575
+  dps: 27987.16083
+  tps: 18574.05589
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-VolcanicRegalia"
  value: {
-  dps: 20918.25366
-  tps: 14229.53768
+  dps: 19994.39486
+  tps: 13366.74924
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WingedTalisman-37844"
  value: {
-  dps: 28801.53731
-  tps: 19551.03008
+  dps: 27448.36916
+  tps: 18241.90269
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 28891.89081
-  tps: 19561.73205
+  dps: 27638.75663
+  tps: 18366.53612
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 29091.84069
-  tps: 19715.15989
+  dps: 27803.15296
+  tps: 18462.44933
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 29195.27606
-  tps: 19768.58628
+  dps: 27815.67483
+  tps: 18434.48797
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WrathfulGladiator'sTotemofSurvival-51513"
  value: {
-  dps: 29875.51607
-  tps: 20274.64952
+  dps: 28409.99719
+  tps: 18929.345
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 29233.98843
-  tps: 19794.84754
+  dps: 27838.06826
+  tps: 18450.28513
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 29233.98843
-  tps: 19794.84754
+  dps: 27838.06826
+  tps: 18450.28513
  }
 }
 dps_results: {
  key: "TestEnhancement-Average-Default"
  value: {
-  dps: 30694.47518
-  tps: 20816.40988
+  dps: 29346.8626
+  tps: 19547.40024
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 31139.82792
-  tps: 25204.73346
+  dps: 29754.63646
+  tps: 23861.20738
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 30578.5899
-  tps: 20764.84874
+  dps: 29153.4987
+  tps: 19414.07258
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 34589.49576
-  tps: 23049.62408
+  dps: 33077.03442
+  tps: 21584.82519
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 23979.22664
-  tps: 20646.07194
+  dps: 22977.29511
+  tps: 19662.05225
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 23475.84573
-  tps: 16129.98701
+  dps: 22469.81897
+  tps: 15212.03865
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 25811.64685
-  tps: 17435.10942
+  dps: 24372.54634
+  tps: 16307.77515
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 31655.99582
-  tps: 25615.46353
+  dps: 30467.02643
+  tps: 24319.57925
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 31131.1334
-  tps: 21084.57221
+  dps: 29689.89824
+  tps: 19787.33792
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 35591.03696
-  tps: 23732.79037
+  dps: 33970.00279
+  tps: 22207.40937
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 24476.99408
-  tps: 21013.0761
+  dps: 23234.4788
+  tps: 19853.40547
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 23961.47008
-  tps: 16481.60809
+  dps: 22817.71479
+  tps: 15411.14633
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 26344.33298
-  tps: 17779.68351
+  dps: 24993.59441
+  tps: 16687.78931
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 31296.83377
-  tps: 25277.1922
+  dps: 30000.48668
+  tps: 24008.6624
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 30659.51519
-  tps: 20766.82856
+  dps: 29259.23788
+  tps: 19501.85522
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 35072.28826
-  tps: 23349.25582
+  dps: 33520.57984
+  tps: 21964.47069
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 24153.29322
-  tps: 20796.42775
+  dps: 23047.072
+  tps: 19674.28953
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 23509.35451
-  tps: 16111.94304
+  dps: 22627.6713
+  tps: 15295.81974
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 25756.87684
-  tps: 17386.59878
+  dps: 24697.97864
+  tps: 16514.42731
  }
 }
 dps_results: {
  key: "TestEnhancement-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 28336.82278
-  tps: 18797.54731
+  dps: 26928.4113
+  tps: 17405.27165
  }
 }

--- a/sim/shaman/stormstrike.go
+++ b/sim/shaman/stormstrike.go
@@ -49,25 +49,39 @@ func (shaman *Shaman) calcDamageStormstrikeCritChance(sim *core.Simulation, targ
 	return result
 }
 
-func (shaman *Shaman) newStormstrikeHitSpell(isMH bool) func(*core.Simulation, *core.Unit, *core.Spell) {
+func (shaman *Shaman) newStormstrikeHitSpell(isMH bool) *core.Spell {
 	var procMask core.ProcMask
+	var actionTag int32
 	if isMH {
 		procMask = core.ProcMaskMeleeMHSpecial
+		actionTag = 1
 	} else {
 		procMask = core.ProcMaskMeleeOHSpecial
+		actionTag = 2
 	}
 
-	return func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-		var baseDamage float64
-		spell.ProcMask = procMask
-		if isMH {
-			baseDamage = spell.Unit.MHWeaponDamage(sim, spell.MeleeAttackPower())
-		} else {
-			baseDamage = spell.Unit.OHWeaponDamage(sim, spell.MeleeAttackPower())
-		}
+	return shaman.RegisterSpell(core.SpellConfig{
+		ActionID:       StormstrikeActionID.WithTag(actionTag),
+		SpellSchool:    core.SpellSchoolPhysical,
+		ProcMask:       procMask,
+		Flags:          core.SpellFlagMeleeMetrics | core.SpellFlagIncludeTargetBonusDamage,
+		ClassSpellMask: SpellMaskStormstrike,
 
-		spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeSpecialCritOnly)
-	}
+		ThreatMultiplier: 1,
+		DamageMultiplier: 2.25,
+		CritMultiplier:   shaman.DefaultMeleeCritMultiplier(),
+
+		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
+			var baseDamage float64
+			if isMH {
+				baseDamage = spell.Unit.MHWeaponDamage(sim, spell.MeleeAttackPower())
+			} else {
+				baseDamage = spell.Unit.OHWeaponDamage(sim, spell.MeleeAttackPower())
+			}
+			spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeSpecialCritOnly)
+			spell.SpellMetrics[target.UnitIndex].Casts--
+		},
+	})
 }
 
 func (shaman *Shaman) registerStormstrikeSpell() {
@@ -79,8 +93,8 @@ func (shaman *Shaman) registerStormstrikeSpell() {
 	shaman.Stormstrike = shaman.RegisterSpell(core.SpellConfig{
 		ActionID:       StormstrikeActionID,
 		SpellSchool:    core.SpellSchoolPhysical,
-		ProcMask:       core.ProcMaskMeleeMHSpecial,
-		Flags:          core.SpellFlagMeleeMetrics | core.SpellFlagAPL | core.SpellFlagIncludeTargetBonusDamage,
+		ProcMask:       core.ProcMaskEmpty,
+		Flags:          core.SpellFlagMeleeMetrics | core.SpellFlagAPL,
 		ClassSpellMask: SpellMaskStormstrike,
 		ManaCost: core.ManaCostOptions{
 			BaseCost: 0.08,
@@ -96,10 +110,6 @@ func (shaman *Shaman) registerStormstrikeSpell() {
 			},
 		},
 
-		ThreatMultiplier: 1,
-		DamageMultiplier: 2.25,
-		CritMultiplier:   shaman.DefaultMeleeCritMultiplier(),
-
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 			result := spell.CalcOutcome(sim, target, spell.OutcomeMeleeSpecialHit)
 			if result.Landed() {
@@ -107,11 +117,11 @@ func (shaman *Shaman) registerStormstrikeSpell() {
 				ssDebuffAura.Activate(sim)
 
 				if shaman.HasMHWeapon() {
-					mhHit(sim, target, spell)
+					mhHit.Cast(sim, target)
 				}
 
 				if shaman.AutoAttacks.IsDualWielding && shaman.HasOHWeapon() {
-					ohHit(sim, target, spell)
+					ohHit.Cast(sim, target)
 				}
 
 				shaman.Stormstrike.SpellMetrics[target.UnitIndex].Hits--

--- a/ui/core/proto_utils/action_id.ts
+++ b/ui/core/proto_utils/action_id.ts
@@ -353,6 +353,15 @@ export class ActionId {
 					name += ' (DoT)';
 				}
 				break;
+			case 'Stormstrike':
+				if (this.tag == 0) {
+					name += ' (Cast)';
+				} else if (this.tag == 1) {
+					name += ' (Main Hand)';
+				} else if (this.tag == 2) {
+					name += ' (Off Hand)';
+				}
+				break;
 			case 'Chain Lightning':
 			case 'Lightning Bolt':
 			case 'Lava Burst':


### PR DESCRIPTION
Makes the main Stormstrike spell trigger spells for MH and OH to deal damage, like it does in the game. The previous implementation caused side effects from changing procmasks.

Resolves https://github.com/wowsims/cata/issues/327