### PR TITLE
Add quit signal to stop threads on error

### DIFF
--- a/sim/core/api.go
+++ b/sim/core/api.go
@@ -46,7 +46,7 @@ func StatWeightsAsync(request *proto.StatWeightsRequest, progress chan *proto.Pr
  * Runs multiple iterations of the sim with a full raid.
  */
 func RunRaidSim(request *proto.RaidSimRequest) *proto.RaidSimResult {
-	return RunSim(request, nil)
+	return RunSim(request, nil, nil)
 }
 
 func RunRaidSimAsync(request *proto.RaidSimRequest, progress chan *proto.ProgressMetrics) {

--- a/sim/core/api_raidsim_wasm.go
+++ b/sim/core/api_raidsim_wasm.go
@@ -9,9 +9,9 @@ import (
 // Note: WASM can't do threads with go, so there's no reason to even compile the whole concurrency code. Instead just run sims directly.
 
 func RunConcurrentRaidSimAsync(request *proto.RaidSimRequest, progress chan *proto.ProgressMetrics) {
-	go RunSim(request, progress)
+	go RunSim(request, progress, nil)
 }
 
 func RunConcurrentRaidSimSync(request *proto.RaidSimRequest) *proto.RaidSimResult {
-	return RunSim(request, nil)
+	return RunSim(request, nil, nil)
 }

--- a/sim/core/bulksim.go
+++ b/sim/core/bulksim.go
@@ -22,7 +22,7 @@ const (
 )
 
 // raidSimRunner runs a standard raid simulation.
-type raidSimRunner func(*proto.RaidSimRequest, chan *proto.ProgressMetrics, bool) *proto.RaidSimResult
+type raidSimRunner func(*proto.RaidSimRequest, chan *proto.ProgressMetrics, bool, chan bool) *proto.RaidSimResult
 
 // bulkSimRunner runs a bulk simulation.
 type bulkSimRunner struct {
@@ -380,7 +380,7 @@ func (b *bulkSimRunner) getRankedResults(pctx context.Context, validCombos []sin
 				sub.req.SimOptions.Iterations = int32(iterations)
 				results <- &itemSubstitutionSimResult{
 					Request:      sub.req,
-					Result:       b.SingleRaidSimRunner(sub.req, singleSimProgress, false),
+					Result:       b.SingleRaidSimRunner(sub.req, singleSimProgress, false, nil),
 					Substitution: sub.eq,
 					ChangeLog:    sub.cl,
 				}

--- a/sim/core/bulksim_test.go
+++ b/sim/core/bulksim_test.go
@@ -91,7 +91,7 @@ func createEquipmentFromItems(items ...*itemWithSlot) *proto.EquipmentSpec {
 func TestBulkSim(t *testing.T) {
 	t.Skip("TODO: Implement")
 
-	fakeRunSim := func(rsr *proto.RaidSimRequest, progress chan *proto.ProgressMetrics, skipPresim bool) *proto.RaidSimResult {
+	fakeRunSim := func(rsr *proto.RaidSimRequest, progress chan *proto.ProgressMetrics, skipPresim bool, quitChan chan bool) *proto.RaidSimResult {
 		return &proto.RaidSimResult{}
 	}
 

--- a/sim/core/presim.go
+++ b/sim/core/presim.go
@@ -94,7 +94,7 @@ func (sim *Simulation) runPresims(request *proto.RaidSimRequest) *proto.RaidSimR
 		}
 
 		// Run the presim.
-		presimResult := runSim(presimRequest, nil, true)
+		presimResult := runSim(presimRequest, nil, true, nil)
 		lastResult = presimResult
 
 		if presimResult.ErrorResult != "" {

--- a/sim/core/statweight.go
+++ b/sim/core/statweight.go
@@ -179,7 +179,7 @@ func CalcStatWeight(swr *proto.StatWeightsRequest, referenceStat stats.Stat, pro
 		stat.AddToStatsProto(simRequest.Raid.Parties[0].Players[0].BonusStats, value)
 
 		reporter := make(chan *proto.ProgressMetrics, 10)
-		go RunSim(simRequest, reporter) // RunRaidSim(simRequest)
+		go RunSim(simRequest, reporter, nil) // RunRaidSim(simRequest)
 
 		var localIterations int32
 		var errorStr string

--- a/sim/lib/library.go
+++ b/sim/lib/library.go
@@ -36,7 +36,7 @@ func runSim(json *C.char) *C.char {
 		log.Fatalf("failed to load input json file: %s", err)
 	}
 	sim.RegisterAll()
-	result := core.RunSim(input, nil)
+	result := core.RunSim(input, nil, nil)
 	out, err := protojson.Marshal(result)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Adds an optional stop signal channel to the sim. 

If quit channel exists it is checked before every iteration. If a message was received a RaidSimResult containing an error message is returned. If a progress channel exists a ProgressMetrics message is also sent.

Concurrent sim code sends quit signal to all threads in case of an error.