### PR TITLE
[UI][FIX] Decode URI wowhead data

### DIFF
--- a/ui/core/wowhead.ts
+++ b/ui/core/wowhead.ts
@@ -129,5 +129,5 @@ export const buildWowheadTooltipDataset = async (options: WowheadTooltipItemPara
 		}
 	}
 
-	return params.toString();
+	return decodeURIComponent(params.toString());
 };


### PR DESCRIPTION
The wowhead dataset is not an actual URL, thus the data must be decoded before adding to the dataset.
- Fixes `pcs` param for set piece bonuses not working