### PR TITLE
Added shared cd between on-use trinket and synapse

### DIFF
--- a/sim/core/consumes.go
+++ b/sim/core/consumes.go
@@ -967,6 +967,10 @@ func registerTinkerHandsCD(agent Agent, consumes *proto.Consumes) {
 					Timer:    character.NewTimer(),
 					Duration: time.Second * 60,
 				},
+				SharedCD: Cooldown{
+					Timer:    character.GetOffensiveTrinketCD(),
+					Duration: time.Second * 10,
+				},
 			},
 
 			ApplyEffects: func(sim *Simulation, _ *Unit, _ *Spell) {

--- a/sim/mage/arcane/TestArcane.results
+++ b/sim/mage/arcane/TestArcane.results
@@ -108,8 +108,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 26220.03805
-  tps: 26338.51187
+  dps: 26096.85845
+  tps: 26271.8376
  }
 }
 dps_results: {
@@ -129,22 +129,22 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 25941.1424
-  tps: 26059.61622
+  dps: 25956.73644
+  tps: 26032.17108
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 27099.35139
-  tps: 27184.16427
+  dps: 27137.43239
+  tps: 27184.65408
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 25941.1424
-  tps: 26059.61622
+  dps: 25958.49618
+  tps: 26039.51289
  }
 }
 dps_results: {
@@ -192,8 +192,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-BottledLightning-66879"
  value: {
-  dps: 26884.65111
-  tps: 26967.93831
+  dps: 26872.65792
+  tps: 26985.81909
  }
 }
 dps_results: {
@@ -220,8 +220,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 27159.12743
-  tps: 27301.24101
+  dps: 27314.21276
+  tps: 27429.09849
  }
 }
 dps_results: {
@@ -311,8 +311,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 26769.04207
-  tps: 26849.84541
+  dps: 26533.20769
+  tps: 26618.10812
  }
 }
 dps_results: {
@@ -367,15 +367,15 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 26841.3229
-  tps: 26932.86899
+  dps: 26645.97253
+  tps: 26745.99659
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 27188.61757
-  tps: 27340.49834
+  dps: 27092.11154
+  tps: 27220.38717
  }
 }
 dps_results: {
@@ -388,15 +388,15 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 28292.17659
-  tps: 28412.6329
+  dps: 28196.93767
+  tps: 28293.68409
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 26304.08879
-  tps: 26422.56261
+  dps: 26326.13083
+  tps: 26407.14754
  }
 }
 dps_results: {
@@ -493,15 +493,15 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 27029.52108
-  tps: 27074.92859
+  dps: 27040.17113
+  tps: 27093.35359
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 27126.53335
-  tps: 27181.04733
+  dps: 27120.77352
+  tps: 27183.45465
  }
 }
 dps_results: {
@@ -570,15 +570,15 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 26349.93465
-  tps: 26468.40847
+  dps: 26372.56889
+  tps: 26453.58561
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 26349.93465
-  tps: 26468.40847
+  dps: 26372.56889
+  tps: 26453.58561
  }
 }
 dps_results: {
@@ -605,8 +605,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 26719.32333
-  tps: 26826.22025
+  dps: 26605.55076
+  tps: 26767.55552
  }
 }
 dps_results: {
@@ -626,8 +626,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 26220.03805
-  tps: 26338.51187
+  dps: 26096.85845
+  tps: 26271.8376
  }
 }
 dps_results: {
@@ -647,22 +647,22 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 26073.9033
-  tps: 26164.43387
+  dps: 26041.01861
+  tps: 26154.99677
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 26073.9033
-  tps: 26164.43387
+  dps: 26041.01861
+  tps: 26154.99677
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 26055.03318
-  tps: 26172.14148
+  dps: 26034.97665
+  tps: 26139.87197
  }
 }
 dps_results: {
@@ -703,15 +703,15 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 25941.1424
-  tps: 26059.61622
+  dps: 25816.41481
+  tps: 25991.39396
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 25941.1424
-  tps: 26059.61622
+  dps: 25816.41481
+  tps: 25991.39396
  }
 }
 dps_results: {
@@ -731,29 +731,29 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 26338.78354
-  tps: 26457.25736
+  dps: 26222.27885
+  tps: 26397.258
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 26390.61798
-  tps: 26509.0918
+  dps: 26275.16701
+  tps: 26450.14615
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 26496.22681
-  tps: 26581.10432
+  dps: 26211.03196
+  tps: 26349.27777
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 26841.3229
-  tps: 26932.86899
+  dps: 26475.9795
+  tps: 26612.9545
  }
 }
 dps_results: {
@@ -773,15 +773,15 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 28068.65894
-  tps: 28211.56647
+  dps: 28080.8804
+  tps: 28195.95253
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 26347.24804
-  tps: 26453.66229
+  dps: 26382.92232
+  tps: 26472.02478
  }
 }
 dps_results: {
@@ -885,22 +885,22 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-SeaStar-55256"
  value: {
-  dps: 26539.39129
-  tps: 26639.59558
+  dps: 26552.81387
+  tps: 26616.65335
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SeaStar-56290"
  value: {
-  dps: 27043.89147
-  tps: 27129.42057
+  dps: 27065.1899
+  tps: 27114.28359
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ShardofWoe-60233"
  value: {
-  dps: 27690.7984
-  tps: 27716.16761
+  dps: 27714.56255
+  tps: 27807.22579
  }
 }
 dps_results: {
@@ -920,15 +920,15 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 26427.99512
-  tps: 26546.46894
+  dps: 26441.05553
+  tps: 26522.07224
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 26491.56147
-  tps: 26610.0353
+  dps: 26504.07848
+  tps: 26585.09519
  }
 }
 dps_results: {
@@ -948,15 +948,15 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 26577.44131
-  tps: 26668.38766
+  dps: 26344.57336
+  tps: 26480.28672
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SoulCasket-58183"
  value: {
-  dps: 27836.24925
-  tps: 27912.07112
+  dps: 27885.6023
+  tps: 27923.79716
  }
 }
 dps_results: {
@@ -1074,8 +1074,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 27518.11194
-  tps: 27701.13882
+  dps: 27268.97241
+  tps: 27458.37027
  }
 }
 dps_results: {
@@ -1088,29 +1088,29 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 25955.22416
-  tps: 26072.38917
+  dps: 25959.29207
+  tps: 26040.16382
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 26349.93465
-  tps: 26468.40847
+  dps: 26372.56889
+  tps: 26453.58561
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 26349.93465
-  tps: 26468.40847
+  dps: 26372.56889
+  tps: 26453.58561
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 26349.93465
-  tps: 26468.40847
+  dps: 26372.56889
+  tps: 26453.58561
  }
 }
 dps_results: {
@@ -1130,22 +1130,22 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 25941.1424
-  tps: 26059.61622
+  dps: 25958.49618
+  tps: 26039.51289
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 27164.11966
-  tps: 27247.05018
+  dps: 27203.35974
+  tps: 27248.69158
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 25941.1424
-  tps: 26059.61622
+  dps: 25958.49618
+  tps: 26039.51289
  }
 }
 dps_results: {
@@ -1228,22 +1228,22 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 26220.03805
-  tps: 26338.51187
+  dps: 26240.99438
+  tps: 26322.0111
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 26286.94909
-  tps: 26405.42292
+  dps: 26169.3907
+  tps: 26344.36985
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 26286.94909
-  tps: 26405.42292
+  dps: 26169.3907
+  tps: 26344.36985
  }
 }
 dps_results: {

--- a/sim/warlock/affliction/TestAffliction.results
+++ b/sim/warlock/affliction/TestAffliction.results
@@ -101,8 +101,8 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 24867.76379
-  tps: 18465.16437
+  dps: 24791.60606
+  tps: 18417.63466
  }
 }
 dps_results: {
@@ -122,22 +122,22 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 24692.10487
-  tps: 18289.50545
+  dps: 24687.37676
+  tps: 18277.94213
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 25571.2892
-  tps: 18926.35378
+  dps: 25427.93907
+  tps: 18798.8832
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 24721.09882
-  tps: 18317.05036
+  dps: 24609.17295
+  tps: 18221.18711
  }
 }
 dps_results: {
@@ -185,8 +185,8 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-BottledLightning-66879"
  value: {
-  dps: 25348.23552
-  tps: 18776.0232
+  dps: 25222.36798
+  tps: 18644.24046
  }
 }
 dps_results: {
@@ -213,8 +213,8 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 25708.5887
-  tps: 19056.48522
+  dps: 25616.96387
+  tps: 18953.82151
  }
 }
 dps_results: {
@@ -297,8 +297,8 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 25065.17594
-  tps: 18541.14081
+  dps: 25003.7218
+  tps: 18485.894
  }
 }
 dps_results: {
@@ -353,15 +353,15 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 24834.57994
-  tps: 18353.06889
+  dps: 24895.24297
+  tps: 18459.04183
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 25574.21802
-  tps: 18905.77072
+  dps: 25495.29635
+  tps: 18875.9813
  }
 }
 dps_results: {
@@ -374,15 +374,15 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 26366.87644
-  tps: 19472.25956
+  dps: 26272.27369
+  tps: 19427.11609
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 24897.28121
-  tps: 18493.23275
+  dps: 24784.214
+  tps: 18396.22816
  }
 }
 dps_results: {
@@ -472,15 +472,15 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 25904.83003
-  tps: 19293.45702
+  dps: 25914.69739
+  tps: 19288.56728
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 26003.71987
-  tps: 19305.86988
+  dps: 26018.62153
+  tps: 19303.73475
  }
 }
 dps_results: {
@@ -542,15 +542,15 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 24985.37241
-  tps: 18581.32395
+  dps: 24871.73452
+  tps: 18483.74868
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 24985.37241
-  tps: 18581.32395
+  dps: 24871.73452
+  tps: 18483.74868
  }
 }
 dps_results: {
@@ -577,8 +577,8 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 25266.41318
-  tps: 18717.47542
+  dps: 25189.62448
+  tps: 18667.54683
  }
 }
 dps_results: {
@@ -598,8 +598,8 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 24867.76379
-  tps: 18465.16437
+  dps: 24791.60606
+  tps: 18417.63466
  }
 }
 dps_results: {
@@ -619,22 +619,22 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 25004.80867
-  tps: 18575.24574
+  dps: 24854.20154
+  tps: 18489.88944
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 25004.80867
-  tps: 18575.24574
+  dps: 24854.20154
+  tps: 18489.88944
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 24903.29303
-  tps: 18447.59801
+  dps: 24793.63483
+  tps: 18364.74418
  }
 }
 dps_results: {
@@ -675,15 +675,15 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 24692.10487
-  tps: 18289.50545
+  dps: 24616.25252
+  tps: 18242.28111
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 24692.10487
-  tps: 18289.50545
+  dps: 24616.25252
+  tps: 18242.28111
  }
 }
 dps_results: {
@@ -703,29 +703,29 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 24896.76569
-  tps: 18494.16627
+  dps: 24817.84491
+  tps: 18443.8735
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 24933.97675
-  tps: 18531.37733
+  dps: 24854.49807
+  tps: 18480.52666
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 24834.57994
-  tps: 18353.06889
+  dps: 24866.5639
+  tps: 18439.09839
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 24834.57994
-  tps: 18353.06889
+  dps: 24866.5639
+  tps: 18439.09839
  }
 }
 dps_results: {
@@ -745,15 +745,15 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 26158.71804
-  tps: 19484.81757
+  dps: 26032.60973
+  tps: 19371.42062
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 24964.75101
-  tps: 18477.07165
+  dps: 24836.69098
+  tps: 18368.35094
  }
 }
 dps_results: {
@@ -857,15 +857,15 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-SeaStar-55256"
  value: {
-  dps: 25148.99069
-  tps: 18623.70636
+  dps: 25021.24932
+  tps: 18511.93547
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SeaStar-56290"
  value: {
-  dps: 25518.1523
-  tps: 18888.27231
+  dps: 25376.76619
+  tps: 18762.77719
  }
 }
 dps_results: {
@@ -878,8 +878,8 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-ShardofWoe-60233"
  value: {
-  dps: 25286.75129
-  tps: 18664.63219
+  dps: 25173.60964
+  tps: 18614.36297
  }
 }
 dps_results: {
@@ -899,15 +899,15 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 24969.30713
-  tps: 18565.25866
+  dps: 24836.74825
+  tps: 18448.76241
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 25014.43591
-  tps: 18610.38745
+  dps: 24878.12558
+  tps: 18490.13974
  }
 }
 dps_results: {
@@ -927,15 +927,15 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 24834.57994
-  tps: 18353.06889
+  dps: 24866.5639
+  tps: 18439.09839
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SoulCasket-58183"
  value: {
-  dps: 26074.23488
-  tps: 19364.95729
+  dps: 25919.95897
+  tps: 19226.51202
  }
 }
 dps_results: {
@@ -1067,8 +1067,8 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 25800.51939
-  tps: 19089.93368
+  dps: 25585.57589
+  tps: 18923.70861
  }
 }
 dps_results: {
@@ -1081,29 +1081,29 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 24721.09882
-  tps: 18317.05036
+  dps: 24609.17295
+  tps: 18221.18711
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 24985.37241
-  tps: 18581.32395
+  dps: 24871.73452
+  tps: 18483.74868
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 24985.37241
-  tps: 18581.32395
+  dps: 24871.73452
+  tps: 18483.74868
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 24985.37241
-  tps: 18581.32395
+  dps: 24871.73452
+  tps: 18483.74868
  }
 }
 dps_results: {
@@ -1123,22 +1123,22 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 24721.09882
-  tps: 18317.05036
+  dps: 24609.17295
+  tps: 18221.18711
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 25618.83274
-  tps: 18960.42667
+  dps: 25473.72534
+  tps: 18831.18857
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 24721.09882
-  tps: 18317.05036
+  dps: 24609.17295
+  tps: 18221.18711
  }
 }
 dps_results: {
@@ -1221,22 +1221,22 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 24897.28121
-  tps: 18493.23275
+  dps: 24784.214
+  tps: 18396.22816
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 24943.78984
-  tps: 18505.89427
+  dps: 24834.03892
+  tps: 18406.94982
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 24943.78984
-  tps: 18505.89427
+  dps: 24834.03892
+  tps: 18406.94982
  }
 }
 dps_results: {

--- a/sim/warlock/destruction/TestDestruction.results
+++ b/sim/warlock/destruction/TestDestruction.results
@@ -101,8 +101,8 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 25763.96998
-  tps: 17049.16846
+  dps: 25779.24633
+  tps: 17099.65031
  }
 }
 dps_results: {
@@ -122,22 +122,22 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 25551.51293
-  tps: 16894.33394
+  dps: 25601.87249
+  tps: 16947.69203
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 26393.97974
-  tps: 17396.30623
+  dps: 26459.8982
+  tps: 17470.33689
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 25551.51293
-  tps: 16894.33394
+  dps: 25617.60086
+  tps: 16968.79568
  }
 }
 dps_results: {
@@ -185,8 +185,8 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-BottledLightning-66879"
  value: {
-  dps: 26275.11081
-  tps: 17321.36509
+  dps: 26280.98353
+  tps: 17373.57108
  }
 }
 dps_results: {
@@ -213,8 +213,8 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 26560.90739
-  tps: 17528.52504
+  dps: 26547.58344
+  tps: 17539.53599
  }
 }
 dps_results: {
@@ -297,8 +297,8 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 26070.12557
-  tps: 17237.88812
+  dps: 25997.15247
+  tps: 17162.77404
  }
 }
 dps_results: {
@@ -353,15 +353,15 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 25787.65455
-  tps: 17014.89453
+  dps: 25763.4273
+  tps: 17023.77274
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 26499.8898
-  tps: 17540.41411
+  dps: 26422.15769
+  tps: 17471.729
  }
 }
 dps_results: {
@@ -374,15 +374,15 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 27297.9884
-  tps: 18020.40691
+  dps: 27216.09239
+  tps: 17948.32811
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 25827.99813
-  tps: 17095.83091
+  dps: 25896.41536
+  tps: 17172.08324
  }
 }
 dps_results: {
@@ -472,15 +472,15 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 26800.64443
-  tps: 17756.87611
+  dps: 26772.16104
+  tps: 17736.83199
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 26977.15818
-  tps: 17877.36471
+  dps: 26979.92604
+  tps: 17895.67059
  }
 }
 dps_results: {
@@ -542,15 +542,15 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 25862.92258
-  tps: 17121.28316
+  dps: 25931.63404
+  tps: 17197.76166
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 25862.92258
-  tps: 17121.28316
+  dps: 25931.63404
+  tps: 17197.76166
  }
 }
 dps_results: {
@@ -577,8 +577,8 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 26248.6237
-  tps: 17330.96639
+  dps: 26262.05851
+  tps: 17382.9365
  }
 }
 dps_results: {
@@ -598,8 +598,8 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 25763.96998
-  tps: 17049.16846
+  dps: 25779.24633
+  tps: 17099.65031
  }
 }
 dps_results: {
@@ -619,22 +619,22 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 25790.45876
-  tps: 17105.36597
+  dps: 25731.70853
+  tps: 17061.44155
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 25790.45876
-  tps: 17105.36597
+  dps: 25731.70853
+  tps: 17061.44155
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 25761.2906
-  tps: 16958.06334
+  dps: 25671.73084
+  tps: 16936.27315
  }
 }
 dps_results: {
@@ -675,15 +675,15 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 25551.51293
-  tps: 16894.33394
+  dps: 25566.04456
+  tps: 16943.94174
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 25551.51293
-  tps: 16894.33394
+  dps: 25566.04456
+  tps: 16943.94174
  }
 }
 dps_results: {
@@ -703,29 +703,29 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 25825.8346
-  tps: 17095.96153
+  dps: 25835.90416
+  tps: 17144.08059
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 25861.75767
-  tps: 17122.36514
+  dps: 25871.24291
+  tps: 17170.28925
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 25787.65455
-  tps: 17014.89453
+  dps: 25780.90667
+  tps: 17043.71195
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 25787.65455
-  tps: 17014.89453
+  dps: 25780.90667
+  tps: 17043.71195
  }
 }
 dps_results: {
@@ -745,15 +745,15 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 27131.06787
-  tps: 17957.68846
+  dps: 27087.90612
+  tps: 17946.69716
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 25910.49382
-  tps: 17101.47662
+  dps: 25886.99881
+  tps: 17103.34687
  }
 }
 dps_results: {
@@ -857,15 +857,15 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-SeaStar-55256"
  value: {
-  dps: 25973.20384
-  tps: 17150.60824
+  dps: 26030.36735
+  tps: 17200.92965
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SeaStar-56290"
  value: {
-  dps: 26338.94247
-  tps: 17368.57402
+  dps: 26382.96415
+  tps: 17401.99889
  }
 }
 dps_results: {
@@ -878,8 +878,8 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-ShardofWoe-60233"
  value: {
-  dps: 26273.4474
-  tps: 17258.23291
+  dps: 26219.14431
+  tps: 17242.04355
  }
 }
 dps_results: {
@@ -899,15 +899,15 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 25875.17028
-  tps: 17131.08828
+  dps: 25937.23454
+  tps: 17202.68006
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 25917.55398
-  tps: 17162.09182
+  dps: 25979.09133
+  tps: 17233.30777
  }
 }
 dps_results: {
@@ -927,15 +927,15 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 25787.65455
-  tps: 17014.89453
+  dps: 25780.90667
+  tps: 17043.71195
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SoulCasket-58183"
  value: {
-  dps: 26942.92111
-  tps: 17766.49198
+  dps: 27011.53096
+  tps: 17842.51055
  }
 }
 dps_results: {
@@ -1067,8 +1067,8 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 26510.56793
-  tps: 17490.76495
+  dps: 26252.96284
+  tps: 17348.63811
  }
 }
 dps_results: {
@@ -1081,29 +1081,29 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 25549.27951
-  tps: 16897.95145
+  dps: 25606.27239
+  tps: 16948.31802
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 25862.92258
-  tps: 17121.28316
+  dps: 25931.63404
+  tps: 17197.76166
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 25862.92258
-  tps: 17121.28316
+  dps: 25931.63404
+  tps: 17197.76166
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 25862.92258
-  tps: 17121.28316
+  dps: 25931.63404
+  tps: 17197.76166
  }
 }
 dps_results: {
@@ -1123,22 +1123,22 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 25551.51293
-  tps: 16894.33394
+  dps: 25617.60086
+  tps: 16968.79568
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 26441.09138
-  tps: 17424.37704
+  dps: 26507.00035
+  tps: 17498.38361
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 25551.51293
-  tps: 16894.33394
+  dps: 25617.60086
+  tps: 16968.79568
  }
 }
 dps_results: {
@@ -1221,22 +1221,22 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 25763.96998
-  tps: 17049.16846
+  dps: 25831.84779
+  tps: 17125.00612
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 25806.24642
-  tps: 17091.7684
+  dps: 25783.78768
+  tps: 17096.13788
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 25806.24642
-  tps: 17091.7684
+  dps: 25783.78768
+  tps: 17096.13788
  }
 }
 dps_results: {


### PR DESCRIPTION
Not sure of the interaction with on-use defensive trinket. Are they still on a different shared cd than the offensives one ?