### PR TITLE
[UI] Add stats modifier to EquipItem

### DIFF
--- a/ui/core/components/gear_picker/gear_picker.tsx
+++ b/ui/core/components/gear_picker/gear_picker.tsx
@@ -821,11 +821,7 @@ export class SelectorModal extends BaseModal {
 		if (!equippedItem || (equippedItem.hasRandomSuffixOptions() && !equippedItem.randomSuffix)) {
 			return;
 		}
-		if (equippedItem.randomSuffix !== null) {
-			equippedItem._item.stats = equippedItem.randomSuffix.stats.map(stat =>
-				stat > 0 ? Math.floor((stat * equippedItem._item.randPropPoints) / 10000) : stat,
-			);
-		}
+
 		const itemProto = equippedItem.item;
 
 		this.addTab<ReforgeData>({

--- a/ui/core/proto_utils/equipped_item.ts
+++ b/ui/core/proto_utils/equipped_item.ts
@@ -33,6 +33,11 @@ export class EquippedItem {
 
 		this.numPossibleSockets = this.numSockets(true);
 
+		// Add stats to the item from the random suffix to allow reforging
+		if (!!this.randomSuffix) {
+			this._item.stats = this.randomSuffix.stats.map(stat => (stat > 0 ? Math.floor((stat * this._item.randPropPoints) / 10000) : stat));
+		}
+
 		// Fill gems with null so we always have the same number of gems as gem slots.
 		if (this._gems.length < this.numPossibleSockets) {
 			this._gems = this._gems.concat(new Array(this.numPossibleSockets - this._gems.length).fill(null));


### PR DESCRIPTION
Currently randomSuffix stats are only applied in the reforge tab which results in some broken UI references.
This PR moves the stats modification to the EquipItem where it belongs.