### PR TITLE
Added fix to show reforge on wowhead tooltips in gearpicker

### DIFF
--- a/ui/core/components/gear_picker/gear_picker.tsx
+++ b/ui/core/components/gear_picker/gear_picker.tsx
@@ -11,7 +11,15 @@ import { ActionId } from '../../proto_utils/action_id';
 import { getEnchantDescription, getUniqueEnchantString } from '../../proto_utils/enchants';
 import { EquippedItem } from '../../proto_utils/equipped_item';
 import { gemMatchesSocket, getEmptyGemSocketIconUrl } from '../../proto_utils/gems';
-import { difficultyNames, professionNames, REP_FACTION_NAMES, REP_FACTION_QUARTERMASTERS, REP_LEVEL_NAMES, shortSecondaryStatNames, slotNames } from '../../proto_utils/names';
+import {
+	difficultyNames,
+	professionNames,
+	REP_FACTION_NAMES,
+	REP_FACTION_QUARTERMASTERS,
+	REP_LEVEL_NAMES,
+	shortSecondaryStatNames,
+	slotNames,
+} from '../../proto_utils/names';
 import { Stats } from '../../proto_utils/stats';
 import { getPVPSeasonFromItem, isPVPItem } from '../../proto_utils/utils';
 import { Sim } from '../../sim';
@@ -1637,7 +1645,7 @@ export class ItemList<T extends ItemListType> {
 					source.source.oneofKind == 'rep' ? REP_FACTION_NAMES[source.source.rep.repFactionId] : REP_FACTION_NAMES[RepFaction.RepFactionUnknown],
 				);
 			const src = source.source.rep;
-			const npcId = REP_FACTION_QUARTERMASTERS[src.repFactionId]
+			const npcId = REP_FACTION_QUARTERMASTERS[src.repFactionId];
 			return makeAnchor(
 				ActionId.makeNpcUrl(npcId),
 				<>

--- a/ui/core/proto_utils/action_id.ts
+++ b/ui/core/proto_utils/action_id.ts
@@ -555,7 +555,7 @@ export class ActionId {
 			iconUrl = ActionId.makeIconUrl(overrideTooltipData['icon']);
 		}
 
-		return new ActionId(this.itemId, this.spellId, this.otherId, this.tag, baseName, name, iconUrl, this.randomSuffixId);
+		return new ActionId(this.itemId, this.spellId, this.otherId, this.tag, baseName, name, iconUrl, this.randomSuffixId, this.reforgeId);
 	}
 
 	toString(): string {
@@ -604,7 +604,7 @@ export class ActionId {
 	}
 
 	withoutTag(): ActionId {
-		return new ActionId(this.itemId, this.spellId, this.otherId, 0, this.baseName, this.baseName, this.iconUrl, this.randomSuffixId);
+		return new ActionId(this.itemId, this.spellId, this.otherId, 0, this.baseName, this.baseName, this.iconUrl, this.randomSuffixId, this.reforgeId);
 	}
 
 	static fromEmpty(): ActionId {


### PR DESCRIPTION
- Adds reforge parameter to show the reforge stats on mouseover

![image](https://github.com/wowsims/cata/assets/1216787/b93f0452-aa9e-4834-ab77-2d1507366364)
