### PR TITLE
hunter: fix survival aoe apl

### DIFF
--- a/sim/hunter/survival/TestSV.results
+++ b/sim/hunter/survival/TestSV.results
@@ -1333,43 +1333,43 @@ dps_results: {
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-FullBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 322616.0937
-  tps: 173412.51846
+  dps: 142233.14894
+  tps: 103802.71006
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-FullBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 21151.09289
-  tps: 17251.73853
+  dps: 22600.95698
+  tps: 18320.3442
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 26685.4616
-  tps: 21187.97862
+  dps: 28714.26479
+  tps: 22859.12165
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-NoBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 228778.01327
-  tps: 126581.09442
+  dps: 99656.89975
+  tps: 73588.36287
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-NoBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 14267.89856
-  tps: 11636.53604
+  dps: 15940.32403
+  tps: 12933.44161
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-NoBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 16060.69901
-  tps: 12901.8411
+  dps: 17577.50736
+  tps: 14144.37529
  }
 }
 dps_results: {
@@ -1459,43 +1459,43 @@ dps_results: {
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-FullBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 323301.30663
-  tps: 174017.39622
+  dps: 142885.81646
+  tps: 104362.45597
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-FullBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 21342.19883
-  tps: 17314.19976
+  dps: 22787.9293
+  tps: 18356.71473
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 27169.77636
-  tps: 21479.82882
+  dps: 29154.74762
+  tps: 23059.74559
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-NoBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 229437.10843
-  tps: 127122.04078
+  dps: 100190.36187
+  tps: 74060.6512
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-NoBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 14409.10434
-  tps: 11688.65218
+  dps: 16069.23218
+  tps: 12970.10366
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-NoBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 16353.06861
-  tps: 13064.13694
+  dps: 17798.05868
+  tps: 14221.93996
  }
 }
 dps_results: {

--- a/ui/hunter/survival/apls/aoe.apl.json
+++ b/ui/hunter/survival/apls/aoe.apl.json
@@ -1,78 +1,17 @@
 {
-    "type": "TypeAPL",
-    "prepullActions": [
-    {"action":{"castSpell":{"spellId":{"otherId":"OtherActionPotion"}}},"doAtValue":{"const":{"val":"-1s"}}}
-    ],
-    "priorityList": [
-		{
-			"action": {
-				"condition": { "cmp": { "op": "OpGt", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "1s" } } } },
-				"autocastOtherCooldowns": {}
-			}
-		},
-		{
-			"action": {
-				"condition": {
-					"and": {
-						"vals": [
-							{ "cmp": { "op": "OpGe", "lhs": { "remainingTime": {} }, "rhs": { "const": { "val": "8s" } } } },
-							{ "spellIsReady": { "spellId": { "spellId": 13812 } } }
-						]
-					}
-				},
-				"castSpell": { "spellId": { "spellId": 13812 } }
-			}
-		},
-		{
-			"action": {
-				"condition": {
-					"and": {
-						"vals": [
-							{ "not": { "val": { "dotIsActive": { "spellId": { "spellId": 1978 } } } } },
-							{ "cmp": { "op": "OpGe", "lhs": { "remainingTime": {} }, "rhs": { "const": { "val": "6s" } } } }
-						]
-					}
-				},
-				"castSpell": { "spellId": { "spellId": 1978 } }
-			}
-		},
-		{
-			"action": {
-				"condition": { "cmp": { "op": "OpGt", "lhs": { "numberTargets": {} }, "rhs": { "const": { "val": "4" } } } },
-				"castSpell": { "spellId": { "spellId": 2643 } }
-			}
-		},
-		{
-			"action": {
-				"condition": {
-					"or": {
-						"vals": [
-							{
-								"cmp": {
-									"op": "OpLt",
-									"lhs": { "spellTimeToReady": { "spellId": { "spellId": 53351 } } },
-									"rhs": { "const": { "val": "250ms" } }
-								}
-							}
-						]
-					}
-				},
-				"waitUntil": { "condition": { "spellIsReady": { "spellId": { "spellId": 53351 } } } }
-			}
-		},
-		{ "action": { "castSpell": { "spellId": { "spellId": 53351 } } } },
-		{
-			"action": {
-				"condition": { "not": { "val": { "dotIsActive": { "spellId": { "spellId": 53301 } } } } },
-				"castSpell": { "spellId": { "spellId": 53301 } }
-			}
-		},
-		{
-			"action": {
-				"condition": { "cmp": { "op": "OpGe", "lhs": { "currentFocus": {} }, "rhs": { "const": { "val": "65" } } } },
-				"castSpell": { "spellId": { "spellId": 2643 } }
-			}
-		},
-		{ "action": { "castSpell": { "spellId": { "spellId": 77767 } } } }
+	"type": "TypeAPL",
+	"prepullActions": [
+		{"action":{"castSpell":{"spellId":{"spellId":13165}}},"doAtValue":{"const":{"val":"-10s"}}},
+		{"action":{"castSpell":{"spellId":{"spellId":1130}}},"doAtValue":{"const":{"val":"-5s"}}},
+		{"action":{"castSpell":{"spellId":{"otherId":"OtherActionPotion"}}},"doAtValue":{"const":{"val":"-1s"}}},
+		{"action":{"castSpell":{"spellId":{"spellId":13812}}},"doAtValue":{"const":{"val":"-1s"}}}
+	],
+	"priorityList": [
+		{"action":{"condition":{"cmp":{"op":"OpGt","lhs":{"currentTime":{}},"rhs":{"const":{"val":"1s"}}}},"autocastOtherCooldowns":{}}},
+		{"action":{"castSpell":{"spellId":{"spellId":13812}}}},
+		{"action":{"castSpell":{"spellId":{"spellId":2643}}}},
+		{"action":{"castSpell":{"spellId":{"spellId":53351}}}},
+		{"action":{"condition":{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":56343}}},{"or":{"vals":[{"not":{"val":{"dotIsActive":{"spellId":{"spellId":53301}}}}},{"cmp":{"op":"OpLt","lhs":{"dotRemainingTime":{"spellId":{"spellId":53301}}},"rhs":{"math":{"op":"OpAdd","lhs":{"spellTravelTime":{"spellId":{"spellId":53301}}},"rhs":{"const":{"val":"1s"}}}}}}]}}]}},"castSpell":{"spellId":{"spellId":53301}}}},
+		{"action":{"castSpell":{"spellId":{"spellId":77767}}}}
 	]
 }


### PR DESCRIPTION
The previous AOE APL had many problems, the largest of which was being in Aspect of the Fox, leading to essentially infinite focus, presumably due to the targets attacking the player.

The new APL is fixes that and makes some improvements:

- The result with no condition for Explosive Trap seems to always be better.
- Serpent Sting can be ignored since it will be applied passively via Multi Shot, which is a high priority cast.
- Mutli Shot seems to be worth spamming on aoe regardless of target count.
- The Kill Shot wait seems to not matter.
- Explosive Shot should only be used with Lock and Load. The same condition as the single target APL is used, since it's equivalent in dps to only using Explosive Shot when the debuff is not present on the target.

One notable thing still missing is Trap Launcher.