### PR TITLE
Several improvements to item picker

### DIFF
--- a/proto/api.proto
+++ b/proto/api.proto
@@ -305,11 +305,18 @@ message EncounterMetrics {
 	repeated UnitMetrics targets = 1;
 }
 
+enum SimType {
+	SimTypeUnknown = 0;
+	SimTypeIndividual = 1;
+	SimTypeRaid = 2;
+}
+
 // RPC RaidSim
 message RaidSimRequest {
 	Raid raid = 1;
 	Encounter encounter = 2;
 	SimOptions sim_options = 3;
+	SimType type = 4;
 }
 
 // Result from running the raid sim.

--- a/proto/ui.proto
+++ b/proto/ui.proto
@@ -247,7 +247,7 @@ enum RaidFilterOption {
 	RaidDragonSoul = 8;
 }
 
-// Next tag: 20.
+// NextIndex: 22
 message DatabaseFilters {
 	repeated ArmorType armor_types = 1;
 	repeated WeaponType weapon_types = 2;
@@ -255,6 +255,8 @@ message DatabaseFilters {
 	repeated SourceFilterOption sources = 17;
 	repeated RaidFilterOption raids = 18;
 	UIItem.FactionRestriction faction_restriction = 19;
+	int32 min_ilvl = 20;
+	int32 max_ilvl = 21;
 
 	double min_mh_weapon_speed = 4;
 	double max_mh_weapon_speed = 5;

--- a/ui/core/components/filters_menu.tsx
+++ b/ui/core/components/filters_menu.tsx
@@ -1,10 +1,13 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { element } from 'tsx-vanilla';
+
 import { Player } from '../player.js';
 import { ItemSlot } from '../proto/common.js';
 import { RaidFilterOption, SourceFilterOption, UIItem_FactionRestriction } from '../proto/ui.js';
 import { armorTypeNames, raidNames, rangedWeaponTypeNames, sourceNames, weaponTypeNames } from '../proto_utils/names.js';
 import { Sim } from '../sim.js';
 import { EventID } from '../typed_event.js';
-import { BaseModal } from './base_modal.js';
+import { BaseModal } from './base_modal.jsx';
 import { BooleanPicker } from './boolean_picker.js';
 import { EnumPicker } from './enum_picker.js';
 import { NumberPicker } from './number_picker.js';
@@ -19,7 +22,36 @@ export class FiltersMenu extends BaseModal {
 	constructor(rootElem: HTMLElement, player: Player<any>, slot: ItemSlot) {
 		super(rootElem, 'filters-menu', { size: 'md', title: 'Filters', disposeOnClose: false });
 
-		let section = this.newSection('Factions');
+		let section = this.newSection('General');
+
+		const ilvlFiltersContainer = <div className="ilvl-filters" />;
+		section.appendChild(ilvlFiltersContainer);
+
+		new NumberPicker(ilvlFiltersContainer as HTMLElement, player.sim, {
+			label: 'Min ILvl',
+			showZeroes: false,
+			changedEvent: sim => sim.filtersChangeEmitter,
+			getValue: (sim: Sim) => sim.getFilters().minIlvl,
+			setValue: (eventID: EventID, sim: Sim, newValue: number) => {
+				const newFilters = sim.getFilters();
+				newFilters.minIlvl = newValue;
+				sim.setFilters(eventID, newFilters);
+			},
+		});
+
+		ilvlFiltersContainer.appendChild(<span className="ilvl-filters-separator">-</span>);
+
+		new NumberPicker(ilvlFiltersContainer as HTMLElement, player.sim, {
+			label: 'Max ILvl',
+			showZeroes: false,
+			changedEvent: sim => sim.filtersChangeEmitter,
+			getValue: (sim: Sim) => sim.getFilters().maxIlvl,
+			setValue: (eventID: EventID, sim: Sim, newValue: number) => {
+				const newFilters = sim.getFilters();
+				newFilters.maxIlvl = newValue;
+				sim.setFilters(eventID, newFilters);
+			},
+		});
 
 		new EnumPicker(section, player.sim, {
 			label: 'Faction Restrictions',

--- a/ui/core/components/filters_menu.tsx
+++ b/ui/core/components/filters_menu.tsx
@@ -22,12 +22,12 @@ export class FiltersMenu extends BaseModal {
 	constructor(rootElem: HTMLElement, player: Player<any>, slot: ItemSlot) {
 		super(rootElem, 'filters-menu', { size: 'md', title: 'Filters', disposeOnClose: false });
 
-		let section = this.newSection('General');
+		const generalSection = this.newSection('General');
 
-		const ilvlFiltersContainer = <div className="ilvl-filters" />;
-		section.appendChild(ilvlFiltersContainer);
+		const ilvlFiltersContainer = (<div className="ilvl-filters" />) as HTMLElement;
+		generalSection.appendChild(ilvlFiltersContainer);
 
-		new NumberPicker(ilvlFiltersContainer as HTMLElement, player.sim, {
+		new NumberPicker(ilvlFiltersContainer, player.sim, {
 			label: 'Min ILvl',
 			showZeroes: false,
 			changedEvent: sim => sim.filtersChangeEmitter,
@@ -41,7 +41,7 @@ export class FiltersMenu extends BaseModal {
 
 		ilvlFiltersContainer.appendChild(<span className="ilvl-filters-separator">-</span>);
 
-		new NumberPicker(ilvlFiltersContainer as HTMLElement, player.sim, {
+		new NumberPicker(ilvlFiltersContainer, player.sim, {
 			label: 'Max ILvl',
 			showZeroes: false,
 			changedEvent: sim => sim.filtersChangeEmitter,
@@ -53,7 +53,7 @@ export class FiltersMenu extends BaseModal {
 			},
 		});
 
-		new EnumPicker(section, player.sim, {
+		new EnumPicker(generalSection, player.sim, {
 			label: 'Faction Restrictions',
 			values: [UIItem_FactionRestriction.UNSPECIFIED, UIItem_FactionRestriction.ALLIANCE_ONLY, UIItem_FactionRestriction.HORDE_ONLY].map(restriction => {
 				return {
@@ -70,11 +70,11 @@ export class FiltersMenu extends BaseModal {
 			},
 		});
 
-		section = this.newSection('Source');
-		section.classList.add('filters-menu-section-bool-list');
+		const sourceSection = this.newSection('Source');
+		sourceSection.classList.add('filters-menu-section-bool-list');
 		const sources = Sim.ALL_SOURCES.filter(s => s != SourceFilterOption.SourceUnknown);
 		sources.forEach(source => {
-			new BooleanPicker<Sim>(section, player.sim, {
+			new BooleanPicker<Sim>(sourceSection, player.sim, {
 				label: sourceNames.get(source),
 				inline: true,
 				changedEvent: (sim: Sim) => sim.filtersChangeEmitter,
@@ -91,11 +91,11 @@ export class FiltersMenu extends BaseModal {
 			});
 		});
 
-		section = this.newSection('Raids');
-		section.classList.add('filters-menu-section-bool-list');
+		const raidsSection = this.newSection('Raids');
+		raidsSection.classList.add('filters-menu-section-bool-list');
 		const raids = Sim.ALL_RAIDS.filter(s => s != RaidFilterOption.RaidUnknown);
 		raids.forEach(raid => {
-			new BooleanPicker<Sim>(section, player.sim, {
+			new BooleanPicker<Sim>(raidsSection, player.sim, {
 				label: raidNames.get(raid),
 				inline: true,
 				changedEvent: (sim: Sim) => sim.filtersChangeEmitter,
@@ -116,11 +116,11 @@ export class FiltersMenu extends BaseModal {
 			const armorTypes = player.getPlayerClass().armorTypes;
 
 			if (armorTypes.length > 1) {
-				const section = this.newSection('Armor Type');
-				section.classList.add('filters-menu-section-bool-list');
+				const armorTypesSection = this.newSection('Armor Type');
+				armorTypesSection.classList.add('filters-menu-section-bool-list');
 
 				armorTypes.forEach(armorType => {
-					new BooleanPicker<Sim>(section, player.sim, {
+					new BooleanPicker<Sim>(armorTypesSection, player.sim, {
 						label: armorTypeNames.get(armorType),
 						inline: true,
 						changedEvent: (sim: Sim) => sim.filtersChangeEmitter,

--- a/ui/core/components/filters_menu.tsx
+++ b/ui/core/components/filters_menu.tsx
@@ -1,16 +1,16 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { element } from 'tsx-vanilla';
 
-import { Player } from '../player.js';
-import { ItemSlot } from '../proto/common.js';
-import { RaidFilterOption, SourceFilterOption, UIItem_FactionRestriction } from '../proto/ui.js';
-import { armorTypeNames, raidNames, rangedWeaponTypeNames, sourceNames, weaponTypeNames } from '../proto_utils/names.js';
-import { Sim } from '../sim.js';
-import { EventID } from '../typed_event.js';
-import { BaseModal } from './base_modal.jsx';
-import { BooleanPicker } from './boolean_picker.js';
-import { EnumPicker } from './enum_picker.js';
-import { NumberPicker } from './number_picker.js';
+import { Player } from '../player';
+import { ItemSlot } from '../proto/common';
+import { RaidFilterOption, SourceFilterOption, UIItem_FactionRestriction } from '../proto/ui';
+import { armorTypeNames, raidNames, rangedWeaponTypeNames, sourceNames, weaponTypeNames } from '../proto_utils/names';
+import { Sim } from '../sim';
+import { EventID } from '../typed_event';
+import { BaseModal } from './base_modal';
+import { BooleanPicker } from './boolean_picker';
+import { EnumPicker } from './enum_picker';
+import { NumberPicker } from './number_picker';
 
 const factionRestrictionsToLabels: Record<UIItem_FactionRestriction, string> = {
 	[UIItem_FactionRestriction.UNSPECIFIED]: 'None',

--- a/ui/core/components/input.tsx
+++ b/ui/core/components/input.tsx
@@ -1,4 +1,5 @@
 import tippy from 'tippy.js';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { element, fragment } from 'tsx-vanilla';
 
 import { EventID, TypedEvent } from '../typed_event.js';

--- a/ui/core/components/number_picker.ts
+++ b/ui/core/components/number_picker.ts
@@ -1,12 +1,16 @@
-import { EventID, TypedEvent } from '../typed_event.js';
+import { TypedEvent } from '../typed_event.js';
 import { Input, InputConfig } from './input.js';
 
 /**
  * Data for creating a number picker.
  */
 export interface NumberPickerConfig<ModObject> extends InputConfig<ModObject, number> {
+	// Whether the picker represents a float value. Default `false`
 	float?: boolean;
+	// Whether to only allow positive values. Default `false`
 	positive?: boolean;
+	// Whether to show values of zero within the input. Default `true`
+	showZeroes?: boolean;
 }
 
 // UI element for picking an arbitrary number field.
@@ -14,18 +18,20 @@ export class NumberPicker<ModObject> extends Input<ModObject, number> {
 	private readonly inputElem: HTMLInputElement;
 	private float: boolean;
 	private positive: boolean;
+	private showZeroes: boolean;
 
 	constructor(parent: HTMLElement | null, modObject: ModObject, config: NumberPickerConfig<ModObject>) {
 		super(parent, 'number-picker-root', modObject, config);
-		this.float = config.float || false;
-		this.positive = config.positive || false;
+		this.float = config.float ?? false;
+		this.positive = config.positive ?? false;
+		this.showZeroes = config.showZeroes ?? true;
 
 		this.inputElem = document.createElement('input');
 		this.inputElem.type = 'text';
 		this.inputElem.classList.add('form-control', 'number-picker-input');
 
 		if (this.positive) {
-			this.inputElem.onchange = e => {
+			this.inputElem.onchange = _event => {
 				if (this.float) {
 					this.inputElem.value = Math.abs(parseFloat(this.inputElem.value)).toFixed(2);
 				} else {
@@ -37,11 +43,11 @@ export class NumberPicker<ModObject> extends Input<ModObject, number> {
 		this.rootElem.appendChild(this.inputElem);
 		this.init();
 
-		this.inputElem.addEventListener('change', event => {
+		this.inputElem.addEventListener('change', _event => {
 			this.inputChanged(TypedEvent.nextEventID());
 		});
 
-		this.inputElem.addEventListener('input', event => {
+		this.inputElem.addEventListener('input', _event => {
 			this.updateSize();
 		});
 		this.updateSize();
@@ -60,8 +66,15 @@ export class NumberPicker<ModObject> extends Input<ModObject, number> {
 	}
 
 	setInputValue(newValue: number) {
-		if (this.float) this.inputElem.value = newValue.toFixed(2);
-		else this.inputElem.value = String(newValue);
+		if (newValue == 0 && !this.showZeroes) {
+			return;
+		}
+
+		if (this.float) {
+			this.inputElem.value = newValue.toFixed(2);
+		} else {
+			this.inputElem.value = String(newValue);
+		}
 	}
 
 	private updateSize() {

--- a/ui/core/components/number_picker.ts
+++ b/ui/core/components/number_picker.ts
@@ -1,5 +1,5 @@
-import { TypedEvent } from '../typed_event.js';
-import { Input, InputConfig } from './input.js';
+import { TypedEvent } from '../typed_event';
+import { Input, InputConfig } from './input';
 
 /**
  * Data for creating a number picker.

--- a/ui/core/components/number_picker.ts
+++ b/ui/core/components/number_picker.ts
@@ -31,7 +31,7 @@ export class NumberPicker<ModObject> extends Input<ModObject, number> {
 		this.inputElem.classList.add('form-control', 'number-picker-input');
 
 		if (this.positive) {
-			this.inputElem.onchange = _event => {
+			this.inputElem.onchange = _ => {
 				if (this.float) {
 					this.inputElem.value = Math.abs(parseFloat(this.inputElem.value)).toFixed(2);
 				} else {
@@ -43,11 +43,11 @@ export class NumberPicker<ModObject> extends Input<ModObject, number> {
 		this.rootElem.appendChild(this.inputElem);
 		this.init();
 
-		this.inputElem.addEventListener('change', _event => {
+		this.inputElem.addEventListener('change', _ => {
 			this.inputChanged(TypedEvent.nextEventID());
 		});
 
-		this.inputElem.addEventListener('input', _event => {
+		this.inputElem.addEventListener('input', _ => {
 			this.updateSize();
 		});
 		this.updateSize();

--- a/ui/core/constants/other.ts
+++ b/ui/core/constants/other.ts
@@ -17,3 +17,8 @@ const repoPartIdx = pathnameParts.findIndex(part => part == REPO_NAME);
 export const SPEC_DIRECTORY = repoPartIdx == -1 ? '' : pathnameParts[repoPartIdx + 1];
 
 export const LOCAL_STORAGE_PREFIX = '__cata';
+
+export enum SortDirection {
+	ASC,
+	DESC,
+}

--- a/ui/core/player.ts
+++ b/ui/core/player.ts
@@ -1240,6 +1240,13 @@ export class Player<SpecType extends Spec> {
 			return itemData.filter(itemElem => filterFunc(getItemFunc(itemElem)));
 		};
 
+		if (filters.minIlvl != 0) {
+			itemData = filterItems(itemData, item => item.ilvl >= filters.minIlvl);
+		}
+		if (filters.maxIlvl != 0) {
+			itemData = filterItems(itemData, item => item.ilvl <= filters.maxIlvl);
+		}
+
 		if (filters.factionRestriction != UIItem_FactionRestriction.UNSPECIFIED) {
 			itemData = filterItems(
 				itemData,
@@ -1284,12 +1291,6 @@ export class Player<SpecType extends Spec> {
 			}
 		}
 
-		// if (!filters.raids.includes(RaidFilterOption.RaidVanilla)) {
-		// 	itemData = filterItems(itemData, item => item.expansion != Expansion.ExpansionVanilla);
-		// }
-		// if (!filters.raids.includes(RaidFilterOption.RaidTbc)) {
-		// 	itemData = filterItems(itemData, item => item.expansion != Expansion.ExpansionTbc);
-		// }
 		for (const [raidOptionStr, zoneId] of Object.entries(Player.RAID_IDS)) {
 			const raidOption = parseInt(raidOptionStr) as RaidFilterOption;
 			if (!filters.raids.includes(raidOption)) {

--- a/ui/core/sim.ts
+++ b/ui/core/sim.ts
@@ -209,6 +209,7 @@ export class Sim {
 		// TODO: remove any replenishment from sim request here? probably makes more sense to do it inside the sim to protect against accidents
 
 		return RaidSimRequest.create({
+			type: this.type,
 			raid: raid,
 			encounter: encounter,
 			simOptions: SimOptions.create({

--- a/ui/core/sim.ts
+++ b/ui/core/sim.ts
@@ -624,7 +624,12 @@ export class Sim {
 
 			const filters = proto.filters || Sim.defaultFilters();
 			if (filters.armorTypes.length == 0) {
-				filters.armorTypes = Sim.ALL_ARMOR_TYPES.slice();
+				// TODO: Can we specify the time of sim so that we can do this without querying the DOM?
+				if (!!document.querySelector('.not-within-raid-sim')) {
+					filters.armorTypes = [this.raid.getActivePlayers()[0].getPlayerClass().armorTypes[0]];
+				} else {
+					filters.armorTypes = Sim.ALL_ARMOR_TYPES.slice();
+				}
 			}
 			if (filters.weaponTypes.length == 0) {
 				filters.weaponTypes = Sim.ALL_WEAPON_TYPES.slice();

--- a/ui/core/sim.ts
+++ b/ui/core/sim.ts
@@ -1,8 +1,8 @@
 import { hasTouch } from '../shared/bootstrap_overrides';
-import { getBrowserLanguageCode, setLanguageCode } from './constants/lang.js';
-import * as OtherConstants from './constants/other.js';
-import { Encounter } from './encounter.js';
-import { Player, UnitMetadata } from './player.js';
+import { getBrowserLanguageCode, setLanguageCode } from './constants/lang';
+import * as OtherConstants from './constants/other';
+import { Encounter } from './encounter';
+import { Player, UnitMetadata } from './player';
 import {
 	BulkSettings,
 	BulkSimRequest,

--- a/ui/raid/raid_sim_ui.tsx
+++ b/ui/raid/raid_sim_ui.tsx
@@ -6,7 +6,7 @@ import { EmbeddedDetailedResults } from '../core/components/detailed_results';
 import { addRaidSimAction, RaidSimResultsManager, ReferenceData } from '../core/components/raid_sim_action';
 import { raidSimStatus } from '../core/launched_sims';
 import { Player } from '../core/player';
-import { Raid as RaidProto } from '../core/proto/api';
+import { Raid as RaidProto, SimType } from '../core/proto/api';
 import { Class, Encounter as EncounterProto } from '../core/proto/common';
 import { Blessings } from '../core/proto/paladin';
 import { BlessingsAssignments, RaidSimSettings } from '../core/proto/ui';
@@ -41,7 +41,7 @@ export class RaidSimUI extends SimUI {
 	readonly referenceChangeEmitter = new TypedEvent<void>();
 
 	constructor(parentElem: HTMLElement, config: RaidSimConfig) {
-		super(parentElem, new Sim(), {
+		super(parentElem, new Sim({ type: SimType.SimTypeRaid }), {
 			cssClass: 'raid-sim-ui',
 			cssScheme: 'raid',
 			spec: null,

--- a/ui/scss/core/components/_filters_menu.scss
+++ b/ui/scss/core/components/_filters_menu.scss
@@ -1,11 +1,38 @@
 .filters-menu {
-	.menu-section:not(:last-child) {
-		margin-bottom: var(--spacer-3);
-	}
+	.menu-section {
+		display: flex;
+		@include media-breakpoint-down(sm) {
+			display: block;
+		}
 
-	[class*="filters-menu-section-"] {
-		display: grid;
-		grid-template-columns: repeat(3, 1fr);
-		grid-column-gap: var(--bs-modal-padding);
+		&:not(:last-child) {
+			margin-bottom: var(--spacer-3);
+		}
+
+		.menu-section-header {
+			flex: 1;
+		}
+
+		.menu-section-content {
+			flex: 3;
+
+			.ilvl-filters {
+				display: grid;
+				grid-template-columns: 1fr 0 1fr;
+				grid-column-gap: var(--bs-modal-padding);
+
+				.ilvl-filters-separator {
+					display: flex;
+					align-items: center;
+					justify-content: center;
+				}
+			}
+
+			&[class*='filters-menu-section-'] {
+				display: grid;
+				grid-template-columns: repeat(2, 1fr);
+				grid-column-gap: var(--bs-modal-padding);
+			}
+		}
 	}
 }

--- a/ui/scss/core/components/_gear_picker.scss
+++ b/ui/scss/core/components/_gear_picker.scss
@@ -1,5 +1,6 @@
 @import './filters_menu';
 :root {
+	--ilvl-cell-width: 3rem;
 	--source-cell-width: 16rem;
 	--ep-cell-width: 6rem;
 	--favorite-cell-width: 2rem;
@@ -110,11 +111,6 @@
 	height: 100%;
 	width: 100%;
 
-	@include media-breakpoint-down(lg) {
-		width: 3rem;
-		height: 3rem;
-	}
-
 	.item-picker-labels-container {
 		align-items: flex-start;
 		text-align: left;
@@ -129,6 +125,9 @@
 	align-items: flex-end;
 	margin-right: -1px;
 	z-index: 1;
+	@include media-breakpoint-down(sm) {
+		display: none;
+	}
 
 	.item-picker-icon-wrapper {
 		width: var(--icon-size-md);
@@ -194,7 +193,7 @@
 		padding: 0;
 
 		.selector-modal-filters {
-			margin-bottom: var(--spacer-4);
+			margin-bottom: var(--bs-modal-padding);
 			display: flex;
 			align-items: center;
 
@@ -235,22 +234,20 @@
 	margin-bottom: var(--spacer-2);
 	font-size: 1.125rem;
 	justify-content: space-between; // Ensures labels are evenly spaced
-
-	label {
-		font-weight: normal;
+	@include media-breakpoint-down(xl) {
+		margin-right: 0;
 	}
 
 	.item-label {
 		flex: 1;
 	}
-
+	.ilvl-label {
+		width: var(--ilvl-cell-width);
+		margin-left: var(--spacer-3);
+	}
 	.source-label {
 		width: var(--source-cell-width);
 		margin-left: var(--spacer-3);
-	}
-	.reforge-label {
-		flex-grow: 1; // Allows it to stay centered by taking more space
-		justify-content: center; // Centers the content inside the label
 	}
 	.ep-label {
 		width: var(--ep-cell-width);
@@ -357,11 +354,16 @@
 
 	.selector-modal-list-item-name {
 		font-size: 1.125rem;
-		margin-left: var(--spacer-3);
+		margin-left: var(--spacer-2);
 		letter-spacing: normal;
 		font-weight: normal;
 		cursor: pointer;
 	}
+}
+
+.selector-modal-list-item-ilvl-container {
+	margin-left: var(--spacer-3);
+	width: var(--ilvl-cell-width);
 }
 
 .selector-modal-list-item-source-container {

--- a/ui/scss/shared/_global.scss
+++ b/ui/scss/shared/_global.scss
@@ -95,6 +95,11 @@ kbd {
 	filter: brightness(0.75);
 }
 
+.interactive {
+	cursor: pointer;
+	user-select: none;
+}
+
 .hide {
 	display: none !important;
 }

--- a/ui/scss/shared/_modal.scss
+++ b/ui/scss/shared/_modal.scss
@@ -2,6 +2,9 @@
 	.modal-dialog {
 		max-height: calc(100vh - (2 * var(--bs-modal-margin)));
 		display: flex;
+		@include media-breakpoint-down(lg) {
+			max-width: calc(100vw - (2 * var(--bs-modal-margin)));
+		}
 
 		&.modal-overflow-scroll {
 			.modal-content {


### PR DESCRIPTION
- Updated reforge text to include values (Screenshot 1)
- Added ilvl to the gear picker modal and made the modal larger to accommodate space a bit better (Screenshot 2)
- Added sorting by both ILvl and EP in the modal (Screenshot 2)
- Added min and max ilvl filters (Screenshot 3)
- By default disabled all armor types except the spec's primary armor type for Armor Specializationbonus

<img width="319" alt="image" src="https://github.com/wowsims/cata/assets/12898988/fcd72d5a-6093-4620-b86b-60a8e9a91e46">
<img width="1728" alt="image" src="https://github.com/wowsims/cata/assets/12898988/f247f539-eaf4-4f62-ab03-71327e964428">
<img width="1728" alt="image" src="https://github.com/wowsims/cata/assets/12898988/ceaa6445-4844-481f-8b7f-58988b8217fa">
