### PR TITLE
Flame Cap Nerf

### DIFF
--- a/proto/common.proto
+++ b/proto/common.proto
@@ -312,12 +312,12 @@ enum Potions {
 	MightyRagePotion = 11;
 	RunicManaInjector = 12;
 	RunicHealingInjector = 13;
+	FlameCap = 14;
 }
 
 enum Conjured {
 	ConjuredUnknown = 0;
 	ConjuredDarkRune = 1;
-	ConjuredFlameCap = 2;
 	ConjuredHealthstone = 5;
 	ConjuredRogueThistleTea = 4;
 }

--- a/sim/core/consumes.go
+++ b/sim/core/consumes.go
@@ -695,55 +695,7 @@ func makePotionActivationInternal(potionType proto.Potions, character *Character
 				},
 			}),
 		}
-	} else {
-		return MajorCooldown{}
-	}
-	return MajorCooldown{}
-}
-
-var ConjuredAuraTag = "Conjured"
-
-func registerConjuredCD(agent Agent, consumes *proto.Consumes) {
-	character := agent.GetCharacter()
-	conjuredType := consumes.DefaultConjured
-
-	if conjuredType == proto.Conjured_ConjuredDarkRune {
-		actionID := ActionID{ItemID: 20520}
-		manaMetrics := character.NewManaMetrics(actionID)
-		// damageTakenManaMetrics := character.NewManaMetrics(ActionID{SpellID: 33776})
-		spell := character.RegisterSpell(SpellConfig{
-			ActionID: actionID,
-			Flags:    SpellFlagNoOnCastComplete,
-			Cast: CastConfig{
-				CD: Cooldown{
-					Timer:    character.GetConjuredCD(),
-					Duration: time.Minute * 15,
-				},
-			},
-			ApplyEffects: func(sim *Simulation, _ *Unit, _ *Spell) {
-				// Restores 900 to 1500 mana. (2 Min Cooldown)
-				manaGain := sim.RollWithLabel(900, 1500, "dark rune")
-				character.AddMana(sim, manaGain, manaMetrics)
-
-				// if character.Class == proto.Class_ClassPaladin {
-				// 	// Paladins gain extra mana from self-inflicted damage
-				// 	// TO-DO: It is possible for damage to be resisted or to crit
-				// 	// This would affect mana returns for Paladins
-				// 	manaFromDamage := manaGain * 2.0 / 3.0 * 0.1
-				// 	character.AddMana(sim, manaFromDamage, damageTakenManaMetrics, false)
-				// }
-			},
-		})
-		character.AddMajorCooldown(MajorCooldown{
-			Spell: spell,
-			Type:  CooldownTypeMana,
-			ShouldActivate: func(sim *Simulation, character *Character) bool {
-				// Only pop if we have less than the max mana provided by the potion minus 1mp5 tick.
-				totalRegen := character.ManaRegenPerSecondWhileCombat() * 5
-				return character.MaxMana()-(character.CurrentMana()+totalRegen) >= 1500
-			},
-		})
-	} else if conjuredType == proto.Conjured_ConjuredFlameCap {
+	} else if potionType == proto.Potions_FlameCap {
 		actionID := ActionID{ItemID: 22788}
 
 		flameCapProc := character.RegisterSpell(SpellConfig{
@@ -794,22 +746,64 @@ func registerConjuredCD(agent Agent, consumes *proto.Consumes) {
 			},
 		})
 
+		return MajorCooldown{
+			Type: CooldownTypeDPS,
+			Spell: character.RegisterSpell(SpellConfig{
+				ActionID: actionID,
+				Flags:    SpellFlagNoOnCastComplete,
+				Cast:     potionCast,
+				ApplyEffects: func(sim *Simulation, _ *Unit, _ *Spell) {
+					flameCapAura.Activate(sim)
+				},
+			}),
+		}
+	} else {
+		return MajorCooldown{}
+	}
+	return MajorCooldown{}
+}
+
+var ConjuredAuraTag = "Conjured"
+
+func registerConjuredCD(agent Agent, consumes *proto.Consumes) {
+	character := agent.GetCharacter()
+	conjuredType := consumes.DefaultConjured
+
+	if conjuredType == proto.Conjured_ConjuredDarkRune {
+		actionID := ActionID{ItemID: 20520}
+		manaMetrics := character.NewManaMetrics(actionID)
+		// damageTakenManaMetrics := character.NewManaMetrics(ActionID{SpellID: 33776})
 		spell := character.RegisterSpell(SpellConfig{
 			ActionID: actionID,
 			Flags:    SpellFlagNoOnCastComplete,
 			Cast: CastConfig{
 				CD: Cooldown{
 					Timer:    character.GetConjuredCD(),
-					Duration: time.Minute * 3,
+					Duration: time.Minute * 15,
 				},
 			},
 			ApplyEffects: func(sim *Simulation, _ *Unit, _ *Spell) {
-				flameCapAura.Activate(sim)
+				// Restores 900 to 1500 mana. (2 Min Cooldown)
+				manaGain := sim.RollWithLabel(900, 1500, "dark rune")
+				character.AddMana(sim, manaGain, manaMetrics)
+
+				// if character.Class == proto.Class_ClassPaladin {
+				// 	// Paladins gain extra mana from self-inflicted damage
+				// 	// TO-DO: It is possible for damage to be resisted or to crit
+				// 	// This would affect mana returns for Paladins
+				// 	manaFromDamage := manaGain * 2.0 / 3.0 * 0.1
+				// 	character.AddMana(sim, manaFromDamage, damageTakenManaMetrics, false)
+				// }
 			},
 		})
 		character.AddMajorCooldown(MajorCooldown{
 			Spell: spell,
-			Type:  CooldownTypeDPS,
+			Type:  CooldownTypeMana,
+			ShouldActivate: func(sim *Simulation, character *Character) bool {
+				// Only pop if we have less than the max mana provided by the potion minus 1mp5 tick.
+				totalRegen := character.ManaRegenPerSecondWhileCombat() * 5
+				return character.MaxMana()-(character.CurrentMana()+totalRegen) >= 1500
+			},
 		})
 	} else if conjuredType == proto.Conjured_ConjuredHealthstone {
 		actionID := ActionID{ItemID: 36892}

--- a/ui/core/components/inputs/consumables.ts
+++ b/ui/core/components/inputs/consumables.ts
@@ -649,7 +649,7 @@ export const MightyRagePotion = {
 };
 export const FlameCap = {
 	actionId: ActionId.fromItemId(22788),
-	value: Potions.FlameCape,
+	value: Potions.FlameCap,
 };
 
 export const POTIONS_CONFIG = [

--- a/ui/core/components/inputs/consumables.ts
+++ b/ui/core/components/inputs/consumables.ts
@@ -75,10 +75,6 @@ export const ConjuredDarkRune = {
 	actionId: ActionId.fromItemId(12662),
 	value: Conjured.ConjuredDarkRune,
 };
-export const ConjuredFlameCap = {
-	actionId: ActionId.fromItemId(22788),
-	value: Conjured.ConjuredFlameCap,
-};
 export const ConjuredHealthstone = {
 	actionId: ActionId.fromItemId(22105),
 	value: Conjured.ConjuredHealthstone,
@@ -93,7 +89,6 @@ export const CONJURED_CONFIG = [
 	{ config: ConjuredRogueThistleTea, stats: [] },
 	{ config: ConjuredHealthstone, stats: [Stat.StatStamina] },
 	{ config: ConjuredDarkRune, stats: [Stat.StatIntellect] },
-	{ config: ConjuredFlameCap, stats: [] },
 ] as ConsumableStatOption<Conjured>[];
 
 export const makeConjuredInput = makeConsumeInputFactory({ consumesFieldName: 'defaultConjured' });
@@ -652,6 +647,10 @@ export const MightyRagePotion = {
 	actionId: ActionId.fromItemId(13442),
 	value: Potions.MightyRagePotion,
 };
+export const FlameCap = {
+	actionId: ActionId.fromItemId(22788),
+	value: Potions.FlameCape,
+};
 
 export const POTIONS_CONFIG = [
 	{ config: GolembloodPotion, stats: [Stat.StatStrength] },
@@ -663,6 +662,7 @@ export const POTIONS_CONFIG = [
 	{ config: MythicalHealingPotion, stats: [Stat.StatHealth] },
 	{ config: MythicalManaPotion, stats: [Stat.StatIntellect] },
 	{ config: PotionOfSpeed, stats: [Stat.StatMeleeHaste, Stat.StatSpellHaste] },
+	{ config: FlameCap, stats: [] },
 ] as ConsumableStatOption<Potions>[];
 
 export const PRE_POTIONS_CONFIG = [
@@ -671,6 +671,7 @@ export const PRE_POTIONS_CONFIG = [
 	{ config: VolcanicPotion, stats: [Stat.StatIntellect] },
 	{ config: EarthenPotion, stats: [Stat.StatArmor] },
 	{ config: PotionOfSpeed, stats: [Stat.StatMeleeHaste, Stat.StatSpellHaste] },
+	{ config: FlameCap, stats: [] },
 ] as ConsumableStatOption<Potions>[];
 
 export const makePotionsInput = makeConsumeInputFactory({ consumesFieldName: 'defaultPotion' });

--- a/ui/mage/frost/presets.ts
+++ b/ui/mage/frost/presets.ts
@@ -50,7 +50,7 @@ export const DefaultFrostOptions = MageOptions.create({
 
 export const DefaultFrostConsumes = Consumes.create({
 	defaultPotion: Potions.PotionOfSpeed,
-	defaultConjured: Conjured.ConjuredFlameCap,
+	defaultConjured: Conjured.ConjuredDarkRune,
 	flask: Flask.FlaskOfTheFrostWyrm,
 	food: Food.FoodFishFeast,
 });


### PR DESCRIPTION
Blizzard made a change to Flame Cap in patch 3.4.1 that causes it to share a cooldown with other potions (https://www.wowhead.com/blue-tracker/topic/us/wrath-classic-patch-notes-version-3-4-1-1490168).

This PR will move Flame Cap from a Conjured item category to a Potion so that it properly reflects this nerf.

Closes #355.