### PR TITLE
Implemented Cata formula for Rage gains from incoming damage

### DIFF
--- a/sim/core/rage.go
+++ b/sim/core/rage.go
@@ -7,7 +7,6 @@ import (
 )
 
 const MaxRage = 100.0
-const RageFactor = 453.3
 const ThreatPerRageGained = 5
 
 type OnRageGainCB func(sim *Simulation, spell *Spell, result *SpellResult, rage float64) float64
@@ -103,8 +102,14 @@ func (unit *Unit) EnableRageBar(options RageBarOptions) {
 				return
 			}
 
-			// TODO: Figure out the new health-based damage taken rage formula
-			generatedRage := result.Damage * 2.5 / RageFactor
+			// Formula taken from simc and verified using in-game
+			// measurements. The in-game measurements agree closely for
+			// incoming melee attacks but not for spells, so more work is
+			// required to determine whether spells use a different formula or
+			// whether Beta is simply bugged for spell Rage calculations. Note
+			// that the below formula delivers full Rage even on missed
+			// attacks! This is intentional and matches in-game behavior.
+			generatedRage := result.PreOutcomeDamage / result.ResistanceMultiplier * 18.92 / unit.MaxHealth()
 
 			if options.OnHitTakenRageGain != nil {
 				generatedRage = options.OnHitTakenRageGain(sim, spell, result, generatedRage)

--- a/sim/druid/guardian/TestGuardian.results
+++ b/sim/druid/guardian/TestGuardian.results
@@ -1266,7 +1266,7 @@ dps_results: {
  key: "TestGuardian-Average-Default"
  value: {
   dps: 3383.29649
-  tps: 15843.0236
+  tps: 15843.12915
   dtps: 469.05636
  }
 }
@@ -1316,7 +1316,7 @@ dps_results: {
  key: "TestGuardian-SwitchInFrontOfTarget-Default"
  value: {
   dps: 3718.64029
-  tps: 17507.50196
+  tps: 17507.64296
   dtps: 457.97699
  }
 }

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -1320,9 +1320,9 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-Average-Default"
  value: {
-  dps: 6244.27954
-  tps: 36290.55827
-  dtps: 422.891
+  dps: 5703.02635
+  tps: 33292.78487
+  dtps: 419.22715
  }
 }
 dps_results: {
@@ -1412,8 +1412,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 6909.75068
-  tps: 40235.04603
-  dtps: 391.20457
+  dps: 6401.99826
+  tps: 37355.59539
+  dtps: 392.61819
  }
 }


### PR DESCRIPTION
 On branch feral
 Changes to be committed:
	modified:   sim/core/rage.go
	modified:   sim/druid/guardian/TestGuardian.results
	modified:   sim/warrior/protection/TestProtectionWarrior.results