### PR TITLE
Add support for Docker watch/devmode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,29 +3,29 @@
 FROM golang:1.21
 
 WORKDIR /cata
-COPY . .
-COPY gitconfig /etc/gitconfig
 
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 
-RUN apt-get update
-RUN apt-get install -y protobuf-compiler
-RUN go get -u google.golang.org/protobuf
-RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+COPY . .
+COPY gitconfig /etc/gitconfig
 
-ENV NODE_VERSION=20.11.1
+# Install all Go dependencies
+RUN apt-get update \
+	&& apt-get install -y protobuf-compiler \
+	&& go get -u google.golang.org/protobuf \
+	&& go install google.golang.org/protobuf/cmd/protoc-gen-go@latest \
+	&& curl -sSfL https://raw.githubusercontent.com/cosmtrek/air/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin
+
+ENV NODE_VERSION=20.13.1
 ENV NVM_DIR="/root/.nvm"
 
-RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash \
+# Install all Frontend dependencies
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash \
     && . $NVM_DIR/nvm.sh \
     && nvm install $NODE_VERSION \
     && nvm alias default $NODE_VERSION \
     && nvm use default
 
-#RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
-#RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
-#RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
-
 ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
 
-EXPOSE 8080/tcp
+EXPOSE 8080 3333 5173

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ go get -u -v google.golang.org/protobuf
 go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 
 # Install node
-curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
-nvm install 19.8.0
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash
+nvm install 20.13.1
 
 # Install the npm package dependencies using node
 npm install
@@ -64,6 +64,9 @@ docker run --rm -v $(pwd):/cata wowsims-cata npm install
 # Now you can run the commands as shown in the Commands sections, preceding everything with, "docker run --rm -it -p 8080:8080 -v $(pwd):/cata wowsims-cata".
 # For convenience, set this as an environment variable:
 CATA_CMD="docker run --rm -it -p 8080:8080 -v $(pwd):/cata wowsims-cata"
+
+#For the watch commands assign this environment variable:
+CATA_WATCH_CMD="docker run --rm -it -p 8080:8080 -p 3333:3333 -p 5173:5173 -e WATCH=1 -v $(pwd):/cata wowsims-cata"
 
 # ... do some coding on the sim ...
 
@@ -84,7 +87,7 @@ If you want to develop on Windows, we recommend setting up a Ubuntu virtual mach
 * You can also use the Ubuntu setup instructions as above to run natively, with a few modifications:
   * You may need a different Go installer if `go1.18.3.linux-amd64.tar.gz` is not compatible with your system's architecture; you can do the Go install manually from `https://go.dev/doc/install`.
   * OS X uses Homebrew instead of apt, so in order to install protobuf-compiler you’ll instead need to run `brew install protobuf-c` (note the package name is also a little different than in apt). You might need to first update or upgrade brew.
-  * The provided install script for Node will not included a precompiled binary for OS X, but it’s smart enough to compile one. Be ready for your CPU to melt on running `curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash`.
+  * The provided install script for Node will not included a precompiled binary for OS X, but it’s smart enough to compile one. Be ready for your CPU to melt on running `curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash`.
 
 # Commands
 We use a makefile for our build system. These commands will usually be all you need while developing for this project:
@@ -122,8 +125,8 @@ make rundevserver
 WATCH=1 make rundevserver
 
 
-# The same as rundevserver, recompiles  `wowsimcata` binary and runs it on port 3333. Instead of serving content from the dist folder, 
-# this command also runs `vite serve` to start the Vite dev server on port 3174 (or similar) and automatically reloads the page on .ts changes in less than a second.
+# The same as rundevserver, recompiles  `wowsimcata` binary and runs it on port 3333. Instead of serving content from the dist folder,
+# this command also runs `vite serve` to start the Vite dev server on port 5173 (or similar) and automatically reloads the page on .ts changes in less than a second.
 # This allows for more rapid development, with sub second reloads on TS changes. This combines the benefits of `WATCH=1 make rundevserver` and `WATCH=1 make host`
 # to create something that allows you to work in any part of the code with ease and speed.
 # This might get rolled into `WATCH=1 make rundevserver` at some point.

--- a/makefile
+++ b/makefile
@@ -270,7 +270,7 @@ endif
 
 devmode: air devserver
 ifeq ($(WATCH), 1)
-	npx vite serve &
+	npx vite serve --host &
 	air -tmp_dir "/tmp" -build.include_ext "go,proto" -build.args_bin "--usefs=true --launch=false --wasm=false" -build.bin "./wowsimcata" -build.cmd "make devserver" -build.exclude_dir "assets,dist,node_modules,ui,tools"
 else
 	./wowsimcata --usefs=true --launch=false --host=":3333"


### PR DESCRIPTION
- Merged some RUN rules for efficiency
- Add Air to Dockerfile dependencies
- Added additional `watch` mode ports
- Added `--host` flag in `devmode` command to allow Docker to expose the host. Shouldn't impact non-Docker users (just local network)
- Updated README with `CATA_WATCH_CMD`
- Updated all outdated Node version references to use the same one everywhere
- Updated outdated NVM version