### PR TITLE
Fix database modification of item stats object

### DIFF
--- a/ui/core/components/encounter_picker.ts
+++ b/ui/core/components/encounter_picker.ts
@@ -597,7 +597,7 @@ class TargetInputPicker extends Input<Encounter, TargetInput> {
 				this.enumPicker.rootElem.remove();
 				this.enumPicker = null;
 			}
-			console.log(this, newValue);
+
 			this.numberPicker = new NumberPicker(this.rootElem, null, {
 				id: randomUUID(),
 				label: newValue.label,

--- a/ui/core/components/gear_picker/gear_picker.tsx
+++ b/ui/core/components/gear_picker/gear_picker.tsx
@@ -189,7 +189,7 @@ export class ItemRenderer extends Component {
 		}
 
 		if (newItem.reforge) {
-			const reforgeData = this.player.getReforgeData(newItem.item, newItem.reforge);
+			const reforgeData = this.player.getReforgeData(newItem, newItem.reforge);
 			const fromText = shortSecondaryStatNames.get(newItem.reforge?.fromStat[0]);
 			const toText = shortSecondaryStatNames.get(newItem.reforge?.toStat[0]);
 			this.reforgeElem.innerText = `Reforged ${Math.abs(reforgeData.fromAmount)} ${fromText} → ${reforgeData.toAmount} ${toText}`;
@@ -556,7 +556,7 @@ export class SelectorModal extends BaseModal {
 
 		const eligibleItems = this.player.getItems(selectedSlot);
 		const eligibleEnchants = this.player.getEnchants(selectedSlot);
-		const eligibleReforges = equippedItem?.item ? this.player.getAvailableReforgings(equippedItem.item) : [];
+		const eligibleReforges = equippedItem?.item ? this.player.getAvailableReforgings(equippedItem.getWithRandomSuffixStats()) : [];
 
 		// If the enchant tab is selected but the item has no eligible enchants, default to items
 		// If the reforge tab is selected but the item has no eligible reforges, default to items
@@ -833,7 +833,7 @@ export class SelectorModal extends BaseModal {
 		this.addTab<ReforgeData>({
 			label: SelectorModalTabs.Reforging,
 			gearData,
-			itemData: this.player.getAvailableReforgings(itemProto).map(reforgeData => {
+			itemData: this.player.getAvailableReforgings(equippedItem).map(reforgeData => {
 				return {
 					item: reforgeData,
 					id: reforgeData.id,
@@ -861,7 +861,7 @@ export class SelectorModal extends BaseModal {
 			}),
 			computeEP: (reforge: ReforgeData) => this.player.computeReforgingEP(reforge),
 			equippedToItemFn: (equippedItem: EquippedItem | null) =>
-				equippedItem?.reforge ? this.player.getReforgeData(equippedItem.item, equippedItem.reforge) : null,
+				equippedItem?.reforge ? this.player.getReforgeData(equippedItem, equippedItem.reforge) : null,
 			onRemove: (eventID: number) => {
 				const equippedItem = gearData.getEquippedItem();
 				if (equippedItem) gearData.equipItem(eventID, equippedItem.withItem(equippedItem.item));

--- a/ui/core/components/individual_sim_ui/reforge_summary.tsx
+++ b/ui/core/components/individual_sim_ui/reforge_summary.tsx
@@ -38,12 +38,11 @@ export class ReforgeSummary extends Component {
 		gear.getItemSlots().forEach(itemSlot => {
 			const item = gear.getEquippedItem(itemSlot);
 			if (item?.reforge && item.reforge?.id !== 0) {
-				const reforge = this.player.getReforge(item.reforge.id);
+				const reforge = this.player.getReforgeData(item, item.reforge);
 				if (reforge) {
+					const { fromAmount, toAmount } = reforge;
 					const fromStat = reforge.fromStat[0];
 					const toStat = reforge.toStat[0];
-					const fromAmount = Math.ceil(-item.item.stats[fromStat] * reforge.multiplier);
-					const toAmount = Math.floor(item.item.stats[fromStat] * reforge.multiplier);
 
 					if (typeof totals[fromStat] !== 'number') {
 						totals[fromStat] = 0;

--- a/ui/core/player.ts
+++ b/ui/core/player.ts
@@ -446,9 +446,10 @@ export class Player<SpecType extends Spec> {
 	}
 
 	// Returns all reforgings that are valid with a given item
-	getAvailableReforgings(item: Item): Array<ReforgeData> {
-		return this.sim.db.getAvailableReforges(item).map(reforge => {
-			return this.getReforgeData(item, reforge);
+	getAvailableReforgings(equippedItem: EquippedItem): Array<ReforgeData> {
+		const withRandomSuffixStats = equippedItem.getWithRandomSuffixStats();
+		return this.sim.db.getAvailableReforges(withRandomSuffixStats.item).map(reforge => {
+			return this.getReforgeData(equippedItem, reforge);
 		});
 	}
 
@@ -457,10 +458,11 @@ export class Player<SpecType extends Spec> {
 		return this.sim.db.getReforgeById(id);
 	}
 
-	getReforgeData(item: Item, reforge: ReforgeStat): ReforgeData {
+	getReforgeData(equippedItem: EquippedItem, reforge: ReforgeStat): ReforgeData {
+		const withRandomSuffixStats = equippedItem.getWithRandomSuffixStats();
+		const item = withRandomSuffixStats.item;
 		const fromAmount = Math.ceil(-item.stats[reforge.fromStat[0]] * reforge.multiplier);
 		const toAmount = Math.floor(item.stats[reforge.fromStat[0]] * reforge.multiplier);
-
 		return {
 			id: reforge.id,
 			reforge: reforge,

--- a/ui/core/proto_utils/equipped_item.ts
+++ b/ui/core/proto_utils/equipped_item.ts
@@ -195,7 +195,11 @@ export class EquippedItem {
 
 	getWithRandomSuffixStats() {
 		const item = this.item;
-		if (this._randomSuffix) item.stats = this._randomSuffix.stats.map(stat => (stat > 0 ? Math.floor((stat * item.randPropPoints) / 10000) : stat));
+		if (this._randomSuffix)
+			item.stats = item.stats.map((stat, index) =>
+				this._randomSuffix!.stats[index] > 0 ? Math.floor((this._randomSuffix!.stats[index] * item.randPropPoints) / 10000) : stat,
+			);
+
 		return new EquippedItem(item, this._enchant, this._gems, this._randomSuffix, this._reforge);
 	}
 

--- a/ui/core/proto_utils/equipped_item.ts
+++ b/ui/core/proto_utils/equipped_item.ts
@@ -33,11 +33,6 @@ export class EquippedItem {
 
 		this.numPossibleSockets = this.numSockets(true);
 
-		// Add stats to the item from the random suffix to allow reforging
-		if (!!this.randomSuffix) {
-			this._item.stats = this.randomSuffix.stats.map(stat => (stat > 0 ? Math.floor((stat * this._item.randPropPoints) / 10000) : stat));
-		}
-
 		// Fill gems with null so we always have the same number of gems as gem slots.
 		if (this._gems.length < this.numPossibleSockets) {
 			this._gems = this._gems.concat(new Array(this.numPossibleSockets - this._gems.length).fill(null));
@@ -196,6 +191,12 @@ export class EquippedItem {
 
 	withRandomSuffix(randomSuffix: ItemRandomSuffix | null): EquippedItem {
 		return new EquippedItem(this._item, this._enchant, this._gems, randomSuffix, this._reforge);
+	}
+
+	getWithRandomSuffixStats() {
+		const item = this.item;
+		if (this._randomSuffix) item.stats = this._randomSuffix.stats.map(stat => (stat > 0 ? Math.floor((stat * item.randPropPoints) / 10000) : stat));
+		return new EquippedItem(item, this._enchant, this._gems, this._randomSuffix, this._reforge);
 	}
 
 	asActionId(): ActionId {


### PR DESCRIPTION
This fixes the modification of the `UIItem` core stats resulting in double random affix / reforge values.