### PR TITLE
Added support for not showing auras in APLs

### DIFF
--- a/proto/api.proto
+++ b/proto/api.proto
@@ -345,6 +345,7 @@ message AuraStats {
 	int32 max_stacks = 2;
 	bool has_icd = 3;
 	bool has_exclusive_effect = 4;
+	bool should_show_in_apl = 5;
 }
 message SpellStats {
 	ActionID id = 1;

--- a/sim/core/aura.go
+++ b/sim/core/aura.go
@@ -101,6 +101,9 @@ type Aura struct {
 	// included in Character Stats in the UI.
 	BuildPhase CharacterBuildPhase
 
+	// Flags
+	Flags AuraFlag
+
 	// Metrics for this aura.
 	metrics AuraMetrics
 
@@ -370,6 +373,7 @@ func (at *auraTracker) registerAura(unit *Unit, aura Aura) *Aura {
 	newAura.Unit = unit
 	newAura.Icd = aura.Icd
 	newAura.metrics.ID = aura.ActionID
+	newAura.Flags = aura.Flags
 	newAura.activeIndex = Inactive
 	newAura.onApplyEffectsIndex = Inactive
 	newAura.onCastCompleteIndex = Inactive

--- a/sim/core/flags.go
+++ b/sim/core/flags.go
@@ -168,6 +168,17 @@ func (ho HitOutcome) PartialResistString() string {
 	}
 }
 
+type AuraFlag uint32
+
+func (af AuraFlag) Matches(other AuraFlag) bool {
+	return (af & other) != 0
+}
+
+const (
+	AuraFlagNone  AuraFlag = 0
+	AuraFlagNoAPL AuraFlag = 1 << iota //make the aura not show in the apl
+)
+
 // Other flags
 type SpellFlag uint32
 

--- a/sim/core/unit.go
+++ b/sim/core/unit.go
@@ -648,6 +648,7 @@ func (unit *Unit) GetMetadata() *proto.UnitMetadata {
 			MaxStacks:          aura.MaxStacks,
 			HasIcd:             aura.Icd != nil,
 			HasExclusiveEffect: len(aura.ExclusiveEffects) > 0,
+			ShouldShowInApl:    !aura.Flags.Matches(AuraFlagNoAPL),
 		}
 	})
 

--- a/sim/shaman/talents.go
+++ b/sim/shaman/talents.go
@@ -211,6 +211,7 @@ func (shaman *Shaman) applyRollingThunder() {
 	wastedLSChargeAura := shaman.RegisterAura(core.Aura{
 		Label:    "Wasted Lightning Shield Charge",
 		Duration: core.NeverExpires,
+		Flags:    core.AuraFlagNoAPL,
 		ActionID: core.ActionID{
 			SpellID: 324,
 			Tag:     1,

--- a/ui/core/components/individual_sim_ui/apl_helpers.ts
+++ b/ui/core/components/individual_sim_ui/apl_helpers.ts
@@ -35,7 +35,9 @@ const actionIdSets: Record<
 	auras: {
 		defaultLabel: 'Aura',
 		getActionIDs: async metadata => {
-			return metadata.getAuras().map(actionId => {
+			return metadata.getAuras()
+			.filter(aura => aura.data.shouldShowInApl)
+			.map(actionId => {
 				return {
 					value: actionId.id,
 				};
@@ -47,6 +49,7 @@ const actionIdSets: Record<
 		getActionIDs: async metadata => {
 			return metadata
 				.getAuras()
+				.filter(aura => aura.data.shouldShowInApl)
 				.filter(aura => aura.data.maxStacks > 0)
 				.map(actionId => {
 					return {
@@ -60,6 +63,7 @@ const actionIdSets: Record<
 		getActionIDs: async metadata => {
 			return metadata
 				.getAuras()
+				.filter(aura => aura.data.shouldShowInApl)
 				.filter(aura => aura.data.hasIcd)
 				.map(actionId => {
 					return {
@@ -73,6 +77,7 @@ const actionIdSets: Record<
 		getActionIDs: async metadata => {
 			return metadata
 				.getAuras()
+				.filter(aura => aura.data.shouldShowInApl)
 				.filter(aura => aura.data.hasExclusiveEffect)
 				.map(actionId => {
 					return {


### PR DESCRIPTION
Might be counter intuitive with how the flag works for spells since here you need the flag to not having it displayed in the dropdown menu.