### PR TITLE
Move Feral DPS sim to Beta

### DIFF
--- a/sim/druid/faerie_fire.go
+++ b/sim/druid/faerie_fire.go
@@ -95,7 +95,7 @@ func (druid *Druid) ShouldFaerieFire(sim *core.Simulation, target *core.Unit) bo
 		return false
 	}
 
-	if !druid.FaerieFire.IsReady(sim) {
+	if !druid.FaerieFire.CanCastOrQueue(sim, target) {
 		return false
 	}
 

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -1272,8 +1272,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 60678.17452
-  tps: 43111.19421
+  dps: 60680.98523
+  tps: 43113.26461
  }
 }
 dps_results: {
@@ -1293,29 +1293,29 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 40625.70668
-  tps: 28875.06385
+  dps: 40621.57641
+  tps: 28872.4305
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 10664.48176
-  tps: 7574.39959
+  dps: 10673.26661
+  tps: 7580.7864
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 10680.63637
-  tps: 7590.73049
+  dps: 10682.4781
+  tps: 7592.03812
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 31792.24155
-  tps: 46957.54511
+  dps: 31705.7823
+  tps: 46896.25119
  }
 }
 dps_results: {
@@ -1335,8 +1335,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 21239.13063
-  tps: 32087.55284
+  dps: 21560.68233
+  tps: 33297.35924
  }
 }
 dps_results: {
@@ -1356,8 +1356,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 28096.47509
-  tps: 19978.11283
+  dps: 28054.46116
+  tps: 19948.43251
  }
 }
 dps_results: {
@@ -1377,15 +1377,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 18636.63571
-  tps: 13262.89825
+  dps: 18613.85287
+  tps: 13246.94679
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
   dps: 18676.61586
-  tps: 13262.79043
+  tps: 13263.16436
  }
 }
 dps_results: {
@@ -1398,8 +1398,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 59013.2943
-  tps: 41929.20405
+  dps: 59143.60139
+  tps: 42021.72208
  }
 }
 dps_results: {
@@ -1419,15 +1419,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 39525.85405
-  tps: 28093.86933
+  dps: 39735.99276
+  tps: 28243.66612
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
   dps: 10581.48635
-  tps: 7515.39806
+  tps: 7515.62242
  }
 }
 dps_results: {
@@ -1440,8 +1440,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 31002.02321
-  tps: 45750.89887
+  dps: 31227.08593
+  tps: 46651.72729
  }
 }
 dps_results: {
@@ -1461,8 +1461,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 20599.94177
-  tps: 30771.34731
+  dps: 20728.28376
+  tps: 31418.59008
  }
 }
 dps_results: {
@@ -1482,8 +1482,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 27210.32162
-  tps: 19348.71951
+  dps: 27233.86007
+  tps: 19365.80575
  }
 }
 dps_results: {
@@ -1503,15 +1503,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 17981.4165
-  tps: 12797.46825
+  dps: 17996.15688
+  tps: 12808.38264
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 18095.62226
-  tps: 12850.50934
+  dps: 18094.83897
+  tps: 12850.10277
  }
 }
 dps_results: {
@@ -1524,8 +1524,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 49655.23449
-  tps: 35284.83201
+  dps: 50021.16522
+  tps: 35544.7924
  }
 }
 dps_results: {
@@ -1545,29 +1545,29 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 32615.43054
-  tps: 23187.99215
+  dps: 32662.87977
+  tps: 23221.75589
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 8429.133
-  tps: 5987.22718
+  dps: 8429.07367
+  tps: 5987.40941
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 9055.25768
-  tps: 6436.71162
+  dps: 9054.96101
+  tps: 6436.50098
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 27017.77489
-  tps: 40721.68385
+  dps: 26879.49536
+  tps: 41208.51818
  }
 }
 dps_results: {
@@ -1587,8 +1587,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 17803.55618
-  tps: 27722.30553
+  dps: 17975.54267
+  tps: 28491.69582
  }
 }
 dps_results: {
@@ -1608,8 +1608,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 23405.01225
-  tps: 16646.80029
+  dps: 23369.30754
+  tps: 16621.97345
  }
 }
 dps_results: {
@@ -1629,15 +1629,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 15083.81853
-  tps: 10740.39805
+  dps: 15059.21807
+  tps: 10723.15609
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 15170.25376
-  tps: 10773.34813
+  dps: 15170.23337
+  tps: 10773.6328
  }
 }
 dps_results: {
@@ -1650,8 +1650,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 48645.48251
-  tps: 34567.08545
+  dps: 48663.9811
+  tps: 34581.19167
  }
 }
 dps_results: {
@@ -1671,29 +1671,29 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 31504.88503
-  tps: 22399.57962
+  dps: 31525.56514
+  tps: 22414.2625
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 8281.28363
-  tps: 5882.25412
+  dps: 8281.12065
+  tps: 5882.36277
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 8954.06513
-  tps: 6364.86491
+  dps: 8953.25027
+  tps: 6364.28636
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 26097.38239
-  tps: 39428.24717
+  dps: 26335.06937
+  tps: 40999.2459
  }
 }
 dps_results: {
@@ -1713,8 +1713,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 17012.43828
-  tps: 25811.17564
+  dps: 17411.87807
+  tps: 28194.18731
  }
 }
 dps_results: {
@@ -1734,8 +1734,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 22673.90191
-  tps: 16128.01109
+  dps: 22691.63834
+  tps: 16140.82832
  }
 }
 dps_results: {
@@ -1755,15 +1755,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 14521.23407
-  tps: 10340.96309
+  dps: 14555.03735
+  tps: 10365.18777
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 14544.33451
-  tps: 10329.02025
+  dps: 14544.55058
+  tps: 10329.39802
  }
 }
 dps_results: {

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -1111,8 +1111,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 24039.4165
-  tps: 32873.91951
+  dps: 24215.81858
+  tps: 32599.08941
  }
 }
 dps_results: {

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -1272,43 +1272,43 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 60680.98523
-  tps: 43113.26461
+  dps: 60701.53188
+  tps: 43127.85273
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 16555.80212
-  tps: 11754.6195
+  dps: 16481.02288
+  tps: 11701.52624
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 19148.25419
-  tps: 13595.26048
+  dps: 19001.41289
+  tps: 13491.00315
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 40621.57641
-  tps: 28872.4305
+  dps: 40750.90478
+  tps: 28964.25365
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 10673.26661
-  tps: 7580.7864
+  dps: 10643.40238
+  tps: 7559.5828
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 10682.4781
-  tps: 7592.03812
+  dps: 10667.45095
+  tps: 7581.36884
  }
 }
 dps_results: {
@@ -1398,43 +1398,43 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 59143.60139
-  tps: 42021.72208
+  dps: 59145.30974
+  tps: 42022.93501
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 16384.22383
-  tps: 11632.79892
+  dps: 16273.99606
+  tps: 11554.5372
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 19023.35007
-  tps: 13506.57855
+  dps: 18944.45717
+  tps: 13450.56459
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 39735.99276
-  tps: 28243.66612
+  dps: 39717.02922
+  tps: 28230.202
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 10581.48635
-  tps: 7515.62242
+  dps: 10518.89419
+  tps: 7471.18198
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 10551.63505
-  tps: 7499.13955
+  dps: 10508.84848
+  tps: 7468.76109
  }
 }
 dps_results: {
@@ -1524,43 +1524,43 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 50021.16522
-  tps: 35544.7924
+  dps: 50100.72581
+  tps: 35601.28042
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 13440.7682
-  tps: 9542.94542
+  dps: 13331.031
+  tps: 9465.03201
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 16769.77021
-  tps: 11906.53685
+  dps: 16724.69774
+  tps: 11874.53539
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 32662.87977
-  tps: 23221.75589
+  dps: 32710.04111
+  tps: 23255.24044
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 8429.07367
-  tps: 5987.40941
+  dps: 8360.47126
+  tps: 5938.7017
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 9054.96101
-  tps: 6436.50098
+  dps: 8944.67445
+  tps: 6358.19753
  }
 }
 dps_results: {
@@ -1650,43 +1650,43 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 48663.9811
-  tps: 34581.19167
+  dps: 48675.3098
+  tps: 34589.23505
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 13294.90736
-  tps: 9439.38423
+  dps: 13206.05548
+  tps: 9376.29939
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 16753.50894
-  tps: 11894.99135
+  dps: 16658.26239
+  tps: 11827.3663
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 31525.56514
-  tps: 22414.2625
+  dps: 31587.12416
+  tps: 22457.9694
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 8281.12065
-  tps: 5882.36277
+  dps: 8259.01474
+  tps: 5866.66757
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 8953.25027
-  tps: 6364.28636
+  dps: 8920.065
+  tps: 6340.72482
  }
 }
 dps_results: {

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -1272,43 +1272,43 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 60701.53188
-  tps: 43127.85273
+  dps: 73643.00656
+  tps: 103297.19555
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 16481.02288
-  tps: 11701.52624
+  dps: 16688.68674
+  tps: 28633.53183
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 19001.41289
-  tps: 13491.00315
+  dps: 19288.3179
+  tps: 25705.62444
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 40750.90478
-  tps: 28964.25365
+  dps: 50485.54979
+  tps: 72501.85534
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 10643.40238
-  tps: 7559.5828
+  dps: 10434.68966
+  tps: 19539.03682
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 10667.45095
-  tps: 7581.36884
+  dps: 10652.70485
+  tps: 19438.30754
  }
 }
 dps_results: {
@@ -1398,43 +1398,43 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 59145.30974
-  tps: 42022.93501
+  dps: 72908.86837
+  tps: 103013.18929
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 16273.99606
-  tps: 11554.5372
+  dps: 16393.57945
+  tps: 28072.98795
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 18944.45717
-  tps: 13450.56459
+  dps: 19297.34194
+  tps: 25751.85405
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 39717.02922
-  tps: 28230.202
+  dps: 50035.14913
+  tps: 73365.57044
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 10518.89419
-  tps: 7471.18198
+  dps: 10398.26637
+  tps: 19588.22919
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 10508.84848
-  tps: 7468.76109
+  dps: 10513.3594
+  tps: 20450.69096
  }
 }
 dps_results: {
@@ -1524,43 +1524,43 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 50100.72581
-  tps: 35601.28042
+  dps: 62688.87715
+  tps: 90628.67769
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 13331.031
-  tps: 9465.03201
+  dps: 13626.8144
+  tps: 24769.66361
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 16724.69774
-  tps: 11874.53539
+  dps: 16558.57554
+  tps: 26908.47207
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 32710.04111
-  tps: 23255.24044
+  dps: 41728.64327
+  tps: 62314.72339
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 8360.47126
-  tps: 5938.7017
+  dps: 8364.19002
+  tps: 16035.49312
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 8944.67445
-  tps: 6358.19753
+  dps: 9077.90939
+  tps: 17326.67874
  }
 }
 dps_results: {
@@ -1650,43 +1650,43 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 48675.3098
-  tps: 34589.23505
+  dps: 61587.17537
+  tps: 92338.23236
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 13206.05548
-  tps: 9376.29939
+  dps: 13497.93608
+  tps: 24537.55491
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 16658.26239
-  tps: 11827.3663
+  dps: 16591.42395
+  tps: 26845.47793
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 31587.12416
-  tps: 22457.9694
+  dps: 40993.39408
+  tps: 63159.22215
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 8259.01474
-  tps: 5866.66757
+  dps: 8275.25009
+  tps: 15978.61567
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 8920.065
-  tps: 6340.72482
+  dps: 8960.79042
+  tps: 17544.31828
  }
 }
 dps_results: {

--- a/sim/druid/feral/apl_values.go
+++ b/sim/druid/feral/apl_values.go
@@ -155,7 +155,7 @@ func (action *APLActionCatOptimalRotationAction) Execute(sim *core.Simulation) {
 	if cat.Rotation.MaintainFaerieFire {
 		for _, aoeTarget := range sim.Encounter.TargetUnits {
 			if cat.ShouldFaerieFire(sim, aoeTarget) {
-				cat.FaerieFire.Cast(sim, aoeTarget)
+				cat.FaerieFire.CastOrQueue(sim, aoeTarget)
 			}
 		}
 	}

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -383,7 +383,7 @@ func (cat *FeralDruid) canMeleeWeave(sim *core.Simulation, regenRate float64, cu
 }
 
 func (cat *FeralDruid) canBearWeave(sim *core.Simulation, furorCap float64, regenRate float64, currentEnergy float64, upcomingTimers *PoolingActions, shiftCost float64) bool {
-	if !cat.Rotation.BearWeave || cat.ClearcastingAura.IsActive() || cat.BerserkAura.IsActive() || cat.StampedeCatAura.IsActive() {
+	if !cat.Rotation.BearWeave || cat.ClearcastingAura.IsActive() || cat.BerserkAura.IsActive() || (cat.StampedeCatAura.IsActive() && (cat.Rotation.RotationType == proto.FeralDruid_Rotation_SingleTarget)) {
 		return false
 	}
 
@@ -761,7 +761,7 @@ func (cat *FeralDruid) setupRotation(rotation *proto.FeralDruid_Rotation) {
 		SnekWeave:          rotation.SnekWeave,
 		RakeDpeCheck:       true,
 		UseBerserk:         cat.Talents.Berserk && ((rotation.RotationType == proto.FeralDruid_Rotation_SingleTarget) || rotation.AllowAoeBerserk),
-		MeleeWeave:         rotation.MeleeWeave && (cat.Talents.Stampede > 0),
+		MeleeWeave:         rotation.MeleeWeave && (cat.Talents.Stampede > 0) && (rotation.RotationType == proto.FeralDruid_Rotation_SingleTarget),
 	}
 
 	// Use automatic values unless specified

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -201,7 +201,7 @@ func (cat *FeralDruid) tfExpectedBefore(sim *core.Simulation, futureTime time.Du
 }
 
 func (cat *FeralDruid) calcTfEnergyThresh(leewayTime time.Duration) float64 {
-	delayTime := leewayTime + core.TernaryDuration(cat.ClearcastingAura.IsActive(), time.Second, 0) + core.TernaryDuration(cat.StampedeCatAura.IsActive(), time.Second, 0)
+	delayTime := leewayTime + core.TernaryDuration(cat.ClearcastingAura.IsActive(), time.Second, 0) + core.TernaryDuration(cat.StampedeCatAura.IsActive() && (cat.Rotation.RotationType == proto.FeralDruid_Rotation_SingleTarget), time.Second, 0)
 	return 40.0 - delayTime.Seconds()*cat.EnergyRegenPerSecond()
 }
 

--- a/sim/druid/swipe.go
+++ b/sim/druid/swipe.go
@@ -7,15 +7,10 @@ import (
 )
 
 func (druid *Druid) registerSwipeBearSpell() {
-	flatBaseDamage := 108.0
-	if druid.Ranged().ID == 23198 { // Idol of Brutality
-		flatBaseDamage += 10
-	} else if druid.Ranged().ID == 38365 { // Idol of Perspicacious Attacks
-		flatBaseDamage += 24
-	}
+	flatBaseDamage := 0.94199997187 * druid.ClassSpellScaling // ~929
 
 	druid.SwipeBear = druid.RegisterSpell(Bear, core.SpellConfig{
-		ActionID:    core.ActionID{SpellID: 48562},
+		ActionID:    core.ActionID{SpellID: 779},
 		SpellSchool: core.SpellSchoolPhysical,
 		ProcMask:    core.ProcMaskMeleeMHSpecial,
 		Flags:       core.SpellFlagMeleeMetrics | core.SpellFlagIncludeTargetBonusDamage | core.SpellFlagAPL,
@@ -28,14 +23,19 @@ func (druid *Druid) registerSwipeBearSpell() {
 				GCD: core.GCDDefault,
 			},
 			IgnoreHaste: true,
+			CD: core.Cooldown{
+				Timer:    druid.NewTimer(),
+				Duration: time.Second * 3,
+			},
 		},
 
 		DamageMultiplier: 1,
 		CritMultiplier:   druid.DefaultMeleeCritMultiplier(),
 		ThreatMultiplier: 1,
+		MaxRange:         8,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			baseDamage := flatBaseDamage + 0.063*spell.MeleeAttackPower()
+			baseDamage := flatBaseDamage + 0.123*spell.MeleeAttackPower()
 			baseDamage *= sim.Encounter.AOECapMultiplier()
 			for _, aoeTarget := range sim.Encounter.TargetUnits {
 				spell.CalcAndDealDamage(sim, aoeTarget, baseDamage, spell.OutcomeMeleeSpecialHitAndCrit)

--- a/sim/rogue/assassination/TestAssassination.results
+++ b/sim/rogue/assassination/TestAssassination.results
@@ -1104,8 +1104,8 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 29060.52976
-  tps: 20632.97613
+  dps: 29076.06405
+  tps: 20644.00548
  }
 }
 dps_results: {

--- a/sim/rogue/combat/TestCombat.results
+++ b/sim/rogue/combat/TestCombat.results
@@ -1132,8 +1132,8 @@ dps_results: {
 dps_results: {
  key: "TestCombat-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 28791.49966
-  tps: 20441.96476
+  dps: 28905.09746
+  tps: 20522.61919
  }
 }
 dps_results: {

--- a/ui/core/launched_sims.ts
+++ b/ui/core/launched_sims.ts
@@ -48,7 +48,7 @@ export const simLaunchStatuses: Record<Spec, SimStatus> = {
 	},
 	[Spec.SpecFeralDruid]: {
 		phase: Phase.Phase1,
-		status: LaunchStatus.Alpha,
+		status: LaunchStatus.Beta,
 	},
 	[Spec.SpecRestorationDruid]: {
 		phase: Phase.Phase1,

--- a/ui/druid/feral/apls/aoe.apl.json
+++ b/ui/druid/feral/apls/aoe.apl.json
@@ -3,6 +3,6 @@
       "priorityList": [
         {"action":{"autocastOtherCooldowns":{}}},
         {"action":{"condition":{"const":{"val":"false"}},"castSpell":{"spellId":{"spellId":50334}}}},
-        {"action":{"catOptimalRotationAction":{"rotationType":"Aoe","manualParams":false,"maintainFaerieFire":true}}}
+        {"action":{"catOptimalRotationAction":{"rotationType":"Aoe","manualParams":false,"maintainFaerieFire":false,"bearWeave":true,"snekWeave":true}}}
       ]
 }

--- a/ui/druid/feral/inputs.ts
+++ b/ui/druid/feral/inputs.ts
@@ -52,8 +52,6 @@ export const FeralDruidRotationConfig = {
 			fieldName: 'bearWeave',
 			label: 'Enable bear-weaving',
 			labelTooltip: 'Weave into Bear Form while pooling Energy',
-			showWhen: (player: Player<Spec.SpecFeralDruid>) =>
-				player.getSimpleRotation().rotationType == AplType.SingleTarget,
 		}),
 		InputHelpers.makeRotationBooleanInput<Spec.SpecFeralDruid>({
 			fieldName: 'snekWeave',
@@ -73,6 +71,8 @@ export const FeralDruidRotationConfig = {
 			fieldName: 'manualParams',
 			label: 'Manual Advanced Parameters',
 			labelTooltip: 'Manually specify advanced parameters, otherwise will use preset defaults',
+			showWhen: (player: Player<Spec.SpecFeralDruid>) =>
+				player.getSimpleRotation().rotationType == AplType.SingleTarget,
 		}),
 		InputHelpers.makeRotationNumberInput<Spec.SpecFeralDruid>({
 			fieldName: 'minRoarOffset',

--- a/ui/druid/feral/presets.ts
+++ b/ui/druid/feral/presets.ts
@@ -51,7 +51,17 @@ export const DefaultRotation = FeralDruidRotation.create({
 	meleeWeave: true,
 });
 
-export const SIMPLE_ROTATION_DEFAULT = PresetUtils.makePresetSimpleRotation('Simple Default', Spec.SpecFeralDruid, DefaultRotation);
+export const SIMPLE_ROTATION_DEFAULT = PresetUtils.makePresetSimpleRotation('Single Target Default', Spec.SpecFeralDruid, DefaultRotation);
+
+export const AoeRotation = FeralDruidRotation.create({
+	rotationType: FeralDruid_Rotation_AplType.Aoe,
+	bearWeave: true,
+	maintainFaerieFire: false,
+	snekWeave: true,
+	allowAoeBerserk: false,
+});
+
+export const AOE_ROTATION_DEFAULT = PresetUtils.makePresetSimpleRotation('AoE Default', Spec.SpecFeralDruid, AoeRotation);
 
 // Default talents. Uses the wowhead calculator format, make the talents on
 // https://wowhead.com/cata/talent-calc and copy the numbers in the url.

--- a/ui/druid/feral/sim.ts
+++ b/ui/druid/feral/sim.ts
@@ -178,7 +178,7 @@ export class FeralDruidSimUI extends IndividualSimUI<Spec.SpecFeralDruid> {
 	constructor(parentElem: HTMLElement, player: Player<Spec.SpecFeralDruid>) {
 		super(parentElem, player, SPEC_CONFIG);
 
-		const _gemOptimizer = new FeralGemOptimizer(this);
+		//const _gemOptimizer = new FeralGemOptimizer(this);
 	}
 }
 

--- a/ui/druid/feral/sim.ts
+++ b/ui/druid/feral/sim.ts
@@ -116,7 +116,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFeralDruid, {
 	presets: {
 		// Preset talents that the user can quickly select.
 		talents: [Presets.StandardTalents, Presets.HybridTalents],
-		rotations: [Presets.SIMPLE_ROTATION_DEFAULT],
+		rotations: [Presets.SIMPLE_ROTATION_DEFAULT, Presets.AOE_ROTATION_DEFAULT],
 		// Preset gear configurations that the user can quickly select.
 		gear: [Presets.PRERAID_PRESET, Presets.P1_PRESET],
 	},

--- a/ui/index.html
+++ b/ui/index.html
@@ -202,7 +202,7 @@
 												<div class="d-flex flex-column">
 													<span class="sim-link-label">Druid</span>
 													<span class="sim-link-title">Feral</span>
-													<span class="launch-status-label text-brand">Alpha</span>
+													<span class="launch-status-label text-brand">Beta</span>
 												</div>
 											</div>
 										</a>


### PR DESCRIPTION
- Fixed unmerged test changes from earlier Bison PR
- Fixed bug with Faerie Fire usage in AoE rotation
- Fixed bug in TF Energy threshold calculation for AoE rotation
- Implemented AoE bear-weaving
- Added bear-weaving to default AoE APL and to UI rotation presets
- Removed Suggest Gems button from UI until the feature is developed for Cata
- Set sim to Beta launch status