### PR TITLE
Bugfix/raid sim gear picker filter

### DIFF
--- a/ui/core/components/gear_picker/gear_picker.tsx
+++ b/ui/core/components/gear_picker/gear_picker.tsx
@@ -1359,17 +1359,11 @@ export class ItemList<T extends ItemListType> {
 		const newItem = this.equippedToItemFn(currentEquippedItem);
 		const type = this.getUpdateType(newItem);
 
-		switch (type) {
-			case 'item':
-				itemIdxs = this.player.filterItemData(itemIdxs, i => this.itemData[i].item as unknown as Item, this.slot);
-				break;
-			case 'enchant':
-				itemIdxs = this.player.filterEnchantData(itemIdxs, i => this.itemData[i].item as unknown as Enchant, this.slot, currentEquippedItem);
-				break;
-			case 'gem':
-				itemIdxs = this.player.filterGemData(itemIdxs, i => this.itemData[i].item as unknown as Gem, this.slot, this.socketColor);
-				break;
-		}
+		if (type === 'item' || this.label === SelectorModalTabs.Items)
+			itemIdxs = this.player.filterItemData(itemIdxs, i => this.itemData[i].item as unknown as Item, this.slot);
+		else if (type === 'enchant' || this.label === SelectorModalTabs.Enchants)
+			itemIdxs = this.player.filterEnchantData(itemIdxs, i => this.itemData[i].item as unknown as Enchant, this.slot, currentEquippedItem);
+		else if (type === 'gem') itemIdxs = this.player.filterGemData(itemIdxs, i => this.itemData[i].item as unknown as Gem, this.slot, this.socketColor);
 
 		itemIdxs = itemIdxs.filter(i => {
 			const listItemData = this.itemData[i];

--- a/ui/raid/presets.ts
+++ b/ui/raid/presets.ts
@@ -7,6 +7,7 @@ import { FrostDeathKnightSimUI } from '../death_knight/frost/sim';
 import { UnholyDeathKnightSimUI } from '../death_knight/unholy/sim';
 import { BalanceDruidSimUI } from '../druid/balance/sim.js';
 import { FeralDruidSimUI } from '../druid/feral/sim.js';
+import { GuardianDruidSimUI } from '../druid/guardian/sim';
 import { RestorationDruidSimUI } from '../druid/restoration/sim.js';
 import { BeastMasteryHunterSimUI } from '../hunter/beast_mastery/sim';
 import { MarksmanshipHunterSimUI } from '../hunter/marksmanship/sim';
@@ -42,6 +43,7 @@ export const specSimFactories: Partial<Record<Spec, (parentElem: HTMLElement, pl
 	[Spec.SpecBalanceDruid]: (parentElem: HTMLElement, player: Player<any>) => new BalanceDruidSimUI(parentElem, player),
 	[Spec.SpecFeralDruid]: (parentElem: HTMLElement, player: Player<any>) => new FeralDruidSimUI(parentElem, player),
 	[Spec.SpecRestorationDruid]: (parentElem: HTMLElement, player: Player<any>) => new RestorationDruidSimUI(parentElem, player),
+	[Spec.SpecGuardianDruid]: (parentElem: HTMLElement, player: Player<any>) => new GuardianDruidSimUI(parentElem, player),
 	// Hunter
 	[Spec.SpecBeastMasteryHunter]: (parentElem: HTMLElement, player: Player<any>) => new BeastMasteryHunterSimUI(parentElem, player),
 	[Spec.SpecMarksmanshipHunter]: (parentElem: HTMLElement, player: Player<any>) => new MarksmanshipHunterSimUI(parentElem, player),


### PR DESCRIPTION
- Fix broken raid sim by adding missing Guardian druid spec
- Fix filters not working when item is empty