### PR TITLE
fix blood frenzy being overwritten by other bleed effects 

### DIFF
--- a/sim/core/debuffs.go
+++ b/sim/core/debuffs.go
@@ -41,6 +41,7 @@ func applyDebuffEffects(target *Unit, targetIdx int, debuffs *proto.Debuffs, rai
 	// +4% Phsyical Damage
 	if debuffs.BloodFrenzy && targetIdx < 4 {
 		MakePermanent(BloodFrenzyAura(target, 2))
+		MakePermanent(TraumaAura(target, 2))
 	}
 
 	if debuffs.SavageCombat {
@@ -323,9 +324,7 @@ func spellDamageEffect(aura *Aura, multiplier float64) *ExclusiveEffect {
 }
 
 func BloodFrenzyAura(target *Unit, points int32) *Aura {
-	baseAura := bloodFrenzySavageCombatAura(target, "Blood Frenzy", ActionID{SpellID: 29859}, points)
-	bleedDamageEffect(baseAura, 1.3)
-	return baseAura
+	return bloodFrenzySavageCombatAura(target, "Blood Frenzy", ActionID{SpellID: 29859}, points)
 }
 func SavageCombatAura(target *Unit, points int32) *Aura {
 	return bloodFrenzySavageCombatAura(target, "Savage Combat", ActionID{SpellID: 58413}, points)

--- a/sim/death_knight/blood/TestBlood.results
+++ b/sim/death_knight/blood/TestBlood.results
@@ -37,1448 +37,1448 @@ character_stats_results: {
 dps_results: {
  key: "TestBlood-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 13685.78673
-  tps: 65473.66851
+  dps: 14187.66894
+  tps: 67858.60806
   hps: 4752.37404
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4912.39092
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4871.6611
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 13571.8526
-  tps: 64858.76353
+  dps: 14069.19597
+  tps: 67219.19808
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 13763.7478
-  tps: 65885.05572
+  dps: 14268.30356
+  tps: 68284.37673
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 13787.09131
-  tps: 66011.84462
+  dps: 14292.49862
+  tps: 68415.80881
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BindingPromise-67037"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 13673.91289
-  tps: 65228.18073
+  dps: 14175.4879
+  tps: 67604.15545
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 13756.26844
-  tps: 65606.11299
+  dps: 14261.13766
+  tps: 67997.205
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 14048.55146
-  tps: 66860.14972
+  dps: 14562.82044
+  tps: 69289.06445
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 13758.84281
-  tps: 65857.74316
+  dps: 14263.27613
+  tps: 68256.32643
   hps: 4887.66972
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4887.66972
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4887.66972
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 13668.55075
-  tps: 65277.97597
+  dps: 14169.91126
+  tps: 67655.9425
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 13981.01355
-  tps: 66743.59617
+  dps: 14492.77509
+  tps: 69169.28285
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BottledLightning-66879"
  value: {
-  dps: 13630.36619
-  tps: 65111.26716
+  dps: 14129.98737
+  tps: 67481.4628
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 13532.37867
-  tps: 63348.14236
+  dps: 14028.37632
+  tps: 65653.99988
   hps: 4752.37404
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 14326.86299
-  tps: 68135.07553
+  dps: 14846.24078
+  tps: 70583.89952
   hps: 4946.09503
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 13649.71268
-  tps: 65276.88085
+  dps: 14150.15193
+  tps: 67653.9489
   hps: 4752.37404
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 13688.91061
-  tps: 65487.46377
+  dps: 14190.8165
+  tps: 67872.40333
   hps: 4752.37404
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CrushingWeight-59506"
  value: {
-  dps: 14432.7148
-  tps: 69149.98562
+  dps: 14961.94412
+  tps: 71669.2728
   hps: 4918.49692
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CrushingWeight-65118"
  value: {
-  dps: 14518.5194
-  tps: 69686.37784
+  dps: 15050.98712
+  tps: 72226.65327
   hps: 4873.14065
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4888.87474
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 14245.05603
-  tps: 68214.86697
+  dps: 14755.14044
+  tps: 70634.96632
   hps: 4776.60428
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 13987.17803
-  tps: 67028.4353
+  dps: 14489.24894
+  tps: 69412.85766
   hps: 4776.60428
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 13583.78137
-  tps: 64945.90286
+  dps: 14080.26379
+  tps: 67301.52716
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 13890.30963
-  tps: 66472.10582
+  dps: 14399.77653
+  tps: 68894.09557
   hps: 4815.66304
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 13569.51681
-  tps: 64839.62473
+  dps: 14066.90444
+  tps: 67199.96651
   hps: 4752.37404
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 13821.51592
-  tps: 66182.73711
+  dps: 14328.44048
+  tps: 68594.14369
   hps: 4824.94021
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 13532.37867
-  tps: 64640.96159
+  dps: 14028.37632
+  tps: 66993.87743
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 13532.37867
-  tps: 64640.96159
+  dps: 14028.37632
+  tps: 66993.87743
   hps: 4752.37404
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 13569.51681
-  tps: 64839.62473
+  dps: 14066.90444
+  tps: 67199.96651
   hps: 4752.37404
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 13900.15818
-  tps: 66484.62951
+  dps: 14410.12426
+  tps: 68907.45497
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 13949.13911
-  tps: 66677.35544
+  dps: 14460.85962
+  tps: 69106.85377
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 13532.37867
-  tps: 64640.96159
+  dps: 14028.37632
+  tps: 66993.87743
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FallofMortality-59500"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FallofMortality-65124"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 13737.98217
-  tps: 65510.71765
+  dps: 14242.11995
+  tps: 67897.99384
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4975.2598
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 14017.17939
-  tps: 66726.35413
+  dps: 14530.33671
+  tps: 69150.68821
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 13532.37867
-  tps: 64640.96159
+  dps: 14028.37632
+  tps: 66993.87743
   hps: 4752.37404
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FluidDeath-58181"
  value: {
-  dps: 13727.34625
-  tps: 65752.86752
+  dps: 14231.05859
+  tps: 68149.82971
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 13532.37867
-  tps: 64640.96159
+  dps: 14028.37632
+  tps: 66993.87743
   hps: 4752.37404
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 14262.98104
-  tps: 68665.95477
+  dps: 14784.63525
+  tps: 71161.02299
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GaleofShadows-56138"
  value: {
-  dps: 13727.85242
-  tps: 65468.22799
+  dps: 14231.6822
+  tps: 67854.6701
   hps: 4818.18213
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GaleofShadows-56462"
  value: {
-  dps: 13796.66611
-  tps: 65601.80851
+  dps: 14302.9384
+  tps: 67991.84404
   hps: 4844.49665
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GearDetector-61462"
  value: {
-  dps: 13799.28855
-  tps: 65894.33582
+  dps: 14305.73982
+  tps: 68296.58634
   hps: 4818.94052
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4852.90291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 13735.69197
-  tps: 65610.26516
+  dps: 14239.54046
+  tps: 68000.47079
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 13821.05841
-  tps: 66078.00544
+  dps: 14328.27741
+  tps: 68486.61334
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HarmlightToken-63839"
  value: {
-  dps: 13624.93751
-  tps: 65141.11291
+  dps: 14121.41993
+  tps: 67496.73721
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 13863.42428
-  tps: 66287.27512
+  dps: 14370.90081
+  tps: 68697.02317
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 13622.71987
-  tps: 65201.2145
+  dps: 14121.98683
+  tps: 67575.35303
   hps: 4792.85618
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 13662.76724
-  tps: 65381.20646
+  dps: 14163.82805
+  tps: 67763.07645
   hps: 4851.63392
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HeartofRage-59224"
  value: {
-  dps: 14194.60136
-  tps: 67834.46932
+  dps: 14714.83595
+  tps: 70303.62813
   hps: 4815.90675
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HeartofRage-65072"
  value: {
-  dps: 14289.2761
-  tps: 68326.36744
+  dps: 14812.71939
+  tps: 70812.13117
   hps: 4815.90675
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HeartofSolace-55868"
  value: {
-  dps: 13727.85242
-  tps: 65468.22799
+  dps: 14231.6822
+  tps: 67854.6701
   hps: 4818.18213
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HeartofSolace-56393"
  value: {
-  dps: 14299.48379
-  tps: 67921.59981
+  dps: 14823.81185
+  tps: 70393.59535
   hps: 4844.49665
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HeartofThunder-55845"
  value: {
-  dps: 13563.51968
-  tps: 64812.7857
+  dps: 14060.57897
+  tps: 67171.63306
   hps: 4830.47259
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HeartofThunder-56370"
  value: {
-  dps: 13568.98324
-  tps: 64842.93154
+  dps: 14066.2288
+  tps: 67202.81956
   hps: 4844.32923
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 13752.79396
-  tps: 65768.53255
+  dps: 14257.30505
+  tps: 68164.96871
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 13569.51681
-  tps: 64839.62473
+  dps: 14066.90444
+  tps: 67199.96651
   hps: 4752.37404
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 14076.6212
-  tps: 66979.86156
+  dps: 14591.88483
+  tps: 69412.87477
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 14076.6212
-  tps: 66979.86156
+  dps: 14591.88483
+  tps: 69412.87477
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4826.3211
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 13673.91289
-  tps: 65228.18073
+  dps: 14175.4879
+  tps: 67604.15545
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 13636.10985
-  tps: 65192.22295
+  dps: 14136.17272
+  tps: 67566.75936
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 13696.13239
-  tps: 65422.16639
+  dps: 14198.59617
+  tps: 67805.90053
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 14076.91472
-  tps: 66989.98192
+  dps: 14593.12409
+  tps: 69428.38297
   hps: 4810.53017
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 14076.91472
-  tps: 66989.98192
+  dps: 14593.12409
+  tps: 69428.38297
   hps: 4810.53017
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 13754.76565
-  tps: 65589.22957
+  dps: 14259.4401
+  tps: 67979.32998
   hps: 4799.60074
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LastWord-50708"
  value: {
-  dps: 14248.16298
-  tps: 67241.65778
+  dps: 14765.50161
+  tps: 69662.07669
   hps: 4953.16173
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LeadenDespair-55816"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4929.62965
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LeadenDespair-56347"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4975.2598
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 13786.18763
-  tps: 65960.62027
+  dps: 14292.21354
+  tps: 68365.81698
   hps: 4779.93587
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 13788.51576
-  tps: 65848.23522
+  dps: 14294.67945
+  tps: 68249.25987
   hps: 4815.90675
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 14029.22538
-  tps: 67176.46995
+  dps: 14542.49294
+  tps: 69617.62068
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MagmaPlatedBattlearmor"
  value: {
-  dps: 13270.58921
-  tps: 63631.42122
+  dps: 13757.13969
+  tps: 65949.05496
   hps: 4341.18356
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MagmaPlatedBattlegear"
  value: {
-  dps: 14514.22731
-  tps: 69639.90047
+  dps: 15048.64673
+  tps: 72188.09502
   hps: 4566.87316
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 14140.48136
-  tps: 66961.5525
+  dps: 14658.45945
+  tps: 69396.28705
   hps: 4768.58666
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 14268.1508
-  tps: 67329.56394
+  dps: 14790.89469
+  tps: 69777.79526
   hps: 4815.90675
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 13887.79551
-  tps: 66407.87933
+  dps: 14396.11773
+  tps: 68821.79075
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 13932.47609
-  tps: 66628.98706
+  dps: 14442.34876
+  tps: 69050.53131
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 13862.00785
-  tps: 65793.79352
+  dps: 14369.7025
+  tps: 68185.8743
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 14134.12584
-  tps: 66720.7037
+  dps: 14651.4938
+  tps: 69144.23713
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 13957.77969
-  tps: 66660.76442
+  dps: 14468.85665
+  tps: 69084.44059
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 13561.06304
-  tps: 64799.23092
+  dps: 14058.03858
+  tps: 67157.61035
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 13683.40117
-  tps: 65451.94018
+  dps: 14185.04315
+  tps: 67835.3521
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 13532.37867
-  tps: 64640.96159
+  dps: 14028.37632
+  tps: 66993.87743
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 14106.52491
-  tps: 67402.7677
+  dps: 14625.24565
+  tps: 69865.01431
   hps: 4860.04427
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 14218.41195
-  tps: 68315.5103
+  dps: 14741.40288
+  tps: 70813.21834
   hps: 4857.68772
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Rainsong-55854"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Rainsong-56377"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 13723.45456
-  tps: 65642.1301
+  dps: 14226.45386
+  tps: 68031.81467
   hps: 4752.37404
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 13649.71268
-  tps: 65276.88085
+  dps: 14150.15193
+  tps: 67653.9489
   hps: 4752.37404
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 13851.21279
-  tps: 66207.72304
+  dps: 14358.30283
+  tps: 68614.88182
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 13861.18166
-  tps: 66278.88088
+  dps: 14368.65072
+  tps: 68688.96361
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 13682.01722
-  tps: 65450.18543
+  dps: 14183.91639
+  tps: 67835.04034
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SeaStar-55256"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SeaStar-56290"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Shadowmourne-49623"
  value: {
-  dps: 14905.65313
-  tps: 71156.91239
+  dps: 15445.73297
+  tps: 73713.60541
   hps: 5029.53549
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ShardofWoe-60233"
  value: {
-  dps: 14080.91778
-  tps: 67152.16061
+  dps: 14598.67458
+  tps: 69604.87515
   hps: 4842.53282
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 14045.46913
-  tps: 67210.74061
+  dps: 14560.29355
+  tps: 69658.05855
   hps: 4799.62779
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4901.1108
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 13688.41258
-  tps: 65483.86263
+  dps: 14190.56757
+  tps: 67870.06463
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 13703.68244
-  tps: 65563.45345
+  dps: 14206.44823
+  tps: 67952.83908
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Sorrowsong-55879"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Sorrowsong-56400"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 13862.00785
-  tps: 65793.79352
+  dps: 14369.7025
+  tps: 68185.8743
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SoulCasket-58183"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 13660.48419
-  tps: 65342.64347
+  dps: 14161.19098
+  tps: 67721.42837
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StumpofTime-62465"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StumpofTime-62470"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4999.39113
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 14020.00278
-  tps: 67028.34504
+  dps: 14533.57011
+  tps: 69466.95125
   hps: 4837.77915
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TearofBlood-55819"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TearofBlood-56351"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 13693.58517
-  tps: 65553.8743
+  dps: 14195.94706
+  tps: 67942.87676
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 13706.87003
-  tps: 65622.2443
+  dps: 14209.76332
+  tps: 68013.98157
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 13746.76668
-  tps: 65489.51718
+  dps: 14250.79854
+  tps: 67873.60073
   hps: 4822.29916
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 13550.79218
-  tps: 64748.32113
+  dps: 14047.2746
+  tps: 67103.94543
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-UnheededWarning-59520"
  value: {
-  dps: 13889.35855
-  tps: 66590.79632
+  dps: 14398.54699
+  tps: 69016.04926
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 13721.65255
-  tps: 65488.61162
+  dps: 14225.13714
+  tps: 67875.00357
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 13721.65255
-  tps: 65488.61162
+  dps: 14225.13714
+  tps: 67875.00357
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 13721.65255
-  tps: 65488.61162
+  dps: 14225.13714
+  tps: 67875.00357
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 8030.12208
-  tps: 36326.93149
+  dps: 8305.56614
+  tps: 37545.00882
   hps: 4721.12722
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4999.39113
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 5026.59373
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 13721.65255
-  tps: 65488.61162
+  dps: 14225.13714
+  tps: 67875.00357
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 14076.6212
-  tps: 66979.86156
+  dps: 14591.88483
+  tps: 69412.87477
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4893.40826
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 13820.86077
-  tps: 66049.18288
+  dps: 14327.98103
+  tps: 68456.16002
   hps: 4953.81228
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 13766.56067
-  tps: 65896.70193
+  dps: 14271.19907
+  tps: 68296.33944
   hps: 4893.40826
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 13671.98419
-  tps: 65301.22322
+  dps: 14173.48662
+  tps: 67680.36738
   hps: 4921.95006
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4893.40826
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4893.40826
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 13674.91236
-  tps: 65317.05164
+  dps: 14176.52734
+  tps: 67696.58119
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 13979.18416
-  tps: 66757.06872
+  dps: 14490.6517
+  tps: 69182.45293
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 13605.36472
-  tps: 64942.05277
+  dps: 14103.9084
+  tps: 67305.77641
   hps: 4824.83178
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 13710.32014
-  tps: 65503.90664
+  dps: 14213.19515
+  tps: 67890.43253
   hps: 4800.53519
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4932.26215
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4932.26215
  }
 }
 dps_results: {
  key: "TestBlood-Average-Default"
  value: {
-  dps: 13501.74136
-  tps: 64745.6486
+  dps: 13997.14657
+  tps: 67106.31281
   hps: 4754.31545
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Goblin-p1-Basic-simple-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17163.94254
-  tps: 82257.41131
+  dps: 17661.96332
+  tps: 84598.58155
   hps: 4860.93792
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Goblin-p1-Basic-simple-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 13425.26652
-  tps: 64130.44981
+  dps: 13917.4981
+  tps: 66465.99182
   hps: 4766.5552
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Goblin-p1-Basic-simple-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 18993.14985
-  tps: 78235.55995
+  dps: 19707.96374
+  tps: 81120.00022
   hps: 8503.49867
  }
 }
@@ -1509,24 +1509,24 @@ dps_results: {
 dps_results: {
  key: "TestBlood-Settings-Worgen-p1-Basic-simple-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17488.75437
-  tps: 83926.91701
+  dps: 17994.50227
+  tps: 86308.46375
   hps: 4874.48114
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Worgen-p1-Basic-simple-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 13546.59836
-  tps: 64719.42035
+  dps: 14043.08078
+  tps: 67075.04465
   hps: 4787.91291
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Worgen-p1-Basic-simple-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 19127.51703
-  tps: 78718.78467
+  dps: 19846.78573
+  tps: 81617.93716
   hps: 8469.7759
  }
 }
@@ -1557,8 +1557,8 @@ dps_results: {
 dps_results: {
  key: "TestBlood-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 12434.48946
-  tps: 59905.22454
+  dps: 12887.30167
+  tps: 62072.5853
   hps: 4626.32857
  }
 }

--- a/sim/death_knight/frost/TestFrost.results
+++ b/sim/death_knight/frost/TestFrost.results
@@ -37,1269 +37,1269 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 21998.85907
-  tps: 19401.86587
+  dps: 21999.14507
+  tps: 19402.15187
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 21071.15353
-  tps: 18668.28771
+  dps: 21071.4239
+  tps: 18668.55808
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 21092.88396
-  tps: 18688.2805
+  dps: 21093.15433
+  tps: 18688.55087
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 21702.86883
-  tps: 19107.66598
+  dps: 21703.15072
+  tps: 19107.94787
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
   hps: 95.30298
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 20767.29959
-  tps: 18446.90505
+  dps: 20767.52546
+  tps: 18447.13092
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 20996.6409
-  tps: 18638.41734
+  dps: 20996.86633
+  tps: 18638.64278
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 21022.71089
-  tps: 18660.9626
+  dps: 21022.93633
+  tps: 18661.18804
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BindingPromise-67037"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 20982.31203
-  tps: 18661.91749
+  dps: 20982.53747
+  tps: 18662.14292
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 20919.753
-  tps: 18599.35846
+  dps: 20919.97843
+  tps: 18599.58389
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 20944.2296
-  tps: 18623.83506
+  dps: 20944.45503
+  tps: 18624.06049
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 20932.19779
-  tps: 18570.26628
+  dps: 20932.42323
+  tps: 18570.49171
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 21583.53986
-  tps: 19136.84103
+  dps: 21583.7653
+  tps: 19137.06647
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 20985.70885
-  tps: 18629.50388
+  dps: 20985.93429
+  tps: 18629.72932
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 20908.33759
-  tps: 18560.8059
+  dps: 20908.56303
+  tps: 18561.03134
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 21543.01838
-  tps: 19090.39878
+  dps: 21543.24381
+  tps: 19090.62421
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BottledLightning-66879"
  value: {
-  dps: 20847.06197
-  tps: 18510.65844
+  dps: 20847.2874
+  tps: 18510.88388
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 21691.52782
-  tps: 18714.39847
+  dps: 21691.80953
+  tps: 18714.67455
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 22106.44158
-  tps: 19496.97883
+  dps: 22106.72913
+  tps: 19497.26638
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 21980.30066
-  tps: 19385.0978
+  dps: 21980.58666
+  tps: 19385.3838
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 22035.78195
-  tps: 19436.67312
+  dps: 22036.06795
+  tps: 19436.95912
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CrushingWeight-59506"
  value: {
-  dps: 21806.34922
-  tps: 19290.64191
+  dps: 21806.62245
+  tps: 19290.91514
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CrushingWeight-65118"
  value: {
-  dps: 22163.25989
-  tps: 19566.17795
+  dps: 22163.4935
+  tps: 19566.41157
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 21786.47532
-  tps: 19394.53365
+  dps: 21786.73391
+  tps: 19394.79224
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 21186.74859
-  tps: 18851.02827
+  dps: 21186.99913
+  tps: 18851.27881
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 21032.56139
-  tps: 18712.16685
+  dps: 21032.78683
+  tps: 18712.39228
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 21119.09186
-  tps: 18703.5499
+  dps: 21119.3173
+  tps: 18703.77533
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 21744.08976
-  tps: 19144.98092
+  dps: 21744.37147
+  tps: 19145.26264
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 20676.15158
-  tps: 18495.03636
+  dps: 20676.37702
+  tps: 18495.26179
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 21691.52782
-  tps: 19096.32497
+  dps: 21691.80953
+  tps: 19096.60668
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 21691.52782
-  tps: 19096.32497
+  dps: 21691.80953
+  tps: 19096.60668
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 21744.08976
-  tps: 19144.98092
+  dps: 21744.37147
+  tps: 19145.26264
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 21158.86578
-  tps: 18785.96009
+  dps: 21159.09122
+  tps: 18786.18553
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 21186.61385
-  tps: 18813.00619
+  dps: 21186.83929
+  tps: 18813.23163
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 21691.52782
-  tps: 19096.32497
+  dps: 21691.80953
+  tps: 19096.60668
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FallofMortality-59500"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FallofMortality-65124"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 21264.55721
-  tps: 18816.04636
+  dps: 21264.82758
+  tps: 18816.31674
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 21749.44658
-  tps: 19310.64177
+  dps: 21749.67201
+  tps: 19310.8672
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 21732.89802
-  tps: 19137.69516
+  dps: 21733.17973
+  tps: 19137.97688
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FluidDeath-58181"
  value: {
-  dps: 21212.30899
-  tps: 18787.59783
+  dps: 21212.57993
+  tps: 18787.86877
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 21691.52782
-  tps: 19096.32497
+  dps: 21691.80953
+  tps: 19096.60668
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 21814.86905
-  tps: 19416.61406
+  dps: 21815.09449
+  tps: 19416.83949
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GaleofShadows-56138"
  value: {
-  dps: 21021.81498
-  tps: 18664.30628
+  dps: 21022.07617
+  tps: 18664.56747
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GaleofShadows-56462"
  value: {
-  dps: 20995.47865
-  tps: 18534.25939
+  dps: 20995.78314
+  tps: 18534.56388
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GearDetector-61462"
  value: {
-  dps: 20926.05888
-  tps: 18472.51176
+  dps: 20926.28431
+  tps: 18472.73719
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 20895.78027
-  tps: 18554.3697
+  dps: 20896.0057
+  tps: 18554.59514
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 21019.04576
-  tps: 18659.74991
+  dps: 21019.27119
+  tps: 18659.97534
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HarmlightToken-63839"
  value: {
-  dps: 20827.86661
-  tps: 18507.47207
+  dps: 20828.09204
+  tps: 18507.6975
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 21422.26477
-  tps: 19041.69153
+  dps: 21422.49548
+  tps: 19041.92224
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 20891.75224
-  tps: 18592.97529
+  dps: 20891.99017
+  tps: 18593.21322
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 21030.86749
-  tps: 18680.58422
+  dps: 21031.15273
+  tps: 18680.80965
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartofRage-65072"
  value: {
-  dps: 22202.08233
-  tps: 19569.94452
+  dps: 22202.3694
+  tps: 19570.23159
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartofSolace-55868"
  value: {
-  dps: 21021.81498
-  tps: 18664.30628
+  dps: 21022.07617
+  tps: 18664.56747
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartofSolace-56393"
  value: {
-  dps: 21968.52182
-  tps: 19265.83864
+  dps: 21968.84105
+  tps: 19266.15786
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartofThunder-55845"
  value: {
-  dps: 20755.92952
-  tps: 18435.53498
+  dps: 20756.15525
+  tps: 18435.7607
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartofThunder-56370"
  value: {
-  dps: 20763.38443
-  tps: 18442.98988
+  dps: 20763.61025
+  tps: 18443.2157
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 20932.84027
-  tps: 18584.16253
+  dps: 20933.0657
+  tps: 18584.38796
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 21744.08976
-  tps: 19144.98092
+  dps: 21744.37147
+  tps: 19145.26264
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 21878.95353
-  tps: 19425.19163
+  dps: 21879.17896
+  tps: 19425.41706
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 21878.95353
-  tps: 19425.19163
+  dps: 21879.17896
+  tps: 19425.41706
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 20919.753
-  tps: 18599.35846
+  dps: 20919.97843
+  tps: 18599.58389
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 20944.2296
-  tps: 18623.83506
+  dps: 20944.45503
+  tps: 18624.06049
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 20876.73352
-  tps: 18556.33897
+  dps: 20876.95895
+  tps: 18556.56441
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 20982.31203
-  tps: 18661.91749
+  dps: 20982.53747
+  tps: 18662.14292
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 21107.41268
-  tps: 18701.77926
+  dps: 21107.68305
+  tps: 18702.04963
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 21241.52709
-  tps: 18821.92156
+  dps: 21241.79746
+  tps: 18822.19193
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 21142.46138
-  tps: 18718.16074
+  dps: 21142.68681
+  tps: 18718.38617
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 21142.46138
-  tps: 18718.16074
+  dps: 21142.68681
+  tps: 18718.38617
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 20868.52132
-  tps: 18422.25743
+  dps: 20868.76565
+  tps: 18422.48286
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LastWord-50708"
  value: {
-  dps: 22106.44158
-  tps: 19496.97883
+  dps: 22106.72913
+  tps: 19497.26638
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LeadenDespair-55816"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LeadenDespair-56347"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 21093.31288
-  tps: 18707.84679
+  dps: 21093.59277
+  tps: 18708.12668
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 21162.7504
-  tps: 18770.38438
+  dps: 21163.03007
+  tps: 18770.66405
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MagmaPlatedBattlearmor"
  value: {
-  dps: 18256.05466
-  tps: 15983.83909
+  dps: 18256.28366
+  tps: 15984.06809
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MagmaPlatedBattlegear"
  value: {
-  dps: 20051.19808
-  tps: 17565.91017
+  dps: 20051.4842
+  tps: 17566.19628
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 21412.7099
-  tps: 19034.165
+  dps: 21412.9898
+  tps: 19034.44489
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 21650.64848
-  tps: 19263.95447
+  dps: 21650.92815
+  tps: 19264.23414
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 21502.17072
-  tps: 19116.96835
+  dps: 21502.40183
+  tps: 19117.19946
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 21603.71587
-  tps: 19210.02676
+  dps: 21603.94773
+  tps: 19210.25862
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 21285.21722
-  tps: 18866.41372
+  dps: 21285.48759
+  tps: 18866.6841
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 21712.8281
-  tps: 19308.22464
+  dps: 21713.09847
+  tps: 19308.49501
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 20970.93135
-  tps: 18650.5368
+  dps: 20971.15678
+  tps: 18650.76224
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 20970.93135
-  tps: 18650.5368
+  dps: 20971.15678
+  tps: 18650.76224
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 21014.6592
-  tps: 18694.26466
+  dps: 21014.88464
+  tps: 18694.4901
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 21381.23607
-  tps: 18984.22925
+  dps: 21381.46587
+  tps: 18984.45905
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 20752.57749
-  tps: 18432.18295
+  dps: 20752.80318
+  tps: 18432.40864
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 20876.82809
-  tps: 18536.84589
+  dps: 20877.05352
+  tps: 18537.07132
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 20877.60213
-  tps: 18557.20759
+  dps: 20877.82757
+  tps: 18557.43303
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 21000.58828
-  tps: 18680.19374
+  dps: 21000.81372
+  tps: 18680.41918
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 21691.52782
-  tps: 19096.32497
+  dps: 21691.80953
+  tps: 19096.60668
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 21192.43485
-  tps: 18742.63385
+  dps: 21192.68387
+  tps: 18742.88287
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 21353.13794
-  tps: 18862.0616
+  dps: 21353.36337
+  tps: 18862.28704
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Rainsong-55854"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Rainsong-56377"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 22106.44158
-  tps: 19496.97883
+  dps: 22106.72913
+  tps: 19497.26638
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 21980.30066
-  tps: 19385.0978
+  dps: 21980.58666
+  tps: 19385.3838
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 21711.32308
-  tps: 19272.79103
+  dps: 21711.5956
+  tps: 19273.06355
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 21784.69867
-  tps: 19371.45242
+  dps: 21784.97148
+  tps: 19371.72523
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 20990.41304
-  tps: 18648.41613
+  dps: 20990.63847
+  tps: 18648.64156
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SeaStar-55256"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SeaStar-56290"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Shadowmourne-49623"
  value: {
-  dps: 22106.44158
-  tps: 19496.97883
+  dps: 22106.72913
+  tps: 19497.26638
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShardofWoe-60233"
  value: {
-  dps: 20953.22008
-  tps: 18601.51982
+  dps: 20953.63518
+  tps: 18601.89359
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 21434.31004
-  tps: 18997.14455
+  dps: 21434.54041
+  tps: 18997.37492
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 21059.23794
-  tps: 18714.8449
+  dps: 21059.46338
+  tps: 18715.07033
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 21100.6368
-  tps: 18752.1865
+  dps: 21100.86223
+  tps: 18752.41193
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sorrowsong-55879"
  value: {
-  dps: 20919.753
-  tps: 18599.35846
+  dps: 20919.97843
+  tps: 18599.58389
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sorrowsong-56400"
  value: {
-  dps: 20944.2296
-  tps: 18623.83506
+  dps: 20944.45503
+  tps: 18624.06049
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 21403.48385
-  tps: 19000.61803
+  dps: 21403.75422
+  tps: 19000.8884
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SoulCasket-58183"
  value: {
-  dps: 20970.93135
-  tps: 18650.5368
+  dps: 20971.15678
+  tps: 18650.76224
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 20862.56666
-  tps: 18523.59168
+  dps: 20862.79209
+  tps: 18523.81712
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-StumpofTime-62465"
  value: {
-  dps: 21040.48313
-  tps: 18639.23107
+  dps: 21040.75406
+  tps: 18639.50201
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-StumpofTime-62470"
  value: {
-  dps: 21040.48313
-  tps: 18639.23107
+  dps: 21040.75406
+  tps: 18639.50201
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 20878.60519
-  tps: 18558.21065
+  dps: 20878.83063
+  tps: 18558.43608
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 21494.48629
-  tps: 19020.59436
+  dps: 21494.71665
+  tps: 19020.82473
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TearofBlood-55819"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TearofBlood-56351"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 20892.30954
-  tps: 18571.91499
+  dps: 20892.53497
+  tps: 18572.14043
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 20944.2296
-  tps: 18623.83506
+  dps: 20944.45503
+  tps: 18624.06049
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 20910.4214
-  tps: 18590.02686
+  dps: 20910.64684
+  tps: 18590.25229
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 20952.86196
-  tps: 18632.46742
+  dps: 20953.08739
+  tps: 18632.69285
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 21048.16449
-  tps: 18702.82446
+  dps: 21048.38992
+  tps: 18703.0499
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 21085.85733
-  tps: 18736.61274
+  dps: 21086.08276
+  tps: 18736.83817
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 20927.9677
-  tps: 18636.17849
+  dps: 20928.21671
+  tps: 18636.4275
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 20758.7865
-  tps: 18440.50702
+  dps: 20759.07393
+  tps: 18440.73246
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UnheededWarning-59520"
  value: {
-  dps: 21179.07093
-  tps: 18828.1773
+  dps: 21179.29637
+  tps: 18828.40273
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 21143.30733
-  tps: 18790.73398
+  dps: 21143.53276
+  tps: 18790.95941
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 21143.30733
-  tps: 18790.73398
+  dps: 21143.53276
+  tps: 18790.95941
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 21143.30733
-  tps: 18790.73398
+  dps: 21143.53276
+  tps: 18790.95941
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 18423.96876
-  tps: 15803.65068
+  dps: 18424.28672
+  tps: 15803.96864
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 20904.34077
-  tps: 18551.76742
+  dps: 20904.56621
+  tps: 18551.99285
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 21631.11185
-  tps: 19177.34995
+  dps: 21631.33728
+  tps: 19177.57539
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 21070.62847
-  tps: 18669.28879
+  dps: 21070.89941
+  tps: 18669.55973
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 21052.583
-  tps: 18665.81025
+  dps: 21052.80843
+  tps: 18666.03569
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 21010.2044
-  tps: 18649.73362
+  dps: 21010.42983
+  tps: 18649.95906
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 21028.41081
-  tps: 18645.33337
+  dps: 21028.6904
+  tps: 18645.61297
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 20985.02394
-  tps: 18664.62939
+  dps: 20985.24937
+  tps: 18664.85483
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 20920.76047
-  tps: 18570.51211
+  dps: 20920.98591
+  tps: 18570.73755
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 20732.84077
-  tps: 18412.44622
+  dps: 20733.0662
+  tps: 18412.67166
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 21587.17324
-  tps: 19138.5174
+  dps: 21587.39868
+  tps: 19138.74284
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 20800.69553
-  tps: 18407.22449
+  dps: 20800.92097
+  tps: 18407.44992
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 20866.21446
-  tps: 18502.83585
+  dps: 20866.54405
+  tps: 18503.12908
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 20895.2764
-  tps: 18574.88185
+  dps: 20895.50183
+  tps: 18575.10729
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 20893.46553
-  tps: 18573.07099
+  dps: 20893.69097
+  tps: 18573.29642
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 20893.46553
-  tps: 18573.07099
+  dps: 20893.69097
+  tps: 18573.29642
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 22049.9151
-  tps: 19388.11074
+  dps: 22050.32534
+  tps: 19388.47636
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p1.dw-DefaultTalents-Basic-2h-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 62256.95078
-  tps: 59823.68233
+  dps: 62257.20844
+  tps: 59823.94
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p1.dw-DefaultTalents-Basic-2h-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 21851.83304
-  tps: 19365.84742
+  dps: 21852.12056
+  tps: 19366.13493
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p1.dw-DefaultTalents-Basic-2h-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 29836.6826
-  tps: 23974.79748
+  dps: 29837.97092
+  tps: 23976.0858
  }
 }
 dps_results: {
@@ -1326,22 +1326,22 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Human-p1.dw-DefaultTalents-Basic-dw-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 62077.98341
-  tps: 59640.21877
+  dps: 62078.24107
+  tps: 59640.47643
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p1.dw-DefaultTalents-Basic-dw-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 21850.30292
-  tps: 19364.31729
+  dps: 21850.59043
+  tps: 19364.60481
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p1.dw-DefaultTalents-Basic-dw-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 29836.6826
-  tps: 23974.79748
+  dps: 29837.97092
+  tps: 23976.0858
  }
 }
 dps_results: {
@@ -1368,22 +1368,22 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Human-p1.dw-DefaultTalents-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 77036.33149
-  tps: 75199.47269
+  dps: 77036.58915
+  tps: 75199.73036
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p1.dw-DefaultTalents-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 23901.90136
-  tps: 21449.11367
+  dps: 23902.15902
+  tps: 21449.37134
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p1.dw-DefaultTalents-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 31241.3567
-  tps: 24759.2165
+  dps: 31242.64502
+  tps: 24760.50482
  }
 }
 dps_results: {
@@ -1410,22 +1410,22 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Human-p1.dw-Masterfrost-Basic-2h-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 72081.19907
-  tps: 69463.67785
+  dps: 72082.08277
+  tps: 69464.38886
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p1.dw-Masterfrost-Basic-2h-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 29625.08268
-  tps: 26922.00319
+  dps: 29626.134
+  tps: 26922.94949
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p1.dw-Masterfrost-Basic-2h-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 39451.00546
-  tps: 33168.93513
+  dps: 39452.48568
+  tps: 33170.41534
  }
 }
 dps_results: {
@@ -1452,22 +1452,22 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Human-p1.dw-Masterfrost-Basic-dw-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 71087.76459
-  tps: 68503.19379
+  dps: 71088.74452
+  tps: 68503.94206
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p1.dw-Masterfrost-Basic-dw-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 29611.85485
-  tps: 26908.77536
+  dps: 29612.90616
+  tps: 26909.72166
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p1.dw-Masterfrost-Basic-dw-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 39451.00546
-  tps: 33168.93513
+  dps: 39452.48568
+  tps: 33170.41534
  }
 }
 dps_results: {
@@ -1494,22 +1494,22 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Human-p1.dw-Masterfrost-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 101093.93152
-  tps: 98908.48499
+  dps: 101094.22756
+  tps: 98908.78103
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p1.dw-Masterfrost-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 31085.86628
-  tps: 28323.48587
+  dps: 31086.16233
+  tps: 28323.78191
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p1.dw-Masterfrost-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 40137.27132
-  tps: 32619.43051
+  dps: 40138.75154
+  tps: 32620.91072
  }
 }
 dps_results: {
@@ -1536,22 +1536,22 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Human-p1.dw-TwoHand-Basic-2h-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 62256.95078
-  tps: 59823.68233
+  dps: 62257.20844
+  tps: 59823.94
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p1.dw-TwoHand-Basic-2h-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 21851.83304
-  tps: 19365.84742
+  dps: 21852.12056
+  tps: 19366.13493
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p1.dw-TwoHand-Basic-2h-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 29836.6826
-  tps: 23974.79748
+  dps: 29837.97092
+  tps: 23976.0858
  }
 }
 dps_results: {
@@ -1578,22 +1578,22 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Human-p1.dw-TwoHand-Basic-dw-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 62077.98341
-  tps: 59640.21877
+  dps: 62078.24107
+  tps: 59640.47643
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p1.dw-TwoHand-Basic-dw-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 21850.30292
-  tps: 19364.31729
+  dps: 21850.59043
+  tps: 19364.60481
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p1.dw-TwoHand-Basic-dw-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 29836.6826
-  tps: 23974.79748
+  dps: 29837.97092
+  tps: 23976.0858
  }
 }
 dps_results: {
@@ -1620,22 +1620,22 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Human-p1.dw-TwoHand-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 77036.33149
-  tps: 75199.47269
+  dps: 77036.58915
+  tps: 75199.73036
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p1.dw-TwoHand-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 23901.90136
-  tps: 21449.11367
+  dps: 23902.15902
+  tps: 21449.37134
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Human-p1.dw-TwoHand-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 31241.3567
-  tps: 24759.2165
+  dps: 31242.64502
+  tps: 24760.50482
  }
 }
 dps_results: {
@@ -1662,22 +1662,22 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Orc-p1.dw-DefaultTalents-Basic-2h-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 62558.17321
-  tps: 60028.58168
+  dps: 62558.44308
+  tps: 60028.85155
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p1.dw-DefaultTalents-Basic-2h-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 22108.16003
-  tps: 19498.69729
+  dps: 22108.44758
+  tps: 19498.98484
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p1.dw-DefaultTalents-Basic-2h-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 30212.41035
-  tps: 24173.10432
+  dps: 30213.69905
+  tps: 24174.39303
  }
 }
 dps_results: {
@@ -1704,22 +1704,22 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Orc-p1.dw-DefaultTalents-Basic-dw-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 62317.37693
-  tps: 59779.02862
+  dps: 62317.6468
+  tps: 59779.29849
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p1.dw-DefaultTalents-Basic-dw-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 22106.44158
-  tps: 19496.97883
+  dps: 22106.72913
+  tps: 19497.26638
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p1.dw-DefaultTalents-Basic-dw-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 30212.41035
-  tps: 24173.10432
+  dps: 30213.69905
+  tps: 24174.39303
  }
 }
 dps_results: {
@@ -1746,22 +1746,22 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Orc-p1.dw-DefaultTalents-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 76955.11707
-  tps: 75102.57594
+  dps: 76955.37481
+  tps: 75102.83369
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p1.dw-DefaultTalents-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 24166.07192
-  tps: 21602.12577
+  dps: 24166.32966
+  tps: 21602.38352
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p1.dw-DefaultTalents-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 31725.4712
-  tps: 25068.41584
+  dps: 31726.75991
+  tps: 25069.70454
  }
 }
 dps_results: {
@@ -1788,22 +1788,22 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Orc-p1.dw-Masterfrost-Basic-2h-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 72302.6289
-  tps: 69674.74539
+  dps: 72303.29652
+  tps: 69675.23184
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p1.dw-Masterfrost-Basic-2h-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 29962.30972
-  tps: 27132.89155
+  dps: 29963.54963
+  tps: 27133.78476
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p1.dw-Masterfrost-Basic-2h-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 39818.46142
-  tps: 33323.79968
+  dps: 39819.94207
+  tps: 33325.28034
  }
 }
 dps_results: {
@@ -1830,22 +1830,22 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Orc-p1.dw-Masterfrost-Basic-dw-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 71680.30065
-  tps: 68983.67711
+  dps: 71681.04956
+  tps: 68984.24702
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p1.dw-Masterfrost-Basic-dw-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 29945.25894
-  tps: 27115.84077
+  dps: 29946.49884
+  tps: 27116.73397
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p1.dw-Masterfrost-Basic-dw-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 39818.46142
-  tps: 33323.79968
+  dps: 39819.94207
+  tps: 33325.28034
  }
 }
 dps_results: {
@@ -1872,22 +1872,22 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Orc-p1.dw-Masterfrost-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 101661.17859
-  tps: 99355.33599
+  dps: 101661.47472
+  tps: 99355.63213
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p1.dw-Masterfrost-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 31382.06422
-  tps: 28512.84905
+  dps: 31382.36035
+  tps: 28513.14518
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p1.dw-Masterfrost-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 40577.15995
-  tps: 32866.54814
+  dps: 40578.6406
+  tps: 32868.02879
  }
 }
 dps_results: {
@@ -1914,22 +1914,22 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Orc-p1.dw-TwoHand-Basic-2h-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 62558.17321
-  tps: 60028.58168
+  dps: 62558.44308
+  tps: 60028.85155
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p1.dw-TwoHand-Basic-2h-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 22108.16003
-  tps: 19498.69729
+  dps: 22108.44758
+  tps: 19498.98484
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p1.dw-TwoHand-Basic-2h-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 30212.41035
-  tps: 24173.10432
+  dps: 30213.69905
+  tps: 24174.39303
  }
 }
 dps_results: {
@@ -1956,22 +1956,22 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Orc-p1.dw-TwoHand-Basic-dw-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 62317.37693
-  tps: 59779.02862
+  dps: 62317.6468
+  tps: 59779.29849
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p1.dw-TwoHand-Basic-dw-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 22106.44158
-  tps: 19496.97883
+  dps: 22106.72913
+  tps: 19497.26638
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p1.dw-TwoHand-Basic-dw-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 30212.41035
-  tps: 24173.10432
+  dps: 30213.69905
+  tps: 24174.39303
  }
 }
 dps_results: {
@@ -1998,22 +1998,22 @@ dps_results: {
 dps_results: {
  key: "TestFrost-Settings-Orc-p1.dw-TwoHand-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 76955.11707
-  tps: 75102.57594
+  dps: 76955.37481
+  tps: 75102.83369
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p1.dw-TwoHand-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 24166.07192
-  tps: 21602.12577
+  dps: 24166.32966
+  tps: 21602.38352
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p1.dw-TwoHand-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 31725.4712
-  tps: 25068.41584
+  dps: 31726.75991
+  tps: 25069.70454
  }
 }
 dps_results: {
@@ -2040,7 +2040,7 @@ dps_results: {
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 20521.47421
-  tps: 18036.58326
+  dps: 20521.69758
+  tps: 18036.80664
  }
 }

--- a/sim/death_knight/unholy/TestUnholy.results
+++ b/sim/death_knight/unholy/TestUnholy.results
@@ -37,1269 +37,1269 @@ character_stats_results: {
 dps_results: {
  key: "TestUnholy-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 33064.54417
-  tps: 23898.02404
+  dps: 33931.96122
+  tps: 24409.56908
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 32818.82068
-  tps: 23657.24253
+  dps: 33680.36085
+  tps: 24163.56397
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
   hps: 96.7093
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 31129.31984
-  tps: 22632.18813
+  dps: 31945.64176
+  tps: 23115.85835
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 31563.12119
-  tps: 22955.79853
+  dps: 32392.19101
+  tps: 23447.62616
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 31624.81845
-  tps: 23009.79827
+  dps: 32455.75749
+  tps: 23503.06317
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BindingPromise-67037"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 31556.15814
-  tps: 23030.7022
+  dps: 32381.90825
+  tps: 23521.55044
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 31430.76002
-  tps: 22965.74268
+  dps: 32250.21559
+  tps: 23452.54654
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 31475.23684
-  tps: 23014.40383
+  dps: 32295.19225
+  tps: 23501.70753
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 31420.31074
-  tps: 22811.28513
+  dps: 32249.09667
+  tps: 23302.93715
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 32460.58088
-  tps: 23579.1423
+  dps: 33304.2277
+  tps: 24076.51803
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 31534.71788
-  tps: 22934.56825
+  dps: 32363.0795
+  tps: 23425.98836
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 31351.05772
-  tps: 22780.05369
+  dps: 32177.07353
+  tps: 23270.45645
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 32423.06966
-  tps: 23512.85188
+  dps: 33268.23737
+  tps: 24010.96654
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BottledLightning-66879"
  value: {
-  dps: 31262.66208
-  tps: 22732.91018
+  dps: 32082.67296
+  tps: 23219.07002
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 32806.4693
-  tps: 23172.05096
+  dps: 33667.78427
+  tps: 23668.02527
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 34590.4614
-  tps: 25156.55124
+  dps: 35497.31328
+  tps: 25699.35443
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 33012.37405
-  tps: 23862.18594
+  dps: 33877.70429
+  tps: 24372.29746
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 33102.1928
-  tps: 23930.24675
+  dps: 33970.06147
+  tps: 24442.19755
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CrushingWeight-59506"
  value: {
-  dps: 32784.84601
-  tps: 23752.35771
+  dps: 33647.87085
+  tps: 24261.34659
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CrushingWeight-65118"
  value: {
-  dps: 33140.08583
-  tps: 24017.66326
+  dps: 34013.04377
+  tps: 24532.85418
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 32623.17206
-  tps: 23730.06405
+  dps: 33467.61248
+  tps: 24225.5249
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 31664.83257
-  tps: 23055.35481
+  dps: 32490.0397
+  tps: 23542.78805
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 31546.47705
-  tps: 23108.74092
+  dps: 32366.97773
+  tps: 23596.5899
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 31834.86095
-  tps: 23132.20802
+  dps: 32671.54568
+  tps: 23626.96082
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 32892.50659
-  tps: 23709.15827
+  dps: 33756.25587
+  tps: 24216.98968
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 31367.15189
-  tps: 22798.22126
+  dps: 32190.41209
+  tps: 23286.68304
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 32806.4693
-  tps: 23644.94996
+  dps: 33667.78427
+  tps: 24151.04619
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 32806.4693
-  tps: 23644.94996
+  dps: 33667.78427
+  tps: 24151.04619
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 32892.50659
-  tps: 23709.15827
+  dps: 33756.25587
+  tps: 24216.98968
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 31812.5732
-  tps: 23100.0301
+  dps: 32650.58708
+  tps: 23597.24098
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 32015.50243
-  tps: 23298.45728
+  dps: 32858.58715
+  tps: 23799.55638
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 32806.4693
-  tps: 23644.94996
+  dps: 33667.78427
+  tps: 24151.04619
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FallofMortality-59500"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FallofMortality-65124"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 31399.01218
-  tps: 22794.66678
+  dps: 32226.94616
+  tps: 23285.65406
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 32774.91072
-  tps: 23955.63008
+  dps: 33621.23544
+  tps: 24456.53493
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 32882.60186
-  tps: 23728.19669
+  dps: 33744.78078
+  tps: 24235.15688
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FluidDeath-58181"
  value: {
-  dps: 31386.54627
-  tps: 22792.94704
+  dps: 32213.98161
+  tps: 23283.86554
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 32806.4693
-  tps: 23644.94996
+  dps: 33667.78427
+  tps: 24151.04619
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 33001.39365
-  tps: 23965.11426
+  dps: 33870.3761
+  tps: 24477.01386
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GaleofShadows-56138"
  value: {
-  dps: 31385.07149
-  tps: 22776.81473
+  dps: 32211.38234
+  tps: 23265.02058
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GaleofShadows-56462"
  value: {
-  dps: 31438.97313
-  tps: 22764.63978
+  dps: 32266.71586
+  tps: 23251.94169
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GearDetector-61462"
  value: {
-  dps: 31654.29079
-  tps: 22970.30013
+  dps: 32487.34985
+  tps: 23463.43728
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 31391.92898
-  tps: 22820.11707
+  dps: 32217.83312
+  tps: 23310.07078
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 31555.96217
-  tps: 22932.80987
+  dps: 32386.79685
+  tps: 23425.74884
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HarmlightToken-63839"
  value: {
-  dps: 31232.48681
-  tps: 22735.51641
+  dps: 32048.12543
+  tps: 23218.50333
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 32254.84929
-  tps: 23510.07576
+  dps: 33095.59148
+  tps: 24007.50444
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 31583.80811
-  tps: 22874.82098
+  dps: 32417.08319
+  tps: 23366.81324
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 31550.1361
-  tps: 22894.56548
+  dps: 32380.42958
+  tps: 23384.5807
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HeartofRage-59224"
  value: {
-  dps: 32826.85679
-  tps: 23741.33703
+  dps: 33684.83669
+  tps: 24246.70754
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HeartofSolace-55868"
  value: {
-  dps: 31385.07149
-  tps: 22776.81473
+  dps: 32211.38234
+  tps: 23265.02058
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HeartofSolace-56393"
  value: {
-  dps: 32915.61032
-  tps: 23729.21886
+  dps: 33777.81546
+  tps: 24233.7416
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HeartofThunder-55845"
  value: {
-  dps: 31116.88306
-  tps: 22619.80457
+  dps: 31932.97951
+  tps: 23103.24933
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HeartofThunder-56370"
  value: {
-  dps: 31125.03736
-  tps: 22627.92398
+  dps: 31941.28165
+  tps: 23111.51657
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 31428.482
-  tps: 22827.10493
+  dps: 32256.05545
+  tps: 23317.73007
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 32892.50659
-  tps: 23709.15827
+  dps: 33756.25587
+  tps: 24216.98968
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 32989.93755
-  tps: 24130.22734
+  dps: 33840.1543
+  tps: 24633.41139
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 32989.93755
-  tps: 24130.22734
+  dps: 33840.1543
+  tps: 24633.41139
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 31430.76002
-  tps: 22965.74268
+  dps: 32250.21559
+  tps: 23452.54654
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 31475.23684
-  tps: 23014.40383
+  dps: 32295.19225
+  tps: 23501.70753
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 31352.62608
-  tps: 22880.25445
+  dps: 32171.20314
+  tps: 23366.17982
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 31556.15814
-  tps: 23030.7022
+  dps: 32381.90825
+  tps: 23521.55044
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 31265.92427
-  tps: 22703.45934
+  dps: 32088.53474
+  tps: 23190.79832
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 31337.92078
-  tps: 22762.88748
+  dps: 32163.4111
+  tps: 23252.60359
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 31930.52404
-  tps: 23230.8716
+  dps: 32765.64261
+  tps: 23724.48533
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 31930.52404
-  tps: 23230.8716
+  dps: 32765.64261
+  tps: 23724.48533
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 31287.47823
-  tps: 22631.89949
+  dps: 32111.41037
+  tps: 23117.02988
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LastWord-50708"
  value: {
-  dps: 34077.12997
-  tps: 24729.4436
+  dps: 34976.88432
+  tps: 25266.34545
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LeadenDespair-55816"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LeadenDespair-56347"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 31438.27961
-  tps: 22833.10244
+  dps: 32266.47443
+  tps: 23324.39758
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 31517.86083
-  tps: 22899.54691
+  dps: 32348.82499
+  tps: 23393.11967
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MagmaPlatedBattlearmor"
  value: {
-  dps: 27575.6409
-  tps: 19812.65962
+  dps: 28293.52081
+  tps: 20229.44309
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MagmaPlatedBattlegear"
  value: {
-  dps: 30246.73282
-  tps: 21903.6011
+  dps: 31034.35847
+  tps: 22367.25003
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 32015.26289
-  tps: 23321.71766
+  dps: 32852.39726
+  tps: 23816.69746
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 32359.17598
-  tps: 23577.81952
+  dps: 33203.95008
+  tps: 24076.41837
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 32444.79961
-  tps: 23700.66384
+  dps: 33287.64337
+  tps: 24199.37396
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 32624.02723
-  tps: 23847.75427
+  dps: 33470.44547
+  tps: 24348.53527
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 31668.44671
-  tps: 23045.59111
+  dps: 32497.10802
+  tps: 23535.35203
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 32166.09407
-  tps: 23434.63163
+  dps: 33005.99064
+  tps: 23930.23679
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 31523.77462
-  tps: 23067.50633
+  dps: 32344.2753
+  tps: 23555.35531
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 31523.77462
-  tps: 23067.50633
+  dps: 32344.2753
+  tps: 23555.35531
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 31626.07631
-  tps: 23185.63094
+  dps: 32446.55063
+  tps: 23673.45357
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 32152.19399
-  tps: 23374.99627
+  dps: 32993.82161
+  tps: 23872.83137
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 31113.21655
-  tps: 22616.15376
+  dps: 31929.24654
+  tps: 23099.53205
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 31325.64812
-  tps: 22772.39722
+  dps: 32148.45963
+  tps: 23260.15242
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 31355.15881
-  tps: 22880.9259
+  dps: 32173.66262
+  tps: 23366.77802
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 31570.56574
-  tps: 23113.96036
+  dps: 32391.66028
+  tps: 23602.40321
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 32806.4693
-  tps: 23644.94996
+  dps: 33667.78427
+  tps: 24151.04619
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 31766.29267
-  tps: 23054.2035
+  dps: 32607.84766
+  tps: 23553.58434
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 31964.22212
-  tps: 23144.89379
+  dps: 32811.99687
+  tps: 23646.60221
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Rainsong-55854"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Rainsong-56377"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 33222.5284
-  tps: 24009.70439
+  dps: 34093.03154
+  tps: 24522.50772
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 33012.37405
-  tps: 23862.18594
+  dps: 33877.70429
+  tps: 24372.29746
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 32080.40237
-  tps: 23263.33134
+  dps: 32919.13918
+  tps: 23758.06044
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 32196.9854
-  tps: 23350.06272
+  dps: 33038.54473
+  tps: 23845.85604
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 31531.93855
-  tps: 22991.66831
+  dps: 32357.96672
+  tps: 23482.46614
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SeaStar-55256"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SeaStar-56290"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Shadowmourne-49623"
  value: {
-  dps: 35713.1491
-  tps: 25906.43743
+  dps: 36653.27083
+  tps: 26465.94975
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ShardofWoe-60233"
  value: {
-  dps: 31574.13502
-  tps: 22802.8824
+  dps: 32406.35945
+  tps: 23291.32191
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 32247.46013
-  tps: 23389.9076
+  dps: 33095.01262
+  tps: 23890.10704
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 31688.5974
-  tps: 23167.85611
+  dps: 32515.87944
+  tps: 23659.85981
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 31764.9848
-  tps: 23243.6847
+  dps: 32593.70933
+  tps: 23736.88909
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Sorrowsong-55879"
  value: {
-  dps: 31430.76002
-  tps: 22965.74268
+  dps: 32250.21559
+  tps: 23452.54654
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Sorrowsong-56400"
  value: {
-  dps: 31475.23684
-  tps: 23014.40383
+  dps: 32295.19225
+  tps: 23501.70753
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 31668.44671
-  tps: 23045.59111
+  dps: 32497.10802
+  tps: 23535.35203
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SoulCasket-58183"
  value: {
-  dps: 31523.77462
-  tps: 23067.50633
+  dps: 32344.2753
+  tps: 23555.35531
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 31433.78159
-  tps: 22845.72789
+  dps: 32258.4267
+  tps: 23334.465
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-StumpofTime-62465"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-StumpofTime-62470"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 31348.76978
-  tps: 22873.55523
+  dps: 32167.36057
+  tps: 23359.49433
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 32355.26074
-  tps: 23427.58834
+  dps: 33205.20492
+  tps: 23927.62633
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TearofBlood-55819"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TearofBlood-56351"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 31380.91044
-  tps: 22911.20158
+  dps: 32199.80558
+  tps: 23397.44502
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 31475.23684
-  tps: 23014.40383
+  dps: 32295.19225
+  tps: 23501.70753
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 31599.82422
-  tps: 23154.00883
+  dps: 32421.61161
+  tps: 23643.14452
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 31685.95617
-  tps: 23239.58502
+  dps: 32507.96844
+  tps: 23728.94559
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 31666.82718
-  tps: 23129.09787
+  dps: 32495.72543
+  tps: 23622.43594
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 31751.57556
-  tps: 23203.24408
+  dps: 32582.58451
+  tps: 23698.1014
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 31705.12406
-  tps: 23086.00557
+  dps: 32537.54133
+  tps: 23581.16923
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 31093.63238
-  tps: 22616.16288
+  dps: 31909.271
+  tps: 23099.1498
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-UnheededWarning-59520"
  value: {
-  dps: 31660.58878
-  tps: 23083.21507
+  dps: 32491.47868
+  tps: 23578.1363
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 31771.79979
-  tps: 23238.49989
+  dps: 32602.22148
+  tps: 23733.18862
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 31771.79979
-  tps: 23238.49989
+  dps: 32602.22148
+  tps: 23733.18862
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 31771.79979
-  tps: 23238.49989
+  dps: 32602.22148
+  tps: 23733.18862
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 23507.78817
-  tps: 15945.01437
+  dps: 24081.32544
+  tps: 16221.81177
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 31338.16582
-  tps: 22764.16381
+  dps: 32163.66594
+  tps: 23253.93097
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 32537.13415
-  tps: 23634.19571
+  dps: 33382.34723
+  tps: 24132.37608
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 31497.88204
-  tps: 22831.07946
+  dps: 32329.22742
+  tps: 23322.1178
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 31594.8307
-  tps: 22984.25193
+  dps: 32424.71588
+  tps: 23476.69348
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 31140.59552
-  tps: 22628.82611
+  dps: 31957.80126
+  tps: 23113.04024
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 31549.3992
-  tps: 23095.54006
+  dps: 32370.18766
+  tps: 23583.67683
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 31377.84214
-  tps: 22798.80446
+  dps: 32204.92932
+  tps: 23289.95725
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 31091.62817
-  tps: 22594.65777
+  dps: 31907.26679
+  tps: 23077.64469
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 32478.21424
-  tps: 23567.11089
+  dps: 33325.14709
+  tps: 24066.14904
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 31302.53498
-  tps: 22688.68563
+  dps: 32125.06883
+  tps: 23173.59584
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 31510.95609
-  tps: 22838.15215
+  dps: 32340.68945
+  tps: 23327.89957
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 31386.29865
-  tps: 22917.09698
+  dps: 32205.25438
+  tps: 23403.401
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 31411.88337
-  tps: 22951.17757
+  dps: 32230.36398
+  tps: 23437.00648
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 31411.88337
-  tps: 22951.17757
+  dps: 32230.36398
+  tps: 23437.00648
  }
 }
 dps_results: {
  key: "TestUnholy-Average-Default"
  value: {
-  dps: 33454.25991
-  tps: 24208.27327
+  dps: 34326.19123
+  tps: 24721.30978
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Goblin-p1-Basic-st-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 59449.78149
-  tps: 70285.11356
+  dps: 60318.46338
+  tps: 70794.6042
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Goblin-p1-Basic-st-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 33170.24689
-  tps: 23922.75842
+  dps: 34039.53237
+  tps: 24433.22462
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Goblin-p1-Basic-st-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 44206.73935
-  tps: 27558.79431
+  dps: 45392.51152
+  tps: 28197.72835
  }
 }
 dps_results: {
@@ -1326,22 +1326,22 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-Settings-Worgen-p1-Basic-st-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 59938.74978
-  tps: 70979.65375
+  dps: 60811.9555
+  tps: 71494.47098
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Worgen-p1-Basic-st-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 33222.5284
-  tps: 24009.70439
+  dps: 34093.03154
+  tps: 24522.50772
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Worgen-p1-Basic-st-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 44667.53548
-  tps: 27947.03706
+  dps: 45862.80686
+  tps: 28594.09848
  }
 }
 dps_results: {
@@ -1368,7 +1368,7 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 31460.92265
-  tps: 22882.59948
+  dps: 32272.73824
+  tps: 23360.33675
  }
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -37,1255 +37,1255 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 24529.48332
-  tps: 33134.11649
+  dps: 25506.29607
+  tps: 34436.83337
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 22827.49441
-  tps: 30590.91563
+  dps: 23736.6612
+  tps: 31794.12782
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 23096.10039
-  tps: 31233.5041
+  dps: 24015.59978
+  tps: 32460.28045
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 23096.99376
-  tps: 31238.01093
+  dps: 24016.49314
+  tps: 32464.78728
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 23957.14383
-  tps: 32337.49693
+  dps: 24911.11053
+  tps: 33608.57545
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 22827.49441
-  tps: 30591.21393
+  dps: 23736.6612
+  tps: 31794.42613
   hps: 96.7093
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 22827.49441
-  tps: 30591.21393
+  dps: 23736.6612
+  tps: 31794.42613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 23113.22696
-  tps: 30986.09313
+  dps: 24033.46242
+  tps: 32203.26674
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 23164.16861
-  tps: 30869.24179
+  dps: 24086.60414
+  tps: 32082.56301
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BindingPromise-67037"
  value: {
-  dps: 22827.49441
-  tps: 30591.21393
+  dps: 23736.6612
+  tps: 31794.42613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 23767.29365
-  tps: 31534.23403
+  dps: 24714.1291
+  tps: 32775.52877
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 23089.95035
-  tps: 30990.93762
+  dps: 24009.61539
+  tps: 32210.13876
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 23124.31959
-  tps: 31043.28239
+  dps: 24045.35939
+  tps: 32264.57732
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 24006.40798
-  tps: 32078.17058
+  dps: 24962.36086
+  tps: 33338.95664
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 22827.49441
-  tps: 30591.21393
+  dps: 23736.6612
+  tps: 31794.42613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 23225.32823
-  tps: 31057.71635
+  dps: 24150.37073
+  tps: 32279.4004
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 23093.44955
-  tps: 30966.12366
+  dps: 24012.89391
+  tps: 32182.49634
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 22827.49441
-  tps: 30591.21393
+  dps: 23736.6612
+  tps: 31794.42613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 22827.49441
-  tps: 30591.21393
+  dps: 23736.6612
+  tps: 31794.42613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 24043.27408
-  tps: 32026.8722
+  dps: 25001.05504
+  tps: 33287.40028
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 22827.49441
-  tps: 30591.21393
+  dps: 23736.6612
+  tps: 31794.42613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 23265.53769
-  tps: 31118.07965
+  dps: 24192.18784
+  tps: 32342.17457
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledLightning-66879"
  value: {
-  dps: 22898.50447
-  tps: 30728.99893
+  dps: 23810.39012
+  tps: 31937.10675
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 23957.58881
-  tps: 31693.10535
+  dps: 24911.55551
+  tps: 32938.7623
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 24386.74466
-  tps: 32889.83928
+  dps: 25357.84204
+  tps: 34182.74751
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 24381.72457
-  tps: 32967.91825
+  dps: 25352.72076
+  tps: 34264.45113
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 22828.02254
-  tps: 30593.30205
+  dps: 23737.18934
+  tps: 31796.51425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 22827.49441
-  tps: 30591.21393
+  dps: 23736.6612
+  tps: 31794.42613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-59506"
  value: {
-  dps: 23754.06726
-  tps: 32141.61768
+  dps: 24699.93259
+  tps: 33404.9543
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-65118"
  value: {
-  dps: 23740.41989
-  tps: 31563.23711
+  dps: 24685.59423
+  tps: 32802.77021
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 22827.49441
-  tps: 30591.21393
+  dps: 23736.6612
+  tps: 31794.42613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 23493.07876
-  tps: 31677.47309
+  dps: 24420.06056
+  tps: 32909.75113
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 24200.60473
-  tps: 32543.77801
+  dps: 25155.91126
+  tps: 33811.21366
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 22828.02254
-  tps: 30593.30205
+  dps: 23737.18934
+  tps: 31796.51425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 23156.52833
-  tps: 31602.31516
+  dps: 24078.50834
+  tps: 32843.71186
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 23508.83127
-  tps: 31680.20317
+  dps: 24445.05427
+  tps: 32925.93723
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 23952.44999
-  tps: 32415.95671
+  dps: 24906.30877
+  tps: 33690.57895
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 23002.83029
-  tps: 31252.54555
+  dps: 23919.13667
+  tps: 32482.81523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 23957.14383
-  tps: 32337.49693
+  dps: 24911.11053
+  tps: 33608.57545
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 22828.41263
-  tps: 30620.64266
+  dps: 23737.59668
+  tps: 31823.63297
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 23957.58881
-  tps: 32339.61225
+  dps: 24911.55551
+  tps: 33610.69077
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 23952.44999
-  tps: 32415.95671
+  dps: 24906.30877
+  tps: 33690.57895
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 24372.93784
-  tps: 32426.25618
+  dps: 25343.7047
+  tps: 33701.75589
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 24389.02472
-  tps: 32793.2061
+  dps: 25360.0692
+  tps: 34081.54042
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 23957.14383
-  tps: 32337.49693
+  dps: 24911.11053
+  tps: 33608.57545
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-59500"
  value: {
-  dps: 22828.02254
-  tps: 30593.30205
+  dps: 23737.18934
+  tps: 31796.51425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-65124"
  value: {
-  dps: 22828.02254
-  tps: 30593.22921
+  dps: 23737.18934
+  tps: 31796.4414
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 24182.38055
-  tps: 32372.84359
+  dps: 25145.48382
+  tps: 33645.96137
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 22828.02254
-  tps: 30593.36449
+  dps: 23737.18934
+  tps: 31796.57668
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 22827.49441
-  tps: 30591.21393
+  dps: 23736.6612
+  tps: 31794.42613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 22828.02254
-  tps: 30593.36449
+  dps: 23737.18934
+  tps: 31796.57668
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 23501.73079
-  tps: 31486.86333
+  dps: 24437.83175
+  tps: 32725.72503
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 24016.03599
-  tps: 32427.17528
+  dps: 24972.35837
+  tps: 33701.84094
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FluidDeath-58181"
  value: {
-  dps: 24368.97584
-  tps: 33107.47041
+  dps: 25339.40685
+  tps: 34409.29904
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 23957.58881
-  tps: 32339.65204
+  dps: 24911.55551
+  tps: 33610.73056
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 23706.07568
-  tps: 31744.18239
+  dps: 24649.99438
+  tps: 32991.52608
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56138"
  value: {
-  dps: 23109.39305
-  tps: 32082.24592
+  dps: 24030.07184
+  tps: 33346.22149
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56462"
  value: {
-  dps: 23122.0629
-  tps: 31044.05508
+  dps: 24043.05215
+  tps: 32265.5463
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GearDetector-61462"
  value: {
-  dps: 23750.89478
-  tps: 32717.91864
+  dps: 24695.94402
+  tps: 34000.83978
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 22827.49441
-  tps: 30590.89482
+  dps: 23736.6612
+  tps: 31794.10701
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 23574.82533
-  tps: 31496.68789
+  dps: 24513.5492
+  tps: 32734.42855
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 24018.75712
-  tps: 31992.9457
+  dps: 24975.41479
+  tps: 33251.43163
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HarmlightToken-63839"
  value: {
-  dps: 22855.94755
-  tps: 30722.72662
+  dps: 23765.32678
+  tps: 31929.75224
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 23363.31218
-  tps: 31290.44354
+  dps: 24293.88
+  tps: 32521.46647
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 22827.49441
-  tps: 30591.21393
+  dps: 23736.6612
+  tps: 31794.42613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 22827.49441
-  tps: 30591.21393
+  dps: 23736.6612
+  tps: 31794.42613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-59224"
  value: {
-  dps: 23431.36521
-  tps: 31414.38008
+  dps: 24364.4429
+  tps: 32649.28155
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-65072"
  value: {
-  dps: 23522.40544
-  tps: 31497.65656
+  dps: 24459.11079
+  tps: 32735.81933
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-55868"
  value: {
-  dps: 23109.39305
-  tps: 32082.24592
+  dps: 24030.07184
+  tps: 33346.22149
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-56393"
  value: {
-  dps: 23637.56379
-  tps: 31662.15986
+  dps: 24579.13406
+  tps: 32908.18016
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-55845"
  value: {
-  dps: 22827.49441
-  tps: 30591.21393
+  dps: 23736.6612
+  tps: 31794.42613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-56370"
  value: {
-  dps: 22827.49441
-  tps: 30591.21393
+  dps: 23736.6612
+  tps: 31794.42613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 23733.2784
-  tps: 31828.73799
+  dps: 24678.37315
+  tps: 33079.92372
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-50641"
  value: {
-  dps: 24963.3273
-  tps: 33960.49376
+  dps: 25957.28445
+  tps: 35295.13596
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 23952.44999
-  tps: 32415.95671
+  dps: 24906.30877
+  tps: 33690.57895
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 23587.52946
-  tps: 31600.88505
+  dps: 24527.0579
+  tps: 32844.28532
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 23587.52946
-  tps: 31600.88505
+  dps: 24527.0579
+  tps: 32844.28532
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 23089.95035
-  tps: 30990.93762
+  dps: 24009.61539
+  tps: 32210.13876
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 23124.31959
-  tps: 31043.28239
+  dps: 24045.35939
+  tps: 32264.57732
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 22827.49441
-  tps: 30591.21393
+  dps: 23736.6612
+  tps: 31794.42613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 23039.12401
-  tps: 30901.66288
+  dps: 23956.72764
+  tps: 32117.12997
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 22827.49441
-  tps: 30591.41579
+  dps: 23736.6612
+  tps: 31794.62799
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 22827.49441
-  tps: 30591.41579
+  dps: 23736.6612
+  tps: 31794.62799
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 23767.29365
-  tps: 31534.23403
+  dps: 24714.1291
+  tps: 32775.52877
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 24129.66398
-  tps: 32383.99656
+  dps: 25090.70985
+  tps: 33657.84613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 23183.21916
-  tps: 31140.55574
+  dps: 24106.75881
+  tps: 32366.43354
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 23183.21916
-  tps: 31140.55574
+  dps: 24106.75881
+  tps: 32366.43354
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 22998.47914
-  tps: 31557.38777
+  dps: 23914.11314
+  tps: 32797.3446
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50708"
  value: {
-  dps: 24689.83706
-  tps: 33351.32376
+  dps: 25673.04701
+  tps: 34662.64413
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-55816"
  value: {
-  dps: 22827.49441
-  tps: 30591.21393
+  dps: 23736.6612
+  tps: 31794.42613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-56347"
  value: {
-  dps: 22827.49441
-  tps: 30591.21393
+  dps: 23736.6612
+  tps: 31794.42613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 23945.0172
-  tps: 31959.94619
+  dps: 24898.66704
+  tps: 33216.80049
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 24131.92548
-  tps: 32362.39383
+  dps: 25092.89827
+  tps: 33634.5779
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 23618.69579
-  tps: 31942.73642
+  dps: 24559.00604
+  tps: 33197.41572
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 23121.4521
-  tps: 31008.66217
+  dps: 24042.1342
+  tps: 32227.31646
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 23206.36607
-  tps: 31094.60442
+  dps: 24130.43934
+  tps: 32316.66952
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 22827.49441
-  tps: 30591.21393
+  dps: 23736.6612
+  tps: 31794.42613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 22827.49441
-  tps: 30591.21393
+  dps: 23736.6612
+  tps: 31794.42613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 23399.43746
-  tps: 31304.56284
+  dps: 24331.41951
+  tps: 32535.97529
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 23473.65741
-  tps: 31398.42425
+  dps: 24408.60378
+  tps: 32633.56881
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 23234.6786
-  tps: 31394.68433
+  dps: 24159.69306
+  tps: 32627.77049
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 23393.55157
-  tps: 31564.35346
+  dps: 24324.83453
+  tps: 32803.7911
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 23161.81329
-  tps: 31100.38577
+  dps: 24084.35285
+  tps: 32323.96484
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 23161.81329
-  tps: 31100.38577
+  dps: 24084.35285
+  tps: 32323.96484
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 23091.86553
-  tps: 30969.39334
+  dps: 24011.58605
+  tps: 32187.65051
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 23255.8778
-  tps: 31290.31472
+  dps: 24181.80091
+  tps: 32519.56604
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 22827.49441
-  tps: 30591.21393
+  dps: 23736.6612
+  tps: 31794.42613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 22958.3089
-  tps: 30664.14669
+  dps: 23872.6482
+  tps: 31869.97363
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 23027.87467
-  tps: 30855.34286
+  dps: 23945.05667
+  tps: 32069.12022
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 23199.23238
-  tps: 31110.19259
+  dps: 24123.2687
+  tps: 32334.16393
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 23957.14383
-  tps: 32337.49693
+  dps: 24911.11053
+  tps: 33608.57545
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 24335.6247
-  tps: 32946.30899
+  dps: 25304.65287
+  tps: 34241.36148
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 24607.07671
-  tps: 32973.64949
+  dps: 25587.32738
+  tps: 34271.63346
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-55854"
  value: {
-  dps: 22827.49441
-  tps: 30591.21393
+  dps: 23736.6612
+  tps: 31794.42613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-56377"
  value: {
-  dps: 22827.49441
-  tps: 30591.21393
+  dps: 23736.6612
+  tps: 31794.42613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 24462.30035
-  tps: 32989.74185
+  dps: 25436.43139
+  tps: 34286.70059
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 24386.25963
-  tps: 32887.48392
+  dps: 25357.35701
+  tps: 34180.39216
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 23528.50678
-  tps: 31813.76582
+  dps: 24465.26116
+  tps: 33063.54632
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 23596.00404
-  tps: 31885.34516
+  dps: 24535.42266
+  tps: 33137.80899
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 23832.84241
-  tps: 31799.84793
+  dps: 24782.15975
+  tps: 33051.09094
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-55256"
  value: {
-  dps: 22827.49441
-  tps: 30591.21393
+  dps: 23736.6612
+  tps: 31794.42613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-56290"
  value: {
-  dps: 22827.49441
-  tps: 30591.21393
+  dps: 23736.6612
+  tps: 31794.42613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShardofWoe-60233"
  value: {
-  dps: 23123.6484
-  tps: 31163.46894
+  dps: 24044.41126
+  tps: 32388.44041
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 23466.83955
-  tps: 31645.15563
+  dps: 24400.91141
+  tps: 32887.12921
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 22827.49441
-  tps: 30591.21393
+  dps: 23736.6612
+  tps: 31794.42613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 23873.83867
-  tps: 31893.40208
+  dps: 24824.79098
+  tps: 33148.36023
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 24018.37791
-  tps: 32078.28627
+  dps: 24975.10286
+  tps: 33340.59404
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-55879"
  value: {
-  dps: 23089.95035
-  tps: 30990.93762
+  dps: 24009.61539
+  tps: 32210.13876
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-56400"
  value: {
-  dps: 23124.31959
-  tps: 31043.28239
+  dps: 24045.35939
+  tps: 32264.57732
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 23235.57197
-  tps: 31399.19116
+  dps: 24160.58643
+  tps: 32632.27732
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulCasket-58183"
  value: {
-  dps: 23161.81329
-  tps: 31100.38577
+  dps: 24084.35285
+  tps: 32323.96484
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 22866.32311
-  tps: 30631.82094
+  dps: 23777.04306
+  tps: 31836.67112
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stormrider'sBattlegarb"
  value: {
-  dps: 23356.00511
-  tps: 31730.46505
+  dps: 24286.31469
+  tps: 32979.20789
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62465"
  value: {
-  dps: 23096.99376
-  tps: 31238.01093
+  dps: 24016.49314
+  tps: 32464.78728
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62470"
  value: {
-  dps: 23096.99376
-  tps: 31238.01093
+  dps: 24016.49314
+  tps: 32464.78728
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 22827.49441
-  tps: 30591.21393
+  dps: 23736.6612
+  tps: 31794.42613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 22827.49441
-  tps: 30591.21393
+  dps: 23736.6612
+  tps: 31794.42613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 22848.76193
-  tps: 30628.25582
+  dps: 23758.7583
+  tps: 31832.86014
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 23531.65569
-  tps: 32033.90211
+  dps: 24468.42436
+  tps: 33291.94443
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-55819"
  value: {
-  dps: 22828.02254
-  tps: 30593.48589
+  dps: 23737.18934
+  tps: 31796.69809
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-56351"
  value: {
-  dps: 22828.02254
-  tps: 30593.36449
+  dps: 23737.18934
+  tps: 31796.57668
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 23051.41516
-  tps: 30932.24803
+  dps: 23969.53878
+  tps: 32149.10159
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 23124.31959
-  tps: 31043.28239
+  dps: 24045.35939
+  tps: 32264.57732
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 22854.87395
-  tps: 30626.99601
+  dps: 23765.1148
+  tps: 31831.55597
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 22856.20125
-  tps: 30628.76408
+  dps: 23766.4952
+  tps: 31833.39767
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 22827.49441
-  tps: 30591.21393
+  dps: 23736.6612
+  tps: 31794.42613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 22827.49441
-  tps: 30591.21393
+  dps: 23736.6612
+  tps: 31794.42613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 24098.07248
-  tps: 32225.88537
+  dps: 25057.98115
+  tps: 33494.07646
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 24282.76565
-  tps: 32486.38675
+  dps: 25250.01564
+  tps: 33764.75557
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 23173.83313
-  tps: 31871.43001
+  dps: 24096.71763
+  tps: 33125.1209
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 22053.06279
-  tps: 30085.39343
+  dps: 22930.40956
+  tps: 31265.69834
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnheededWarning-59520"
  value: {
-  dps: 24439.00033
-  tps: 32614.37287
+  dps: 25412.46999
+  tps: 33897.71252
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 22827.49441
-  tps: 30591.21393
+  dps: 23736.6612
+  tps: 31794.42613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 24266.20012
-  tps: 32545.16808
+  dps: 25232.53439
+  tps: 33824.60398
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 24266.20012
-  tps: 32545.16808
+  dps: 25232.53439
+  tps: 33824.60398
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 20740.86876
-  tps: 28700.44947
+  dps: 21566.20314
+  tps: 29826.16266
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 22827.49441
-  tps: 30591.21393
+  dps: 23736.6612
+  tps: 31794.42613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 22827.49441
-  tps: 30591.21393
+  dps: 23736.6612
+  tps: 31794.42613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 23918.13778
-  tps: 32011.06539
+  dps: 24870.54956
+  tps: 33269.13719
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 22827.49441
-  tps: 30591.21393
+  dps: 23736.6612
+  tps: 31794.42613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 23247.57551
-  tps: 31083.80366
+  dps: 24173.5058
+  tps: 32306.52067
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 23096.99376
-  tps: 31238.01093
+  dps: 24016.49314
+  tps: 32464.78728
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 23194.47298
-  tps: 30934.75724
+  dps: 24118.89158
+  tps: 32154.5502
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 23125.78422
-  tps: 31002.92322
+  dps: 24046.52196
+  tps: 32220.77279
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 22852.76279
-  tps: 30725.78238
+  dps: 23762.73813
+  tps: 31933.34864
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 23181.60164
-  tps: 31130.52367
+  dps: 24104.93273
+  tps: 32355.30825
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 22827.49441
-  tps: 30591.21393
+  dps: 23736.6612
+  tps: 31794.42613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 24102.84218
-  tps: 32213.74806
+  dps: 25062.7222
+  tps: 33480.33382
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 22827.49441
-  tps: 30591.21393
+  dps: 23736.6612
+  tps: 31794.42613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 23322.89085
-  tps: 31180.48449
+  dps: 24251.84413
+  tps: 32407.12064
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 22814.38906
-  tps: 30773.26356
+  dps: 23722.81724
+  tps: 31982.67742
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 22861.39477
-  tps: 30646.22309
+  dps: 23771.773
+  tps: 31850.92806
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 23055.58112
-  tps: 30938.59285
+  dps: 23973.87139
+  tps: 32155.7002
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 23020.96452
-  tps: 30803.78253
+  dps: 23937.84178
+  tps: 32015.3344
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 23020.96452
-  tps: 30803.78253
+  dps: 23937.84178
+  tps: 32015.3344
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 24725.67056
-  tps: 33608.14916
+  dps: 25710.40875
+  tps: 34930.20309
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 73757.33549
-  tps: 103193.54631
+  dps: 74119.18225
+  tps: 104000.07327
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 16712.27177
-  tps: 28601.23473
+  dps: 17380.76264
+  tps: 29744.38321
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 19330.56117
-  tps: 25712.33329
+  dps: 20103.78362
+  tps: 26740.11404
  }
 }
 dps_results: {
@@ -1312,22 +1312,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 31758.09328
-  tps: 46789.21075
+  dps: 32906.71729
+  tps: 48300.3829
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29346.51828
-  tps: 39222.20705
+  dps: 30515.96759
+  tps: 40768.19338
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 35907.50708
-  tps: 34941.40251
+  dps: 37341.15715
+  tps: 36325.21044
  }
 }
 dps_results: {
@@ -1354,22 +1354,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 28103.18902
-  tps: 19955.52484
+  dps: 29227.31658
+  tps: 20753.65541
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28491.93044
-  tps: 20229.27061
+  dps: 29631.60766
+  tps: 21038.44144
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 35408.85952
-  tps: 25140.29026
+  dps: 36825.21391
+  tps: 26145.90187
  }
 }
 dps_results: {
@@ -1396,22 +1396,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 73002.87205
-  tps: 102839.59015
+  dps: 73357.5604
+  tps: 103620.87115
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 16424.04413
-  tps: 28095.4789
+  dps: 17081.00589
+  tps: 29218.4511
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 19336.66867
-  tps: 25773.224
+  dps: 20110.13542
+  tps: 26803.55054
  }
 }
 dps_results: {
@@ -1438,22 +1438,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 31273.74626
-  tps: 46476.03058
+  dps: 32389.19895
+  tps: 47929.205
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28507.05766
-  tps: 38016.46662
+  dps: 29643.26075
+  tps: 39515.96666
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 35117.95997
-  tps: 33070.77909
+  dps: 36521.11309
+  tps: 34385.34117
  }
 }
 dps_results: {
@@ -1480,22 +1480,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 27266.94827
-  tps: 19361.79391
+  dps: 28357.6262
+  tps: 20136.17524
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 27618.34075
-  tps: 19609.02193
+  dps: 28723.07438
+  tps: 20393.38281
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 34451.75909
-  tps: 24460.74895
+  dps: 35829.82945
+  tps: 25439.17891
  }
 }
 dps_results: {
@@ -1522,22 +1522,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 62764.03054
-  tps: 90502.82326
+  dps: 63062.43385
+  tps: 91182.22628
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 13654.56567
-  tps: 24782.51774
+  dps: 14200.7483
+  tps: 25772.91658
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 16578.10242
-  tps: 26851.18825
+  dps: 17241.22652
+  tps: 27924.37367
  }
 }
 dps_results: {
@@ -1564,22 +1564,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 26941.37917
-  tps: 41132.2418
+  dps: 27902.15201
+  tps: 42417.57179
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24529.48332
-  tps: 33134.11649
+  dps: 25506.29607
+  tps: 34436.83337
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 32128.02999
-  tps: 28330.6837
+  dps: 33411.44575
+  tps: 29454.93146
  }
 }
 dps_results: {
@@ -1606,22 +1606,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 23420.01479
-  tps: 16630.47114
+  dps: 24356.81538
+  tps: 17295.59956
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 23709.84991
-  tps: 16833.99344
+  dps: 24658.24391
+  tps: 17507.35317
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 31703.13102
-  tps: 22509.22302
+  dps: 32971.25626
+  tps: 23409.59195
  }
 }
 dps_results: {
@@ -1648,22 +1648,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 61688.39425
-  tps: 92032.59827
+  dps: 61984.62736
+  tps: 92712.91881
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 13528.50145
-  tps: 24562.52759
+  dps: 14069.64151
+  tps: 25544.17643
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 16620.13541
-  tps: 26846.17869
+  dps: 17284.94083
+  tps: 27919.31479
  }
 }
 dps_results: {
@@ -1690,22 +1690,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 26455.82908
-  tps: 41066.9761
+  dps: 27384.84705
+  tps: 42319.79544
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 23755.13009
-  tps: 32588.89015
+  dps: 24700.81828
+  tps: 33869.15544
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 31299.88904
-  tps: 28095.52672
+  dps: 32550.17917
+  tps: 29210.40816
  }
 }
 dps_results: {
@@ -1732,22 +1732,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 22733.32544
-  tps: 16142.9217
+  dps: 23642.65846
+  tps: 16788.54815
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 22953.59388
-  tps: 16297.05166
+  dps: 23871.73764
+  tps: 16948.93372
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 30906.02157
-  tps: 21943.27531
+  dps: 32142.26243
+  tps: 22821.00633
  }
 }
 dps_results: {
@@ -1774,7 +1774,7 @@ dps_results: {
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 21499.27281
-  tps: 29809.37795
+  dps: 22354.89998
+  tps: 30979.25459
  }
 }

--- a/sim/druid/guardian/TestGuardian.results
+++ b/sim/druid/guardian/TestGuardian.results
@@ -37,1256 +37,1256 @@ character_stats_results: {
 dps_results: {
  key: "TestGuardian-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 7437.63425
-  tps: 37253.31125
+  dps: 7705.54073
+  tps: 38592.84363
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 7246.84319
-  tps: 36299.25177
+  dps: 7507.48277
+  tps: 37602.44969
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 7538.02611
-  tps: 37757.36515
+  dps: 7809.38938
+  tps: 39114.18149
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 7563.69026
-  tps: 37885.48503
+  dps: 7836.06222
+  tps: 39247.34486
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
   hps: 98.46889
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 7335.6515
-  tps: 36743.57169
+  dps: 7599.84191
+  tps: 38064.5237
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 7304.11272
-  tps: 36586.25799
+  dps: 7566.97313
+  tps: 37900.56004
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-BindingPromise-67037"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 7507.95904
-  tps: 37605.03166
+  dps: 7778.60139
+  tps: 38958.24339
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 7710.16039
-  tps: 38616.17092
+  dps: 7988.59077
+  tps: 40008.32281
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 7406.88458
-  tps: 37099.54622
+  dps: 7673.6528
+  tps: 38433.38735
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 7311.11041
-  tps: 36620.6562
+  dps: 7574.33552
+  tps: 37936.78175
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 7589.57858
-  tps: 38013.06872
+  dps: 7863.3835
+  tps: 39382.09333
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 7377.6213
-  tps: 36953.22981
+  dps: 7643.25887
+  tps: 38281.4177
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-BottledLightning-66879"
  value: {
-  dps: 7321.24392
-  tps: 36671.26587
+  dps: 7584.83259
+  tps: 37989.20919
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 7252.30604
-  tps: 35600.33216
+  dps: 7513.14778
+  tps: 36878.4567
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 7366.86526
-  tps: 36899.42294
+  dps: 7632.01126
+  tps: 38225.15297
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 7386.80802
-  tps: 36999.01073
+  dps: 7652.75053
+  tps: 38328.72326
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 7232.52124
-  tps: 36227.73206
+  dps: 7492.52254
+  tps: 37527.73853
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CrushingWeight-59506"
  value: {
-  dps: 7510.00337
-  tps: 37616.17683
+  dps: 7780.94869
+  tps: 38970.90346
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CrushingWeight-65118"
  value: {
-  dps: 7484.19611
-  tps: 37487.16573
+  dps: 7754.12152
+  tps: 38836.79278
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 7642.65353
-  tps: 38278.00076
+  dps: 7908.61053
+  tps: 39607.78577
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 7772.74112
-  tps: 38928.84145
+  dps: 8043.74599
+  tps: 40283.8658
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 7232.52124
-  tps: 36227.73206
+  dps: 7492.52254
+  tps: 37527.73853
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 7275.75243
-  tps: 36495.71736
+  dps: 7536.29288
+  tps: 37798.41959
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 7409.3651
-  tps: 37111.94321
+  dps: 7676.39994
+  tps: 38447.11741
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 7270.5008
-  tps: 36417.4746
+  dps: 7532.07487
+  tps: 37725.34498
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 7273.31582
-  tps: 36431.74119
+  dps: 7535.08002
+  tps: 37740.56218
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 7265.30599
-  tps: 36419.94529
+  dps: 7526.73314
+  tps: 37727.08106
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 7252.30604
-  tps: 36326.62686
+  dps: 7513.14778
+  tps: 37630.83558
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 7270.5008
-  tps: 36417.4746
+  dps: 7532.07487
+  tps: 37725.34498
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 7702.5489
-  tps: 38579.32136
+  dps: 7980.45015
+  tps: 39968.82762
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 7702.76705
-  tps: 38580.54588
+  dps: 7980.61217
+  tps: 39969.7715
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-FallofMortality-59500"
  value: {
-  dps: 7232.52124
-  tps: 36227.73206
+  dps: 7492.52254
+  tps: 37527.73853
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-FallofMortality-65124"
  value: {
-  dps: 7232.52124
-  tps: 36227.73206
+  dps: 7492.52254
+  tps: 37527.73853
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 7970.16943
-  tps: 39918.50778
+  dps: 8257.8199
+  tps: 41356.76011
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 7232.52124
-  tps: 36227.73206
+  dps: 7492.52254
+  tps: 37527.73853
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 7232.52124
-  tps: 36227.73206
+  dps: 7492.52254
+  tps: 37527.73853
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 7397.7735
-  tps: 37053.99084
+  dps: 7664.19844
+  tps: 38386.11552
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-FluidDeath-58181"
  value: {
-  dps: 7981.39598
-  tps: 39974.84219
+  dps: 8269.74414
+  tps: 41416.58299
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 7252.30604
-  tps: 36326.62686
+  dps: 7513.14778
+  tps: 37630.83558
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 7481.7147
-  tps: 37473.88769
+  dps: 7751.33096
+  tps: 38821.96898
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-GaleofShadows-56138"
  value: {
-  dps: 7373.46663
-  tps: 36932.93105
+  dps: 7639.26927
+  tps: 38261.94424
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-GaleofShadows-56462"
  value: {
-  dps: 7319.69083
-  tps: 36664.09416
+  dps: 7583.30519
+  tps: 37982.16596
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-GearDetector-61462"
  value: {
-  dps: 7469.74231
-  tps: 37414.78945
+  dps: 7739.01012
+  tps: 38761.12849
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 7246.84319
-  tps: 36299.25177
+  dps: 7507.48277
+  tps: 37602.44969
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 7458.88483
-  tps: 37359.67517
+  dps: 7727.61963
+  tps: 38703.3492
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 7612.39112
-  tps: 38127.54412
+  dps: 7887.24663
+  tps: 39501.82171
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-HarmlightToken-63839"
  value: {
-  dps: 7340.5102
-  tps: 36767.591
+  dps: 7601.08202
+  tps: 38070.45011
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 7353.98438
-  tps: 36835.04526
+  dps: 7618.71601
+  tps: 38158.70336
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 7321.55429
-  tps: 36673.68622
+  dps: 7585.3086
+  tps: 37992.45777
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 7265.20322
-  tps: 36391.92046
+  dps: 7526.68562
+  tps: 37699.33246
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-HeartofRage-59224"
  value: {
-  dps: 7842.92949
-  tps: 39279.91869
+  dps: 8127.15217
+  tps: 40701.03209
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-HeartofRage-65072"
  value: {
-  dps: 7893.55924
-  tps: 39533.77664
+  dps: 8179.63749
+  tps: 40964.16787
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-HeartofSolace-55868"
  value: {
-  dps: 7470.6284
-  tps: 37418.7399
+  dps: 7740.08386
+  tps: 38766.01721
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-HeartofSolace-56393"
  value: {
-  dps: 7467.49935
-  tps: 37403.13674
+  dps: 7736.66797
+  tps: 38748.97985
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-HeartofThunder-55845"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 7540.81891
-  tps: 37769.73891
+  dps: 7812.85721
+  tps: 39129.93041
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Heartpierce-50641"
  value: {
-  dps: 7425.38595
-  tps: 37194.49559
+  dps: 7693.46351
+  tps: 38534.88336
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 7270.5008
-  tps: 36417.4746
+  dps: 7532.07487
+  tps: 37725.34498
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 7415.03659
-  tps: 37140.30629
+  dps: 7682.11197
+  tps: 38475.6832
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 7415.03659
-  tps: 37140.30629
+  dps: 7682.11197
+  tps: 38475.6832
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 7507.95904
-  tps: 37605.03166
+  dps: 7778.60139
+  tps: 38958.24339
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 7720.51452
-  tps: 38670.06197
+  dps: 7998.98438
+  tps: 40062.41129
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 7897.91929
-  tps: 39557.30685
+  dps: 8182.93685
+  tps: 40982.39466
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 7301.1793
-  tps: 36571.65692
+  dps: 7563.89668
+  tps: 37885.24384
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 7301.1793
-  tps: 36571.65692
+  dps: 7563.89668
+  tps: 37885.24384
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 7262.35308
-  tps: 36376.22893
+  dps: 7523.85381
+  tps: 37683.73259
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-LastWord-50708"
  value: {
-  dps: 7305.27674
-  tps: 36591.50705
+  dps: 7568.19701
+  tps: 37906.10837
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-LeadenDespair-55816"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 7846.66151
-  tps: 39298.89466
+  dps: 8130.83894
+  tps: 40719.78179
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 8055.21887
-  tps: 40342.25039
+  dps: 8347.63876
+  tps: 41804.34986
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 7731.69202
-  tps: 38725.15551
+  dps: 8010.52732
+  tps: 40119.33202
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 7610.85931
-  tps: 38119.51301
+  dps: 7886.02744
+  tps: 39495.35364
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 7824.53738
-  tps: 39188.2369
+  dps: 8107.96866
+  tps: 40605.3933
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 7361.12877
-  tps: 36870.76718
+  dps: 7626.12624
+  tps: 38195.75454
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 7374.22681
-  tps: 36936.25738
+  dps: 7639.71167
+  tps: 38263.6817
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 7559.54924
-  tps: 37864.34472
+  dps: 7832.06258
+  tps: 39226.91144
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 7697.97131
-  tps: 38556.89032
+  dps: 7975.33973
+  tps: 39943.73238
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 7232.52124
-  tps: 36227.73206
+  dps: 7492.52254
+  tps: 37527.73853
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 7408.99419
-  tps: 37110.58992
+  dps: 7675.94038
+  tps: 38445.32088
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 7255.27761
-  tps: 36341.64011
+  dps: 7516.38539
+  tps: 37647.17903
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 7665.33972
-  tps: 38392.31693
+  dps: 7942.35881
+  tps: 39777.41239
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 7688.57948
-  tps: 38509.52533
+  dps: 7966.23905
+  tps: 39897.82317
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Rainsong-55854"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Rainsong-56377"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 7397.62443
-  tps: 37053.24547
+  dps: 7664.02664
+  tps: 38385.25655
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 7375.84413
-  tps: 36944.34398
+  dps: 7641.43547
+  tps: 38272.30068
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 7665.84182
-  tps: 38396.44368
+  dps: 7942.00587
+  tps: 39777.26392
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 7703.45173
-  tps: 38584.29242
+  dps: 7981.04853
+  tps: 39972.2764
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 7477.08909
-  tps: 37450.77671
+  dps: 7746.5555
+  tps: 38798.10875
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-SeaStar-55256"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-SeaStar-56290"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-ShardofWoe-60233"
  value: {
-  dps: 7287.14617
-  tps: 36501.81025
+  dps: 7549.48994
+  tps: 37813.52908
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 7409.14168
-  tps: 37110.73027
+  dps: 7676.28652
+  tps: 38446.45447
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 7468.16586
-  tps: 37406.02472
+  dps: 7737.28559
+  tps: 38751.62338
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 7493.81658
-  tps: 37534.13583
+  dps: 7763.88958
+  tps: 38884.5008
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Sorrowsong-55879"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Sorrowsong-56400"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 7610.21217
-  tps: 38118.29542
+  dps: 7884.26263
+  tps: 39488.54776
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-SoulCasket-58183"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 7288.26175
-  tps: 36506.37957
+  dps: 7550.47631
+  tps: 37817.45238
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Stormrider'sBattlegarb"
  value: {
-  dps: 7972.09609
-  tps: 39930.49943
+  dps: 8260.69857
+  tps: 41373.51181
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-StumpofTime-62465"
  value: {
-  dps: 7577.77229
-  tps: 37955.55687
+  dps: 7850.87561
+  tps: 39321.07346
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-StumpofTime-62470"
  value: {
-  dps: 7577.77229
-  tps: 37955.55687
+  dps: 7850.87561
+  tps: 39321.07346
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 7247.25201
-  tps: 36301.30006
+  dps: 7507.8916
+  tps: 37604.49798
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 7352.45277
-  tps: 36827.75053
+  dps: 7617.19072
+  tps: 38151.44026
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TearofBlood-55819"
  value: {
-  dps: 7247.25201
-  tps: 36301.30006
+  dps: 7507.8916
+  tps: 37604.49798
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TearofBlood-56351"
  value: {
-  dps: 7232.52124
-  tps: 36227.73206
+  dps: 7492.52254
+  tps: 37527.73853
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 7232.52124
-  tps: 36227.73206
+  dps: 7492.52254
+  tps: 37527.73853
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 7232.52124
-  tps: 36227.73206
+  dps: 7492.52254
+  tps: 37527.73853
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 7495.72669
-  tps: 37543.67802
+  dps: 7765.83498
+  tps: 38894.2195
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 7538.37846
-  tps: 37756.89064
+  dps: 7810.10614
+  tps: 39115.52903
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 7450.62014
-  tps: 37318.75193
+  dps: 7719.37022
+  tps: 38662.50237
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 7209.12394
-  tps: 36110.74909
+  dps: 7467.99966
+  tps: 37405.12766
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-UnheededWarning-59520"
  value: {
-  dps: 7643.34363
-  tps: 38281.82939
+  dps: 7918.92197
+  tps: 39659.72111
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 7633.47802
-  tps: 38232.92116
+  dps: 7908.98802
+  tps: 39610.47113
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 7633.47802
-  tps: 38232.92116
+  dps: 7908.98802
+  tps: 39610.47113
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 7633.47802
-  tps: 38232.92116
+  dps: 7908.98802
+  tps: 39610.47113
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 6192.09509
-  tps: 31024.29463
+  dps: 6411.45444
+  tps: 32121.09139
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 7633.47802
-  tps: 38232.92116
+  dps: 7908.98802
+  tps: 39610.47113
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 7415.03659
-  tps: 37140.30629
+  dps: 7682.11197
+  tps: 38475.6832
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 7548.89635
-  tps: 37811.60529
+  dps: 7820.75984
+  tps: 39170.92273
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 7312.28888
-  tps: 36627.33042
+  dps: 7575.51934
+  tps: 37943.48273
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 7328.88689
-  tps: 36709.88965
+  dps: 7592.82306
+  tps: 38029.5705
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 7706.2895
-  tps: 38597.22041
+  dps: 7985.4317
+  tps: 39992.93144
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 7634.10181
-  tps: 38235.72927
+  dps: 7909.51176
+  tps: 39612.77903
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 7398.89409
-  tps: 37059.59378
+  dps: 7665.33673
+  tps: 38391.80697
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 7268.08177
-  tps: 36405.52966
+  dps: 7529.82224
+  tps: 37714.23205
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 7305.06995
-  tps: 36590.6008
+  dps: 7568.25271
+  tps: 37906.51458
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 7261.10738
-  tps: 36370.66023
+  dps: 7522.38294
+  tps: 37677.03805
  }
 }
 dps_results: {
  key: "TestGuardian-Average-Default"
  value: {
-  dps: 12273.7455
-  tps: 61447.79497
+  dps: 12726.44131
+  tps: 63711.27403
   dtps: 6471.47554
  }
 }
 dps_results: {
  key: "TestGuardian-Settings-Tauren-p1-Default-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 21204.15523
-  tps: 106781.70534
+  dps: 21595.75446
+  tps: 108739.70145
  }
 }
 dps_results: {
  key: "TestGuardian-Settings-Tauren-p1-Default-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 9869.15043
-  tps: 49415.88421
+  dps: 10232.6501
+  tps: 51233.38256
  }
 }
 dps_results: {
  key: "TestGuardian-Settings-Tauren-p1-Default-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 11329.41278
-  tps: 56723.88681
+  dps: 11750.50067
+  tps: 58829.32626
  }
 }
 dps_results: {
@@ -1313,22 +1313,22 @@ dps_results: {
 dps_results: {
  key: "TestGuardian-Settings-Tauren-preraid-Default-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 18727.29128
-  tps: 94328.69141
+  dps: 19061.61368
+  tps: 96000.30338
  }
 }
 dps_results: {
  key: "TestGuardian-Settings-Tauren-preraid-Default-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 8537.26839
-  tps: 42754.63548
+  dps: 8849.08921
+  tps: 44313.73957
  }
 }
 dps_results: {
  key: "TestGuardian-Settings-Tauren-preraid-Default-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 9669.09343
-  tps: 48419.06821
+  dps: 10024.86254
+  tps: 50197.91375
  }
 }
 dps_results: {
@@ -1355,8 +1355,8 @@ dps_results: {
 dps_results: {
  key: "TestGuardian-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 13889.30903
-  tps: 69532.99101
+  dps: 14407.47808
+  tps: 72123.83627
   dtps: 5825.96244
  }
 }

--- a/sim/hunter/beast_mastery/TestBM.results
+++ b/sim/hunter/beast_mastery/TestBM.results
@@ -37,1318 +37,1318 @@ character_stats_results: {
 dps_results: {
  key: "TestBM-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 21291.69637
-  tps: 17969.31342
+  dps: 21795.26851
+  tps: 18339.99025
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
-  dps: 18312.28235
-  tps: 15541.22502
+  dps: 18738.76223
+  tps: 15856.86261
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 20130.21752
-  tps: 16973.79913
+  dps: 20602.26977
+  tps: 17319.59464
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 20130.21752
-  tps: 16973.79913
+  dps: 20602.26977
+  tps: 17319.59464
  }
 }
 dps_results: {
  key: "TestBM-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 20815.24011
-  tps: 17515.96224
+  dps: 21305.2301
+  tps: 17873.98112
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 19926.75273
-  tps: 16817.97375
+  dps: 20397.14416
+  tps: 17164.01401
   hps: 105.16583
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 20194.69638
-  tps: 17042.95813
+  dps: 20670.21849
+  tps: 17392.41071
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 20275.48715
-  tps: 17108.57672
+  dps: 20753.77704
+  tps: 17460.19019
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BindingPromise-67037"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlackBruise-50692"
  value: {
-  dps: 19761.85845
-  tps: 16670.0235
+  dps: 20227.71065
+  tps: 17012.2023
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 20546.40425
-  tps: 17299.88792
+  dps: 21034.05472
+  tps: 17657.67774
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 20034.16318
-  tps: 16865.03557
+  dps: 20508.85102
+  tps: 17212.95831
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 20048.20536
-  tps: 16871.19843
+  dps: 20523.45489
+  tps: 17219.36768
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 20768.50592
-  tps: 17508.07003
+  dps: 21259.16692
+  tps: 17868.31359
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 20151.3964
-  tps: 16999.04437
+  dps: 20625.77896
+  tps: 17347.33285
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 20655.46033
-  tps: 17413.0434
+  dps: 21142.45501
+  tps: 17770.3414
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodthirstyGladiator'sPursuit"
  value: {
-  dps: 18779.55085
-  tps: 15838.67519
+  dps: 19223.40214
+  tps: 16164.89145
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BottledLightning-66879"
  value: {
-  dps: 19982.40524
-  tps: 16862.70096
+  dps: 20453.61037
+  tps: 17209.11792
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 20815.24011
-  tps: 17165.64299
+  dps: 21305.2301
+  tps: 17516.50149
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 21345.89074
-  tps: 18023.64956
+  dps: 21849.45721
+  tps: 18394.32639
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 21071.91808
-  tps: 17772.64021
+  dps: 21567.44872
+  tps: 18136.19974
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 21209.07909
-  tps: 17908.85951
+  dps: 21710.91523
+  tps: 18278.68687
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CrushingWeight-59506"
  value: {
-  dps: 20162.27735
-  tps: 17045.6188
+  dps: 20638.29626
+  tps: 17396.97138
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CrushingWeight-65118"
  value: {
-  dps: 20142.27738
-  tps: 17017.56976
+  dps: 20615.40596
+  tps: 17365.71003
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 20363.20323
-  tps: 17268.29285
+  dps: 20831.77141
+  tps: 17613.06461
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 21100.69368
-  tps: 17860.73276
+  dps: 21587.48028
+  tps: 18217.92092
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 20063.5241
-  tps: 16877.92155
+  dps: 20539.38638
+  tps: 17226.35972
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 20415.13463
-  tps: 17200.47078
+  dps: 20899.3915
+  tps: 17556.1411
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 20945.60211
-  tps: 17645.38253
+  dps: 21441.60207
+  tps: 18009.37371
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 19971.9684
-  tps: 16859.234
+  dps: 20440.55591
+  tps: 17203.31213
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 20815.24011
-  tps: 17515.96224
+  dps: 21305.2301
+  tps: 17873.98112
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 20815.24011
-  tps: 17515.96224
+  dps: 21305.2301
+  tps: 17873.98112
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 20945.60211
-  tps: 17645.38253
+  dps: 21441.60207
+  tps: 18009.37371
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 21042.47828
-  tps: 17752.38152
+  dps: 21540.19449
+  tps: 18118.49386
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 21075.81427
-  tps: 17765.2074
+  dps: 21572.99116
+  tps: 18129.96002
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 20815.24011
-  tps: 17515.96224
+  dps: 21305.2301
+  tps: 17873.98112
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FallofMortality-59500"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FallofMortality-65124"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 21039.30384
-  tps: 17739.49511
+  dps: 21536.33592
+  tps: 18104.53484
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 20048.20536
-  tps: 16871.19843
+  dps: 20523.45489
+  tps: 17219.36768
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 20839.34991
-  tps: 17526.38931
+  dps: 21330.30429
+  tps: 17884.82527
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FluidDeath-58181"
  value: {
-  dps: 21108.34486
-  tps: 17791.98851
+  dps: 21606.16077
+  tps: 18157.15017
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 20815.24011
-  tps: 17515.96224
+  dps: 21305.2301
+  tps: 17873.98112
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 20191.32037
-  tps: 17038.6044
+  dps: 20666.87036
+  tps: 17388.04575
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GaleofShadows-56138"
  value: {
-  dps: 20050.09482
-  tps: 16899.08512
+  dps: 20524.79955
+  tps: 17247.74946
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GaleofShadows-56462"
  value: {
-  dps: 20136.46085
-  tps: 17002.47522
+  dps: 20609.93601
+  tps: 17350.59095
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GearDetector-61462"
  value: {
-  dps: 20443.93315
-  tps: 17248.69216
+  dps: 20927.85242
+  tps: 17604.8018
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 18430.06234
-  tps: 15523.75154
+  dps: 18862.08982
+  tps: 15839.52658
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 20426.90995
-  tps: 17224.06385
+  dps: 20906.3934
+  tps: 17575.43346
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 20774.08088
-  tps: 17531.10072
+  dps: 21264.46074
+  tps: 17891.76138
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HarmlightToken-63839"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 19983.25814
-  tps: 16840.99376
+  dps: 20455.90978
+  tps: 17187.95483
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HeartofRage-59224"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HeartofRage-65072"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HeartofSolace-55868"
  value: {
-  dps: 20050.09482
-  tps: 16899.08512
+  dps: 20524.79955
+  tps: 17247.74946
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HeartofSolace-56393"
  value: {
-  dps: 20136.46085
-  tps: 17002.47522
+  dps: 20609.93601
+  tps: 17350.59095
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HeartofThunder-55845"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HeartofThunder-56370"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 20511.03383
-  tps: 17287.61637
+  dps: 20993.01726
+  tps: 17640.66309
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Heartpierce-50641"
  value: {
-  dps: 21420.37021
-  tps: 18082.58469
+  dps: 21927.51074
+  tps: 18456.2138
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 20945.60211
-  tps: 17645.38253
+  dps: 21441.60207
+  tps: 18009.37371
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 20063.5241
-  tps: 16877.92155
+  dps: 20539.38638
+  tps: 17226.35972
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 20063.5241
-  tps: 16877.92155
+  dps: 20539.38638
+  tps: 17226.35972
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 20034.16318
-  tps: 16865.03557
+  dps: 20508.85102
+  tps: 17212.95831
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 20048.20536
-  tps: 16871.19843
+  dps: 20523.45489
+  tps: 17219.36768
  }
 }
 dps_results: {
  key: "TestBM-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 20035.95251
-  tps: 16877.24837
+  dps: 20510.55148
+  tps: 17225.49918
  }
 }
 dps_results: {
  key: "TestBM-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 20546.40425
-  tps: 17299.88792
+  dps: 21034.05472
+  tps: 17657.67774
  }
 }
 dps_results: {
  key: "TestBM-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 20868.09188
-  tps: 17604.03762
+  dps: 21358.67727
+  tps: 17964.06084
  }
 }
 dps_results: {
  key: "TestBM-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 19927.95688
-  tps: 16798.98771
+  dps: 20394.60876
+  tps: 17140.48083
  }
 }
 dps_results: {
  key: "TestBM-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 19927.95688
-  tps: 16798.98771
+  dps: 20394.60876
+  tps: 17140.48083
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 19978.58966
-  tps: 16873.97244
+  dps: 20448.41571
+  tps: 17219.6138
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LastWord-50708"
  value: {
-  dps: 21291.69637
-  tps: 17969.31342
+  dps: 21795.26851
+  tps: 18339.99025
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LeadenDespair-55816"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LeadenDespair-56347"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 20665.96015
-  tps: 17412.79463
+  dps: 21155.16881
+  tps: 17771.87667
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 20702.54767
-  tps: 17427.19995
+  dps: 21191.68882
+  tps: 17785.32718
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 20130.21752
-  tps: 16973.79913
+  dps: 20602.26977
+  tps: 17319.59464
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Lightning-ChargedBattlegear"
  value: {
-  dps: 20380.17852
-  tps: 17155.42854
+  dps: 20855.36531
+  tps: 17501.62533
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 19953.22599
-  tps: 16840.89301
+  dps: 20424.5159
+  tps: 17187.6896
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 19953.22599
-  tps: 16840.89301
+  dps: 20424.5159
+  tps: 17187.6896
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 20040.34879
-  tps: 16875.25183
+  dps: 20515.12361
+  tps: 17223.42277
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 20051.75773
-  tps: 16879.7512
+  dps: 20526.98891
+  tps: 17228.10211
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 20205.18612
-  tps: 17032.3008
+  dps: 20679.95719
+  tps: 17380.15645
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 20205.18612
-  tps: 17032.3008
+  dps: 20679.95719
+  tps: 17380.15645
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 20063.5241
-  tps: 16877.92155
+  dps: 20539.38638
+  tps: 17226.35972
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 20063.5241
-  tps: 16877.92155
+  dps: 20539.38638
+  tps: 17226.35972
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 20063.76438
-  tps: 16876.20661
+  dps: 20539.63627
+  tps: 17224.57618
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 20098.26051
-  tps: 16959.55814
+  dps: 20573.57479
+  tps: 17309.32432
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 20087.50612
-  tps: 16954.17929
+  dps: 20560.8823
+  tps: 17302.22239
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 19975.5891
-  tps: 16837.27215
+  dps: 20447.93398
+  tps: 17184.08436
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 20013.34246
-  tps: 16852.96867
+  dps: 20487.19747
+  tps: 17200.40873
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 20815.24011
-  tps: 17515.96224
+  dps: 21305.2301
+  tps: 17873.98112
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 21100.76692
-  tps: 17801.12486
+  dps: 21601.02315
+  tps: 18169.3954
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 21105.01099
-  tps: 17788.05445
+  dps: 21603.7403
+  tps: 18154.1055
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Rainsong-55854"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Rainsong-56377"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 21071.91808
-  tps: 17772.64021
+  dps: 21567.44872
+  tps: 18136.19974
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 21071.91808
-  tps: 17772.64021
+  dps: 21567.44872
+  tps: 18136.19974
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 20130.21752
-  tps: 16973.79913
+  dps: 20602.26977
+  tps: 17319.59464
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 20130.21752
-  tps: 16973.79913
+  dps: 20602.26977
+  tps: 17319.59464
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RuthlessGladiator'sPursuit"
  value: {
-  dps: 20675.52907
-  tps: 17394.30813
+  dps: 21167.64427
+  tps: 17755.17449
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 20544.12478
-  tps: 17297.9994
+  dps: 21028.46667
+  tps: 17652.49627
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SeaStar-55256"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SeaStar-56290"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Shadowmourne-49623"
  value: {
-  dps: 21491.61089
-  tps: 18145.87747
+  dps: 21999.10685
+  tps: 18519.54409
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ShardofWoe-60233"
  value: {
-  dps: 20224.81245
-  tps: 17082.33128
+  dps: 20701.75107
+  tps: 17433.57065
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 20084.22031
-  tps: 16969.36307
+  dps: 20561.2841
+  tps: 17321.83257
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 20638.77482
-  tps: 17360.4268
+  dps: 21126.37544
+  tps: 17716.89349
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 20774.31319
-  tps: 17473.36723
+  dps: 21266.85946
+  tps: 17833.87566
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Sorrowsong-55879"
  value: {
-  dps: 20034.16318
-  tps: 16865.03557
+  dps: 20508.85102
+  tps: 17212.95831
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Sorrowsong-56400"
  value: {
-  dps: 20048.20536
-  tps: 16871.19843
+  dps: 20523.45489
+  tps: 17219.36768
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 20205.18612
-  tps: 17032.3008
+  dps: 20679.95719
+  tps: 17380.15645
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SoulCasket-58183"
  value: {
-  dps: 20063.5241
-  tps: 16877.92155
+  dps: 20539.38638
+  tps: 17226.35972
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-StumpofTime-62465"
  value: {
-  dps: 20130.21752
-  tps: 16973.79913
+  dps: 20602.26977
+  tps: 17319.59464
  }
 }
 dps_results: {
  key: "TestBM-AllItems-StumpofTime-62470"
  value: {
-  dps: 20130.21752
-  tps: 16973.79913
+  dps: 20602.26977
+  tps: 17319.59464
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 19986.23901
-  tps: 16864.44149
+  dps: 20457.89619
+  tps: 17211.22677
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TearofBlood-55819"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TearofBlood-56351"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 20018.41891
-  tps: 16858.1257
+  dps: 20492.47699
+  tps: 17205.77204
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 20048.20536
-  tps: 16871.19843
+  dps: 20523.45489
+  tps: 17219.36768
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 20735.83066
-  tps: 17434.40087
+  dps: 21227.4301
+  tps: 17793.94312
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 20847.15395
-  tps: 17519.85131
+  dps: 21341.32496
+  tps: 17880.93021
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 20146.85353
-  tps: 16994.82668
+  dps: 20620.97604
+  tps: 17342.86811
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 19336.1869
-  tps: 16304.99044
+  dps: 19791.28185
+  tps: 16638.83753
  }
 }
 dps_results: {
  key: "TestBM-AllItems-UnheededWarning-59520"
  value: {
-  dps: 20848.1777
-  tps: 17568.71062
+  dps: 21340.4859
+  tps: 17929.84015
  }
 }
 dps_results: {
  key: "TestBM-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 20901.20542
-  tps: 17566.97858
+  dps: 21399.01581
+  tps: 17931.41989
  }
 }
 dps_results: {
  key: "TestBM-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 20901.20542
-  tps: 17566.97858
+  dps: 21399.01581
+  tps: 17931.41989
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 19895.48468
-  tps: 16820.14285
+  dps: 20363.7901
+  tps: 17165.43459
  }
 }
 dps_results: {
  key: "TestBM-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 20758.15108
-  tps: 17504.1444
+  dps: 21250.23929
+  tps: 17866.07235
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 20130.21752
-  tps: 16973.79913
+  dps: 20602.26977
+  tps: 17319.59464
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 20054.94963
-  tps: 16895.22745
+  dps: 20527.59945
+  tps: 17241.48838
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 20222.43846
-  tps: 17061.47508
+  dps: 20698.54938
+  tps: 17411.14747
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 20071.609
-  tps: 16881.46986
+  dps: 20547.79467
+  tps: 17230.04997
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 20753.27177
-  tps: 17504.79711
+  dps: 21243.66828
+  tps: 17865.25464
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sPursuit"
  value: {
-  dps: 19475.32576
-  tps: 16392.48401
+  dps: 19932.88417
+  tps: 16726.72874
  }
 }
 dps_results: {
  key: "TestBM-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 19926.93197
-  tps: 16817.97375
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
  key: "TestBM-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 20020.121
-  tps: 16858.87271
+  dps: 20494.24715
+  tps: 17206.54894
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 20028.93985
-  tps: 16870.75246
+  dps: 20503.25832
+  tps: 17218.74342
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 20028.93985
-  tps: 16870.75246
+  dps: 20503.25832
+  tps: 17218.74342
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 19739.17794
-  tps: 16519.43358
+  dps: 20215.79882
+  tps: 16867.26469
  }
 }
 dps_results: {
  key: "TestBM-Average-Default"
  value: {
-  dps: 21169.60464
-  tps: 17872.29061
+  dps: 21670.52248
+  tps: 18241.31589
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm-FullBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 21039.04709
-  tps: 17905.75955
+  dps: 21532.60209
+  tps: 18273.98305
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm-FullBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 21039.04709
-  tps: 17905.75955
+  dps: 21532.60209
+  tps: 18273.98305
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 25989.08298
-  tps: 21937.07097
+  dps: 26602.43322
+  tps: 22388.34073
  }
 }
 dps_results: {
@@ -1375,22 +1375,22 @@ dps_results: {
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm_advanced-FullBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 21039.04709
-  tps: 17905.75955
+  dps: 21532.60209
+  tps: 18273.98305
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm_advanced-FullBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 21039.04709
-  tps: 17905.75955
+  dps: 21532.60209
+  tps: 18273.98305
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm_advanced-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 25989.08298
-  tps: 21937.07097
+  dps: 26602.43322
+  tps: 22388.34073
  }
 }
 dps_results: {
@@ -1417,22 +1417,22 @@ dps_results: {
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm-FullBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 21291.69637
-  tps: 17969.31342
+  dps: 21795.26851
+  tps: 18339.99025
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm-FullBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 21291.69637
-  tps: 17969.31342
+  dps: 21795.26851
+  tps: 18339.99025
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 26479.23085
-  tps: 22147.83926
+  dps: 27109.09763
+  tps: 22604.45038
  }
 }
 dps_results: {
@@ -1459,22 +1459,22 @@ dps_results: {
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm_advanced-FullBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 21291.69637
-  tps: 17969.31342
+  dps: 21795.26851
+  tps: 18339.99025
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm_advanced-FullBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 21291.69637
-  tps: 17969.31342
+  dps: 21795.26851
+  tps: 18339.99025
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm_advanced-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 26479.23085
-  tps: 22147.83926
+  dps: 27109.09763
+  tps: 22604.45038
  }
 }
 dps_results: {
@@ -1501,7 +1501,7 @@ dps_results: {
 dps_results: {
  key: "TestBM-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 21006.66187
-  tps: 17732.58238
+  dps: 21503.18709
+  tps: 18098.14442
  }
 }

--- a/sim/hunter/marksmanship/TestMM.results
+++ b/sim/hunter/marksmanship/TestMM.results
@@ -37,1318 +37,1318 @@ character_stats_results: {
 dps_results: {
  key: "TestMM-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 21947.70202
-  tps: 19712.72514
+  dps: 22480.89993
+  tps: 20156.52396
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
-  dps: 18366.83501
-  tps: 16474.89797
+  dps: 18816.76693
+  tps: 16849.15241
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 20702.63662
-  tps: 18592.89461
+  dps: 21202.26103
+  tps: 19008.12934
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 20702.63662
-  tps: 18592.89461
+  dps: 21202.26103
+  tps: 19008.12934
  }
 }
 dps_results: {
  key: "TestMM-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 21477.03363
-  tps: 19257.70669
+  dps: 21998.31947
+  tps: 19690.21946
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 20451.54517
-  tps: 18377.42421
+  dps: 20944.81652
+  tps: 18787.73073
   hps: 94.5854
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 20913.28981
-  tps: 18813.0939
+  dps: 21415.97307
+  tps: 19231.76933
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 20948.6472
-  tps: 18845.43151
+  dps: 21451.93232
+  tps: 19264.588
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BindingPromise-67037"
  value: {
-  dps: 20451.59427
-  tps: 18377.40128
+  dps: 20944.8668
+  tps: 18787.7061
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlackBruise-50692"
  value: {
-  dps: 20463.09207
-  tps: 18354.25528
+  dps: 20960.97789
+  tps: 18767.78763
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 21075.73911
-  tps: 18947.86314
+  dps: 21583.44713
+  tps: 19370.45612
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 20502.83255
-  tps: 18416.58611
+  dps: 20996.05282
+  tps: 18826.35652
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 20600.22449
-  tps: 18505.57384
+  dps: 21092.05509
+  tps: 18913.61841
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 21359.97212
-  tps: 19204.03648
+  dps: 21875.22928
+  tps: 19633.05621
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 20574.16327
-  tps: 18499.97029
+  dps: 21067.43581
+  tps: 18910.27511
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 20842.16761
-  tps: 18742.78181
+  dps: 21344.4963
+  tps: 19161.13508
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 20451.59427
-  tps: 18377.40128
+  dps: 20944.8668
+  tps: 18787.7061
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 20451.59427
-  tps: 18377.40128
+  dps: 20944.8668
+  tps: 18787.7061
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 21289.94606
-  tps: 19125.5446
+  dps: 21803.98906
+  tps: 19553.01155
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 20468.12593
-  tps: 18393.93294
+  dps: 20961.39846
+  tps: 18804.23776
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sPursuit"
  value: {
-  dps: 19192.89799
-  tps: 17214.84627
+  dps: 19650.43408
+  tps: 17593.26029
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BottledLightning-66879"
  value: {
-  dps: 20539.31371
-  tps: 18458.32142
+  dps: 21034.50309
+  tps: 18870.27112
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 21477.03363
-  tps: 18872.55256
+  dps: 21998.31947
+  tps: 19296.41507
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 21947.70202
-  tps: 19712.72514
+  dps: 22480.89993
+  tps: 20156.52396
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 21820.58301
-  tps: 19601.25607
+  dps: 22350.78004
+  tps: 20042.68003
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 21867.28537
-  tps: 19643.40076
+  dps: 22398.71896
+  tps: 20085.87896
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CrushingWeight-59506"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CrushingWeight-65118"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 20451.59427
-  tps: 18377.40128
+  dps: 20944.8668
+  tps: 18787.7061
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 20900.46998
-  tps: 18827.74875
+  dps: 21396.07475
+  tps: 19240.44467
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 21731.1262
-  tps: 19570.09399
+  dps: 22246.50142
+  tps: 19999.02792
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 20578.42899
-  tps: 18482.30411
+  dps: 21070.1109
+  tps: 18890.14103
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 21113.48927
-  tps: 18979.25528
+  dps: 21623.25187
+  tps: 19403.64851
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 21521.77916
-  tps: 19297.89455
+  dps: 22044.25797
+  tps: 19731.41798
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 20501.37788
-  tps: 18386.91543
+  dps: 20992.42922
+  tps: 18793.38826
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 21477.03363
-  tps: 19257.70669
+  dps: 21998.31947
+  tps: 19690.21946
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 21477.03363
-  tps: 19257.70669
+  dps: 21998.31947
+  tps: 19690.21946
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 21521.77916
-  tps: 19297.89455
+  dps: 22044.25797
+  tps: 19731.41798
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 21724.43568
-  tps: 19526.23029
+  dps: 22247.60113
+  tps: 19961.46753
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 21840.82816
-  tps: 19630.05381
+  dps: 22365.90833
+  tps: 20066.703
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 21477.03363
-  tps: 19257.70669
+  dps: 21998.31947
+  tps: 19690.21946
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FallofMortality-59500"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FallofMortality-65124"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 21575.93562
-  tps: 19385.56376
+  dps: 22095.20504
+  tps: 19817.21831
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 20451.59427
-  tps: 18377.40128
+  dps: 20944.8668
+  tps: 18787.7061
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 20566.50148
-  tps: 18492.3085
+  dps: 21059.77402
+  tps: 18902.61332
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 20600.22449
-  tps: 18505.57384
+  dps: 21092.05509
+  tps: 18913.61841
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 21327.21196
-  tps: 19122.79478
+  dps: 21847.76111
+  tps: 19555.16724
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FluidDeath-58181"
  value: {
-  dps: 21647.79088
-  tps: 19431.30131
+  dps: 22169.87857
+  tps: 19864.72941
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 21477.03363
-  tps: 19257.70669
+  dps: 21998.31947
+  tps: 19690.21946
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 20855.48185
-  tps: 18755.28594
+  dps: 21358.16511
+  tps: 19173.96137
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GaleofShadows-56138"
  value: {
-  dps: 20563.12426
-  tps: 18427.3575
+  dps: 21059.93374
+  tps: 18838.7363
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GaleofShadows-56462"
  value: {
-  dps: 20484.90076
-  tps: 18374.18191
+  dps: 20981.09609
+  tps: 18785.94848
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GearDetector-61462"
  value: {
-  dps: 21230.24944
-  tps: 19071.04007
+  dps: 21742.7503
+  tps: 19497.17256
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 18880.51773
-  tps: 16922.74368
+  dps: 19337.23939
+  tps: 17301.15438
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 20451.59427
-  tps: 18377.40128
+  dps: 20944.8668
+  tps: 18787.7061
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 21112.74568
-  tps: 18970.5629
+  dps: 21622.05078
+  tps: 19394.18068
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 21455.34747
-  tps: 19278.73186
+  dps: 21973.71693
+  tps: 19710.03669
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HarmlightToken-63839"
  value: {
-  dps: 20457.5679
-  tps: 18383.4082
+  dps: 20950.84022
+  tps: 18793.71413
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 20452.97418
-  tps: 18378.7812
+  dps: 20946.24672
+  tps: 18789.08602
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 20453.15339
-  tps: 18378.96041
+  dps: 20946.42593
+  tps: 18789.26523
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofRage-59224"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofRage-65072"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofSolace-55868"
  value: {
-  dps: 20558.27266
-  tps: 18422.5059
+  dps: 21055.08214
+  tps: 18833.88471
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofSolace-56393"
  value: {
-  dps: 20479.44896
-  tps: 18368.73011
+  dps: 20975.64429
+  tps: 18780.49668
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofThunder-55845"
  value: {
-  dps: 20451.59427
-  tps: 18377.40128
+  dps: 20944.8668
+  tps: 18787.7061
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofThunder-56370"
  value: {
-  dps: 20451.59427
-  tps: 18377.40128
+  dps: 20944.8668
+  tps: 18787.7061
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 21188.63403
-  tps: 19040.65488
+  dps: 21699.5738
+  tps: 19465.67549
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Heartpierce-50641"
  value: {
-  dps: 22083.66947
-  tps: 19835.62799
+  dps: 22620.35354
+  tps: 20282.3904
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 21521.77916
-  tps: 19297.89455
+  dps: 22044.25797
+  tps: 19731.41798
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 20574.03226
-  tps: 18477.76385
+  dps: 21065.72015
+  tps: 18885.60101
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 20574.03226
-  tps: 18477.76385
+  dps: 21065.72015
+  tps: 18885.60101
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 20502.85221
-  tps: 18416.60576
+  dps: 20996.07248
+  tps: 18826.37618
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 20600.24415
-  tps: 18505.5935
+  dps: 21092.07475
+  tps: 18913.63807
  }
 }
 dps_results: {
  key: "TestMM-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 20451.59427
-  tps: 18377.40128
+  dps: 20944.8668
+  tps: 18787.7061
  }
 }
 dps_results: {
  key: "TestMM-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 20657.68509
-  tps: 18587.88912
+  dps: 21152.58336
+  tps: 18999.99555
  }
 }
 dps_results: {
  key: "TestMM-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 21075.73911
-  tps: 18947.86314
+  dps: 21583.44713
+  tps: 19370.45612
  }
 }
 dps_results: {
  key: "TestMM-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 21494.21809
-  tps: 19304.21256
+  dps: 22015.48203
+  tps: 19737.87628
  }
 }
 dps_results: {
  key: "TestMM-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 20479.0418
-  tps: 18366.52808
+  dps: 20972.82794
+  tps: 18775.81368
  }
 }
 dps_results: {
  key: "TestMM-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 20479.0418
-  tps: 18366.52808
+  dps: 20972.82794
+  tps: 18775.81368
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 20723.21257
-  tps: 18634.57787
+  dps: 21220.02976
+  tps: 19047.84967
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LastWord-50708"
  value: {
-  dps: 21947.70202
-  tps: 19712.72514
+  dps: 22480.89993
+  tps: 20156.52396
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LeadenDespair-55816"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LeadenDespair-56347"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 21320.88452
-  tps: 19161.83008
+  dps: 21836.87132
+  tps: 19591.4547
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 21445.24719
-  tps: 19272.35819
+  dps: 21964.89733
+  tps: 19705.09277
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 20702.63662
-  tps: 18592.89461
+  dps: 21202.26103
+  tps: 19008.12934
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Lightning-ChargedBattlegear"
  value: {
-  dps: 21517.07671
-  tps: 19411.92059
+  dps: 22030.08297
+  tps: 19840.7206
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 20456.0438
-  tps: 18382.77351
+  dps: 20949.55469
+  tps: 18793.35359
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 20456.0438
-  tps: 18382.77351
+  dps: 20949.55469
+  tps: 18793.35359
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 20534.13978
-  tps: 18451.98167
+  dps: 21027.74793
+  tps: 18862.3035
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 20685.83658
-  tps: 18614.76292
+  dps: 21181.50157
+  tps: 19027.58497
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 20720.03711
-  tps: 18612.67487
+  dps: 21219.07717
+  tps: 19027.42044
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 20720.03711
-  tps: 18612.67487
+  dps: 21219.07717
+  tps: 19027.42044
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 20574.05192
-  tps: 18477.78351
+  dps: 21065.73981
+  tps: 18885.62067
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 20574.05192
-  tps: 18477.78351
+  dps: 21065.73981
+  tps: 18885.62067
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 20813.24578
-  tps: 18719.97218
+  dps: 21308.70325
+  tps: 19131.69872
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 20650.96336
-  tps: 18565.62612
+  dps: 21149.21908
+  tps: 18980.46836
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 20690.39985
-  tps: 18601.20559
+  dps: 21188.21414
+  tps: 19015.45212
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 21477.03363
-  tps: 19257.70669
+  dps: 21998.31947
+  tps: 19690.21946
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 21901.85034
-  tps: 19669.19656
+  dps: 22430.06913
+  tps: 20108.1092
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 22059.10919
-  tps: 19830.91752
+  dps: 22594.97958
+  tps: 20277.66026
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Rainsong-55854"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Rainsong-56377"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 21820.58301
-  tps: 19601.25607
+  dps: 22350.78004
+  tps: 20042.68003
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 21820.58301
-  tps: 19601.25607
+  dps: 22350.78004
+  tps: 20042.68003
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 20702.63662
-  tps: 18592.89461
+  dps: 21202.26103
+  tps: 19008.12934
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 20702.63662
-  tps: 18592.89461
+  dps: 21202.26103
+  tps: 19008.12934
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RuthlessGladiator'sPursuit"
  value: {
-  dps: 21083.95614
-  tps: 18875.85442
+  dps: 21591.06649
+  tps: 19294.6407
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 21075.97431
-  tps: 18936.06001
+  dps: 21583.94605
+  tps: 19358.43518
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SeaStar-55256"
  value: {
-  dps: 20513.27219
-  tps: 18439.07921
+  dps: 21006.54473
+  tps: 18849.38403
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SeaStar-56290"
  value: {
-  dps: 20566.50148
-  tps: 18492.3085
+  dps: 21059.77402
+  tps: 18902.61332
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Shadowmourne-49623"
  value: {
-  dps: 22118.86491
-  tps: 19839.73549
+  dps: 22656.41873
+  tps: 20286.12412
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ShardofWoe-60233"
  value: {
-  dps: 20683.95326
-  tps: 18544.63951
+  dps: 21186.52639
+  tps: 18961.64009
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 20451.59427
-  tps: 18377.40128
+  dps: 20944.8668
+  tps: 18787.7061
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 21359.49955
-  tps: 19207.69203
+  dps: 21874.02757
+  tps: 19636.14774
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 21588.27117
-  tps: 19429.04108
+  dps: 22104.8558
+  tps: 19859.25651
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Sorrowsong-55879"
  value: {
-  dps: 20502.83255
-  tps: 18416.58611
+  dps: 20996.05282
+  tps: 18826.35652
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Sorrowsong-56400"
  value: {
-  dps: 20600.22449
-  tps: 18505.57384
+  dps: 21092.05509
+  tps: 18913.61841
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 20720.03711
-  tps: 18612.67487
+  dps: 21219.07717
+  tps: 19027.42044
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SoulCasket-58183"
  value: {
-  dps: 20761.01759
-  tps: 18664.74919
+  dps: 21252.70548
+  tps: 19072.58634
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 20478.63197
-  tps: 18404.07593
+  dps: 20972.93899
+  tps: 18815.40071
  }
 }
 dps_results: {
  key: "TestMM-AllItems-StumpofTime-62465"
  value: {
-  dps: 20718.35696
-  tps: 18608.61495
+  dps: 21217.98137
+  tps: 19023.84967
  }
 }
 dps_results: {
  key: "TestMM-AllItems-StumpofTime-62470"
  value: {
-  dps: 20731.43147
-  tps: 18621.68946
+  dps: 21231.05588
+  tps: 19036.92419
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 20358.93944
-  tps: 18283.60416
+  dps: 20852.00698
+  tps: 18693.65829
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TearofBlood-55819"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TearofBlood-56351"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 20604.32507
-  tps: 18524.69405
+  dps: 21099.9585
+  tps: 18937.14224
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 20604.27414
-  tps: 18509.62349
+  dps: 21096.10474
+  tps: 18917.66806
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 20385.49314
-  tps: 18301.33482
+  dps: 20877.54181
+  tps: 18710.01716
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 21306.5835
-  tps: 19140.85458
+  dps: 21818.23768
+  tps: 19565.87961
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 21514.43962
-  tps: 19328.08941
+  dps: 22027.37829
+  tps: 19753.57407
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 20707.75531
-  tps: 18611.3583
+  dps: 21206.79819
+  tps: 19026.5453
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 19943.24141
-  tps: 17933.16976
+  dps: 20426.50846
+  tps: 18336.03395
  }
 }
 dps_results: {
  key: "TestMM-AllItems-UnheededWarning-59520"
  value: {
-  dps: 21313.7671
-  tps: 19148.54594
+  dps: 21827.00509
+  tps: 19575.17508
  }
 }
 dps_results: {
  key: "TestMM-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 21426.42092
-  tps: 19246.83655
+  dps: 21939.63777
+  tps: 19672.87003
  }
 }
 dps_results: {
  key: "TestMM-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 21426.42092
-  tps: 19246.83655
+  dps: 21939.63777
+  tps: 19672.87003
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 20880.71779
-  tps: 18796.615
+  dps: 21378.39599
+  tps: 19210.92909
  }
 }
 dps_results: {
  key: "TestMM-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 20451.59427
-  tps: 18377.40128
+  dps: 20944.8668
+  tps: 18787.7061
  }
 }
 dps_results: {
  key: "TestMM-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 20451.59427
-  tps: 18377.40128
+  dps: 20944.8668
+  tps: 18787.7061
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 21287.71675
-  tps: 19136.02369
+  dps: 21801.86341
+  tps: 19564.10262
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 20581.01856
-  tps: 18506.82558
+  dps: 21074.2911
+  tps: 18917.1304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 20702.65628
-  tps: 18592.91427
+  dps: 21202.28069
+  tps: 19008.149
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 20626.54743
-  tps: 18516.29631
+  dps: 21124.56208
+  tps: 18929.90092
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 20873.8762
-  tps: 18772.47726
+  dps: 21376.93576
+  tps: 19191.48087
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 20451.59427
-  tps: 18377.40128
+  dps: 20944.8668
+  tps: 18787.7061
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 20770.96544
-  tps: 18679.9569
+  dps: 21264.2929
+  tps: 19089.64402
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 20451.59427
-  tps: 18377.40128
+  dps: 20944.8668
+  tps: 18787.7061
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 21442.85321
-  tps: 19261.9969
+  dps: 21961.22278
+  tps: 19693.13222
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 20457.95418
-  tps: 18383.7612
+  dps: 20951.22672
+  tps: 18794.06602
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sPursuit"
  value: {
-  dps: 20009.81947
-  tps: 17921.56265
+  dps: 20489.64998
+  tps: 18317.86288
  }
 }
 dps_results: {
  key: "TestMM-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 20451.57461
-  tps: 18377.38163
+  dps: 20944.84714
+  tps: 18787.68644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 20539.16866
-  tps: 18460.95357
+  dps: 21034.42358
+  tps: 18873.07988
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 20529.06232
-  tps: 18435.80146
+  dps: 21023.56255
+  tps: 18846.57125
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 20529.06232
-  tps: 18435.80146
+  dps: 21023.56255
+  tps: 18846.57125
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 20390.90098
-  tps: 18193.15289
+  dps: 20886.37779
+  tps: 18600.71977
  }
 }
 dps_results: {
  key: "TestMM-Average-Default"
  value: {
-  dps: 21859.71278
-  tps: 19622.08309
+  dps: 22389.80848
+  tps: 20062.67361
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-FullBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 23091.97414
-  tps: 20979.94852
+  dps: 23616.56898
+  tps: 21420.06234
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-FullBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 21754.29964
-  tps: 19649.17593
+  dps: 22279.99746
+  tps: 20090.66879
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 26689.96481
-  tps: 23904.52012
+  dps: 27323.50849
+  tps: 24426.64601
  }
 }
 dps_results: {
@@ -1375,22 +1375,22 @@ dps_results: {
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm_advanced-FullBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 23091.97414
-  tps: 20979.94852
+  dps: 23616.56898
+  tps: 21420.06234
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm_advanced-FullBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 21754.29964
-  tps: 19649.17593
+  dps: 22279.99746
+  tps: 20090.66879
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm_advanced-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 26689.96481
-  tps: 23904.52012
+  dps: 27323.50849
+  tps: 24426.64601
  }
 }
 dps_results: {
@@ -1417,22 +1417,22 @@ dps_results: {
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-FullBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 23312.62535
-  tps: 21070.37037
+  dps: 23845.5948
+  tps: 21513.64961
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-FullBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 21947.70202
-  tps: 19712.72514
+  dps: 22480.89993
+  tps: 20156.52396
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 27172.00508
-  tps: 24192.54884
+  dps: 27822.23992
+  tps: 24723.60542
  }
 }
 dps_results: {
@@ -1459,22 +1459,22 @@ dps_results: {
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm_advanced-FullBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 23312.62535
-  tps: 21070.37037
+  dps: 23845.5948
+  tps: 21513.64961
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm_advanced-FullBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 21947.70202
-  tps: 19712.72514
+  dps: 22480.89993
+  tps: 20156.52396
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm_advanced-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 27172.00508
-  tps: 24192.54884
+  dps: 27822.23992
+  tps: 24723.60542
  }
 }
 dps_results: {
@@ -1501,7 +1501,7 @@ dps_results: {
 dps_results: {
  key: "TestMM-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 21649.38252
-  tps: 19444.71869
+  dps: 22174.75545
+  tps: 19881.90506
  }
 }

--- a/sim/hunter/survival/TestSV.results
+++ b/sim/hunter/survival/TestSV.results
@@ -37,1318 +37,1318 @@ character_stats_results: {
 dps_results: {
  key: "TestSV-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 25829.56719
-  tps: 23403.84377
+  dps: 26101.76626
+  tps: 23580.38873
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
-  dps: 21787.01188
-  tps: 19731.98177
+  dps: 22019.79011
+  tps: 19883.67649
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 24433.6546
-  tps: 22147.53489
+  dps: 24691.34266
+  tps: 22314.95856
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 24433.6546
-  tps: 22147.53489
+  dps: 24691.34266
+  tps: 22314.95856
  }
 }
 dps_results: {
  key: "TestSV-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 25251.99838
-  tps: 22844.63904
+  dps: 25519.4944
+  tps: 23017.16461
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 24188.75931
-  tps: 21923.55428
+  dps: 24443.12607
+  tps: 22088.49324
   hps: 96.44839
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 24507.12062
-  tps: 22208.54148
+  dps: 24764.37829
+  tps: 22375.0961
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 24558.20618
-  tps: 22256.99657
+  dps: 24815.97268
+  tps: 22423.95479
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BindingPromise-67037"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlackBruise-50692"
  value: {
-  dps: 23958.32806
-  tps: 21700.53081
+  dps: 24211.24733
+  tps: 21864.39259
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 24991.62015
-  tps: 22670.15179
+  dps: 25253.59468
+  tps: 22840.46078
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 24411.49484
-  tps: 22146.20201
+  dps: 24665.85039
+  tps: 22311.14097
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 24440.61017
-  tps: 22175.26916
+  dps: 24694.96573
+  tps: 22340.20812
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 25273.88469
-  tps: 22910.5639
+  dps: 25539.1849
+  tps: 23082.51167
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 24484.56179
-  tps: 22186.62189
+  dps: 24741.66309
+  tps: 22353.0457
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 25309.87051
-  tps: 22928.59494
+  dps: 25575.68898
+  tps: 23100.36867
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sPursuit"
  value: {
-  dps: 22780.79471
-  tps: 20619.64659
+  dps: 23020.89747
+  tps: 20774.50356
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BottledLightning-66879"
  value: {
-  dps: 24302.26914
-  tps: 22030.81985
+  dps: 24557.84624
+  tps: 22196.71937
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 25251.99838
-  tps: 22387.74626
+  dps: 25519.4944
+  tps: 22556.82132
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 25830.97722
-  tps: 23405.45352
+  dps: 26103.16831
+  tps: 23581.99849
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 25645.6556
-  tps: 23237.21033
+  dps: 25915.94195
+  tps: 23412.52624
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 25696.5346
-  tps: 23283.57658
+  dps: 25967.37736
+  tps: 23459.26839
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CrushingWeight-59506"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CrushingWeight-65118"
  value: {
-  dps: 24149.20109
-  tps: 21879.15068
+  dps: 24403.60119
+  tps: 22043.92917
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 24488.80283
-  tps: 22228.36389
+  dps: 24743.44109
+  tps: 22393.76499
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 25534.06187
-  tps: 23171.22257
+  dps: 25799.18675
+  tps: 23343.11629
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 24477.64528
-  tps: 22212.04794
+  dps: 24732.00898
+  tps: 22376.9869
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 24808.68225
-  tps: 22473.45652
+  dps: 25068.90272
+  tps: 22641.59701
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 25299.99205
-  tps: 22888.11996
+  dps: 25568.02335
+  tps: 23061.00031
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 24274.68486
-  tps: 22016.18757
+  dps: 24528.38101
+  tps: 22180.72422
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 25251.99838
-  tps: 22844.63904
+  dps: 25519.4944
+  tps: 23017.16461
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 25251.99838
-  tps: 22844.63904
+  dps: 25519.4944
+  tps: 23017.16461
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 25299.99205
-  tps: 22888.11996
+  dps: 25568.02335
+  tps: 23061.00031
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 25681.71401
-  tps: 23278.35293
+  dps: 25950.54833
+  tps: 23452.33523
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 25818.41736
-  tps: 23398.02823
+  dps: 26088.24851
+  tps: 23572.33175
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 25251.99838
-  tps: 22844.63904
+  dps: 25519.4944
+  tps: 23017.16461
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FallofMortality-59500"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FallofMortality-65124"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 25447.51552
-  tps: 23068.59985
+  dps: 25714.30619
+  tps: 23241.41429
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 24440.61017
-  tps: 22175.26916
+  dps: 24694.96573
+  tps: 22340.20812
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 25301.60381
-  tps: 22894.15603
+  dps: 25569.09983
+  tps: 23066.6816
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FluidDeath-58181"
  value: {
-  dps: 25676.12742
-  tps: 23266.16199
+  dps: 25947.08102
+  tps: 23441.96711
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 25251.99838
-  tps: 22844.63904
+  dps: 25519.4944
+  tps: 23017.16461
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 24507.12062
-  tps: 22208.54148
+  dps: 24764.37829
+  tps: 22375.0961
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GaleofShadows-56138"
  value: {
-  dps: 24280.35999
-  tps: 21985.61362
+  dps: 24535.95951
+  tps: 22150.60369
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GaleofShadows-56462"
  value: {
-  dps: 24317.4952
-  tps: 22014.29008
+  dps: 24575.4096
+  tps: 22181.25666
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GearDetector-61462"
  value: {
-  dps: 24884.74549
-  tps: 22528.32822
+  dps: 25147.59583
+  tps: 22698.18398
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 22349.56191
-  tps: 20207.60872
+  dps: 22587.13962
+  tps: 20360.6357
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 24944.8742
-  tps: 22598.51954
+  dps: 25206.7263
+  tps: 22767.84491
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 25334.41253
-  tps: 22951.59589
+  dps: 25599.6032
+  tps: 23122.75156
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HarmlightToken-63839"
  value: {
-  dps: 24196.55759
-  tps: 21931.67728
+  dps: 24450.91136
+  tps: 22096.61623
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 24202.44835
-  tps: 21937.5235
+  dps: 24456.80391
+  tps: 22102.46246
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofRage-59224"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofRage-65072"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofSolace-55868"
  value: {
-  dps: 24280.35999
-  tps: 21985.61362
+  dps: 24535.95951
+  tps: 22150.60369
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofSolace-56393"
  value: {
-  dps: 24317.4952
-  tps: 22014.29008
+  dps: 24575.4096
+  tps: 22181.25666
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofThunder-55845"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofThunder-56370"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 25078.18187
-  tps: 22718.23575
+  dps: 25341.40472
+  tps: 22888.39291
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Heartpierce-50641"
  value: {
-  dps: 25981.36792
-  tps: 23539.12107
+  dps: 26255.19373
+  tps: 23716.63847
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 25299.99205
-  tps: 22888.11996
+  dps: 25568.02335
+  tps: 23061.00031
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 24472.37236
-  tps: 22206.97878
+  dps: 24726.72791
+  tps: 22371.91773
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 24472.37236
-  tps: 22206.97878
+  dps: 24726.72791
+  tps: 22371.91773
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 24411.49484
-  tps: 22146.20201
+  dps: 24665.85039
+  tps: 22311.14097
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 24440.61017
-  tps: 22175.26916
+  dps: 24694.96573
+  tps: 22340.20812
  }
 }
 dps_results: {
  key: "TestSV-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 24382.21083
-  tps: 22118.82552
+  dps: 24638.23432
+  tps: 22285.50533
  }
 }
 dps_results: {
  key: "TestSV-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 24991.62015
-  tps: 22670.15179
+  dps: 25253.59468
+  tps: 22840.46078
  }
 }
 dps_results: {
  key: "TestSV-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 25384.65649
-  tps: 23000.43337
+  dps: 25652.49401
+  tps: 23174.17011
  }
 }
 dps_results: {
  key: "TestSV-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 24282.93214
-  tps: 22020.11303
+  dps: 24537.55272
+  tps: 22185.40125
  }
 }
 dps_results: {
  key: "TestSV-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 24282.93214
-  tps: 22020.11303
+  dps: 24537.55272
+  tps: 22185.40125
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 24272.83285
-  tps: 21992.51268
+  dps: 24526.90143
+  tps: 22156.54885
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LastWord-50708"
  value: {
-  dps: 25829.56719
-  tps: 23403.84377
+  dps: 26101.76626
+  tps: 23580.38873
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LeadenDespair-55816"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LeadenDespair-56347"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 25167.7507
-  tps: 22805.07554
+  dps: 25431.75569
+  tps: 22975.85161
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 25343.77092
-  tps: 22970.36041
+  dps: 25609.26107
+  tps: 23142.28337
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 24433.6546
-  tps: 22147.53489
+  dps: 24691.34266
+  tps: 22314.95856
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Lightning-ChargedBattlegear"
  value: {
-  dps: 24605.37008
-  tps: 22335.89314
+  dps: 24859.85149
+  tps: 22500.95291
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 24211.23631
-  tps: 21948.13428
+  dps: 24467.2598
+  tps: 22114.81409
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 24211.23631
-  tps: 21948.13428
+  dps: 24467.2598
+  tps: 22114.81409
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 24379.10607
-  tps: 22116.00404
+  dps: 24635.12956
+  tps: 22282.68385
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 24401.08902
-  tps: 22137.98699
+  dps: 24657.11251
+  tps: 22304.6668
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 24453.16444
-  tps: 22169.23754
+  dps: 24712.05983
+  tps: 22337.95626
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 24453.16444
-  tps: 22169.23754
+  dps: 24712.05983
+  tps: 22337.95626
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 24472.37236
-  tps: 22206.97878
+  dps: 24726.72791
+  tps: 22371.91773
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 24472.37236
-  tps: 22206.97878
+  dps: 24726.72791
+  tps: 22371.91773
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 24466.82609
-  tps: 22201.90124
+  dps: 24721.18164
+  tps: 22366.84019
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 24388.76352
-  tps: 22108.78113
+  dps: 24645.14574
+  tps: 22275.14444
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 24365.51623
-  tps: 22077.74164
+  dps: 24621.41426
+  tps: 22243.3688
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 24193.79399
-  tps: 21928.86914
+  dps: 24448.14955
+  tps: 22093.8081
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 24196.02672
-  tps: 21931.10187
+  dps: 24450.38227
+  tps: 22096.04082
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 25251.99838
-  tps: 22844.63904
+  dps: 25519.4944
+  tps: 23017.16461
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 25601.7169
-  tps: 23179.93851
+  dps: 25869.3599
+  tps: 23351.99278
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 25722.81607
-  tps: 23270.82798
+  dps: 25996.34933
+  tps: 23447.56966
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Rainsong-55854"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Rainsong-56377"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 25645.6556
-  tps: 23237.21033
+  dps: 25915.94195
+  tps: 23412.52624
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 25645.6556
-  tps: 23237.21033
+  dps: 25915.94195
+  tps: 23412.52624
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 24433.6546
-  tps: 22147.53489
+  dps: 24691.34266
+  tps: 22314.95856
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 24433.6546
-  tps: 22147.53489
+  dps: 24691.34266
+  tps: 22314.95856
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RuthlessGladiator'sPursuit"
  value: {
-  dps: 25034.31823
-  tps: 22645.25263
+  dps: 25297.33835
+  tps: 22813.99439
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 24971.24891
-  tps: 22623.20364
+  dps: 25233.18964
+  tps: 22792.4935
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SeaStar-55256"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SeaStar-56290"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Shadowmourne-49623"
  value: {
-  dps: 26002.2783
-  tps: 23526.66367
+  dps: 26276.6885
+  tps: 23703.42411
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ShardofWoe-60233"
  value: {
-  dps: 24231.83852
-  tps: 21932.97417
+  dps: 24488.8663
+  tps: 22099.22777
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 24232.09063
-  tps: 21967.78387
+  dps: 24487.7325
+  tps: 22134.03388
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 25232.7544
-  tps: 22878.64042
+  dps: 25495.3056
+  tps: 23048.30038
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 25366.97174
-  tps: 23003.52219
+  dps: 25630.50712
+  tps: 23173.79725
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Sorrowsong-55879"
  value: {
-  dps: 24411.49484
-  tps: 22146.20201
+  dps: 24665.85039
+  tps: 22311.14097
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Sorrowsong-56400"
  value: {
-  dps: 24440.61017
-  tps: 22175.26916
+  dps: 24694.96573
+  tps: 22340.20812
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 24453.16444
-  tps: 22169.23754
+  dps: 24712.05983
+  tps: 22337.95626
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SoulCasket-58183"
  value: {
-  dps: 24472.37236
-  tps: 22206.97878
+  dps: 24726.72791
+  tps: 22371.91773
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 24200.09134
-  tps: 21932.25215
+  dps: 24454.5937
+  tps: 22097.28105
  }
 }
 dps_results: {
  key: "TestSV-AllItems-StumpofTime-62465"
  value: {
-  dps: 24433.6546
-  tps: 22147.53489
+  dps: 24691.34266
+  tps: 22314.95856
  }
 }
 dps_results: {
  key: "TestSV-AllItems-StumpofTime-62470"
  value: {
-  dps: 24433.6546
-  tps: 22147.53489
+  dps: 24691.34266
+  tps: 22314.95856
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 24254.32826
-  tps: 21989.27162
+  dps: 24508.68382
+  tps: 22154.21057
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 24230.02001
-  tps: 21962.80456
+  dps: 24484.44493
+  tps: 22127.72125
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TearofBlood-55819"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TearofBlood-56351"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 24378.85037
-  tps: 22113.61157
+  dps: 24633.20592
+  tps: 22278.55053
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 24440.61017
-  tps: 22175.26916
+  dps: 24694.96573
+  tps: 22340.20812
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 24197.60383
-  tps: 21932.67898
+  dps: 24451.95938
+  tps: 22097.61793
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 24230.53775
-  tps: 21965.03852
+  dps: 24484.8933
+  tps: 22129.97748
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 25398.5277
-  tps: 23032.13156
+  dps: 25662.56912
+  tps: 23202.78072
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 25561.71252
-  tps: 23182.43233
+  dps: 25826.93993
+  tps: 23353.75522
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 24232.71236
-  tps: 21959.13594
+  dps: 24486.86321
+  tps: 22123.52413
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 23480.33541
-  tps: 21290.2539
+  dps: 23727.10748
+  tps: 21450.60311
  }
 }
 dps_results: {
  key: "TestSV-AllItems-UnheededWarning-59520"
  value: {
-  dps: 25277.98516
-  tps: 22899.96916
+  dps: 25543.06588
+  tps: 23071.21165
  }
 }
 dps_results: {
  key: "TestSV-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 25586.83639
-  tps: 23228.21183
+  dps: 25853.08421
+  tps: 23401.31381
  }
 }
 dps_results: {
  key: "TestSV-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 25586.83639
-  tps: 23228.21183
+  dps: 25853.08421
+  tps: 23401.31381
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 24013.95001
-  tps: 21740.61739
+  dps: 24268.85981
+  tps: 21905.84448
  }
 }
 dps_results: {
  key: "TestSV-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 25290.84694
-  tps: 22932.69111
+  dps: 25557.09475
+  tps: 23105.79309
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 24433.6546
-  tps: 22147.53489
+  dps: 24691.34266
+  tps: 22314.95856
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 24448.20572
-  tps: 22163.88303
+  dps: 24706.72818
+  tps: 22332.21299
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 24529.99925
-  tps: 22230.10248
+  dps: 24787.37756
+  tps: 22396.72504
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 24489.13573
-  tps: 22223.71441
+  dps: 24743.49129
+  tps: 22388.65336
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 25355.03231
-  tps: 22967.64935
+  dps: 25621.54227
+  tps: 23139.89619
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 24189.15955
-  tps: 21924.23469
+  dps: 24443.5151
+  tps: 22089.17365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sPursuit"
  value: {
-  dps: 23771.7815
-  tps: 21504.4526
+  dps: 24025.15659
+  tps: 21668.37339
  }
 }
 dps_results: {
  key: "TestSV-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 24171.9898
-  tps: 21902.20275
+  dps: 24426.58085
+  tps: 22067.18271
  }
 }
 dps_results: {
  key: "TestSV-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 24156.36382
-  tps: 21880.88146
+  dps: 24410.12329
+  tps: 22044.80204
  }
 }
 dps_results: {
  key: "TestSV-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 24382.3795
-  tps: 22117.13486
+  dps: 24636.73505
+  tps: 22282.07382
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 24357.12313
-  tps: 22094.0211
+  dps: 24613.14662
+  tps: 22260.70091
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 24357.12313
-  tps: 22094.0211
+  dps: 24613.14662
+  tps: 22260.70091
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 24453.28715
-  tps: 22066.50055
+  dps: 24708.74851
+  tps: 22227.78785
  }
 }
 dps_results: {
  key: "TestSV-Average-Default"
  value: {
-  dps: 25928.14427
-  tps: 23492.55598
+  dps: 26201.67423
+  tps: 23669.82062
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-FullBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 135140.46152
-  tps: 99908.20291
+  dps: 135464.02164
+  tps: 100140.16515
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-FullBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 22318.04684
-  tps: 18160.52184
+  dps: 22642.17881
+  tps: 18392.31005
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 28315.49242
-  tps: 22481.92882
+  dps: 28750.36874
+  tps: 22793.58777
  }
 }
 dps_results: {
@@ -1375,22 +1375,22 @@ dps_results: {
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-FullBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 28300.49618
-  tps: 25983.63713
+  dps: 28567.83026
+  tps: 26159.54122
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-FullBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 25639.53444
-  tps: 23351.31899
+  dps: 25905.86968
+  tps: 23527.50031
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 32064.97834
-  tps: 29035.41131
+  dps: 32399.99729
+  tps: 29256.121
  }
 }
 dps_results: {
@@ -1417,22 +1417,22 @@ dps_results: {
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv_advanced-FullBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 30864.90938
-  tps: 27904.54918
+  dps: 31133.86345
+  tps: 28081.9763
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv_advanced-FullBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 25731.3254
-  tps: 23437.65462
+  dps: 26000.02812
+  tps: 23615.69266
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv_advanced-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 32243.63973
-  tps: 29203.66129
+  dps: 32576.30459
+  tps: 29420.13775
  }
 }
 dps_results: {
@@ -1459,22 +1459,22 @@ dps_results: {
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-FullBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 135877.27275
-  tps: 100552.45672
+  dps: 136207.28367
+  tps: 100785.33227
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-FullBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 22507.58837
-  tps: 18217.05782
+  dps: 22837.71181
+  tps: 18449.25498
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 28736.00937
-  tps: 22677.33442
+  dps: 29180.8573
+  tps: 22990.71921
  }
 }
 dps_results: {
@@ -1501,22 +1501,22 @@ dps_results: {
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-FullBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 28586.5149
-  tps: 26129.952
+  dps: 28859.14553
+  tps: 26305.56461
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-FullBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 25829.56719
-  tps: 23403.84377
+  dps: 26101.76626
+  tps: 23580.38873
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 32483.31926
-  tps: 29258.35707
+  dps: 32827.24165
+  tps: 29480.15509
  }
 }
 dps_results: {
@@ -1543,22 +1543,22 @@ dps_results: {
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv_advanced-FullBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 31201.95591
-  tps: 28109.8813
+  dps: 31476.62294
+  tps: 28287.45079
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv_advanced-FullBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 25919.81278
-  tps: 23488.03498
+  dps: 26194.20737
+  tps: 23666.24072
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv_advanced-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 32691.95713
-  tps: 29452.48127
+  dps: 33032.74962
+  tps: 29669.10601
  }
 }
 dps_results: {
@@ -1585,7 +1585,7 @@ dps_results: {
 dps_results: {
  key: "TestSV-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 25673.60777
-  tps: 23273.34766
+  dps: 25942.49238
+  tps: 23447.59669
  }
 }

--- a/sim/rogue/assassination/TestAssassination.results
+++ b/sim/rogue/assassination/TestAssassination.results
@@ -37,1255 +37,1255 @@ character_stats_results: {
 dps_results: {
  key: "TestAssassination-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 29980.06751
-  tps: 21285.84794
+  dps: 30454.19474
+  tps: 21622.47827
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 28216.88144
-  tps: 20033.98582
+  dps: 28665.17236
+  tps: 20352.27237
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 28413.97963
-  tps: 20173.92554
+  dps: 28863.12755
+  tps: 20492.82056
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 29473.536
-  tps: 20926.21056
+  dps: 29935.29026
+  tps: 21254.05609
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
   hps: 85.45007
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 28030.58845
-  tps: 19901.7178
+  dps: 28482.23724
+  tps: 20222.38844
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 28049.98516
-  tps: 19915.48946
+  dps: 28502.39215
+  tps: 20236.69842
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BindingPromise-67037"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 28729.98695
-  tps: 20398.29073
+  dps: 29188.37683
+  tps: 20723.74755
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 27872.97056
-  tps: 19789.8091
+  dps: 28316.08164
+  tps: 20104.41796
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 27925.52177
-  tps: 19827.12045
+  dps: 28368.63285
+  tps: 20141.72932
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 29110.04924
-  tps: 20668.13496
+  dps: 29579.90803
+  tps: 21001.7347
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 28028.06713
-  tps: 19899.92766
+  dps: 28479.38923
+  tps: 20220.36635
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 28007.11669
-  tps: 19885.05285
+  dps: 28457.8942
+  tps: 20205.10488
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 28780.02891
-  tps: 20433.82052
+  dps: 29244.15782
+  tps: 20763.35205
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 27979.34201
-  tps: 19865.33283
+  dps: 28429.69324
+  tps: 20185.0822
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BottledLightning-66879"
  value: {
-  dps: 27600.17067
-  tps: 19596.12117
+  dps: 28046.12163
+  tps: 19912.74636
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 29473.536
-  tps: 20507.68635
+  dps: 29935.29026
+  tps: 20828.97497
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 29816.06649
-  tps: 21169.40721
+  dps: 30286.7777
+  tps: 21503.61216
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 29841.67659
-  tps: 21187.59038
+  dps: 30313.5709
+  tps: 21522.63534
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CrushingWeight-59506"
  value: {
-  dps: 28707.03366
-  tps: 20381.9939
+  dps: 29167.56378
+  tps: 20708.97028
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CrushingWeight-65118"
  value: {
-  dps: 28864.81476
-  tps: 20494.01848
+  dps: 29326.77131
+  tps: 20822.00763
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 28595.19808
-  tps: 20302.59064
+  dps: 29044.81094
+  tps: 20621.81577
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 29371.86198
-  tps: 20854.02201
+  dps: 29834.92393
+  tps: 21182.79599
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 28026.79395
-  tps: 19899.02371
+  dps: 28469.90503
+  tps: 20213.63257
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 28361.05077
-  tps: 20136.34605
+  dps: 28816.59236
+  tps: 20459.78057
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 29496.14369
-  tps: 20942.26202
+  dps: 29958.99715
+  tps: 21270.88798
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 27751.54678
-  tps: 19703.59822
+  dps: 28197.87695
+  tps: 20020.49263
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 29473.536
-  tps: 20926.21056
+  dps: 29935.29026
+  tps: 21254.05609
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 29473.536
-  tps: 20926.21056
+  dps: 29935.29026
+  tps: 21254.05609
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 29496.14369
-  tps: 20942.26202
+  dps: 29958.99715
+  tps: 21270.88798
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 29218.00223
-  tps: 20744.78158
+  dps: 29688.7199
+  tps: 21078.99113
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 29430.41107
-  tps: 20895.59186
+  dps: 29905.17769
+  tps: 21232.67616
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 29473.536
-  tps: 20926.21056
+  dps: 29935.29026
+  tps: 21254.05609
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FallofMortality-59500"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FallofMortality-65124"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 29982.85146
-  tps: 21287.82454
+  dps: 30458.9136
+  tps: 21625.82866
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 28456.19113
-  tps: 20203.8957
+  dps: 28907.00004
+  tps: 20523.97003
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 29567.64666
-  tps: 20993.02913
+  dps: 30029.40092
+  tps: 21320.87466
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 29473.536
-  tps: 20926.21056
+  dps: 29935.29026
+  tps: 21254.05609
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 28702.04229
-  tps: 20378.45002
+  dps: 29163.02655
+  tps: 20705.74885
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GaleofShadows-56138"
  value: {
-  dps: 27854.78139
-  tps: 19776.89479
+  dps: 28303.40855
+  tps: 20095.42007
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GaleofShadows-56462"
  value: {
-  dps: 27803.80722
-  tps: 19740.70313
+  dps: 28253.11323
+  tps: 20059.71039
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GearDetector-61462"
  value: {
-  dps: 28412.58644
-  tps: 20172.93637
+  dps: 28868.76714
+  tps: 20496.82467
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Gladiator'sVestments"
  value: {
-  dps: 23740.44271
-  tps: 16855.71433
+  dps: 24133.3667
+  tps: 17134.69036
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 28410.8524
-  tps: 20171.70521
+  dps: 28868.51462
+  tps: 20496.64538
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 28819.3085
-  tps: 20461.70904
+  dps: 29284.87597
+  tps: 20792.26194
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HarmlightToken-63839"
  value: {
-  dps: 27574.47539
-  tps: 19577.87753
+  dps: 28017.1749
+  tps: 19892.19418
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 28171.90584
-  tps: 20002.05314
+  dps: 28620.1312
+  tps: 20320.29315
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 28107.67205
-  tps: 19956.44716
+  dps: 28560.79604
+  tps: 20278.16519
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 28047.80891
-  tps: 19913.94433
+  dps: 28500.09264
+  tps: 20235.06578
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofRage-59224"
  value: {
-  dps: 28624.02602
-  tps: 20323.05847
+  dps: 29083.30466
+  tps: 20649.14631
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofRage-65072"
  value: {
-  dps: 28786.11127
-  tps: 20438.139
+  dps: 29247.60019
+  tps: 20765.79614
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofSolace-55868"
  value: {
-  dps: 27854.78139
-  tps: 19776.89479
+  dps: 28303.40855
+  tps: 20095.42007
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofSolace-56393"
  value: {
-  dps: 28388.37226
-  tps: 20155.7443
+  dps: 28846.24728
+  tps: 20480.83557
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofThunder-55845"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofThunder-56370"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 28528.73508
-  tps: 20255.40191
+  dps: 28987.89171
+  tps: 20581.40312
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Heartpierce-50641"
  value: {
-  dps: 29980.06751
-  tps: 21285.84794
+  dps: 30454.19474
+  tps: 21622.47827
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 29496.14369
-  tps: 20942.26202
+  dps: 29958.99715
+  tps: 21270.88798
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 28581.83883
-  tps: 20293.10557
+  dps: 29033.6201
+  tps: 20613.87027
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 28581.83883
-  tps: 20293.10557
+  dps: 29033.6201
+  tps: 20613.87027
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 27872.97056
-  tps: 19789.8091
+  dps: 28316.08164
+  tps: 20104.41796
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 27925.52177
-  tps: 19827.12045
+  dps: 28368.63285
+  tps: 20141.72932
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 27780.60782
-  tps: 19724.23155
+  dps: 28223.7189
+  tps: 20038.84042
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 28729.98695
-  tps: 20398.29073
+  dps: 29188.37683
+  tps: 20723.74755
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 29246.55745
-  tps: 20765.05579
+  dps: 29710.59032
+  tps: 21094.51913
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 29796.2743
-  tps: 21155.35475
+  dps: 30269.93247
+  tps: 21491.65206
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 27980.30246
-  tps: 19866.01475
+  dps: 28430.57698
+  tps: 20185.70965
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 27980.30246
-  tps: 19866.01475
+  dps: 28430.57698
+  tps: 20185.70965
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 27727.35269
-  tps: 19686.42041
+  dps: 28172.13743
+  tps: 20002.21757
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-LeadenDespair-55816"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-LeadenDespair-56347"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 29008.44753
-  tps: 20595.99774
+  dps: 29475.45256
+  tps: 20927.57131
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 29276.78621
-  tps: 20786.51821
+  dps: 29748.09239
+  tps: 21121.14559
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 29137.18865
-  tps: 20687.40394
+  dps: 29594.83095
+  tps: 21012.32997
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 28128.34156
-  tps: 19971.12251
+  dps: 28580.50812
+  tps: 20292.16076
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 28362.31336
-  tps: 20137.24248
+  dps: 28818.69334
+  tps: 20461.27227
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 28281.70397
-  tps: 20080.00982
+  dps: 28730.32274
+  tps: 20398.52915
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 28388.68264
-  tps: 20155.96468
+  dps: 28838.02266
+  tps: 20474.99609
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 28298.8989
-  tps: 20092.21822
+  dps: 28748.56073
+  tps: 20411.47812
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 28875.86335
-  tps: 20501.86298
+  dps: 29331.83821
+  tps: 20825.60513
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 27982.85036
-  tps: 19867.82376
+  dps: 28425.96144
+  tps: 20182.43262
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 27982.85036
-  tps: 19867.82376
+  dps: 28425.96144
+  tps: 20182.43262
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 28140.46705
-  tps: 19979.73161
+  dps: 28583.57813
+  tps: 20294.34047
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 27988.0521
-  tps: 19871.51699
+  dps: 28439.77844
+  tps: 20192.24269
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 27751.22511
-  tps: 19703.36983
+  dps: 28198.33465
+  tps: 20020.8176
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 27817.12343
-  tps: 19750.15764
+  dps: 28260.23451
+  tps: 20064.7665
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 28120.68124
-  tps: 19965.68368
+  dps: 28563.79232
+  tps: 20280.29255
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 29473.536
-  tps: 20926.21056
+  dps: 29935.29026
+  tps: 21254.05609
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 29318.36562
-  tps: 20816.03959
+  dps: 29790.67952
+  tps: 21151.38246
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Rainsong-55854"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Rainsong-56377"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 29901.71709
-  tps: 21230.21914
+  dps: 30373.64084
+  tps: 21565.285
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 29816.06649
-  tps: 21169.40721
+  dps: 30286.7777
+  tps: 21503.61216
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 28709.40657
-  tps: 20383.67866
+  dps: 29164.56694
+  tps: 20706.84253
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 28959.96266
-  tps: 20561.57349
+  dps: 29416.91727
+  tps: 20886.01126
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 28777.20945
-  tps: 20431.81871
+  dps: 29234.49662
+  tps: 20756.4926
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SeaStar-55256"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SeaStar-56290"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 22482.62014
-  tps: 15962.6603
+  dps: 22852.77096
+  tps: 16225.46738
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ShardofWoe-60233"
  value: {
-  dps: 28043.97759
-  tps: 19911.22409
+  dps: 28494.9618
+  tps: 20231.42288
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 28353.71309
-  tps: 20131.13629
+  dps: 28808.28791
+  tps: 20453.88442
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 29008.51985
-  tps: 20596.04909
+  dps: 29466.81758
+  tps: 20921.44048
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 29195.81276
-  tps: 20729.02706
+  dps: 29656.12036
+  tps: 21055.84546
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Sorrowsong-55879"
  value: {
-  dps: 27872.97056
-  tps: 19789.8091
+  dps: 28316.08164
+  tps: 20104.41796
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Sorrowsong-56400"
  value: {
-  dps: 27925.52177
-  tps: 19827.12045
+  dps: 28368.63285
+  tps: 20141.72932
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 28465.28526
-  tps: 20210.35254
+  dps: 28917.24798
+  tps: 20531.24606
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SoulCasket-58183"
  value: {
-  dps: 27982.85036
-  tps: 19867.82376
+  dps: 28425.96144
+  tps: 20182.43262
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 27733.78348
-  tps: 19690.98627
+  dps: 28181.63094
+  tps: 20008.95797
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-StumpofTime-62465"
  value: {
-  dps: 28541.01414
-  tps: 20264.12004
+  dps: 28990.34628
+  tps: 20583.14586
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-StumpofTime-62470"
  value: {
-  dps: 28541.01414
-  tps: 20264.12004
+  dps: 28990.34628
+  tps: 20583.14586
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 27753.51029
-  tps: 19704.9923
+  dps: 28196.62136
+  tps: 20019.60117
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 28295.49784
-  tps: 20089.80346
+  dps: 28750.82493
+  tps: 20413.0857
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TearofBlood-55819"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TearofBlood-56351"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 27814.0495
-  tps: 19747.97515
+  dps: 28257.16058
+  tps: 20062.58401
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 27925.52177
-  tps: 19827.12045
+  dps: 28368.63285
+  tps: 20141.72932
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 28023.81808
-  tps: 19896.91084
+  dps: 28466.92916
+  tps: 20211.5197
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 28102.98905
-  tps: 19953.12222
+  dps: 28546.10013
+  tps: 20267.73109
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 29116.92673
-  tps: 20673.01798
+  dps: 29578.42966
+  tps: 21000.68506
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 29307.30349
-  tps: 20808.18548
+  dps: 29770.35918
+  tps: 21136.95502
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 28398.69011
-  tps: 20163.06998
+  dps: 28851.88715
+  tps: 20484.83987
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 27448.8337
-  tps: 19488.67193
+  dps: 27890.73707
+  tps: 19802.42332
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-UnheededWarning-59520"
  value: {
-  dps: 29339.15062
-  tps: 20830.79694
+  dps: 29809.46889
+  tps: 21164.72291
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 29422.20458
-  tps: 20889.76525
+  dps: 29888.66833
+  tps: 21220.95452
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 29422.20458
-  tps: 20889.76525
+  dps: 29888.66833
+  tps: 21220.95452
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 29422.20458
-  tps: 20889.76525
+  dps: 29888.66833
+  tps: 21220.95452
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 28885.51517
-  tps: 20508.71577
+  dps: 29351.97892
+  tps: 20839.90503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 28059.18142
-  tps: 19922.01881
+  dps: 28510.96269
+  tps: 20242.78351
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 28557.71843
-  tps: 20275.98008
+  dps: 29007.3043
+  tps: 20595.18605
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 27982.04053
-  tps: 19867.24878
+  dps: 28433.19431
+  tps: 20187.56796
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 28027.50305
-  tps: 19899.52716
+  dps: 28479.27184
+  tps: 20220.28301
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 28039.39453
-  tps: 19907.97011
+  dps: 28490.15993
+  tps: 20228.01355
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 28013.10712
-  tps: 19889.30605
+  dps: 28456.2182
+  tps: 20203.91492
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 28815.68051
-  tps: 20459.13316
+  dps: 29280.37647
+  tps: 20789.06729
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 27471.67041
-  tps: 19504.88599
+  dps: 27914.78149
+  tps: 19819.49485
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 28018.29047
-  tps: 19892.98624
+  dps: 28469.30544
+  tps: 20213.20686
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WindDancer'sRegalia"
  value: {
-  dps: 27020.05109
-  tps: 19184.23628
+  dps: 27461.59147
+  tps: 19497.72994
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 27739.64808
-  tps: 19695.15014
+  dps: 28186.09606
+  tps: 20012.1282
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 27827.13855
-  tps: 19757.26837
+  dps: 28273.78439
+  tps: 20074.38692
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 27820.41935
-  tps: 19752.49774
+  dps: 28263.53043
+  tps: 20067.1066
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 27838.25359
-  tps: 19765.16005
+  dps: 28281.36467
+  tps: 20079.76891
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 27838.25359
-  tps: 19765.16005
+  dps: 28281.36467
+  tps: 20079.76891
  }
 }
 dps_results: {
  key: "TestAssassination-Average-Default"
  value: {
-  dps: 29977.41848
-  tps: 21283.96712
+  dps: 30451.63905
+  tps: 21620.66372
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination_test-Assassination-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 29980.06751
-  tps: 21285.84794
+  dps: 30454.19474
+  tps: 21622.47827
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination_test-Assassination-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 29980.06751
-  tps: 21285.84794
+  dps: 30454.19474
+  tps: 21622.47827
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination_test-Assassination-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 39620.11892
-  tps: 28130.28443
+  dps: 40253.22771
+  tps: 28579.79167
  }
 }
 dps_results: {
@@ -1312,22 +1312,22 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination_test-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 21872.19564
-  tps: 15529.25891
+  dps: 22346.63277
+  tps: 15866.10927
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination_test-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 21872.19564
-  tps: 15529.25891
+  dps: 22346.63277
+  tps: 15866.10927
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination_test-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 28930.49283
-  tps: 20540.64991
+  dps: 29564.08579
+  tps: 20990.50091
  }
 }
 dps_results: {
@@ -1354,22 +1354,22 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 28527.34129
-  tps: 20254.41232
+  dps: 29001.3248
+  tps: 20590.94061
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 28527.34129
-  tps: 20254.41232
+  dps: 29001.3248
+  tps: 20590.94061
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 37425.88383
-  tps: 26572.37752
+  dps: 38059.12267
+  tps: 27021.9771
  }
 }
 dps_results: {
@@ -1396,22 +1396,22 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 16561.4577
-  tps: 11758.63497
+  dps: 16943.38956
+  tps: 12029.80659
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 16561.4577
-  tps: 11758.63497
+  dps: 16943.38956
+  tps: 12029.80659
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination_test-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 20877.00757
-  tps: 14822.67538
+  dps: 21354.79915
+  tps: 15161.9074
  }
 }
 dps_results: {
@@ -1438,22 +1438,22 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination_test-Assassination-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 30293.57836
-  tps: 21508.44064
+  dps: 30772.05113
+  tps: 21848.1563
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination_test-Assassination-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 30293.57836
-  tps: 21508.44064
+  dps: 30772.05113
+  tps: 21848.1563
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination_test-Assassination-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 40255.95439
-  tps: 28581.72762
+  dps: 40898.68793
+  tps: 29038.06843
  }
 }
 dps_results: {
@@ -1480,22 +1480,22 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 22080.92023
-  tps: 15677.45336
+  dps: 22559.2237
+  tps: 16017.04883
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 22080.92023
-  tps: 15677.45336
+  dps: 22559.2237
+  tps: 16017.04883
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 29401.63216
-  tps: 20875.15883
+  dps: 30044.84549
+  tps: 21331.8403
  }
 }
 dps_results: {
@@ -1522,22 +1522,22 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 28822.12185
-  tps: 20463.70651
+  dps: 29300.24889
+  tps: 20803.17671
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 28822.12185
-  tps: 20463.70651
+  dps: 29300.24889
+  tps: 20803.17671
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 38011.10317
-  tps: 26987.88325
+  dps: 38653.93414
+  tps: 27444.29324
  }
 }
 dps_results: {
@@ -1564,22 +1564,22 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 16729.19606
-  tps: 11877.7292
+  dps: 17114.93386
+  tps: 12151.60304
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 16729.19606
-  tps: 11877.7292
+  dps: 17114.93386
+  tps: 12151.60304
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination_test-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 21242.98422
-  tps: 15082.51879
+  dps: 21729.35729
+  tps: 15427.84368
  }
 }
 dps_results: {
@@ -1606,7 +1606,7 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 19646.84079
-  tps: 13949.25696
+  dps: 19941.86924
+  tps: 14158.72716
  }
 }

--- a/sim/rogue/combat/TestCombat.results
+++ b/sim/rogue/combat/TestCombat.results
@@ -37,1290 +37,1290 @@ character_stats_results: {
 dps_results: {
  key: "TestCombat-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 29425.83764
-  tps: 20892.34473
+  dps: 29435.89986
+  tps: 20899.4889
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 27899.20477
-  tps: 19808.43539
+  dps: 27908.9798
+  tps: 19815.37566
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 27987.55123
-  tps: 19871.16137
+  dps: 27997.07335
+  tps: 19877.92208
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 28866.09087
-  tps: 20494.92452
+  dps: 28875.9146
+  tps: 20501.89937
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
   hps: 83.99244
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 27720.62045
-  tps: 19681.64052
+  dps: 27731.9108
+  tps: 19689.65667
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 27774.83435
-  tps: 19720.13239
+  dps: 27786.1247
+  tps: 19728.14854
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BindingPromise-67037"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BlackBruise-50692"
  value: {
-  dps: 27153.55993
-  tps: 19279.02755
+  dps: 27163.36215
+  tps: 19285.98712
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 28827.33508
-  tps: 20467.40791
+  dps: 28841.76428
+  tps: 20477.65264
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 27711.02934
-  tps: 19674.83083
+  dps: 27723.88047
+  tps: 19683.95513
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 27903.12684
-  tps: 19811.22006
+  dps: 27915.29807
+  tps: 19819.86163
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 29261.8919
-  tps: 20775.94325
+  dps: 29274.18057
+  tps: 20784.66821
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 27851.7624
-  tps: 19774.7513
+  dps: 27863.27037
+  tps: 19782.92196
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 27701.82449
-  tps: 19668.29539
+  dps: 27713.08035
+  tps: 19676.28705
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 28678.80644
-  tps: 20361.95257
+  dps: 28690.22976
+  tps: 20370.06313
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 27875.3967
-  tps: 19791.53166
+  dps: 27886.60816
+  tps: 19799.49179
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BottledLightning-66879"
  value: {
-  dps: 27506.36673
-  tps: 19529.52038
+  dps: 27517.66552
+  tps: 19537.54252
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 28866.09087
-  tps: 20085.02603
+  dps: 28875.9146
+  tps: 20091.86138
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 29425.83764
-  tps: 20892.34473
+  dps: 29435.89986
+  tps: 20899.4889
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 29202.15084
-  tps: 20733.5271
+  dps: 29212.11871
+  tps: 20740.60428
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 29279.78684
-  tps: 20788.64866
+  dps: 29289.8254
+  tps: 20795.77603
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CrushingWeight-59506"
  value: {
-  dps: 28564.44001
-  tps: 20280.75241
+  dps: 28575.01446
+  tps: 20288.26027
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-CrushingWeight-65118"
  value: {
-  dps: 28640.66781
-  tps: 20334.87414
+  dps: 28650.42726
+  tps: 20341.80335
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 28542.16601
-  tps: 20264.93787
+  dps: 28554.51354
+  tps: 20273.70461
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 29271.95993
-  tps: 20783.09155
+  dps: 29284.70579
+  tps: 20792.14111
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 27912.15702
-  tps: 19817.63149
+  dps: 27925.23298
+  tps: 19826.91542
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 28109.45121
-  tps: 19957.71036
+  dps: 28121.20162
+  tps: 19966.05315
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 28939.20627
-  tps: 20546.83645
+  dps: 28949.09669
+  tps: 20553.85865
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 27612.21372
-  tps: 19604.67174
+  dps: 27624.02691
+  tps: 19613.05911
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 28866.09087
-  tps: 20494.92452
+  dps: 28875.9146
+  tps: 20501.89937
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 28866.09087
-  tps: 20494.92452
+  dps: 28875.9146
+  tps: 20501.89937
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 28939.20627
-  tps: 20546.83645
+  dps: 28949.09669
+  tps: 20553.85865
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 29092.03389
-  tps: 20655.34406
+  dps: 29103.67693
+  tps: 20663.61062
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 29318.69938
-  tps: 20816.27656
+  dps: 29330.59528
+  tps: 20824.72265
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 28866.09087
-  tps: 20494.92452
+  dps: 28875.9146
+  tps: 20501.89937
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FallofMortality-59500"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FallofMortality-65124"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 29794.15454
-  tps: 21153.84972
+  dps: 29804.78617
+  tps: 21161.39818
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 28359.18123
-  tps: 20135.01867
+  dps: 28371.89979
+  tps: 20144.04885
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 28909.48099
-  tps: 20525.7315
+  dps: 28919.88369
+  tps: 20533.11742
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 28866.09087
-  tps: 20494.92452
+  dps: 28875.9146
+  tps: 20501.89937
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 28307.888
-  tps: 20098.60048
+  dps: 28319.33992
+  tps: 20106.73135
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GaleofShadows-56138"
  value: {
-  dps: 27638.64098
-  tps: 19623.4351
+  dps: 27650.08444
+  tps: 19631.55995
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GaleofShadows-56462"
  value: {
-  dps: 27822.59875
-  tps: 19754.04511
+  dps: 27834.17949
+  tps: 19762.26744
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GearDetector-61462"
  value: {
-  dps: 28289.50386
-  tps: 20085.54774
+  dps: 28303.00575
+  tps: 20095.13408
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Gladiator'sVestments"
  value: {
-  dps: 23480.31714
-  tps: 16671.02517
+  dps: 23492.79177
+  tps: 16679.88216
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 28251.27799
-  tps: 20058.40737
+  dps: 28262.85846
+  tps: 20066.62951
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 28667.08237
-  tps: 20353.62848
+  dps: 28678.71911
+  tps: 20361.89057
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-HarmlightToken-63839"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 28037.24604
-  tps: 19906.44469
+  dps: 28048.78662
+  tps: 19914.6385
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-HeartofRage-59224"
  value: {
-  dps: 27998.68508
-  tps: 19879.06641
+  dps: 28010.08077
+  tps: 19887.15735
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-HeartofRage-65072"
  value: {
-  dps: 28079.7804
-  tps: 19936.64408
+  dps: 28091.25827
+  tps: 19944.79337
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-HeartofSolace-55868"
  value: {
-  dps: 27638.64098
-  tps: 19623.4351
+  dps: 27650.08444
+  tps: 19631.55995
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-HeartofSolace-56393"
  value: {
-  dps: 28385.32062
-  tps: 20153.57764
+  dps: 28397.23319
+  tps: 20162.03557
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-HeartofThunder-55845"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-HeartofThunder-56370"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 28380.02306
-  tps: 20149.81637
+  dps: 28391.54416
+  tps: 20157.99636
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Heartpierce-50641"
  value: {
-  dps: 29425.83764
-  tps: 20892.34473
+  dps: 29435.89986
+  tps: 20899.4889
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 28939.20627
-  tps: 20546.83645
+  dps: 28949.09669
+  tps: 20553.85865
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 28423.55609
-  tps: 20180.72483
+  dps: 28437.31003
+  tps: 20190.49012
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 28423.55609
-  tps: 20180.72483
+  dps: 28437.31003
+  tps: 20190.49012
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 27711.02934
-  tps: 19674.83083
+  dps: 27723.88047
+  tps: 19683.95513
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 27903.12684
-  tps: 19811.22006
+  dps: 27915.29807
+  tps: 19819.86163
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 27714.86321
-  tps: 19677.55288
+  dps: 27728.41776
+  tps: 19687.17661
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 28827.33508
-  tps: 20467.40791
+  dps: 28841.76428
+  tps: 20477.65264
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 28941.15563
-  tps: 20548.2205
+  dps: 28952.22257
+  tps: 20556.07802
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 29505.88905
-  tps: 20949.18123
+  dps: 29516.09795
+  tps: 20956.42954
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 27807.11222
-  tps: 19743.04968
+  dps: 27818.33361
+  tps: 19751.01686
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 27807.11222
-  tps: 19743.04968
+  dps: 27818.33361
+  tps: 19751.01686
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 27523.37294
-  tps: 19541.59479
+  dps: 27535.46158
+  tps: 19550.17772
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-LastWord-50708"
  value: {
-  dps: 29425.83764
-  tps: 20892.34473
+  dps: 29435.89986
+  tps: 20899.4889
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-LeadenDespair-55816"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-LeadenDespair-56347"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 28580.93723
-  tps: 20292.46543
+  dps: 28592.67866
+  tps: 20300.80185
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 28762.86925
-  tps: 20421.63717
+  dps: 28774.90704
+  tps: 20430.184
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 28536.67889
-  tps: 20261.04201
+  dps: 28546.50569
+  tps: 20268.01904
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 27751.63394
-  tps: 19703.6601
+  dps: 27762.98654
+  tps: 19711.72044
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 27877.71111
-  tps: 19793.17489
+  dps: 27889.15985
+  tps: 19801.30349
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 28211.23073
-  tps: 20029.97381
+  dps: 28221.98559
+  tps: 20037.60977
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 28379.41513
-  tps: 20149.38474
+  dps: 28390.33942
+  tps: 20157.14099
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 28045.33873
-  tps: 19912.1905
+  dps: 28056.11068
+  tps: 19919.83858
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 28511.50196
-  tps: 20243.16639
+  dps: 28521.36461
+  tps: 20250.16888
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 27912.15702
-  tps: 19817.63149
+  dps: 27925.23298
+  tps: 19826.91542
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 27912.15702
-  tps: 19817.63149
+  dps: 27925.23298
+  tps: 19826.91542
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 27833.42109
-  tps: 19761.72897
+  dps: 27843.67994
+  tps: 19769.01276
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 27918.04105
-  tps: 19821.80914
+  dps: 27929.54735
+  tps: 19829.97862
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 27538.13728
-  tps: 19552.07747
+  dps: 27549.25659
+  tps: 19559.97218
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 27705.97258
-  tps: 19671.24053
+  dps: 27717.41286
+  tps: 19679.36313
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 27956.69693
-  tps: 19849.25482
+  dps: 27968.16259
+  tps: 19857.39544
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 28866.09087
-  tps: 20494.92452
+  dps: 28875.9146
+  tps: 20501.89937
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 29199.01121
-  tps: 20731.29796
+  dps: 29210.23182
+  tps: 20739.26459
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Rainsong-55854"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Rainsong-56377"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 29286.18408
-  tps: 20793.1907
+  dps: 29296.17916
+  tps: 20800.2872
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 29202.15084
-  tps: 20733.5271
+  dps: 29212.11871
+  tps: 20740.60428
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 28375.01782
-  tps: 20146.26265
+  dps: 28385.0677
+  tps: 20153.39807
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 28538.12738
-  tps: 20262.07044
+  dps: 28547.88189
+  tps: 20268.99614
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 28552.06192
-  tps: 20271.96397
+  dps: 28563.83729
+  tps: 20280.32447
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SeaStar-55256"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SeaStar-56290"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 22329.53909
-  tps: 15853.97275
+  dps: 22341.66803
+  tps: 15862.5843
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Shadowmourne-49623"
  value: {
-  dps: 29425.83764
-  tps: 20892.34473
+  dps: 29435.89986
+  tps: 20899.4889
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ShardofWoe-60233"
  value: {
-  dps: 27860.44757
-  tps: 19780.91778
+  dps: 27871.19119
+  tps: 19788.54575
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 28081.47896
-  tps: 19937.85006
+  dps: 28092.41197
+  tps: 19945.6125
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 28716.49532
-  tps: 20388.71168
+  dps: 28729.65161
+  tps: 20398.05264
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 28846.93391
-  tps: 20481.32308
+  dps: 28860.4069
+  tps: 20490.8889
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Sorrowsong-55879"
  value: {
-  dps: 27711.02934
-  tps: 19674.83083
+  dps: 27723.88047
+  tps: 19683.95513
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Sorrowsong-56400"
  value: {
-  dps: 27903.12684
-  tps: 19811.22006
+  dps: 27915.29807
+  tps: 19819.86163
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 28181.05322
-  tps: 20008.54778
+  dps: 28191.0123
+  tps: 20015.61873
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SoulCasket-58183"
  value: {
-  dps: 27912.15702
-  tps: 19817.63149
+  dps: 27925.23298
+  tps: 19826.91542
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-StumpofTime-62465"
  value: {
-  dps: 27951.03652
-  tps: 19845.23593
+  dps: 27960.71486
+  tps: 19852.10755
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-StumpofTime-62470"
  value: {
-  dps: 27951.03652
-  tps: 19845.23593
+  dps: 27960.71486
+  tps: 19852.10755
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 28117.88397
-  tps: 19963.69762
+  dps: 28128.59769
+  tps: 19971.30436
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TearofBlood-55819"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TearofBlood-56351"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 27751.16458
-  tps: 19703.32685
+  dps: 27765.05795
+  tps: 19713.19114
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 27903.12684
-  tps: 19811.22006
+  dps: 27915.29807
+  tps: 19819.86163
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 28854.06277
-  tps: 20486.38457
+  dps: 28867.36986
+  tps: 20495.8326
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 29220.90843
-  tps: 20746.84499
+  dps: 29233.53644
+  tps: 20755.81087
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 29024.99926
-  tps: 20607.74947
+  dps: 29035.82267
+  tps: 20615.43409
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 27360.72668
-  tps: 19426.11594
+  dps: 27371.93358
+  tps: 19434.07284
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-UnheededWarning-59520"
  value: {
-  dps: 29154.72635
-  tps: 20699.85571
+  dps: 29166.58503
+  tps: 20708.27537
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 29275.4784
-  tps: 20785.58966
+  dps: 29290.54408
+  tps: 20796.2863
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 29275.4784
-  tps: 20785.58966
+  dps: 29290.54408
+  tps: 20796.2863
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 29275.4784
-  tps: 20785.58966
+  dps: 29290.54408
+  tps: 20796.2863
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 25826.28737
-  tps: 18336.66403
+  dps: 25835.84281
+  tps: 18343.44839
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 28727.96451
-  tps: 20396.85481
+  dps: 28740.41221
+  tps: 20405.69267
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 27879.01639
-  tps: 19794.10164
+  dps: 27890.54956
+  tps: 19802.29019
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 27945.24047
-  tps: 19841.12073
+  dps: 27954.6988
+  tps: 19847.83614
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 28002.03882
-  tps: 19881.44756
+  dps: 28012.75675
+  tps: 19889.05729
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 27748.84091
-  tps: 19701.67705
+  dps: 27760.13126
+  tps: 19709.69319
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 28054.43282
-  tps: 19918.6473
+  dps: 28066.8321
+  tps: 19927.45079
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 28856.05366
-  tps: 20487.7981
+  dps: 28867.60614
+  tps: 20496.00036
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 27943.17544
-  tps: 19839.65456
+  dps: 27954.4216
+  tps: 19847.63933
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-WindDancer'sRegalia"
  value: {
-  dps: 26664.67175
-  tps: 18931.91694
+  dps: 26674.30366
+  tps: 18938.7556
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 27364.39693
-  tps: 19428.72182
+  dps: 27375.45423
+  tps: 19436.5725
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 27760.13019
-  tps: 19709.69243
+  dps: 27773.61896
+  tps: 19719.26946
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 27686.01517
-  tps: 19657.07077
+  dps: 27695.58917
+  tps: 19663.86831
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 27686.01517
-  tps: 19657.07077
+  dps: 27695.58917
+  tps: 19663.86831
  }
 }
 dps_results: {
  key: "TestCombat-Average-Default"
  value: {
-  dps: 29421.01564
-  tps: 20888.9211
+  dps: 29430.34331
+  tps: 20895.54375
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat_test-Combat-combat-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 29113.81773
-  tps: 20670.81059
+  dps: 29124.43194
+  tps: 20678.34667
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat_test-Combat-combat-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 29425.83764
-  tps: 20892.34473
+  dps: 29435.89986
+  tps: 20899.4889
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat_test-Combat-combat-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 35300.54041
-  tps: 25063.38369
+  dps: 35330.1724
+  tps: 25084.4224
  }
 }
 dps_results: {
@@ -1347,22 +1347,22 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Deadly-combat-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 25316.38273
-  tps: 17974.63174
+  dps: 25318.56761
+  tps: 17976.183
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Deadly-combat-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 25254.97841
-  tps: 17931.03467
+  dps: 25257.16329
+  tps: 17932.58594
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Deadly-combat-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 30378.73978
-  tps: 21568.90524
+  dps: 30389.6642
+  tps: 21576.66158
  }
 }
 dps_results: {
@@ -1389,22 +1389,22 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Instant-combat-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 28168.36278
-  tps: 19999.53758
+  dps: 28172.29596
+  tps: 20002.33013
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Instant-combat-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 28445.83613
-  tps: 20196.54365
+  dps: 28449.83413
+  tps: 20199.38223
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat_test-MH Deadly OH Instant-combat-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 34105.44702
-  tps: 24214.86738
+  dps: 34122.99825
+  tps: 24227.32876
  }
 }
 dps_results: {
@@ -1431,22 +1431,22 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat_test-MH Instant OH Instant-combat-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 25642.74327
-  tps: 18206.34772
+  dps: 26471.30195
+  tps: 18794.62438
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat_test-MH Instant OH Instant-combat-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 25925.83529
-  tps: 18407.34306
+  dps: 26808.40111
+  tps: 19033.96479
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p1_combat_test-MH Instant OH Instant-combat-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 31756.95185
-  tps: 22547.43581
+  dps: 32835.82048
+  tps: 23313.43254
  }
 }
 dps_results: {
@@ -1473,22 +1473,22 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat_test-Combat-combat-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 29371.97937
-  tps: 20854.10535
+  dps: 29382.878
+  tps: 20861.84338
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat_test-Combat-combat-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 29686.87095
-  tps: 21077.67837
+  dps: 29697.23179
+  tps: 21085.03457
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat_test-Combat-combat-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 35844.98725
-  tps: 25449.94095
+  dps: 35875.96137
+  tps: 25471.93257
  }
 }
 dps_results: {
@@ -1515,22 +1515,22 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Deadly-combat-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 25540.96389
-  tps: 18134.08436
+  dps: 25543.24772
+  tps: 18135.70588
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Deadly-combat-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 25477.56695
-  tps: 18089.07254
+  dps: 25479.85078
+  tps: 18090.69406
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Deadly-combat-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 30851.69243
-  tps: 21904.70162
+  dps: 30863.11158
+  tps: 21912.80922
  }
 }
 dps_results: {
@@ -1557,22 +1557,22 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Instant-combat-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 28419.2846
-  tps: 20177.69207
+  dps: 28423.38719
+  tps: 20180.6049
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Instant-combat-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 28698.54131
-  tps: 20375.96433
+  dps: 28702.7087
+  tps: 20378.92318
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat_test-MH Deadly OH Instant-combat-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 34635.09564
-  tps: 24590.91791
+  dps: 34653.4943
+  tps: 24603.98095
  }
 }
 dps_results: {
@@ -1599,22 +1599,22 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat_test-MH Instant OH Instant-combat-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 25872.0613
-  tps: 18369.16352
+  dps: 26707.74058
+  tps: 18962.49581
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat_test-MH Instant OH Instant-combat-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26158.06345
-  tps: 18572.22505
+  dps: 27048.37414
+  tps: 19204.34564
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p1_combat_test-MH Instant OH Instant-combat-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 32266.14805
-  tps: 22908.96512
+  dps: 33362.00964
+  tps: 23687.02685
  }
 }
 dps_results: {
@@ -1641,7 +1641,7 @@ dps_results: {
 dps_results: {
  key: "TestCombat-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 27862.19692
-  tps: 19782.15981
+  dps: 27875.33962
+  tps: 19791.49113
  }
 }

--- a/sim/rogue/subtlety/TestSubtlety.results
+++ b/sim/rogue/subtlety/TestSubtlety.results
@@ -37,1257 +37,1257 @@ character_stats_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 23140.25851
-  tps: 16429.58354
+  dps: 23893.08624
+  tps: 16964.09123
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
   hps: 143.48424
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 21577.77003
-  tps: 15320.21672
+  dps: 22273.94766
+  tps: 15814.50284
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 21560.56277
-  tps: 15307.99957
+  dps: 22256.18252
+  tps: 15801.88959
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 22544.41066
-  tps: 16006.53157
+  dps: 23275.98796
+  tps: 16525.95145
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
   hps: 92.60297
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 21495.9379
-  tps: 15262.11591
+  dps: 22195.23243
+  tps: 15758.61503
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 21561.27647
-  tps: 15308.50629
+  dps: 22262.67773
+  tps: 15806.50119
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BindingPromise-67037"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 22172.84435
-  tps: 15742.71949
+  dps: 22894.15988
+  tps: 16254.85351
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 21263.78132
-  tps: 15097.28474
+  dps: 21955.12428
+  tps: 15588.13824
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 21423.49058
-  tps: 15210.67831
+  dps: 22119.17398
+  tps: 15704.61353
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 22655.04799
-  tps: 16085.08407
+  dps: 23393.25418
+  tps: 16609.21047
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 21411.5765
-  tps: 15202.21932
+  dps: 22104.71258
+  tps: 15694.34593
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 21488.09363
-  tps: 15256.54648
+  dps: 22187.11506
+  tps: 15752.85169
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 22073.38988
-  tps: 15672.10681
+  dps: 22789.15499
+  tps: 16180.30004
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 21358.62984
-  tps: 15164.62718
+  dps: 22049.52213
+  tps: 15655.16072
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BottledLightning-66879"
  value: {
-  dps: 21085.48938
-  tps: 14970.69746
+  dps: 21770.1159
+  tps: 15456.78229
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 22544.41066
-  tps: 15686.40094
+  dps: 23275.98796
+  tps: 16195.43242
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 22906.17928
-  tps: 16263.38729
+  dps: 23651.62194
+  tps: 16792.65158
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 23023.68953
-  tps: 16346.81957
+  dps: 23772.88631
+  tps: 16878.74928
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-CrushingWeight-59506"
  value: {
-  dps: 22029.58178
-  tps: 15641.00306
+  dps: 22744.53352
+  tps: 16148.6188
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-CrushingWeight-65118"
  value: {
-  dps: 22115.09069
-  tps: 15701.71439
+  dps: 22832.38171
+  tps: 16210.99102
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 21972.53347
-  tps: 15600.49876
+  dps: 22668.26174
+  tps: 16094.46583
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 22664.85469
-  tps: 16092.04683
+  dps: 23383.5972
+  tps: 16602.35401
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 21324.05958
-  tps: 15140.08231
+  dps: 22016.17355
+  tps: 15631.48322
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 21843.7067
-  tps: 15509.03175
+  dps: 22555.1216
+  tps: 16014.13634
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 22657.97025
-  tps: 16087.15888
+  dps: 23393.16099
+  tps: 16609.1443
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 21351.00683
-  tps: 15159.21485
+  dps: 22043.45378
+  tps: 15650.85219
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 22544.41066
-  tps: 16006.53157
+  dps: 23275.98796
+  tps: 16525.95145
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 22544.41066
-  tps: 16006.53157
+  dps: 23275.98796
+  tps: 16525.95145
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 22657.97025
-  tps: 16087.15888
+  dps: 23393.16099
+  tps: 16609.1443
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 22571.67844
-  tps: 16025.89169
+  dps: 23307.42339
+  tps: 16548.27061
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 23046.74739
-  tps: 16363.19065
+  dps: 23798.83988
+  tps: 16897.17631
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 22544.41066
-  tps: 16006.53157
+  dps: 23275.98796
+  tps: 16525.95145
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-FallofMortality-59500"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-FallofMortality-65124"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 23179.03497
-  tps: 16457.11483
+  dps: 23930.65148
+  tps: 16990.76255
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 21758.7185
-  tps: 15448.69013
+  dps: 22465.59326
+  tps: 15950.57121
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 22504.08499
-  tps: 15977.90034
+  dps: 23235.80761
+  tps: 16497.4234
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 22544.41066
-  tps: 16006.53157
+  dps: 23275.98796
+  tps: 16525.95145
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 21847.28069
-  tps: 15511.56929
+  dps: 22557.57062
+  tps: 16015.87514
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-GaleofShadows-56138"
  value: {
-  dps: 21375.21925
-  tps: 15176.40567
+  dps: 22068.13276
+  tps: 15668.37426
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-GaleofShadows-56462"
  value: {
-  dps: 21587.33821
-  tps: 15327.01013
+  dps: 22288.72614
+  tps: 15824.99556
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-GearDetector-61462"
  value: {
-  dps: 22034.10055
-  tps: 15644.21139
+  dps: 22751.08936
+  tps: 16153.27345
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Gladiator'sVestments"
  value: {
-  dps: 18255.83148
-  tps: 12961.64035
+  dps: 18846.58279
+  tps: 13381.07378
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
   hps: 58.826
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 21913.75192
-  tps: 15558.76386
+  dps: 22626.82725
+  tps: 16065.04735
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 22365.90889
-  tps: 15879.79531
+  dps: 23093.87406
+  tps: 16396.65058
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-HarmlightToken-63839"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 21368.21997
-  tps: 15171.43618
+  dps: 22060.94184
+  tps: 15663.26871
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-HeartofRage-59224"
  value: {
-  dps: 21674.30474
-  tps: 15388.75637
+  dps: 22375.23399
+  tps: 15886.41613
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-HeartofRage-65072"
  value: {
-  dps: 21714.29821
-  tps: 15417.15173
+  dps: 22416.46464
+  tps: 15915.6899
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-HeartofSolace-55868"
  value: {
-  dps: 21375.21925
-  tps: 15176.40567
+  dps: 22068.13276
+  tps: 15668.37426
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-HeartofSolace-56393"
  value: {
-  dps: 21960.75215
-  tps: 15592.13402
+  dps: 22674.40738
+  tps: 16098.82924
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-HeartofThunder-55845"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-HeartofThunder-56370"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 22039.43562
-  tps: 15647.99929
+  dps: 22755.52661
+  tps: 16156.42389
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Heartpierce-50641"
  value: {
-  dps: 23140.25851
-  tps: 16429.58354
+  dps: 23893.08624
+  tps: 16964.09123
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 22657.97025
-  tps: 16087.15888
+  dps: 23393.16099
+  tps: 16609.1443
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 21685.47626
-  tps: 15396.68814
+  dps: 22389.56796
+  tps: 15896.59325
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 21685.47626
-  tps: 15396.68814
+  dps: 22389.56796
+  tps: 15896.59325
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 21263.78132
-  tps: 15097.28474
+  dps: 21955.12428
+  tps: 15588.13824
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 21423.49058
-  tps: 15210.67831
+  dps: 22119.17398
+  tps: 15704.61353
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 21329.0001
-  tps: 15143.59007
+  dps: 22022.57009
+  tps: 15636.02477
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 22172.84435
-  tps: 15742.71949
+  dps: 22894.15988
+  tps: 16254.85351
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 22454.58432
-  tps: 15942.75487
+  dps: 23181.16328
+  tps: 16458.62593
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 22985.63814
-  tps: 16319.80308
+  dps: 23730.62688
+  tps: 16848.74509
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 21500.07105
-  tps: 15265.05044
+  dps: 22198.60792
+  tps: 15761.01162
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 21500.07105
-  tps: 15265.05044
+  dps: 22198.60792
+  tps: 15761.01162
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 21367.52964
-  tps: 15170.94604
+  dps: 22061.63282
+  tps: 15663.7593
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-LeadenDespair-55816"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-LeadenDespair-56347"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 22580.15507
-  tps: 16031.9101
+  dps: 23313.66765
+  tps: 16552.70403
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 22845.53789
-  tps: 16220.3319
+  dps: 23589.59412
+  tps: 16748.61182
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 21850.20306
-  tps: 15513.64417
+  dps: 22553.75671
+  tps: 16013.16726
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 21513.24492
-  tps: 15274.4039
+  dps: 22209.17381
+  tps: 15768.5134
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 21590.85759
-  tps: 15329.50889
+  dps: 22289.35092
+  tps: 15825.43915
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 21537.01086
-  tps: 15291.27771
+  dps: 22235.39882
+  tps: 15787.13317
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 21559.02563
-  tps: 15306.9082
+  dps: 22258.83536
+  tps: 15803.77311
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 21530.38251
-  tps: 15286.57158
+  dps: 22224.75724
+  tps: 15779.57764
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 21879.18232
-  tps: 15534.21945
+  dps: 22585.33771
+  tps: 16035.58977
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 21324.05958
-  tps: 15140.08231
+  dps: 22016.17355
+  tps: 15631.48322
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 21324.05958
-  tps: 15140.08231
+  dps: 22016.17355
+  tps: 15631.48322
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 21364.35966
-  tps: 15168.69536
+  dps: 22058.53292
+  tps: 15661.55837
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 21420.63721
-  tps: 15208.65242
+  dps: 22116.83896
+  tps: 15702.95566
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 21336.16758
-  tps: 15148.67898
+  dps: 22029.33055
+  tps: 15640.82469
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 21217.12633
-  tps: 15064.1597
+  dps: 21906.40297
+  tps: 15553.54611
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 21249.45389
-  tps: 15087.11226
+  dps: 21938.40993
+  tps: 15576.27105
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 22544.41066
-  tps: 16006.53157
+  dps: 23275.98796
+  tps: 16525.95145
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 22853.23473
-  tps: 16225.79666
+  dps: 23597.03212
+  tps: 16753.8928
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Rainsong-55854"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Rainsong-56377"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 22957.94984
-  tps: 16300.14438
+  dps: 23705.03447
+  tps: 16830.57447
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 22906.17928
-  tps: 16263.38729
+  dps: 23651.62194
+  tps: 16792.65158
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 21887.92154
-  tps: 15540.4243
+  dps: 22594.33521
+  tps: 16041.978
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 21916.52337
-  tps: 15560.73159
+  dps: 22623.79461
+  tps: 16062.89417
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 21943.34666
-  tps: 15579.77613
+  dps: 22656.47458
+  tps: 16086.09695
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SeaStar-55256"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SeaStar-56290"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Shadowblade'sBattlegear"
  value: {
-  dps: 17366.34777
-  tps: 12330.10691
+  dps: 17932.1138
+  tps: 12731.80079
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ShardofWoe-60233"
  value: {
-  dps: 21618.23163
-  tps: 15348.94446
+  dps: 22320.80913
+  tps: 15847.77448
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 21854.05064
-  tps: 15516.37596
+  dps: 22564.12789
+  tps: 16020.5308
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 22173.58479
-  tps: 15743.2452
+  dps: 22894.60079
+  tps: 16255.16656
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 22226.33357
-  tps: 15780.69684
+  dps: 22949.30653
+  tps: 16294.00764
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Sorrowsong-55879"
  value: {
-  dps: 21263.78132
-  tps: 15097.28474
+  dps: 21955.12428
+  tps: 15588.13824
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Sorrowsong-56400"
  value: {
-  dps: 21423.49058
-  tps: 15210.67831
+  dps: 22119.17398
+  tps: 15704.61353
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 21754.25357
-  tps: 15445.52003
+  dps: 22456.30556
+  tps: 15943.97695
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SoulCasket-58183"
  value: {
-  dps: 21324.05958
-  tps: 15140.08231
+  dps: 22016.17355
+  tps: 15631.48322
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-StumpofTime-62465"
  value: {
-  dps: 21504.05355
-  tps: 15267.87802
+  dps: 22196.83192
+  tps: 15759.75066
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-StumpofTime-62470"
  value: {
-  dps: 21504.05355
-  tps: 15267.87802
+  dps: 22196.83192
+  tps: 15759.75066
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 21763.7589
-  tps: 15452.26882
+  dps: 22470.02484
+  tps: 15953.71764
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TearofBlood-55819"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TearofBlood-56351"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 21321.26447
-  tps: 15138.09777
+  dps: 22014.10842
+  tps: 15630.01698
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 21423.49058
-  tps: 15210.67831
+  dps: 22119.17398
+  tps: 15704.61353
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 22316.68934
-  tps: 15844.84943
+  dps: 23043.01288
+  tps: 16360.53914
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 22485.35979
-  tps: 15964.60545
+  dps: 23217.63069
+  tps: 16484.51779
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 21970.35379
-  tps: 15598.95119
+  dps: 22677.76251
+  tps: 16101.21138
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 21160.38401
-  tps: 15023.87265
+  dps: 21846.61931
+  tps: 15511.09971
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-UnheededWarning-59520"
  value: {
-  dps: 22462.45917
-  tps: 15948.34601
+  dps: 23191.36005
+  tps: 16465.86564
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 22877.25546
-  tps: 16242.85138
+  dps: 23624.65605
+  tps: 16773.5058
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 22877.25546
-  tps: 16242.85138
+  dps: 23624.65605
+  tps: 16773.5058
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 22877.25546
-  tps: 16242.85138
+  dps: 23624.65605
+  tps: 16773.5058
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 22592.55485
-  tps: 16040.71395
+  dps: 23330.11339
+  tps: 16564.38051
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 21430.08497
-  tps: 15215.36033
+  dps: 22123.83294
+  tps: 15707.92139
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 21466.14605
-  tps: 15240.96369
+  dps: 22157.11444
+  tps: 15731.55126
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 21591.00306
-  tps: 15329.61217
+  dps: 22292.44259
+  tps: 15827.63424
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 21543.65746
-  tps: 15295.9968
+  dps: 22244.47345
+  tps: 15793.57615
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 21274.86316
-  tps: 15105.15284
+  dps: 21962.91555
+  tps: 15593.67004
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 21342.77409
-  tps: 15153.3696
+  dps: 22036.40304
+  tps: 15645.84616
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 22267.83321
-  tps: 15810.16158
+  dps: 22990.7676
+  tps: 16323.44499
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 21423.09235
-  tps: 15210.39557
+  dps: 22116.25602
+  tps: 15702.54177
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-WindDancer'sRegalia"
  value: {
-  dps: 20510.53998
-  tps: 14562.48339
+  dps: 21176.12063
+  tps: 15035.04565
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 21080.60157
-  tps: 14967.22711
+  dps: 21762.79539
+  tps: 15451.58473
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 21444.28814
-  tps: 15225.44458
+  dps: 22140.89931
+  tps: 15720.03851
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 21300.96182
-  tps: 15123.6829
+  dps: 21992.29028
+  tps: 15614.5261
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 21300.96182
-  tps: 15123.6829
+  dps: 21992.29028
+  tps: 15614.5261
  }
 }
 dps_results: {
  key: "TestSubtlety-Average-Default"
  value: {
-  dps: 23201.40134
-  tps: 16472.99495
+  dps: 23956.69755
+  tps: 17009.25526
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Deadly-subtlety-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 20755.95835
-  tps: 14736.73043
+  dps: 21504.68081
+  tps: 15268.32337
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Deadly-subtlety-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 20755.95835
-  tps: 14736.73043
+  dps: 21504.68081
+  tps: 15268.32337
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Deadly-subtlety-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 26960.86979
-  tps: 19142.21755
+  dps: 27955.99401
+  tps: 19848.75575
  }
 }
 dps_results: {
@@ -1314,22 +1314,22 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Instant-subtlety-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 23061.27917
-  tps: 16373.50821
+  dps: 23813.65543
+  tps: 16907.69535
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Instant-subtlety-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 23061.27917
-  tps: 16373.50821
+  dps: 23813.65543
+  tps: 16907.69535
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Deadly OH Instant-subtlety-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 29265.95909
-  tps: 20778.83095
+  dps: 30253.59991
+  tps: 21480.05594
  }
 }
 dps_results: {
@@ -1356,22 +1356,22 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Instant OH Instant-subtlety-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 20620.00295
-  tps: 14640.20209
+  dps: 21360.54763
+  tps: 15165.98882
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Instant OH Instant-subtlety-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 20620.00295
-  tps: 14640.20209
+  dps: 21360.54763
+  tps: 15165.98882
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p1_subtlety_test-MH Instant OH Instant-subtlety-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 27096.57074
-  tps: 19238.56522
+  dps: 28078.65526
+  tps: 19935.84524
  }
 }
 dps_results: {
@@ -1398,22 +1398,22 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-Settings-Human-p1_subtlety_test-Subtlety-subtlety-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 23140.25851
-  tps: 16429.58354
+  dps: 23893.08624
+  tps: 16964.09123
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p1_subtlety_test-Subtlety-subtlety-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 23140.25851
-  tps: 16429.58354
+  dps: 23893.08624
+  tps: 16964.09123
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p1_subtlety_test-Subtlety-subtlety-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 29634.40349
-  tps: 21040.42648
+  dps: 30629.95048
+  tps: 21747.26484
  }
 }
 dps_results: {
@@ -1440,22 +1440,22 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Deadly-subtlety-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 20947.32074
-  tps: 14872.59772
+  dps: 21703.10406
+  tps: 15409.20388
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Deadly-subtlety-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 20947.32074
-  tps: 14872.59772
+  dps: 21703.10406
+  tps: 15409.20388
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Deadly-subtlety-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 27367.77185
-  tps: 19431.11801
+  dps: 28378.22653
+  tps: 20148.54084
  }
 }
 dps_results: {
@@ -1482,22 +1482,22 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Instant-subtlety-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 23306.86972
-  tps: 16547.8775
+  dps: 24067.72347
+  tps: 17088.08367
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Instant-subtlety-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 23306.86972
-  tps: 16547.8775
+  dps: 24067.72347
+  tps: 17088.08367
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Deadly OH Instant-subtlety-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 29701.95744
-  tps: 21088.38978
+  dps: 30705.01053
+  tps: 21800.55748
  }
 }
 dps_results: {
@@ -1524,22 +1524,22 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Instant OH Instant-subtlety-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 20807.28994
-  tps: 14773.17586
+  dps: 21554.63967
+  tps: 15303.79417
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Instant OH Instant-subtlety-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 20807.28994
-  tps: 14773.17586
+  dps: 21554.63967
+  tps: 15303.79417
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p1_subtlety_test-MH Instant OH Instant-subtlety-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 27520.71986
-  tps: 19539.7111
+  dps: 28518.29939
+  tps: 20247.99257
  }
 }
 dps_results: {
@@ -1566,22 +1566,22 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p1_subtlety_test-Subtlety-subtlety-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 23358.93617
-  tps: 16584.84468
+  dps: 24119.21994
+  tps: 17124.64616
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p1_subtlety_test-Subtlety-subtlety-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 23358.93617
-  tps: 16584.84468
+  dps: 24119.21994
+  tps: 17124.64616
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p1_subtlety_test-Subtlety-subtlety-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 30068.69045
-  tps: 21348.77022
+  dps: 31079.58313
+  tps: 22066.50403
  }
 }
 dps_results: {
@@ -1608,7 +1608,7 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 19530.45329
-  tps: 13866.62184
+  dps: 20155.20172
+  tps: 14310.19322
  }
 }

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -37,49 +37,49 @@ character_stats_results: {
 dps_results: {
  key: "TestElemental-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 32073.40191
+  dps: 32088.98906
   tps: 565.92809
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 30064.58592
+  dps: 30078.24637
   tps: 571.19014
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 30904.65046
+  dps: 30918.55181
   tps: 570.17702
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 31220.03633
+  dps: 31234.86366
   tps: 568.80056
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 31345.38531
+  dps: 31360.97246
   tps: 564.78527
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BattlegearoftheRagingElements"
  value: {
-  dps: 22824.74651
+  dps: 22838.28134
   tps: 404.22255
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 30144.18802
+  dps: 30157.67562
   tps: 569.27282
   hps: 100.70184
  }
@@ -87,1246 +87,1246 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 31491.82835
+  dps: 31507.28729
   tps: 564.67153
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BindingPromise-67037"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlackBruise-50692"
  value: {
-  dps: 24060.63112
+  dps: 24073.71811
   tps: 533.3688
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 29715.94006
+  dps: 29729.42766
   tps: 569.07709
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 29763.50508
+  dps: 29776.99268
   tps: 571.86745
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 29828.83136
+  dps: 29842.31896
   tps: 570.9482
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 30582.15508
+  dps: 30597.02824
   tps: 564.73496
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 29780.34593
+  dps: 29793.83352
   tps: 563.22025
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 30135.09786
+  dps: 30148.58546
   tps: 569.30964
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 30571.98543
+  dps: 30586.43135
   tps: 565.75867
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BottledLightning-66879"
  value: {
-  dps: 30141.71563
+  dps: 30155.37608
   tps: 570.94746
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 31538.47291
+  dps: 31554.11434
   tps: 565.46838
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 32271.97116
+  dps: 32287.61258
   tps: 568.32557
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 32271.97116
+  dps: 32287.61258
   tps: 568.32557
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 32107.40382
+  dps: 32122.99097
   tps: 565.88118
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 30978.26502
+  dps: 30992.07522
   tps: 577.93417
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CrushingWeight-59506"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CrushingWeight-65118"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 30602.85448
+  dps: 30616.66468
   tps: 577.64229
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 29790.41353
+  dps: 29803.90113
   tps: 564.98201
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 31376.81264
+  dps: 31392.39979
   tps: 564.73836
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 30443.23752
+  dps: 30456.81292
   tps: 566.69729
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 31345.38531
+  dps: 31360.97246
   tps: 564.78527
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 30749.91125
+  dps: 30763.96867
   tps: 580.70165
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 31538.47291
+  dps: 31554.11434
   tps: 573.75103
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 31376.81264
+  dps: 31392.39979
   tps: 564.73836
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 31345.38531
+  dps: 31360.97246
   tps: 564.78527
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FallofMortality-59500"
  value: {
-  dps: 30602.85448
+  dps: 30616.66468
   tps: 577.64229
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FallofMortality-65124"
  value: {
-  dps: 30751.08128
+  dps: 30764.93369
   tps: 579.45195
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 30135.09786
+  dps: 30148.58546
   tps: 569.33666
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 30846.89725
+  dps: 30860.67127
   tps: 576.36724
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 31548.78474
+  dps: 31563.85771
   tps: 577.107
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 29828.83136
+  dps: 29842.31896
   tps: 570.9482
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 31444.33989
+  dps: 31459.92704
   tps: 567.08803
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FluidDeath-58181"
  value: {
-  dps: 30135.09786
+  dps: 30148.58546
   tps: 569.33666
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 31538.47291
+  dps: 31554.11434
   tps: 567.17955
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 29806.61184
+  dps: 29820.09944
   tps: 563.22025
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GaleofShadows-56138"
  value: {
-  dps: 30707.85401
+  dps: 30721.35599
   tps: 578.24411
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GaleofShadows-56462"
  value: {
-  dps: 30865.40506
+  dps: 30879.07944
   tps: 580.57843
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GearDetector-61462"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 30104.50985
+  dps: 30118.18236
   tps: 571.73275
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HarmlightToken-63839"
  value: {
-  dps: 30403.63601
+  dps: 30417.3437
   tps: 726.18101
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 31006.89707
+  dps: 31020.43531
   tps: 581.47982
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 31215.18271
+  dps: 31228.73145
   tps: 581.57871
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofRage-59224"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofRage-65072"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofSolace-55868"
  value: {
-  dps: 29953.57782
+  dps: 29967.06542
   tps: 577.24504
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofSolace-56393"
  value: {
-  dps: 29976.92065
+  dps: 29990.40825
   tps: 579.73516
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofThunder-55845"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofThunder-56370"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Heartpierce-50641"
  value: {
-  dps: 32271.97116
+  dps: 32287.61258
   tps: 568.32557
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 31376.81264
+  dps: 31392.39979
   tps: 564.73836
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 29920.84058
+  dps: 29934.32818
   tps: 571.20998
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 29920.84058
+  dps: 29934.32818
   tps: 571.20998
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 29763.50508
+  dps: 29776.99268
   tps: 571.86745
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 29828.83136
+  dps: 29842.31896
   tps: 570.9482
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 30539.85311
+  dps: 30554.2249
   tps: 572.00978
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 584.8406
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 587.1224
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 29715.94006
+  dps: 29729.42766
   tps: 569.07709
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 30135.09786
+  dps: 30148.58546
   tps: 569.33666
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 30135.09786
+  dps: 30148.58546
   tps: 569.33666
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 29646.69394
+  dps: 29660.18153
   tps: 568.22767
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 29646.69394
+  dps: 29660.18153
   tps: 568.22767
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 30319.03365
+  dps: 30332.52124
   tps: 570.48373
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LastWord-50708"
  value: {
-  dps: 32271.97116
+  dps: 32287.61258
   tps: 568.32557
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LeadenDespair-55816"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LeadenDespair-56347"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 30135.09786
+  dps: 30148.58546
   tps: 569.33666
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 30135.09786
+  dps: 30148.58546
   tps: 569.30779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 30135.09786
+  dps: 30148.58546
   tps: 569.30779
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 29897.88712
+  dps: 29911.37472
   tps: 572.28013
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 29929.53316
+  dps: 29943.02076
   tps: 575.17392
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 30135.09786
+  dps: 30148.58546
   tps: 569.33666
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 30135.09786
+  dps: 30148.58546
   tps: 569.33666
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 29920.84058
+  dps: 29934.32818
   tps: 571.20998
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 29920.84058
+  dps: 29934.32818
   tps: 571.20998
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 31190.33627
+  dps: 31204.16556
   tps: 593.35414
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 29632.8571
+  dps: 29646.3447
   tps: 563.39323
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 30445.14986
+  dps: 30459.07952
   tps: 563.37302
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 31345.38531
+  dps: 31360.97246
   tps: 564.78527
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Rainsong-55854"
  value: {
-  dps: 30135.09786
+  dps: 30148.58546
   tps: 569.31759
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Rainsong-56377"
  value: {
-  dps: 30135.09786
+  dps: 30148.58546
   tps: 569.31112
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RegaliaoftheRagingElements"
  value: {
-  dps: 27809.22471
+  dps: 27824.31436
   tps: 532.89963
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 32073.40191
+  dps: 32088.98906
   tps: 565.92809
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 32073.40191
+  dps: 32088.98906
   tps: 565.92599
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 30135.09786
+  dps: 30148.58546
   tps: 569.33666
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 30135.09786
+  dps: 30148.58546
   tps: 569.33666
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SeaStar-55256"
  value: {
-  dps: 30736.73365
+  dps: 30750.91859
   tps: 569.87803
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SeaStar-56290"
  value: {
-  dps: 31145.52318
+  dps: 31160.30973
   tps: 569.12951
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Shadowmourne-49623"
  value: {
-  dps: 32271.97116
+  dps: 32287.61258
   tps: 568.32557
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ShardofWoe-60233"
  value: {
-  dps: 30039.96943
+  dps: 30053.45703
   tps: 556.52382
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 29790.10353
+  dps: 29803.59113
   tps: 571.78963
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 29837.66014
+  dps: 29851.14774
   tps: 573.81654
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Sorrowsong-55879"
  value: {
-  dps: 30443.00452
+  dps: 30456.49212
   tps: 572.80466
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Sorrowsong-56400"
  value: {
-  dps: 30586.14329
+  dps: 30599.64334
   tps: 577.25776
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 30135.09786
+  dps: 30148.58546
   tps: 569.33666
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SoulCasket-58183"
  value: {
-  dps: 31375.19109
+  dps: 31390.43433
   tps: 571.76383
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Spiritwalker'sRegalia"
  value: {
-  dps: 29324.5654
+  dps: 29339.80179
   tps: 528.87493
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 30417.39831
+  dps: 30431.08088
   tps: 571.46933
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-StumpofTime-62465"
  value: {
-  dps: 31481.14669
+  dps: 31496.47531
   tps: 566.26599
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-StumpofTime-62470"
  value: {
-  dps: 31196.30087
+  dps: 31210.66836
   tps: 570.01881
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 30649.09522
+  dps: 30662.81799
   tps: 583.82577
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TearofBlood-55819"
  value: {
-  dps: 30215.03736
+  dps: 30228.74103
   tps: 573.03461
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TearofBlood-56351"
  value: {
-  dps: 30478.23388
+  dps: 30492.00789
   tps: 576.03865
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 30427.01485
+  dps: 30440.67665
   tps: 570.40985
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 31039.24238
+  dps: 31054.22505
   tps: 572.78776
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 31211.18149
+  dps: 31224.99169
   tps: 590.10855
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 31506.92022
+  dps: 31520.77263
   tps: 590.20856
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 29763.50508
+  dps: 29776.99268
   tps: 571.86745
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 29828.83136
+  dps: 29842.31896
   tps: 570.9482
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 29908.18354
+  dps: 29921.67114
   tps: 566.42729
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 30934.6133
+  dps: 30948.4235
   tps: 672.79929
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-UnheededWarning-59520"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 30135.09786
+  dps: 30148.58546
   tps: 569.32157
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 29920.84058
+  dps: 29934.32818
   tps: 571.20998
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 29920.84058
+  dps: 29934.32818
   tps: 571.20998
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 29920.84058
+  dps: 29934.32818
   tps: 571.20998
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 26312.54568
+  dps: 26326.341
   tps: 537.61661
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 30645.96523
+  dps: 30660.91586
   tps: 564.7637
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 30135.09786
+  dps: 30148.58546
   tps: 569.33666
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 30069.42866
+  dps: 30082.91626
   tps: 577.98083
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 29816.13946
+  dps: 29829.62706
   tps: 563.17342
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 29986.09021
+  dps: 29999.5778
   tps: 570.24747
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 30551.27569
+  dps: 30565.71785
   tps: 565.24609
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 29451.36571
+  dps: 29464.85331
   tps: 563.55299
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-VolcanicRegalia"
  value: {
-  dps: 28200.34355
+  dps: 28215.77191
   tps: 517.77004
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 30393.54355
+  dps: 30407.23214
   tps: 579.95115
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 30978.22174
+  dps: 30991.99576
   tps: 590.53107
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 29715.94006
+  dps: 29729.42766
   tps: 569.07709
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 29896.60772
+  dps: 29910.09532
   tps: 572.30954
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 29896.60772
+  dps: 29910.09532
   tps: 572.30954
  }
 }
 dps_results: {
  key: "TestElemental-Average-Default"
  value: {
-  dps: 32150.92717
+  dps: 32166.53347
   tps: 560.61402
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-DefaultTalents-Standard-aoe-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 72730.4277
+  dps: 72747.41371
   tps: 36637.17222
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-DefaultTalents-Standard-aoe-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 10103.51211
+  dps: 10120.4455
   tps: 242.54239
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-DefaultTalents-Standard-aoe-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 22101.7188
+  dps: 22127.62321
   tps: 598.67006
  }
 }
@@ -1354,21 +1354,21 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-DefaultTalents-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 54388.44318
+  dps: 54405.42721
   tps: 9728.27776
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-DefaultTalents-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 32277.36511
+  dps: 32294.34915
   tps: 569.92983
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-DefaultTalents-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 40359.1127
+  dps: 40386.22723
   tps: 730.55442
  }
 }
@@ -1396,21 +1396,21 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-TalentsImprovedShields-Standard-aoe-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 104348.81087
-  tps: 70823.34186
+  dps: 104450.33045
+  tps: 70912.50127
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-TalentsImprovedShields-Standard-aoe-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 8093.79531
+  dps: 8106.03831
   tps: 233.28859
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-TalentsImprovedShields-Standard-aoe-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 20380.19242
+  dps: 20406.08222
   tps: 583.59663
  }
 }
@@ -1438,21 +1438,21 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-TalentsImprovedShields-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 45955.21787
+  dps: 45967.49712
   tps: 9547.84445
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-TalentsImprovedShields-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 30026.07423
+  dps: 30038.35348
   tps: 556.45217
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-TalentsImprovedShields-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 39050.50845
+  dps: 39077.59536
   tps: 714.74874
  }
 }
@@ -1480,21 +1480,21 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-DefaultTalents-Standard-aoe-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 70647.52831
+  dps: 70663.17152
   tps: 36823.1944
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-DefaultTalents-Standard-aoe-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 9705.86092
+  dps: 9721.45404
   tps: 242.78391
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-DefaultTalents-Standard-aoe-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 21223.36459
+  dps: 21247.1117
   tps: 597.96509
  }
 }
@@ -1522,21 +1522,21 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-DefaultTalents-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 52446.95428
+  dps: 52462.5957
   tps: 9709.71423
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-DefaultTalents-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 32271.97116
+  dps: 32287.61258
   tps: 568.32557
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-DefaultTalents-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 39915.50199
+  dps: 39940.38066
   tps: 716.74039
  }
 }
@@ -1564,21 +1564,21 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-TalentsImprovedShields-Standard-aoe-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 102001.11322
-  tps: 71133.78631
+  dps: 102101.9255
+  tps: 71223.21303
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-TalentsImprovedShields-Standard-aoe-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 7723.65231
+  dps: 7734.92629
   tps: 231.36129
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-TalentsImprovedShields-Standard-aoe-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 19537.16901
+  dps: 19560.90263
   tps: 579.0376
  }
 }
@@ -1606,21 +1606,21 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-TalentsImprovedShields-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 44465.73801
+  dps: 44477.04659
   tps: 9612.06312
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-TalentsImprovedShields-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 29748.77323
+  dps: 29760.08181
   tps: 558.73922
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-TalentsImprovedShields-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 38145.95958
+  dps: 38170.81276
   tps: 696.16067
  }
 }
@@ -1648,7 +1648,7 @@ dps_results: {
 dps_results: {
  key: "TestElemental-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 32017.82869
+  dps: 32033.27222
   tps: 568.32557
  }
 }

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -37,1297 +37,1297 @@ character_stats_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 29333.84099
-  tps: 19422.7469
+  dps: 29818.57848
+  tps: 19857.04209
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 27389.46537
-  tps: 18164.4412
+  dps: 27843.9841
+  tps: 18571.39548
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 27703.37598
-  tps: 18384.02926
+  dps: 28165.88574
+  tps: 18798.39408
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 27712.63653
-  tps: 18377.17113
+  dps: 28176.03535
+  tps: 18792.48724
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 28698.74967
-  tps: 18993.71665
+  dps: 29171.75587
+  tps: 19417.09376
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BattlegearoftheRagingElements"
  value: {
-  dps: 26316.51155
-  tps: 17448.86903
+  dps: 26757.18034
+  tps: 17843.04589
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 27425.52606
-  tps: 18128.03834
+  dps: 27878.60561
+  tps: 18533.10819
   hps: 96.77966
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 27368.3593
-  tps: 18152.84102
+  dps: 27822.56116
+  tps: 18559.47844
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 27683.30588
-  tps: 18387.56313
+  dps: 28144.66266
+  tps: 18801.29029
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 27702.89375
-  tps: 18374.95471
+  dps: 28163.83472
+  tps: 18787.87068
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BindingPromise-67037"
  value: {
-  dps: 27368.3593
-  tps: 18152.84102
+  dps: 27822.56116
+  tps: 18559.47844
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlackBruise-50692"
  value: {
-  dps: 27128.76105
-  tps: 17929.25279
+  dps: 27558.97877
+  tps: 18314.06841
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 28506.91598
-  tps: 18826.90379
+  dps: 28972.46663
+  tps: 19243.71241
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 27768.87144
-  tps: 18347.54597
+  dps: 28223.07331
+  tps: 18754.1834
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 27821.31946
-  tps: 18373.04305
+  dps: 28275.52133
+  tps: 18779.68047
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 28936.50419
-  tps: 19199.57207
+  dps: 29417.81881
+  tps: 19631.06643
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 27368.3593
-  tps: 18152.84102
+  dps: 27822.56116
+  tps: 18559.47844
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 27870.92336
-  tps: 18460.27846
+  dps: 28333.20883
+  tps: 18873.59486
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 27647.96213
-  tps: 18359.54196
+  dps: 28108.77924
+  tps: 18772.77279
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 27425.52606
-  tps: 18128.00838
+  dps: 27878.60561
+  tps: 18533.07823
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 27368.3593
-  tps: 18152.84102
+  dps: 27822.56116
+  tps: 18559.47844
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 28509.97168
-  tps: 18886.66726
+  dps: 28984.0025
+  tps: 19310.4305
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 27368.3593
-  tps: 18152.84102
+  dps: 27822.56116
+  tps: 18559.47844
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 27846.73096
-  tps: 18445.34888
+  dps: 28307.98422
+  tps: 18858.12446
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BottledLightning-66879"
  value: {
-  dps: 27496.75966
-  tps: 18242.38997
+  dps: 27955.10385
+  tps: 18652.65088
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 28702.33894
-  tps: 18618.56787
+  dps: 29175.34514
+  tps: 19033.47744
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 29184.62696
-  tps: 19322.75194
+  dps: 29665.62258
+  tps: 19753.59662
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 29124.97294
-  tps: 19290.15785
+  dps: 29606.09964
+  tps: 19721.29231
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 29184.62696
-  tps: 19322.75194
+  dps: 29665.62258
+  tps: 19753.59662
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 27325.63057
-  tps: 18085.437
+  dps: 27777.56507
+  tps: 18489.47458
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 27368.3593
-  tps: 18152.84102
+  dps: 27822.56116
+  tps: 18559.47844
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CrushingWeight-59506"
  value: {
-  dps: 28141.76458
-  tps: 18627.44272
+  dps: 28611.60269
+  tps: 19048.14539
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CrushingWeight-65118"
  value: {
-  dps: 28052.42418
-  tps: 18627.49021
+  dps: 28521.13642
+  tps: 19047.40622
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 27368.3593
-  tps: 18152.84102
+  dps: 27822.56116
+  tps: 18559.47844
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 28364.84418
-  tps: 19035.94603
+  dps: 28827.12017
+  tps: 19449.3793
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 29083.76293
-  tps: 19475.9486
+  dps: 29558.75602
+  tps: 19901.21478
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 27408.2009
-  tps: 18171.14126
+  dps: 27862.73159
+  tps: 18578.10751
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 27928.76593
-  tps: 18543.79387
+  dps: 28382.30185
+  tps: 18949.56785
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 28103.82426
-  tps: 18658.92374
+  dps: 28571.76366
+  tps: 19078.27269
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 28758.02338
-  tps: 19024.24978
+  dps: 29230.88421
+  tps: 19447.32999
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 27406.33523
-  tps: 18177.78849
+  dps: 27863.08913
+  tps: 18586.84941
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 28698.74967
-  tps: 18993.71665
+  dps: 29171.75587
+  tps: 19417.09376
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 27441.94922
-  tps: 18165.83765
+  dps: 27895.0429
+  tps: 18570.92163
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 28702.33894
-  tps: 18994.25415
+  dps: 29175.34514
+  tps: 19417.63126
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 28758.02338
-  tps: 19024.24978
+  dps: 29230.88421
+  tps: 19447.32999
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 28866.02848
-  tps: 19151.47138
+  dps: 29348.79449
+  tps: 19584.15759
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 28698.74967
-  tps: 18993.71665
+  dps: 29171.75587
+  tps: 19417.09376
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FallofMortality-59500"
  value: {
-  dps: 27408.2009
-  tps: 18171.14126
+  dps: 27862.73159
+  tps: 18578.10751
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FallofMortality-65124"
  value: {
-  dps: 27410.79107
-  tps: 18171.74144
+  dps: 27865.32175
+  tps: 18578.70769
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 29174.81107
-  tps: 19324.58488
+  dps: 29662.49888
+  tps: 19761.90621
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 27321.2571
-  tps: 18084.45957
+  dps: 27773.19161
+  tps: 18488.49715
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 27368.3593
-  tps: 18152.84102
+  dps: 27822.56116
+  tps: 18559.47844
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 27406.00893
-  tps: 18170.60657
+  dps: 27860.53961
+  tps: 18577.57281
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 28300.4414
-  tps: 18664.99053
+  dps: 28762.22165
+  tps: 19077.88949
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 28788.04994
-  tps: 19037.15389
+  dps: 29261.05614
+  tps: 19460.531
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 28702.33894
-  tps: 18994.42838
+  dps: 29175.34514
+  tps: 19417.80549
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 28292.46258
-  tps: 18762.17162
+  dps: 28762.64209
+  tps: 19183.98573
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GaleofShadows-56138"
  value: {
-  dps: 27523.24664
-  tps: 18276.83007
+  dps: 27983.17129
+  tps: 18688.84571
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GaleofShadows-56462"
  value: {
-  dps: 27562.41386
-  tps: 18317.30495
+  dps: 28022.92008
+  tps: 18729.87503
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GearDetector-61462"
  value: {
-  dps: 28114.60198
-  tps: 18633.65802
+  dps: 28582.78794
+  tps: 19052.62903
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 27390.57085
-  tps: 18165.24255
+  dps: 27845.08957
+  tps: 18572.19684
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 28220.5234
-  tps: 18715.75979
+  dps: 28689.44063
+  tps: 19135.65875
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 28634.5774
-  tps: 19012.38902
+  dps: 29111.00271
+  tps: 19439.29571
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HarmlightToken-63839"
  value: {
-  dps: 27583.16391
-  tps: 18348.98509
+  dps: 28037.6946
+  tps: 18755.95134
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 28024.88377
-  tps: 18513.81906
+  dps: 28484.1861
+  tps: 18925.05729
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 27687.38668
-  tps: 18426.56705
+  dps: 28150.30584
+  tps: 18842.28503
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 27563.78899
-  tps: 18287.29396
+  dps: 28025.35681
+  tps: 18701.16973
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartofRage-59224"
  value: {
-  dps: 27969.51757
-  tps: 18520.87598
+  dps: 28432.84201
+  tps: 18935.49381
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartofRage-65072"
  value: {
-  dps: 28049.28527
-  tps: 18563.98184
+  dps: 28513.92075
+  tps: 18979.66955
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartofSolace-55868"
  value: {
-  dps: 27523.24664
-  tps: 18276.83007
+  dps: 27983.17129
+  tps: 18688.84571
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartofSolace-56393"
  value: {
-  dps: 28089.17261
-  tps: 18638.29119
+  dps: 28557.57247
+  tps: 19057.74181
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartofThunder-55845"
  value: {
-  dps: 27368.3593
-  tps: 18152.84102
+  dps: 27822.56116
+  tps: 18559.47844
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartofThunder-56370"
  value: {
-  dps: 27368.3593
-  tps: 18152.84102
+  dps: 27822.56116
+  tps: 18559.47844
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 28333.58683
-  tps: 18783.54439
+  dps: 28804.32072
+  tps: 19204.9952
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Heartpierce-50641"
  value: {
-  dps: 29184.62696
-  tps: 19322.75194
+  dps: 29665.62258
+  tps: 19753.59662
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 28758.02338
-  tps: 19024.24978
+  dps: 29230.88421
+  tps: 19447.32999
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 28419.31173
-  tps: 18730.21304
+  dps: 28882.04925
+  tps: 19143.90294
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 28419.31173
-  tps: 18730.21304
+  dps: 28882.04925
+  tps: 19143.90294
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 27768.87144
-  tps: 18347.54597
+  dps: 28223.07331
+  tps: 18754.1834
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 27821.31946
-  tps: 18373.04305
+  dps: 28275.52133
+  tps: 18779.68047
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 27368.3593
-  tps: 18152.84102
+  dps: 27822.56116
+  tps: 18559.47844
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 27676.69008
-  tps: 18302.73293
+  dps: 28130.89194
+  tps: 18709.37035
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 27368.3593
-  tps: 18157.67703
+  dps: 27822.56116
+  tps: 18564.31445
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 27368.3593
-  tps: 18157.74007
+  dps: 27822.56116
+  tps: 18564.3775
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 28506.91598
-  tps: 18826.90379
+  dps: 28972.46663
+  tps: 19243.71241
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 28657.79669
-  tps: 18990.80589
+  dps: 29135.67969
+  tps: 19418.96929
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 28992.69075
-  tps: 19197.26354
+  dps: 29477.2163
+  tps: 19631.34687
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 27629.9679
-  tps: 18326.15003
+  dps: 28089.9017
+  tps: 18738.04003
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 27629.9679
-  tps: 18326.15003
+  dps: 28089.9017
+  tps: 18738.04003
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 27481.17122
-  tps: 18213.26367
+  dps: 27939.9726
+  tps: 18623.79239
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LastWord-50708"
  value: {
-  dps: 29184.62696
-  tps: 19322.75194
+  dps: 29665.62258
+  tps: 19753.59662
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LeadenDespair-55816"
  value: {
-  dps: 27368.3593
-  tps: 18152.84102
+  dps: 27822.56116
+  tps: 18559.47844
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LeadenDespair-56347"
  value: {
-  dps: 27368.3593
-  tps: 18152.84102
+  dps: 27822.56116
+  tps: 18559.47844
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 28448.6706
-  tps: 18858.75137
+  dps: 28921.41702
+  tps: 19281.91828
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 28629.37193
-  tps: 18992.2299
+  dps: 29105.8466
+  tps: 19418.97094
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 28262.7791
-  tps: 18730.35314
+  dps: 28731.35214
+  tps: 19149.88321
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 27706.79696
-  tps: 18361.65529
+  dps: 28165.84789
+  tps: 18772.68567
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 27816.98597
-  tps: 18429.64133
+  dps: 28277.61566
+  tps: 18842.10198
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 27425.52606
-  tps: 18128.00377
+  dps: 27878.60561
+  tps: 18533.07362
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 27425.52606
-  tps: 18128.00377
+  dps: 27878.60561
+  tps: 18533.07362
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 28184.60329
-  tps: 18598.91577
+  dps: 28644.29797
+  tps: 19010.50791
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 28292.43544
-  tps: 18657.7601
+  dps: 28752.84941
+  tps: 19070.00107
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 27877.56513
-  tps: 18526.36091
+  dps: 28341.84678
+  tps: 18941.99981
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 28176.36712
-  tps: 18665.86538
+  dps: 28646.5655
+  tps: 19087.38449
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 27878.53548
-  tps: 18400.85804
+  dps: 28332.73735
+  tps: 18807.49547
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 27878.53548
-  tps: 18400.85804
+  dps: 28332.73735
+  tps: 18807.49547
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 27993.91413
-  tps: 18460.46741
+  dps: 28448.44481
+  tps: 18867.43366
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 27905.12745
-  tps: 18526.06988
+  dps: 28370.55727
+  tps: 18942.74388
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 27368.3593
-  tps: 18152.84102
+  dps: 27822.56116
+  tps: 18559.47844
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 27538.9864
-  tps: 18282.66808
+  dps: 27996.39689
+  tps: 18692.53436
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 27672.04294
-  tps: 18300.62824
+  dps: 28126.2448
+  tps: 18707.26566
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 27932.21705
-  tps: 18419.76153
+  dps: 28386.41891
+  tps: 18826.39896
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 28698.74967
-  tps: 18993.71665
+  dps: 29171.75587
+  tps: 19417.09376
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 28776.14011
-  tps: 19114.62222
+  dps: 29257.60685
+  tps: 19546.37822
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 28954.69038
-  tps: 19190.42094
+  dps: 29438.94156
+  tps: 19624.45976
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Rainsong-55854"
  value: {
-  dps: 27425.52606
-  tps: 18128.0282
+  dps: 27878.60561
+  tps: 18533.09805
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Rainsong-56377"
  value: {
-  dps: 27425.52606
-  tps: 18128.01207
+  dps: 27878.60561
+  tps: 18533.08191
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RegaliaoftheRagingElements"
  value: {
-  dps: 19958.84299
-  tps: 13204.10443
+  dps: 20301.85938
+  tps: 13507.23358
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 29203.74353
-  tps: 19340.62744
+  dps: 29686.07159
+  tps: 19772.84585
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 29121.06064
-  tps: 19289.34555
+  dps: 29602.18733
+  tps: 19720.48002
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 28179.43546
-  tps: 18683.99185
+  dps: 28649.21609
+  tps: 19104.9039
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 28239.95194
-  tps: 18706.82372
+  dps: 28711.14148
+  tps: 19129.16677
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 28508.17417
-  tps: 18843.59686
+  dps: 28975.8387
+  tps: 19262.66946
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SeaStar-55256"
  value: {
-  dps: 27425.52606
-  tps: 18128.03166
+  dps: 27878.60561
+  tps: 18533.10151
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SeaStar-56290"
  value: {
-  dps: 27425.52606
-  tps: 18128.01207
+  dps: 27878.60561
+  tps: 18533.08191
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Shadowmourne-49623"
  value: {
-  dps: 29184.62696
-  tps: 19322.75194
+  dps: 29665.62258
+  tps: 19753.59662
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ShardofWoe-60233"
  value: {
-  dps: 27580.49097
-  tps: 18301.42598
+  dps: 28040.67978
+  tps: 18713.55053
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 27931.64642
-  tps: 18537.43384
+  dps: 28397.32485
+  tps: 18954.63945
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 27368.3593
-  tps: 18152.84102
+  dps: 27822.56116
+  tps: 18559.47844
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 28704.85197
-  tps: 18957.71606
+  dps: 29173.4108
+  tps: 19377.60235
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 28886.49972
-  tps: 19071.79897
+  dps: 29356.80396
+  tps: 19493.28293
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Sorrowsong-55879"
  value: {
-  dps: 27768.87144
-  tps: 18347.54597
+  dps: 28223.07331
+  tps: 18754.1834
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Sorrowsong-56400"
  value: {
-  dps: 27821.31946
-  tps: 18373.04305
+  dps: 28275.52133
+  tps: 18779.68047
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 27951.57739
-  tps: 18539.29604
+  dps: 28417.72589
+  tps: 18956.96978
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SoulCasket-58183"
  value: {
-  dps: 27878.53548
-  tps: 18400.85804
+  dps: 28332.73735
+  tps: 18807.49547
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Spiritwalker'sRegalia"
  value: {
-  dps: 20217.3142
-  tps: 13157.54915
+  dps: 20550.78254
+  tps: 13451.30996
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 27638.06226
-  tps: 18352.28865
+  dps: 28097.6473
+  tps: 18763.72579
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-StumpofTime-62465"
  value: {
-  dps: 27690.40695
-  tps: 18375.42002
+  dps: 28150.68681
+  tps: 18787.46743
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-StumpofTime-62470"
  value: {
-  dps: 27690.40695
-  tps: 18375.42002
+  dps: 28150.68681
+  tps: 18787.46743
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 27368.3593
-  tps: 18152.84102
+  dps: 27822.56116
+  tps: 18559.47844
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 27368.3593
-  tps: 18152.84102
+  dps: 27822.56116
+  tps: 18559.47844
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 27701.86466
-  tps: 18314.95993
+  dps: 28156.39534
+  tps: 18721.92618
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 28006.68875
-  tps: 18568.1078
+  dps: 28473.53673
+  tps: 18986.72368
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TearofBlood-55819"
  value: {
-  dps: 27395.98549
-  tps: 18166.32137
+  dps: 27850.50422
+  tps: 18573.27566
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TearofBlood-56351"
  value: {
-  dps: 27406.00893
-  tps: 18170.60657
+  dps: 27860.53961
+  tps: 18577.57281
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 27710.06609
-  tps: 18318.95834
+  dps: 28164.26795
+  tps: 18725.59577
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 27821.31946
-  tps: 18373.04305
+  dps: 28275.52133
+  tps: 18779.68047
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 27980.54341
-  tps: 18451.89996
+  dps: 28435.0741
+  tps: 18858.8662
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 28074.73523
-  tps: 18500.05276
+  dps: 28529.26592
+  tps: 18907.01901
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 27368.3593
-  tps: 18152.84102
+  dps: 27822.56116
+  tps: 18559.47844
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 27368.3593
-  tps: 18152.84102
+  dps: 27822.56116
+  tps: 18559.47844
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 28829.14661
-  tps: 19043.28997
+  dps: 29300.50952
+  tps: 19465.74559
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 29033.49083
-  tps: 19164.06558
+  dps: 29507.29152
+  tps: 19588.58758
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 28308.33988
-  tps: 18876.15257
+  dps: 28783.68743
+  tps: 19303.51002
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 27397.98399
-  tps: 18193.1742
+  dps: 27851.73344
+  tps: 18599.2023
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-UnheededWarning-59520"
  value: {
-  dps: 29042.13437
-  tps: 19241.31139
+  dps: 29523.23001
+  tps: 19672.59576
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 27425.52606
-  tps: 18128.03811
+  dps: 27878.60561
+  tps: 18533.10796
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 29260.72745
-  tps: 19306.37127
+  dps: 29740.78466
+  tps: 19734.86219
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 29260.72745
-  tps: 19306.37127
+  dps: 29740.78466
+  tps: 19734.86219
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 29260.72745
-  tps: 19306.37127
+  dps: 29740.78466
+  tps: 19734.86219
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 24699.83469
-  tps: 16171.52122
+  dps: 25062.28486
+  tps: 16494.3235
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 27368.3593
-  tps: 18152.84102
+  dps: 27822.56116
+  tps: 18559.47844
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 27368.3593
-  tps: 18152.84102
+  dps: 27822.56116
+  tps: 18559.47844
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 28727.83258
-  tps: 19047.30202
+  dps: 29207.88979
+  tps: 19475.79295
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 27368.3593
-  tps: 18152.84102
+  dps: 27822.56116
+  tps: 18559.47844
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 27899.02727
-  tps: 18477.47069
+  dps: 28361.76479
+  tps: 18891.16058
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 27698.50163
-  tps: 18405.3022
+  dps: 28159.9066
+  tps: 18818.58537
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 27587.54065
-  tps: 18315.11657
+  dps: 28047.47514
+  tps: 18727.35324
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 27674.39734
-  tps: 18369.05002
+  dps: 28134.69183
+  tps: 18781.50689
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 27368.3593
-  tps: 18152.84102
+  dps: 27822.56116
+  tps: 18559.47844
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 27908.73283
-  tps: 18415.53818
+  dps: 28362.93469
+  tps: 18822.1756
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 27368.3593
-  tps: 18152.84102
+  dps: 27822.56116
+  tps: 18559.47844
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 28598.01216
-  tps: 18950.92281
+  dps: 29073.73139
+  tps: 19376.17395
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 27368.3593
-  tps: 18152.84102
+  dps: 27822.56116
+  tps: 18559.47844
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 27894.7114
-  tps: 18478.33836
+  dps: 28356.81715
+  tps: 18891.89167
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-VolcanicRegalia"
  value: {
-  dps: 20157.6391
-  tps: 13348.11733
+  dps: 20502.52479
+  tps: 13653.25283
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 27528.22867
-  tps: 18297.10716
+  dps: 27986.27331
+  tps: 18707.44166
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 27524.9626
-  tps: 18276.17565
+  dps: 27983.86217
+  tps: 18686.88876
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 27716.42343
-  tps: 18322.0489
+  dps: 28170.62529
+  tps: 18728.68632
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 27743.18153
-  tps: 18334.25803
+  dps: 28197.38339
+  tps: 18740.89545
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 27743.18153
-  tps: 18334.25803
+  dps: 28197.38339
+  tps: 18740.89545
  }
 }
 dps_results: {
  key: "TestEnhancement-Average-Default"
  value: {
-  dps: 29318.46856
-  tps: 19406.68763
+  dps: 29803.6261
+  tps: 19841.86941
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1draenei-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 29522.73022
-  tps: 23474.51156
+  dps: 30003.97231
+  tps: 23905.86674
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1draenei-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 29184.62696
-  tps: 19322.75194
+  dps: 29665.62258
+  tps: 19753.59662
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1draenei-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 33566.07961
-  tps: 21714.06059
+  dps: 34143.06632
+  tps: 22209.37409
  }
 }
 dps_results: {
@@ -1354,22 +1354,22 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1draenei-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 29814.93022
-  tps: 23649.8139
+  dps: 30302.10825
+  tps: 24084.79349
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1draenei-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 29464.33846
-  tps: 19408.83726
+  dps: 29949.5806
+  tps: 19841.99555
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1draenei-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 34102.98125
-  tps: 21958.60297
+  dps: 34687.87019
+  tps: 22457.69499
  }
 }
 dps_results: {
@@ -1396,22 +1396,22 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1draenei-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 29538.32971
-  tps: 23436.9364
+  dps: 30019.47827
+  tps: 23867.87248
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1draenei-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 29126.26594
-  tps: 19214.41351
+  dps: 29604.8169
+  tps: 19642.49033
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1draenei-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 33510.05
-  tps: 21638.69455
+  dps: 34086.45667
+  tps: 22132.8213
  }
 }
 dps_results: {
@@ -1438,7 +1438,7 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 27280.37542
-  tps: 17634.11312
+  dps: 27720.0949
+  tps: 18024.69906
  }
 }

--- a/sim/warlock/affliction/TestAffliction.results
+++ b/sim/warlock/affliction/TestAffliction.results
@@ -37,42 +37,42 @@ character_stats_results: {
 dps_results: {
  key: "TestAffliction-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 26381.7
+  dps: 26434.7706
   tps: 19466.77157
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 25329.43714
+  dps: 25381.09591
   tps: 18734.0336
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 25457.89664
+  dps: 25509.93377
   tps: 18804.50966
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 25481.54608
+  dps: 25533.61077
   tps: 18814.98843
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 26101.3748
+  dps: 26154.43917
   tps: 19212.57338
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 24653.46534
+  dps: 24704.42632
   tps: 18240.58282
   hps: 99.63661
  }
@@ -80,1190 +80,1190 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 24681.7942
+  dps: 24732.76501
   tps: 18258.78068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 26021.47203
+  dps: 26074.55012
   tps: 19183.82141
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BindingPromise-67037"
  value: {
-  dps: 24681.7942
+  dps: 24732.76501
   tps: 18258.78068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 24777.67973
+  dps: 24828.66108
   tps: 18399.50114
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 24857.22199
+  dps: 24908.19279
   tps: 18434.20847
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 24857.22199
+  dps: 24908.19279
   tps: 18434.20847
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 24691.63657
+  dps: 24742.60757
   tps: 18269.16359
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 25463.18366
+  dps: 25515.10561
   tps: 18801.06133
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 24646.3762
+  dps: 24697.34596
   tps: 18224.23596
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 24994.07961
+  dps: 25045.83733
   tps: 18483.50336
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 24688.9168
+  dps: 24739.89881
   tps: 18265.76189
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 24688.9168
+  dps: 24739.89881
   tps: 18265.76189
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 24681.7942
+  dps: 24732.76501
   tps: 18258.78068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 25407.65152
+  dps: 25459.56788
   tps: 18774.53538
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 24681.7942
+  dps: 24732.76501
   tps: 18258.78068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BottledLightning-66879"
  value: {
-  dps: 25310.84051
+  dps: 25362.78318
   tps: 18722.4032
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 26241.02429
+  dps: 26294.30135
   tps: 18920.32697
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 26507.14542
+  dps: 26560.42247
   tps: 19558.41679
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 26439.20724
+  dps: 26492.35082
   tps: 19509.58572
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 25603.42956
+  dps: 25655.66349
   tps: 18934.72157
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 24681.7942
+  dps: 24732.76501
   tps: 18258.78068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CrushingWeight-59506"
  value: {
-  dps: 24681.7942
+  dps: 24732.76501
   tps: 18258.78068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CrushingWeight-65118"
  value: {
-  dps: 24681.7942
+  dps: 24732.76501
   tps: 18258.78068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 24688.9168
+  dps: 24739.89881
   tps: 18265.78853
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 24681.7942
+  dps: 24732.76501
   tps: 18258.78068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 24681.7942
+  dps: 24732.76501
   tps: 18258.78068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 25723.07932
+  dps: 25775.34016
   tps: 19021.49339
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 24875.33665
+  dps: 24926.70611
   tps: 18401.77123
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 26170.07877
+  dps: 26223.22235
   tps: 19248.8845
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 25418.36604
+  dps: 25470.50702
   tps: 18870.59179
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 26101.3748
+  dps: 26154.43917
   tps: 19212.57338
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 25033.76485
+  dps: 25085.21512
   tps: 18492.50814
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 26230.41019
+  dps: 26283.67397
   tps: 19271.05376
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 26170.07877
+  dps: 26223.22235
   tps: 19248.8845
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 24681.7942
+  dps: 24732.76501
   tps: 18258.78068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 24681.7942
+  dps: 24732.76501
   tps: 18258.78068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 26101.3748
+  dps: 26154.43917
   tps: 19212.57338
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FallofMortality-59500"
  value: {
-  dps: 25723.07932
+  dps: 25775.34016
   tps: 19021.49339
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FallofMortality-65124"
  value: {
-  dps: 25847.39939
+  dps: 25899.85287
   tps: 19099.24669
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 24895.96526
+  dps: 24947.31561
   tps: 18430.59428
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 25453.82441
+  dps: 25505.87331
   tps: 18811.05261
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 24657.48523
+  dps: 24708.45736
   tps: 18191.07059
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 26222.18393
+  dps: 26275.12314
   tps: 19353.30722
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 24822.08014
+  dps: 24873.0499
   tps: 18399.9399
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 26206.88987
+  dps: 26259.96047
   tps: 19300.31128
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FluidDeath-58181"
  value: {
-  dps: 24913.56992
+  dps: 24964.89531
   tps: 18428.50011
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 26241.02429
+  dps: 26294.30135
   tps: 19299.9754
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 25014.76439
+  dps: 25066.56977
   tps: 18493.81606
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GaleofShadows-56138"
  value: {
-  dps: 25758.60066
+  dps: 25811.39121
   tps: 19164.5566
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GaleofShadows-56462"
  value: {
-  dps: 25847.70783
+  dps: 25900.65868
   tps: 19183.03441
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GearDetector-61462"
  value: {
-  dps: 24681.7942
+  dps: 24732.76501
   tps: 18258.78068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 25341.66859
+  dps: 25393.36269
   tps: 18734.70275
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 24681.7942
+  dps: 24732.76501
   tps: 18258.78068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 24681.7942
+  dps: 24732.76501
   tps: 18258.78068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HarmlightToken-63839"
  value: {
-  dps: 25560.69937
+  dps: 25612.51893
   tps: 18767.69539
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 24681.7942
+  dps: 24732.76501
   tps: 18258.78068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 25909.20937
+  dps: 25962.26517
   tps: 19294.23831
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 26012.11032
+  dps: 26065.32268
   tps: 19304.19564
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofRage-59224"
  value: {
-  dps: 24681.7942
+  dps: 24732.76501
   tps: 18258.78068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofRage-65072"
  value: {
-  dps: 24681.7942
+  dps: 24732.76501
   tps: 18258.78068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofSolace-55868"
  value: {
-  dps: 25109.13545
+  dps: 25161.05947
   tps: 18675.16993
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofSolace-56393"
  value: {
-  dps: 25110.91412
+  dps: 25162.88248
   tps: 18629.54696
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofThunder-55845"
  value: {
-  dps: 24707.08852
+  dps: 24758.05936
   tps: 18283.73538
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofThunder-56370"
  value: {
-  dps: 24703.47513
+  dps: 24754.44555
   tps: 18278.35616
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 24681.7942
+  dps: 24732.76501
   tps: 18258.78068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 26170.07877
+  dps: 26223.22235
   tps: 19248.8845
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 24909.93211
+  dps: 24960.90187
   tps: 18487.79187
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 24909.93211
+  dps: 24960.90187
   tps: 18487.79187
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 24857.22199
+  dps: 24908.19279
   tps: 18434.20847
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 24857.22199
+  dps: 24908.19279
   tps: 18434.20847
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 24702.40678
+  dps: 24753.3772
   tps: 18281.60132
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 25169.41529
+  dps: 25220.98539
   tps: 18643.35097
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 24735.53552
+  dps: 24786.487
   tps: 18299.67073
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 24729.20624
+  dps: 24780.1723
   tps: 18297.18481
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 24777.67973
+  dps: 24828.66108
   tps: 18399.50114
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 24913.56992
+  dps: 24964.89531
   tps: 18428.50011
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 24913.56992
+  dps: 24964.89531
   tps: 18428.50011
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 24855.53507
+  dps: 24906.94914
   tps: 18488.42704
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 24855.53507
+  dps: 24906.94914
   tps: 18488.42704
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 24774.21512
+  dps: 24825.67727
   tps: 18329.71076
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LeadenDespair-55816"
  value: {
-  dps: 24666.30155
+  dps: 24717.27431
   tps: 18213.0924
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LeadenDespair-56347"
  value: {
-  dps: 24657.48523
+  dps: 24708.45736
   tps: 18191.07059
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 24681.7942
+  dps: 24732.76501
   tps: 18258.78068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 24681.7942
+  dps: 24732.76501
   tps: 18258.78068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 24913.56992
+  dps: 24964.89531
   tps: 18428.50011
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 24602.5405
+  dps: 24653.52186
   tps: 18224.36192
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 24602.5405
+  dps: 24653.52186
   tps: 18224.36192
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 24681.7942
+  dps: 24732.76501
   tps: 18258.78068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 24681.7942
+  dps: 24732.76501
   tps: 18258.78068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 24801.35649
+  dps: 24852.33784
   tps: 18423.1779
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 24837.50485
+  dps: 24888.4862
   tps: 18459.32626
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 24869.43701
+  dps: 24920.77252
   tps: 18409.44627
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 24869.43701
+  dps: 24920.77252
   tps: 18409.44627
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 24944.93588
+  dps: 24995.90669
   tps: 18521.92236
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 24944.93588
+  dps: 24995.90669
   tps: 18521.92236
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 25985.54348
+  dps: 26037.85726
   tps: 19305.76628
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 24881.06157
+  dps: 24932.56346
   tps: 18378.52448
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 24681.7942
+  dps: 24732.76501
   tps: 18258.78068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 25478.00103
+  dps: 25530.16646
   tps: 18829.1165
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 24681.7942
+  dps: 24732.76501
   tps: 18258.78068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 24681.7942
+  dps: 24732.76501
   tps: 18258.78068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 26101.3748
+  dps: 26154.43917
   tps: 19212.57338
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 24681.7942
+  dps: 24732.76501
   tps: 18258.78068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 24681.7942
+  dps: 24732.76501
   tps: 18258.78068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Rainsong-55854"
  value: {
-  dps: 24681.7942
+  dps: 24732.76501
   tps: 18258.78068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Rainsong-56377"
  value: {
-  dps: 24681.7942
+  dps: 24732.76501
   tps: 18258.78068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 26381.7
+  dps: 26434.7706
   tps: 19466.77157
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 26381.7
+  dps: 26434.7706
   tps: 19466.77157
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 24913.56992
+  dps: 24964.89531
   tps: 18428.50011
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 24913.56992
+  dps: 24964.89531
   tps: 18428.50011
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 24681.7942
+  dps: 24732.76501
   tps: 18258.78068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SeaStar-55256"
  value: {
-  dps: 25057.4668
+  dps: 25108.91578
   tps: 18514.5461
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SeaStar-56290"
  value: {
-  dps: 25412.13319
+  dps: 25463.99563
   tps: 18765.00975
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ShadowflameRegalia"
  value: {
-  dps: 24092.45427
+  dps: 24142.53994
   tps: 17813.44847
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ShardofWoe-60233"
  value: {
-  dps: 25088.60626
+  dps: 25140.74908
   tps: 18535.19331
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 24681.7942
+  dps: 24732.76501
   tps: 18258.78068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 24696.17832
+  dps: 24747.16889
   tps: 18249.62929
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 24873.51319
+  dps: 24924.48295
   tps: 18451.37295
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 24914.81083
+  dps: 24965.78059
   tps: 18492.67058
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Sorrowsong-55879"
  value: {
-  dps: 25447.90009
+  dps: 25499.60971
   tps: 18875.62434
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Sorrowsong-56400"
  value: {
-  dps: 25525.25079
+  dps: 25577.05717
   tps: 18933.42879
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 24869.43701
+  dps: 24920.77252
   tps: 18409.44627
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SoulCasket-58183"
  value: {
-  dps: 25955.65522
+  dps: 26007.83151
   tps: 19229.43242
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 25625.33666
+  dps: 25677.74913
   tps: 18941.72079
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StumpofTime-62465"
  value: {
-  dps: 25615.34846
+  dps: 25667.62794
   tps: 18939.33788
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StumpofTime-62470"
  value: {
-  dps: 25652.66911
+  dps: 25704.92396
   tps: 18948.88547
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 24703.26013
+  dps: 24754.228
   tps: 18222.19625
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 24777.77015
+  dps: 24828.73758
   tps: 18300.75692
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 25635.37691
+  dps: 25687.25155
   tps: 19007.26072
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 24681.7942
+  dps: 24732.76501
   tps: 18258.78068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TearofBlood-55819"
  value: {
-  dps: 25407.87872
+  dps: 25459.68515
   tps: 18780.87102
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TearofBlood-56351"
  value: {
-  dps: 25603.15054
+  dps: 25655.25529
   tps: 18913.83247
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 25340.19183
+  dps: 25391.80662
   tps: 18769.25476
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 25479.47144
+  dps: 25531.32852
   tps: 18863.52163
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 26001.92947
+  dps: 26054.19032
   tps: 19300.34354
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 26202.24165
+  dps: 26254.69512
   tps: 19454.08894
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 24681.7942
+  dps: 24732.76501
   tps: 18258.78068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 24681.7942
+  dps: 24732.76501
   tps: 18258.78068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 24857.22199
+  dps: 24908.19279
   tps: 18434.20847
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 24857.22199
+  dps: 24908.19279
   tps: 18434.20847
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 24857.39672
+  dps: 24908.62863
   tps: 18390.20363
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 25573.45837
+  dps: 25625.4636
   tps: 18896.40164
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnheededWarning-59520"
  value: {
-  dps: 24681.7942
+  dps: 24732.76501
   tps: 18258.78068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 24646.3762
+  dps: 24697.34596
   tps: 18224.23596
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 24909.93211
+  dps: 24960.90187
   tps: 18487.79187
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 24909.93211
+  dps: 24960.90187
   tps: 18487.79187
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 24909.93211
+  dps: 24960.90187
   tps: 18487.79187
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 24703.26013
+  dps: 24754.228
   tps: 18222.19625
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 24777.77015
+  dps: 24828.73758
   tps: 18300.75692
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 24646.3762
+  dps: 24697.34596
   tps: 18224.23596
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 25508.86039
+  dps: 25560.83559
   tps: 18833.31801
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 24646.3762
+  dps: 24697.34596
   tps: 18224.23596
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 24901.69336
+  dps: 24953.0312
   tps: 18410.5165
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 25214.05966
+  dps: 25266.19473
   tps: 18715.28312
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 25042.04201
+  dps: 25093.88218
   tps: 18518.90615
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 24688.9168
+  dps: 24739.89881
   tps: 18265.88876
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 24952.31235
+  dps: 25003.29436
   tps: 18529.2843
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 24688.9168
+  dps: 24739.89881
   tps: 18265.88876
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 24681.7942
+  dps: 24732.76501
   tps: 18258.78068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 25413.63109
+  dps: 25465.5549
   tps: 18770.63446
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 24681.7942
+  dps: 24732.76501
   tps: 18258.78068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 25542.16225
+  dps: 25594.60349
   tps: 18934.60841
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 25805.1137
+  dps: 25858.25294
   tps: 19117.00233
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 24822.08014
+  dps: 24873.0499
   tps: 18399.9399
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 24809.9121
+  dps: 24860.88828
   tps: 18390.65746
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 24809.9121
+  dps: 24860.88828
   tps: 18390.65746
  }
 }
 dps_results: {
  key: "TestAffliction-Average-Default"
  value: {
-  dps: 26770.02111
+  dps: 26823.39985
   tps: 19806.64422
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 27134.83529
+  dps: 27185.28998
   tps: 26581.28224
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 26184.8366
+  dps: 26235.2913
   tps: 19621.88775
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p1-Affliction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 33492.70211
+  dps: 33554.16776
   tps: 22338.64774
  }
 }
@@ -1291,21 +1291,21 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Settings-Human-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 26877.7332
+  dps: 26928.21961
   tps: 26366.1807
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25948.13071
+  dps: 25998.61712
   tps: 19378.08482
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p1-Affliction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 33068.54638
+  dps: 33129.90029
   tps: 21895.77022
  }
 }
@@ -1333,21 +1333,21 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Settings-Orc-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 27430.91656
+  dps: 27484.19362
   tps: 26546.30086
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 26507.14542
+  dps: 26560.42247
   tps: 19558.41679
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p1-Affliction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 32692.58462
+  dps: 32757.24304
   tps: 22124.71344
  }
 }
@@ -1375,21 +1375,21 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Settings-Troll-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 27089.45537
+  dps: 27139.85687
   tps: 26680.31912
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 26137.57665
+  dps: 26187.97815
   tps: 19572.62174
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p1-Affliction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 33666.04583
+  dps: 33727.34909
   tps: 22322.05739
  }
 }
@@ -1417,7 +1417,7 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 26397.1825
+  dps: 26446.06104
   tps: 19558.41679
  }
 }

--- a/sim/warlock/demonology/TestDemonology.results
+++ b/sim/warlock/demonology/TestDemonology.results
@@ -37,42 +37,42 @@ character_stats_results: {
 dps_results: {
  key: "TestDemonology-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 28843.63557
+  dps: 28920.02052
   tps: 14873.00155
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 27228.30628
+  dps: 27301.9347
   tps: 14097.39183
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 27444.80812
+  dps: 27518.90159
   tps: 14266.66445
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 27507.54068
+  dps: 27581.71206
   tps: 14299.63919
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 28661.80743
+  dps: 28738.22677
   tps: 14769.00199
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 26694.59637
+  dps: 26767.2857
   tps: 13844.41672
   hps: 98.1253
  }
@@ -80,1190 +80,1190 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 26699.90358
+  dps: 26772.60221
   tps: 13830.67082
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 28343.82494
+  dps: 28419.42605
   tps: 14642.66743
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BindingPromise-67037"
  value: {
-  dps: 26699.90358
+  dps: 26772.60221
   tps: 13830.67082
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 25388.6314
+  dps: 25462.58032
   tps: 14073.91492
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 27095.29112
+  dps: 27169.38432
   tps: 13982.16999
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 27227.08697
+  dps: 27301.64503
   tps: 14032.66971
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 25026.85658
+  dps: 25099.36394
   tps: 13939.96716
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 25976.16091
+  dps: 26049.9944
   tps: 14540.89914
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 25014.57597
+  dps: 25087.11956
   tps: 13952.33595
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 27130.99429
+  dps: 27204.80626
   tps: 14080.49257
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 26690.08757
+  dps: 26762.77481
   tps: 13805.40655
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 26695.68223
+  dps: 26768.37989
   tps: 13833.71159
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 26699.73998
+  dps: 26772.4386
   tps: 13830.50722
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 27577.15422
+  dps: 27651.1663
   tps: 14279.98213
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 26699.73998
+  dps: 26772.4386
   tps: 13830.50722
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BottledLightning-66879"
  value: {
-  dps: 25672.41931
+  dps: 25746.48128
   tps: 14317.59088
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 28847.33998
+  dps: 28924.0515
   tps: 14567.82487
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 29054.25984
+  dps: 29130.97135
   tps: 15016.99359
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 28925.71619
+  dps: 29002.30201
   tps: 14914.90359
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 25880.79214
+  dps: 25955.14721
   tps: 14397.77176
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 26699.90358
+  dps: 26772.60221
   tps: 13830.67082
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CrushingWeight-59506"
  value: {
-  dps: 26699.90358
+  dps: 26772.60221
   tps: 13830.67082
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CrushingWeight-65118"
  value: {
-  dps: 26699.90358
+  dps: 26772.60221
   tps: 13830.67082
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 26695.68223
+  dps: 26768.37989
   tps: 13833.75599
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 26699.90358
+  dps: 26772.60221
   tps: 13830.67082
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 26699.90358
+  dps: 26772.60221
   tps: 13830.67082
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 27669.66963
+  dps: 27744.17936
   tps: 14305.16991
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 26916.31745
+  dps: 26989.65825
   tps: 13949.28232
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 28720.45576
+  dps: 28797.04158
   tps: 14757.42179
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 27426.76354
+  dps: 27501.00026
   tps: 14338.64853
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 28661.80743
+  dps: 28738.22677
   tps: 14769.00199
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 25466.60658
+  dps: 25539.77723
   tps: 14190.3623
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 28839.50157
+  dps: 28916.24173
   tps: 14849.41298
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 28720.45576
+  dps: 28797.04158
   tps: 14757.42179
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 26699.90358
+  dps: 26772.60221
   tps: 13830.67082
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 26699.90358
+  dps: 26772.60221
   tps: 13830.67082
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 28661.80743
+  dps: 28738.22677
   tps: 14769.00199
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FallofMortality-59500"
  value: {
-  dps: 27669.66963
+  dps: 27744.17936
   tps: 14305.16991
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FallofMortality-65124"
  value: {
-  dps: 27802.45714
+  dps: 27877.16563
   tps: 14382.53682
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 25304.7925
+  dps: 25377.71348
   tps: 14115.98158
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 25830.23054
+  dps: 25904.41691
   tps: 14365.04216
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 26716.33968
+  dps: 26789.03276
   tps: 13862.41286
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 26745.30194
+  dps: 26820.70766
   tps: 14927.61737
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 25490.89627
+  dps: 25565.29316
   tps: 14157.09586
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 28781.64332
+  dps: 28858.51303
   tps: 14771.3772
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FluidDeath-58181"
  value: {
-  dps: 26807.08016
+  dps: 26880.15131
   tps: 13957.68796
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 28847.33998
+  dps: 28924.0515
   tps: 14857.4663
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 27136.66155
+  dps: 27210.56087
   tps: 14061.93196
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GaleofShadows-56138"
  value: {
-  dps: 27695.04257
+  dps: 27770.10446
   tps: 14395.91103
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GaleofShadows-56462"
  value: {
-  dps: 27898.63616
+  dps: 27974.08048
   tps: 14547.93182
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GearDetector-61462"
  value: {
-  dps: 26699.90358
+  dps: 26772.60221
   tps: 13830.67082
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 27244.27959
+  dps: 27318.00845
   tps: 14112.31639
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 26699.90358
+  dps: 26772.60221
   tps: 13830.67082
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 26699.90358
+  dps: 26772.60221
   tps: 13830.67082
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HarmlightToken-63839"
  value: {
-  dps: 27727.66965
+  dps: 27801.62402
   tps: 14340.93363
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 26699.90358
+  dps: 26772.60221
   tps: 13830.67082
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 27860.53166
+  dps: 27935.98019
   tps: 14524.1269
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 27941.83011
+  dps: 28018.14211
   tps: 14650.98897
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofRage-59224"
  value: {
-  dps: 26699.90358
+  dps: 26772.60221
   tps: 13830.67082
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofRage-65072"
  value: {
-  dps: 26699.90358
+  dps: 26772.60221
   tps: 13830.67082
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofSolace-55868"
  value: {
-  dps: 27064.60117
+  dps: 27138.48992
   tps: 14063.45699
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofSolace-56393"
  value: {
-  dps: 27180.85996
+  dps: 27254.97265
   tps: 14168.77809
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofThunder-55845"
  value: {
-  dps: 26699.90358
+  dps: 26772.60221
   tps: 13830.67082
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofThunder-56370"
  value: {
-  dps: 26699.90358
+  dps: 26772.60221
   tps: 13830.67082
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 26699.90358
+  dps: 26772.60221
   tps: 13830.67082
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 28720.45576
+  dps: 28797.04158
   tps: 14757.42179
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 25490.89627
+  dps: 25565.29316
   tps: 14157.09586
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 25490.89627
+  dps: 25565.29316
   tps: 14157.09586
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 27095.01866
+  dps: 27169.11186
   tps: 13981.89753
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 27226.8128
+  dps: 27301.37086
   tps: 14032.39555
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 26699.90358
+  dps: 26772.60221
   tps: 13830.67082
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 25700.88633
+  dps: 25775.20887
   tps: 14274.00816
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 26684.81847
+  dps: 26757.4868
   tps: 13885.39077
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 26691.91266
+  dps: 26764.57889
   tps: 13867.86274
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 25388.6314
+  dps: 25462.58032
   tps: 14073.91492
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 26807.08016
+  dps: 26880.15131
   tps: 13957.68796
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 26807.08016
+  dps: 26880.15131
   tps: 13957.68796
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 27073.50814
+  dps: 27146.94107
   tps: 14028.95131
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 27073.50814
+  dps: 27146.94107
   tps: 14028.95131
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 25361.26354
+  dps: 25434.19965
   tps: 14117.08415
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-LeadenDespair-55816"
  value: {
-  dps: 26746.03109
+  dps: 26818.75596
   tps: 13873.03014
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-LeadenDespair-56347"
  value: {
-  dps: 26716.31772
+  dps: 26789.0108
   tps: 13862.39091
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 26699.90358
+  dps: 26772.60221
   tps: 13830.67082
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 26699.90358
+  dps: 26772.60221
   tps: 13830.67082
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 26807.08016
+  dps: 26880.15131
   tps: 13957.68796
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 25030.67686
+  dps: 25103.23506
   tps: 13920.85854
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 25030.67686
+  dps: 25103.23506
   tps: 13920.85854
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 26705.61437
+  dps: 26778.30167
   tps: 13808.86291
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 26705.61437
+  dps: 26778.30167
   tps: 13808.86291
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 25186.70171
+  dps: 25260.9072
   tps: 13920.85854
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 25206.20482
+  dps: 25280.61622
   tps: 13920.85854
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 25346.23878
+  dps: 25419.1837
   tps: 14166.39457
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 25346.23878
+  dps: 25419.1837
   tps: 14166.39457
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 27226.8128
+  dps: 27301.37086
   tps: 14032.39555
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 27226.8128
+  dps: 27301.37086
   tps: 14032.39555
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 26224.95205
+  dps: 26301.79253
   tps: 14463.33879
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 25250.24896
+  dps: 25323.64651
   tps: 14107.99929
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 26699.90358
+  dps: 26772.60221
   tps: 13830.67082
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 27617.49448
+  dps: 27691.89552
   tps: 14297.95744
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 26699.90358
+  dps: 26772.60221
   tps: 13830.67082
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 26699.90358
+  dps: 26772.60221
   tps: 13830.67082
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 28661.80743
+  dps: 28738.22677
   tps: 14769.00199
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 26699.90358
+  dps: 26772.60221
   tps: 13830.67082
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 26699.90358
+  dps: 26772.60221
   tps: 13830.67082
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Rainsong-55854"
  value: {
-  dps: 26707.53178
+  dps: 26780.21667
   tps: 13816.82651
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Rainsong-56377"
  value: {
-  dps: 26697.05541
+  dps: 26769.74363
   tps: 13803.99772
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 28843.63557
+  dps: 28920.02052
   tps: 14873.00155
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 28839.20183
+  dps: 28915.58683
   tps: 14886.25997
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 26807.08016
+  dps: 26880.15131
   tps: 13957.68796
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 26807.08016
+  dps: 26880.15131
   tps: 13957.68796
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 26699.90358
+  dps: 26772.60221
   tps: 13830.67082
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SeaStar-55256"
  value: {
-  dps: 25486.3998
+  dps: 25559.59363
   tps: 14250.67882
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SeaStar-56290"
  value: {
-  dps: 25938.80636
+  dps: 26012.56399
   tps: 14522.77564
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ShadowflameRegalia"
  value: {
-  dps: 26495.21128
+  dps: 26567.77201
   tps: 13640.70212
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ShardofWoe-60233"
  value: {
-  dps: 27592.86508
+  dps: 27667.17547
   tps: 14289.8977
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 26699.90358
+  dps: 26772.60221
   tps: 13830.67082
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 26743.57011
+  dps: 26816.25225
   tps: 13883.18668
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 25231.05358
+  dps: 25305.28113
   tps: 13984.24407
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 25258.11328
+  dps: 25332.55133
   tps: 13988.23258
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Sorrowsong-55879"
  value: {
-  dps: 27671.07232
+  dps: 27746.23019
   tps: 14272.47541
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Sorrowsong-56400"
  value: {
-  dps: 27881.33083
+  dps: 27957.10158
   tps: 14362.1433
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 25346.23878
+  dps: 25419.1837
   tps: 14166.39457
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SoulCasket-58183"
  value: {
-  dps: 26741.18822
+  dps: 26817.26728
   tps: 14921.78455
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 27634.9464
+  dps: 27709.59873
   tps: 14322.18503
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-StumpofTime-62465"
  value: {
-  dps: 27628.27806
+  dps: 27702.58507
   tps: 14398.06925
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-StumpofTime-62470"
  value: {
-  dps: 27671.7602
+  dps: 27746.07382
   tps: 14385.75437
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 26808.75908
+  dps: 26881.44313
   tps: 13872.35098
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 26781.4704
+  dps: 26854.16786
   tps: 13859.96996
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 27861.76062
+  dps: 27937.11658
   tps: 14394.92383
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 26699.90358
+  dps: 26772.60221
   tps: 13830.67082
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TearofBlood-55819"
  value: {
-  dps: 27314.85879
+  dps: 27388.77463
   tps: 14190.66168
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TearofBlood-56351"
  value: {
-  dps: 27519.62347
+  dps: 27593.91806
   tps: 14263.46099
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 27682.90827
+  dps: 27757.95859
   tps: 14273.21667
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 28049.67083
+  dps: 28125.64114
   tps: 14436.31597
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 28240.0962
+  dps: 28317.10922
   tps: 14454.71064
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 28482.46528
+  dps: 28559.98132
   tps: 14591.89051
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 26699.90358
+  dps: 26772.60221
   tps: 13830.67082
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 26699.90358
+  dps: 26772.60221
   tps: 13830.67082
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 27095.29112
+  dps: 27169.38432
   tps: 13982.16999
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 27227.08697
+  dps: 27301.64503
   tps: 14032.66971
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 26781.62264
+  dps: 26854.58099
   tps: 13929.46717
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 26037.05338
+  dps: 26111.20664
   tps: 14540.26178
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-UnheededWarning-59520"
  value: {
-  dps: 26699.90358
+  dps: 26772.60221
   tps: 13830.67082
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 25002.23274
+  dps: 25074.77774
   tps: 13951.28255
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 25490.89627
+  dps: 25565.29316
   tps: 14157.09586
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 25490.89627
+  dps: 25565.29316
   tps: 14157.09586
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 25490.89627
+  dps: 25565.29316
   tps: 14157.09586
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 26808.75908
+  dps: 26881.44313
   tps: 13872.35098
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 26781.4704
+  dps: 26854.16786
   tps: 13859.96996
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 25014.57597
+  dps: 25087.11956
   tps: 13952.33595
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 26029.93375
+  dps: 26103.83938
   tps: 14573.81221
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 25014.57597
+  dps: 25087.11956
   tps: 13952.33595
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 26821.64115
+  dps: 26894.71108
   tps: 13968.3714
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 27374.96577
+  dps: 27449.10319
   tps: 14218.19975
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 27190.89476
+  dps: 27264.87771
   tps: 14113.06631
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 26702.16517
+  dps: 26774.86284
   tps: 13830.96298
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 27229.56467
+  dps: 27304.12175
   tps: 14032.98222
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 26702.16517
+  dps: 26774.86284
   tps: 13830.96298
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 26699.79982
+  dps: 26772.49845
   tps: 13830.56706
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 27595.7214
+  dps: 27669.76378
   tps: 14278.62015
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 26699.73998
+  dps: 26772.4386
   tps: 13830.50722
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 27673.44162
+  dps: 27748.00992
   tps: 14382.7102
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 28240.14218
+  dps: 28315.88593
   tps: 14591.21058
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 25371.81619
+  dps: 25445.74976
   tps: 14105.90588
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 25212.66916
+  dps: 25286.68709
   tps: 13928.78195
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 25212.66916
+  dps: 25286.68709
   tps: 13928.78195
  }
 }
 dps_results: {
  key: "TestDemonology-Average-Default"
  value: {
-  dps: 29177.96322
+  dps: 29255.89143
   tps: 15103.09646
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p1-Demonology Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 43220.55628
+  dps: 43293.3076
   tps: 37009.76728
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p1-Demonology Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28592.66634
+  dps: 28665.36862
   tps: 15015.27308
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p1-Demonology Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 45763.83321
+  dps: 45851.4673
   tps: 22197.67144
  }
 }
@@ -1291,21 +1291,21 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Settings-Human-p1-Demonology Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 42881.54961
+  dps: 42954.28454
   tps: 36650.55859
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p1-Demonology Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28250.43739
+  dps: 28323.1488
   tps: 14868.68133
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p1-Demonology Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 45123.26983
+  dps: 45210.7901
   tps: 21979.53446
  }
 }
@@ -1333,21 +1333,21 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Settings-Orc-p1-Demonology Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 44199.33401
+  dps: 44276.07706
   tps: 37315.43704
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p1-Demonology Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29054.25984
+  dps: 29130.97135
   tps: 15016.99359
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p1-Demonology Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 46794.4227
+  dps: 46887.11528
   tps: 22312.83702
  }
 }
@@ -1375,21 +1375,21 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Settings-Troll-p1-Demonology Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 44891.7816
+  dps: 44964.40448
   tps: 38578.78929
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p1-Demonology Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28626.61688
+  dps: 28699.21516
   tps: 15112.86183
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p1-Demonology Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 47053.23713
+  dps: 47140.37018
   tps: 23293.61828
  }
 }
@@ -1417,7 +1417,7 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 28901.32528
+  dps: 28971.91941
   tps: 15016.99359
  }
 }

--- a/sim/warlock/destruction/TestDestruction.results
+++ b/sim/warlock/destruction/TestDestruction.results
@@ -37,42 +37,42 @@ character_stats_results: {
 dps_results: {
  key: "TestDestruction-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 27349.78426
+  dps: 27353.69598
   tps: 17975.49519
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 26161.84026
+  dps: 26165.7402
   tps: 17253.67239
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 26329.38185
+  dps: 26333.26621
   tps: 17317.16546
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 26387.25362
+  dps: 26391.13799
   tps: 17355.65232
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 27063.34224
+  dps: 27067.25396
   tps: 17745.98643
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 25665.85689
+  dps: 25669.74126
   tps: 16977.21423
   hps: 100.40699
  }
@@ -80,1190 +80,1190 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 25583.89811
+  dps: 25587.78248
   tps: 16872.30322
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 27011.98507
+  dps: 27015.92463
   tps: 17768.16405
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BindingPromise-67037"
  value: {
-  dps: 25583.89811
+  dps: 25587.78248
   tps: 16872.30322
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 25766.51895
+  dps: 25770.40332
   tps: 17009.25895
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 25829.227
+  dps: 25833.11137
   tps: 17050.24953
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 25861.3534
+  dps: 25865.23777
   tps: 17073.55202
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 25587.90558
+  dps: 25591.78995
   tps: 16891.69408
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 26415.76702
+  dps: 26419.65139
   tps: 17375.4692
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 25581.50802
+  dps: 25585.39238
   tps: 16883.09664
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 25952.93474
+  dps: 25956.8743
   tps: 17126.36896
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 25564.22824
+  dps: 25568.11261
   tps: 16843.00813
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 25563.91636
+  dps: 25567.80073
   tps: 16858.37531
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 25583.89811
+  dps: 25587.78248
   tps: 16872.30322
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 26377.89562
+  dps: 26381.77999
   tps: 17358.12688
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 25583.89811
+  dps: 25587.78248
   tps: 16872.30322
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BottledLightning-66879"
  value: {
-  dps: 26276.6308
+  dps: 26280.55157
   tps: 17332.95051
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 27266.43169
+  dps: 27270.3488
   tps: 17536.54105
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 27540.49608
+  dps: 27544.41319
   tps: 18097.32168
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 27404.808
+  dps: 27408.73574
   tps: 18026.49882
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 26614.13245
+  dps: 26618.03807
   tps: 17606.5885
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 25583.89811
+  dps: 25587.78248
   tps: 16872.30322
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CrushingWeight-59506"
  value: {
-  dps: 25583.89811
+  dps: 25587.78248
   tps: 16872.30322
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CrushingWeight-65118"
  value: {
-  dps: 25583.89811
+  dps: 25587.78248
   tps: 16872.30322
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 25562.73239
+  dps: 25566.61676
   tps: 16842.14327
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 25583.89811
+  dps: 25587.78248
   tps: 16872.30322
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 25583.89811
+  dps: 25587.78248
   tps: 16872.30322
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 26566.54007
+  dps: 26570.44568
   tps: 17534.57344
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 25830.42829
+  dps: 25834.33951
   tps: 17068.23766
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 27132.5401
+  dps: 27136.46784
   tps: 17810.25637
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 26370.86516
+  dps: 26374.77408
   tps: 17447.99742
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 27063.34224
+  dps: 27067.25396
   tps: 17745.98643
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 26012.23677
+  dps: 26016.13156
   tps: 17173.95116
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 27259.50083
+  dps: 27263.41793
   tps: 17897.70183
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 27132.5401
+  dps: 27136.46784
   tps: 17810.25637
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 25583.89811
+  dps: 25587.78248
   tps: 16872.30322
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 25583.89811
+  dps: 25587.78248
   tps: 16872.30322
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 27063.34224
+  dps: 27067.25396
   tps: 17745.98643
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FallofMortality-59500"
  value: {
-  dps: 26566.54007
+  dps: 26570.44568
   tps: 17534.57344
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FallofMortality-65124"
  value: {
-  dps: 26718.02682
+  dps: 26721.93244
   tps: 17598.75954
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 25717.66958
+  dps: 25721.55395
   tps: 16956.5516
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 26438.77332
+  dps: 26442.67326
   tps: 17461.27439
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 25582.75622
+  dps: 25586.64059
   tps: 16866.09129
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 27227.3225
+  dps: 27231.22244
   tps: 17930.26936
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 25859.54392
+  dps: 25863.42829
   tps: 17084.59862
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 27135.01913
+  dps: 27138.93084
   tps: 17801.78583
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FluidDeath-58181"
  value: {
-  dps: 25733.59383
+  dps: 25737.4782
   tps: 16945.30467
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 27266.43169
+  dps: 27270.3488
   tps: 17880.51828
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 25960.25282
+  dps: 25964.19238
   tps: 17135.8452
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GaleofShadows-56138"
  value: {
-  dps: 26522.44421
+  dps: 26526.35313
   tps: 17506.57744
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GaleofShadows-56462"
  value: {
-  dps: 26760.63214
+  dps: 26764.54107
   tps: 17650.33531
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GearDetector-61462"
  value: {
-  dps: 25583.89811
+  dps: 25587.78248
   tps: 16872.30322
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 26171.43227
+  dps: 26175.33221
   tps: 17253.67314
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 25583.89811
+  dps: 25587.78248
   tps: 16872.30322
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 25583.89811
+  dps: 25587.78248
   tps: 16872.30322
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HarmlightToken-63839"
  value: {
-  dps: 26441.55254
+  dps: 26445.45248
   tps: 17495.70339
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 25583.89811
+  dps: 25587.78248
   tps: 16872.30322
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 26763.20089
+  dps: 26767.2205
   tps: 17711.57396
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 26965.22944
+  dps: 26969.25366
   tps: 17866.31675
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofRage-59224"
  value: {
-  dps: 25583.89811
+  dps: 25587.78248
   tps: 16872.30322
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofRage-65072"
  value: {
-  dps: 25583.89811
+  dps: 25587.78248
   tps: 16872.30322
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofSolace-55868"
  value: {
-  dps: 25869.61811
+  dps: 25873.52703
   tps: 17084.70076
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofSolace-56393"
  value: {
-  dps: 26017.10623
+  dps: 26021.01515
   tps: 17170.38863
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofThunder-55845"
  value: {
-  dps: 25595.69122
+  dps: 25599.57559
   tps: 16890.32442
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofThunder-56370"
  value: {
-  dps: 25582.86985
+  dps: 25586.75422
   tps: 16874.93714
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 25583.89811
+  dps: 25587.78248
   tps: 16872.30322
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 27132.5401
+  dps: 27136.46784
   tps: 17810.25637
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 25894.66425
+  dps: 25898.54862
   tps: 17110.0515
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 25894.66425
+  dps: 25898.54862
   tps: 17110.0515
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 25829.227
+  dps: 25833.11137
   tps: 17050.24953
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 25861.3534
+  dps: 25865.23777
   tps: 17073.55202
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 25595.69122
+  dps: 25599.57559
   tps: 16890.23382
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 26250.67431
+  dps: 26254.55868
   tps: 17290.36571
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 25635.49847
+  dps: 25639.38284
   tps: 16946.55361
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 25713.29688
+  dps: 25717.18125
   tps: 17010.66915
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 25766.51895
+  dps: 25770.40332
   tps: 17009.25895
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 25733.59383
+  dps: 25737.4782
   tps: 16945.30467
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 25733.59383
+  dps: 25737.4782
   tps: 16945.30467
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 25716.21853
+  dps: 25720.13305
   tps: 17043.53367
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 25716.21853
+  dps: 25720.13305
   tps: 17043.53367
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 25684.8353
+  dps: 25688.72506
   tps: 16917.14609
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LeadenDespair-55816"
  value: {
-  dps: 25585.71829
+  dps: 25589.60265
   tps: 16874.28781
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LeadenDespair-56347"
  value: {
-  dps: 25582.75622
+  dps: 25586.64059
   tps: 16866.09129
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 25583.89811
+  dps: 25587.78248
   tps: 16872.30322
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 25583.89811
+  dps: 25587.78248
   tps: 16872.30322
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 25733.59383
+  dps: 25737.4782
   tps: 16945.30467
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 25553.19639
+  dps: 25557.08076
   tps: 16854.69411
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 25553.19639
+  dps: 25557.08076
   tps: 16854.69411
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 25583.74128
+  dps: 25587.62564
   tps: 16869.53946
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 25583.74128
+  dps: 25587.62564
   tps: 16869.53946
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 25824.4328
+  dps: 25828.31717
   tps: 17053.17718
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 25859.95186
+  dps: 25863.83622
   tps: 17079.16901
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 25714.25089
+  dps: 25718.13525
   tps: 16974.71233
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 25714.25089
+  dps: 25718.13525
   tps: 16974.71233
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 25896.40039
+  dps: 25900.28476
   tps: 17098.97292
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 25896.40039
+  dps: 25900.28476
   tps: 17098.97292
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 27090.48233
+  dps: 27094.38795
   tps: 17934.74745
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 25850.69121
+  dps: 25854.61741
   tps: 16993.08437
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 25583.89811
+  dps: 25587.78248
   tps: 16872.30322
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 26488.13019
+  dps: 26492.04745
   tps: 17475.1359
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 25583.89811
+  dps: 25587.78248
   tps: 16872.30322
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 25583.89811
+  dps: 25587.78248
   tps: 16872.30322
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 27063.34224
+  dps: 27067.25396
   tps: 17745.98643
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 25583.89811
+  dps: 25587.78248
   tps: 16872.30322
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 25583.89811
+  dps: 25587.78248
   tps: 16872.30322
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Rainsong-55854"
  value: {
-  dps: 25583.74128
+  dps: 25587.62564
   tps: 16869.56146
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Rainsong-56377"
  value: {
-  dps: 25583.74128
+  dps: 25587.62564
   tps: 16869.54693
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 27349.78426
+  dps: 27353.69598
   tps: 17975.49519
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 27349.78426
+  dps: 27353.69598
   tps: 17975.4885
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 25733.59383
+  dps: 25737.4782
   tps: 16945.30467
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 25733.59383
+  dps: 25737.4782
   tps: 16945.30467
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 25583.89811
+  dps: 25587.78248
   tps: 16872.30322
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SeaStar-55256"
  value: {
-  dps: 26022.53084
+  dps: 26026.41521
   tps: 17144.26545
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SeaStar-56290"
  value: {
-  dps: 26404.65765
+  dps: 26408.54202
   tps: 17375.00022
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ShadowflameRegalia"
  value: {
-  dps: 24794.50285
+  dps: 24798.31785
   tps: 16294.16992
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ShardofWoe-60233"
  value: {
-  dps: 26190.17076
+  dps: 26194.06072
   tps: 17249.359
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 25583.89811
+  dps: 25587.78248
   tps: 16872.30322
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 25596.92389
+  dps: 25600.80826
   tps: 16871.84821
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 25895.34159
+  dps: 25899.22596
   tps: 17110.44829
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 25936.43885
+  dps: 25940.32322
   tps: 17140.22053
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Sorrowsong-55879"
  value: {
-  dps: 26388.16874
+  dps: 26392.0531
   tps: 17414.46616
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Sorrowsong-56400"
  value: {
-  dps: 26494.2481
+  dps: 26498.13247
   tps: 17486.02464
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 25714.25089
+  dps: 25718.13525
   tps: 16974.71233
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SoulCasket-58183"
  value: {
-  dps: 26964.13917
+  dps: 26968.02354
   tps: 17742.91359
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 26526.26194
+  dps: 26530.1841
   tps: 17482.05079
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-StumpofTime-62465"
  value: {
-  dps: 26477.33613
+  dps: 26481.2205
   tps: 17414.55081
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-StumpofTime-62470"
  value: {
-  dps: 26486.55674
+  dps: 26490.4411
   tps: 17408.80932
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 25580.93146
+  dps: 25584.81583
   tps: 16853.50781
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 25603.57451
+  dps: 25607.45888
   tps: 16885.04277
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 26581.25314
+  dps: 26585.15308
   tps: 17545.3032
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 25583.89811
+  dps: 25587.78248
   tps: 16872.30322
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TearofBlood-55819"
  value: {
-  dps: 26267.28908
+  dps: 26271.18902
   tps: 17322.16614
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TearofBlood-56351"
  value: {
-  dps: 26482.40958
+  dps: 26486.30951
   tps: 17477.37436
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 26372.85348
+  dps: 26376.73785
   tps: 17391.18306
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 26639.30537
+  dps: 26643.18974
   tps: 17557.57072
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 27002.65073
+  dps: 27006.55635
   tps: 17852.61625
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 27214.28593
+  dps: 27218.19155
   tps: 17958.26676
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 25583.89811
+  dps: 25587.78248
   tps: 16872.30322
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 25583.89811
+  dps: 25587.78248
   tps: 16872.30322
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 25829.227
+  dps: 25833.11137
   tps: 17050.24953
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 25861.3534
+  dps: 25865.23777
   tps: 17073.55202
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 25750.68705
+  dps: 25754.57141
   tps: 16977.27006
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 26329.01127
+  dps: 26332.91689
   tps: 17406.42894
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-UnheededWarning-59520"
  value: {
-  dps: 25583.89811
+  dps: 25587.78248
   tps: 16872.30322
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 25590.2215
+  dps: 25594.10587
   tps: 16890.16523
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 25894.66425
+  dps: 25898.54862
   tps: 17110.0515
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 25894.66425
+  dps: 25898.54862
   tps: 17110.0515
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 25894.66425
+  dps: 25898.54862
   tps: 17110.0515
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 25580.93146
+  dps: 25584.81583
   tps: 16853.50781
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 25603.57451
+  dps: 25607.45888
   tps: 16885.04277
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 25581.50802
+  dps: 25585.39238
   tps: 16883.09664
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 26462.41966
+  dps: 26466.30403
   tps: 17403.00319
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 25581.50802
+  dps: 25585.39238
   tps: 16883.09664
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 25757.58209
+  dps: 25761.46646
   tps: 16971.718
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 26019.62037
+  dps: 26023.52929
   tps: 17179.19182
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 25985.0164
+  dps: 25988.95596
   tps: 17144.81563
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 25562.73239
+  dps: 25566.61676
   tps: 16842.23723
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 25893.19503
+  dps: 25897.0794
   tps: 17081.70013
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 25562.73239
+  dps: 25566.61676
   tps: 16842.23723
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 25583.89811
+  dps: 25587.78248
   tps: 16872.30322
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 26369.06126
+  dps: 26372.94563
   tps: 17350.39867
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 25583.89811
+  dps: 25587.78248
   tps: 16872.30322
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 26345.14669
+  dps: 26349.06708
   tps: 17372.22578
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 26808.16501
+  dps: 26812.13904
   tps: 17745.16839
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 25795.15666
+  dps: 25799.04103
   tps: 17037.935
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 25851.2261
+  dps: 25855.11047
   tps: 17081.21954
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 25851.2261
+  dps: 25855.11047
   tps: 17081.21954
  }
 }
 dps_results: {
  key: "TestDestruction-Average-Default"
  value: {
-  dps: 27818.24944
+  dps: 27822.33358
   tps: 18345.19625
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Goblin-p1-Destruction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 28317.63974
+  dps: 28321.3749
   tps: 32364.6365
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Goblin-p1-Destruction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 27110.876
+  dps: 27114.61116
   tps: 17991.06324
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Goblin-p1-Destruction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 36626.99345
+  dps: 36630.31352
   tps: 22551.80784
  }
 }
@@ -1291,21 +1291,21 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Settings-Human-p1-Destruction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 28154.72166
+  dps: 28158.45223
   tps: 32264.74024
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p1-Destruction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 27049.41565
+  dps: 27053.14622
   tps: 17958.34043
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p1-Destruction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 36527.51714
+  dps: 36530.83721
   tps: 22570.78608
  }
 }
@@ -1333,21 +1333,21 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Settings-Orc-p1-Destruction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 28670.90528
+  dps: 28674.82238
   tps: 32407.21752
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p1-Destruction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 27540.49608
+  dps: 27544.41319
   tps: 18097.32168
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p1-Destruction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 37589.98932
+  dps: 37593.47539
   tps: 22876.16243
  }
 }
@@ -1375,21 +1375,21 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Settings-Troll-p1-Destruction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 28521.66413
+  dps: 28525.3947
   tps: 32484.83407
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p1-Destruction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 27347.13814
+  dps: 27350.86871
   tps: 18169.69806
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p1-Destruction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 37857.28161
+  dps: 37860.60168
   tps: 23376.63766
  }
 }
@@ -1417,7 +1417,7 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 27533.13202
+  dps: 27536.75456
   tps: 18097.32168
  }
 }

--- a/sim/warrior/arms/TestArms.results
+++ b/sim/warrior/arms/TestArms.results
@@ -37,1366 +37,1366 @@ character_stats_results: {
 dps_results: {
  key: "TestArms-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 26418.41359
-  tps: 18187.62918
+  dps: 27452.03544
+  tps: 18889.84375
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 25980.4942
-  tps: 17889.19126
+  dps: 26996.59927
+  tps: 18579.46831
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
   hps: 96.7093
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 25418.53589
-  tps: 17299.30617
+  dps: 26435.27732
+  tps: 17989.09819
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 25481.47187
-  tps: 17348.36842
+  dps: 26500.73074
+  tps: 18040.12293
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BindingPromise-67037"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 25137.41361
-  tps: 17125.44859
+  dps: 26142.91015
+  tps: 17808.29835
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 24911.49607
-  tps: 17012.4207
+  dps: 25907.95591
+  tps: 17690.75649
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 24935.51291
-  tps: 17027.70354
+  dps: 25932.93342
+  tps: 17706.64691
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 25324.3464
-  tps: 17236.13022
+  dps: 26337.32026
+  tps: 17923.38651
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 26256.60091
-  tps: 17931.20488
+  dps: 27306.86495
+  tps: 18646.26416
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 25345.41714
-  tps: 17259.17274
+  dps: 26359.23382
+  tps: 17947.35942
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 25332.15321
-  tps: 17184.69468
+  dps: 26345.43934
+  tps: 17869.89528
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 25688.30318
-  tps: 17451.11271
+  dps: 26715.83531
+  tps: 18146.9683
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BottledLightning-66879"
  value: {
-  dps: 25121.47674
-  tps: 17040.96991
+  dps: 26126.33581
+  tps: 17720.42862
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 25980.4942
-  tps: 17531.49991
+  dps: 26996.59927
+  tps: 18207.97143
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 27003.09292
-  tps: 18578.15232
+  dps: 28060.10194
+  tps: 19295.98782
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 26332.13164
-  tps: 18121.53543
+  dps: 27362.30221
+  tps: 18821.10625
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 26445.188
-  tps: 18207.24012
+  dps: 27479.88082
+  tps: 18910.23912
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ColossalDragonplateArmor"
  value: {
-  dps: 23225.31435
-  tps: 16189.45233
+  dps: 24130.7708
+  tps: 16811.33826
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ColossalDragonplateBattlegear"
  value: {
-  dps: 26152.66077
-  tps: 18111.40419
+  dps: 27174.58527
+  tps: 18809.45841
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CrushingWeight-59506"
  value: {
-  dps: 26203.9242
-  tps: 17767.63006
+  dps: 27252.08117
+  tps: 18476.09041
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CrushingWeight-65118"
  value: {
-  dps: 26305.40488
-  tps: 17972.8559
+  dps: 27357.62107
+  tps: 18689.49707
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 26004.12897
-  tps: 17930.47654
+  dps: 27021.17943
+  tps: 18622.4137
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 25059.2723
-  tps: 17215.11999
+  dps: 26061.64319
+  tps: 17901.54066
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 25580.33487
-  tps: 17453.98152
+  dps: 26603.54826
+  tps: 18149.91582
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 26088.91033
-  tps: 17971.65745
+  dps: 27109.35204
+  tps: 18665.23315
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 25229.74832
-  tps: 17181.42433
+  dps: 26238.93825
+  tps: 17866.46754
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EarthenBattleplate"
  value: {
-  dps: 23003.25328
-  tps: 15849.19757
+  dps: 23900.70578
+  tps: 16458.36537
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EarthenWarplate"
  value: {
-  dps: 25084.08408
-  tps: 17331.31942
+  dps: 26063.32163
+  tps: 17998.13474
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 25980.4942
-  tps: 17889.19126
+  dps: 26996.59927
+  tps: 18579.46831
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 25980.4942
-  tps: 17889.19126
+  dps: 26996.59927
+  tps: 18579.46831
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 26088.91033
-  tps: 17971.65745
+  dps: 27109.35204
+  tps: 18665.23315
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 25855.79106
-  tps: 17599.23594
+  dps: 26890.02271
+  tps: 18301.02342
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 25900.23005
-  tps: 17636.56228
+  dps: 26936.23926
+  tps: 18339.84972
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 25980.4942
-  tps: 17889.19126
+  dps: 26996.59927
+  tps: 18579.46831
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FallofMortality-59500"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FallofMortality-65124"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 25302.02016
-  tps: 17215.75322
+  dps: 26314.10097
+  tps: 17902.19444
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 26222.38162
-  tps: 17981.49114
+  dps: 27271.27689
+  tps: 18698.58602
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 26002.2066
-  tps: 17881.20325
+  dps: 27018.95895
+  tps: 18570.93967
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FluidDeath-58181"
  value: {
-  dps: 25332.50733
-  tps: 17251.49975
+  dps: 26345.80763
+  tps: 17939.37952
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 25980.4942
-  tps: 17889.19126
+  dps: 26996.59927
+  tps: 18579.46831
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 26568.43324
-  tps: 18011.48481
+  dps: 27631.17057
+  tps: 18729.76398
  }
 }
 dps_results: {
  key: "TestArms-AllItems-GaleofShadows-56138"
  value: {
-  dps: 25240.2919
-  tps: 17248.76165
+  dps: 26249.90357
+  tps: 17936.46008
  }
 }
 dps_results: {
  key: "TestArms-AllItems-GaleofShadows-56462"
  value: {
-  dps: 25327.05437
-  tps: 17269.15818
+  dps: 26340.13655
+  tps: 17957.67624
  }
 }
 dps_results: {
  key: "TestArms-AllItems-GearDetector-61462"
  value: {
-  dps: 25350.81908
-  tps: 17330.44938
+  dps: 26364.85185
+  tps: 18021.46062
  }
 }
 dps_results: {
  key: "TestArms-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 25296.60672
-  tps: 17222.47745
+  dps: 26308.47098
+  tps: 17909.18764
  }
 }
 dps_results: {
  key: "TestArms-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 25574.66007
-  tps: 17417.0404
+  dps: 26597.64647
+  tps: 18111.5402
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HarmlightToken-63839"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 25795.47487
-  tps: 17600.40121
+  dps: 26827.29387
+  tps: 18302.2594
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartofRage-59224"
  value: {
-  dps: 26042.95989
-  tps: 17803.90822
+  dps: 27084.67829
+  tps: 18513.86506
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartofRage-65072"
  value: {
-  dps: 26232.44403
-  tps: 17956.39627
+  dps: 27281.74179
+  tps: 18672.45263
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartofSolace-55868"
  value: {
-  dps: 25240.2919
-  tps: 17248.76165
+  dps: 26249.90357
+  tps: 17936.46008
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartofSolace-56393"
  value: {
-  dps: 26346.93974
-  tps: 18030.1804
+  dps: 27400.81733
+  tps: 18749.13935
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartofThunder-55845"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartofThunder-56370"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 25340.1178
-  tps: 17249.83883
+  dps: 26353.72251
+  tps: 17937.64346
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 26088.91033
-  tps: 17971.65745
+  dps: 27109.35204
+  tps: 18665.23315
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 26527.20757
-  tps: 18304.63835
+  dps: 27588.29587
+  tps: 19034.63976
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 26527.20757
-  tps: 18304.63835
+  dps: 27588.29587
+  tps: 19034.63976
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 24911.49607
-  tps: 17012.4207
+  dps: 25907.95591
+  tps: 17690.75649
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 24935.51291
-  tps: 17027.70354
+  dps: 25932.93342
+  tps: 17706.64691
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 24990.64421
-  tps: 17043.13424
+  dps: 25990.26998
+  tps: 17722.68936
  }
 }
 dps_results: {
  key: "TestArms-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 25137.41361
-  tps: 17125.44859
+  dps: 26142.91015
+  tps: 17808.29835
  }
 }
 dps_results: {
  key: "TestArms-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 25213.47788
-  tps: 17106.72297
+  dps: 26222.01699
+  tps: 17788.80642
  }
 }
 dps_results: {
  key: "TestArms-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 25358.14748
-  tps: 17223.83892
+  dps: 26372.47338
+  tps: 17910.60356
  }
 }
 dps_results: {
  key: "TestArms-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 25903.77811
-  tps: 17682.52825
+  dps: 26939.92923
+  tps: 18387.6122
  }
 }
 dps_results: {
  key: "TestArms-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 25903.77811
-  tps: 17682.52825
+  dps: 26939.92923
+  tps: 18387.6122
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 24891.39824
-  tps: 17035.83955
+  dps: 25887.05417
+  tps: 17715.03894
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LastWord-50708"
  value: {
-  dps: 26782.57884
-  tps: 18420.89143
+  dps: 27830.76729
+  tps: 19132.43649
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LeadenDespair-55816"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LeadenDespair-56347"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 25188.56655
-  tps: 17168.93469
+  dps: 26196.10921
+  tps: 17853.49259
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 25281.46923
-  tps: 17218.02652
+  dps: 26292.728
+  tps: 17904.54809
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 25805.61223
-  tps: 17632.807
+  dps: 26837.83672
+  tps: 18335.91979
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 26096.25086
-  tps: 17851.44938
+  dps: 27140.1009
+  tps: 18563.30786
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 25933.87576
-  tps: 17702.54173
+  dps: 26971.23079
+  tps: 18408.49009
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 26220.66681
-  tps: 17829.53301
+  dps: 27269.49349
+  tps: 18540.55792
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 25501.19084
-  tps: 17383.95138
+  dps: 26521.23848
+  tps: 18077.12052
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 26045.64975
-  tps: 17796.44421
+  dps: 27087.47574
+  tps: 18506.11307
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 25059.2723
-  tps: 17215.11999
+  dps: 26061.64319
+  tps: 17901.54066
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 25059.2723
-  tps: 17215.11999
+  dps: 26061.64319
+  tps: 17901.54066
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MoltenGiantBattleplate"
  value: {
-  dps: 23933.07029
-  tps: 16600.39663
+  dps: 24866.72978
+  tps: 17238.61215
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MoltenGiantWarplate"
  value: {
-  dps: 28727.49427
-  tps: 20050.64039
+  dps: 29832.11351
+  tps: 20805.92846
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 25161.0472
-  tps: 17298.29962
+  dps: 26167.48909
+  tps: 17988.03251
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 25910.34038
-  tps: 17543.13735
+  dps: 26946.754
+  tps: 18242.68275
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 25201.77697
-  tps: 17144.19554
+  dps: 26209.84805
+  tps: 17827.77444
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 25058.81125
-  tps: 17058.72438
+  dps: 26061.1637
+  tps: 17738.89797
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 25205.00981
-  tps: 17344.51645
+  dps: 26213.2102
+  tps: 18036.1109
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 25980.4942
-  tps: 17889.19126
+  dps: 26996.59927
+  tps: 18579.46831
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 25620.21438
-  tps: 17387.1222
+  dps: 26645.02295
+  tps: 18080.35679
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 25642.98326
-  tps: 17497.32743
+  dps: 26668.70259
+  tps: 18194.96394
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Rainsong-55854"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Rainsong-56377"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 26483.72959
-  tps: 18224.7041
+  dps: 27519.96408
+  tps: 18928.40167
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 26332.13164
-  tps: 18121.53543
+  dps: 27362.30221
+  tps: 18821.10625
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 25633.16495
-  tps: 17412.12211
+  dps: 26658.49154
+  tps: 18106.41808
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 25758.24828
-  tps: 17504.02548
+  dps: 26788.57822
+  tps: 18201.99759
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 25364.50022
-  tps: 17332.78807
+  dps: 26379.08022
+  tps: 18023.94174
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SeaStar-55256"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SeaStar-56290"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Shadowmourne-49623"
  value: {
-  dps: 27804.8131
-  tps: 19299.37236
+  dps: 28889.08569
+  tps: 20041.21916
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ShardofWoe-60233"
  value: {
-  dps: 25176.96718
-  tps: 17230.95081
+  dps: 26184.04587
+  tps: 17917.94446
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 25754.82584
-  tps: 17600.45527
+  dps: 26785.01888
+  tps: 18302.23808
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 25471.51626
-  tps: 17403.70828
+  dps: 26490.37691
+  tps: 18097.66481
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 25582.14998
-  tps: 17547.63078
+  dps: 26605.43597
+  tps: 18247.33998
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Sorrowsong-55879"
  value: {
-  dps: 24911.49607
-  tps: 17012.4207
+  dps: 25907.95591
+  tps: 17690.75649
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Sorrowsong-56400"
  value: {
-  dps: 24935.51291
-  tps: 17027.70354
+  dps: 25932.93342
+  tps: 17706.64691
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 25501.19084
-  tps: 17383.95138
+  dps: 26521.23848
+  tps: 18077.12052
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SoulCasket-58183"
  value: {
-  dps: 25059.2723
-  tps: 17215.11999
+  dps: 26061.64319
+  tps: 17901.54066
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StumpofTime-62465"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StumpofTime-62470"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 25614.03297
-  tps: 17544.33951
+  dps: 26638.59429
+  tps: 18243.86739
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TearofBlood-55819"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TearofBlood-56351"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 24979.6391
-  tps: 17022.04552
+  dps: 25978.82466
+  tps: 17700.759
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 24935.51291
-  tps: 17027.70354
+  dps: 25932.93342
+  tps: 17706.64691
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 25368.63459
-  tps: 17326.79998
+  dps: 26383.37997
+  tps: 18017.70894
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 25314.85515
-  tps: 17326.77156
+  dps: 26327.44936
+  tps: 18017.67161
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 25638.8455
-  tps: 17508.90273
+  dps: 26664.39932
+  tps: 18207.08649
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-UnheededWarning-59520"
  value: {
-  dps: 25794.83924
-  tps: 17572.98345
+  dps: 26826.63281
+  tps: 18273.72256
  }
 }
 dps_results: {
  key: "TestArms-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 25641.96452
-  tps: 17611.54619
+  dps: 26667.6431
+  tps: 18313.82395
  }
 }
 dps_results: {
  key: "TestArms-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 25641.96452
-  tps: 17611.54619
+  dps: 26667.6431
+  tps: 18313.82395
  }
 }
 dps_results: {
  key: "TestArms-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 25641.96452
-  tps: 17611.54619
+  dps: 26667.6431
+  tps: 18313.82395
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 14606.84563
-  tps: 9573.85157
+  dps: 15175.54875
+  tps: 9938.8919
  }
 }
 dps_results: {
  key: "TestArms-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 25497.73462
-  tps: 17263.95078
+  dps: 26517.644
+  tps: 17952.32872
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 26334.13475
-  tps: 17988.54466
+  dps: 27387.50014
+  tps: 18705.89753
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 25295.06694
-  tps: 17204.62706
+  dps: 26306.86962
+  tps: 17890.55973
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 25446.40884
-  tps: 17320.43097
+  dps: 26464.26519
+  tps: 18011.06798
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 24912.93644
-  tps: 16961.26255
+  dps: 25909.4539
+  tps: 17637.51356
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 25106.03449
-  tps: 17176.38651
+  dps: 26110.27587
+  tps: 17861.26202
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 25380.20543
-  tps: 17218.31136
+  dps: 26395.41364
+  tps: 17904.85663
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 25802.9342
-  tps: 17535.81406
+  dps: 26835.05157
+  tps: 18235.05771
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 24870.11347
-  tps: 16905.83468
+  dps: 25864.91801
+  tps: 17579.87915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 24932.59013
-  tps: 16966.35183
+  dps: 25929.89373
+  tps: 17642.83945
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 24998.27509
-  tps: 17111.97644
+  dps: 25998.20609
+  tps: 17794.28322
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 24998.27509
-  tps: 17111.97644
+  dps: 25998.20609
+  tps: 17794.28322
  }
 }
 dps_results: {
  key: "TestArms-Average-Default"
  value: {
-  dps: 26426.55001
-  tps: 18157.89371
+  dps: 27460.62212
+  tps: 18859.01061
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-preraid_arms-Basic-arms-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 55920.92457
-  tps: 29740.1868
+  dps: 57830.92929
+  tps: 31082.89414
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-preraid_arms-Basic-arms-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26483.72959
-  tps: 18224.7041
+  dps: 27519.96408
+  tps: 18928.40167
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-preraid_arms-Basic-arms-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 31092.16389
-  tps: 21613.7219
+  dps: 32312.62858
+  tps: 22452.20975
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-preraid_arms-Basic-arms-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 35183.16633
-  tps: 17443.42739
+  dps: 36834.26121
+  tps: 18768.71225
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-preraid_arms-Basic-arms-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 16072.84803
-  tps: 10692.05663
+  dps: 17286.0209
+  tps: 11688.03712
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-preraid_arms-Basic-arms-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 17474.49577
-  tps: 11645.2779
+  dps: 18829.05611
+  tps: 12764.33659
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-preraid_arms-Basic-arms-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 55761.71123
-  tps: 29515.98175
+  dps: 57703.07795
+  tps: 30877.97759
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-preraid_arms-Basic-arms-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26512.06333
-  tps: 18184.0697
+  dps: 27549.34192
+  tps: 18886.03942
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-preraid_arms-Basic-arms-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 30730.30255
-  tps: 21316.25599
+  dps: 31936.29278
+  tps: 22142.84521
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-preraid_arms-Basic-arms-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 35142.20949
-  tps: 17238.7231
+  dps: 36814.96668
+  tps: 18570.23626
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-preraid_arms-Basic-arms-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 16002.14477
-  tps: 10625.81904
+  dps: 17196.9218
+  tps: 11603.5816
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-preraid_arms-Basic-arms-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 17339.36758
-  tps: 11526.86522
+  dps: 18673.88981
+  tps: 12626.55444
  }
 }
 dps_results: {
  key: "TestArms-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 24303.79759
-  tps: 16928.18648
+  dps: 25253.9291
+  tps: 17581.18352
  }
 }

--- a/sim/warrior/fury/TestFury.results
+++ b/sim/warrior/fury/TestFury.results
@@ -37,1311 +37,1311 @@ character_stats_results: {
 dps_results: {
  key: "TestFury-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 27066.93101
-  tps: 23252.40091
+  dps: 28149.60825
+  tps: 24179.93959
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 25917.86721
-  tps: 22189.58926
+  dps: 26954.5819
+  tps: 23074.55373
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 25885.50448
-  tps: 22202.3268
+  dps: 26920.92466
+  tps: 23087.78823
  }
 }
 dps_results: {
  key: "TestFury-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 26708.97886
-  tps: 23029.01355
+  dps: 27777.33802
+  tps: 23947.60428
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
   hps: 96.7093
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 26405.59758
-  tps: 22606.09865
+  dps: 27461.82148
+  tps: 23507.7987
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 26290.49431
-  tps: 22525.63734
+  dps: 27342.11408
+  tps: 23424.11402
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BindingPromise-67037"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BlackBruise-50692"
  value: {
-  dps: 25530.41414
-  tps: 21984.34636
+  dps: 26551.6307
+  tps: 22861.22744
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 25972.57381
-  tps: 22233.12341
+  dps: 27011.47677
+  tps: 23119.87007
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 25710.97251
-  tps: 21975.12596
+  dps: 26739.41142
+  tps: 22851.58796
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 25776.9774
-  tps: 22007.76027
+  dps: 26808.05649
+  tps: 22885.52383
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 25986.82272
-  tps: 22298.17398
+  dps: 27026.29563
+  tps: 23187.50841
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 26555.03177
-  tps: 22681.17682
+  dps: 27617.23304
+  tps: 23585.87872
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 26229.52533
-  tps: 22419.94531
+  dps: 27278.70635
+  tps: 23314.20577
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 25973.15231
-  tps: 22226.00191
+  dps: 27012.0784
+  tps: 23112.45416
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 26313.32567
-  tps: 22544.27061
+  dps: 27365.85869
+  tps: 23443.49626
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BottledLightning-66879"
  value: {
-  dps: 25718.42566
-  tps: 21943.92779
+  dps: 26747.16269
+  tps: 22819.13943
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 26708.97886
-  tps: 22568.49862
+  dps: 27777.33802
+  tps: 23468.71754
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 27188.37566
-  tps: 23437.51925
+  dps: 28275.91069
+  tps: 24372.45021
  }
 }
 dps_results: {
  key: "TestFury-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 27015.63851
-  tps: 23288.5948
+  dps: 28096.26405
+  tps: 24217.56878
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 27123.28217
-  tps: 23328.46892
+  dps: 28208.21345
+  tps: 24259.03445
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ColossalDragonplateArmor"
  value: {
-  dps: 22764.31774
-  tps: 19159.04934
+  dps: 23674.89045
+  tps: 19923.20645
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ColossalDragonplateBattlegear"
  value: {
-  dps: 25526.51309
-  tps: 21759.41202
+  dps: 26547.57361
+  tps: 22627.36657
  }
 }
 dps_results: {
  key: "TestFury-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-CrushingWeight-59506"
  value: {
-  dps: 27013.91744
-  tps: 23115.6255
+  dps: 28094.47414
+  tps: 24037.62406
  }
 }
 dps_results: {
  key: "TestFury-AllItems-CrushingWeight-65118"
  value: {
-  dps: 27204.24772
-  tps: 23376.78282
+  dps: 28292.41763
+  tps: 24309.17599
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 27026.95191
-  tps: 23247.48342
+  dps: 28085.91556
+  tps: 24152.73522
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 26594.59238
-  tps: 22904.61347
+  dps: 27636.0567
+  tps: 23795.90337
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 25919.90849
-  tps: 22077.54866
+  dps: 26956.70483
+  tps: 22958.08282
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 26318.37567
-  tps: 22662.36437
+  dps: 27371.1107
+  tps: 23566.27377
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 26809.81942
-  tps: 23066.16246
+  dps: 27882.21219
+  tps: 23986.23573
  }
 }
 dps_results: {
  key: "TestFury-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 25850.44751
-  tps: 22173.14886
+  dps: 26884.46541
+  tps: 23057.47789
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EarthenBattleplate"
  value: {
-  dps: 22318.23457
-  tps: 18860.37919
+  dps: 23210.96395
+  tps: 19612.57525
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EarthenWarplate"
  value: {
-  dps: 24893.00992
-  tps: 21269.25405
+  dps: 25888.73032
+  tps: 22117.5517
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 26708.97886
-  tps: 23029.01355
+  dps: 27777.33802
+  tps: 23947.60428
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 26708.97886
-  tps: 23029.01355
+  dps: 27777.33802
+  tps: 23947.60428
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 26809.81942
-  tps: 23066.16246
+  dps: 27882.21219
+  tps: 23986.23573
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 26814.53269
-  tps: 23010.41633
+  dps: 27887.114
+  tps: 23928.21491
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 26872.18687
-  tps: 23144.04849
+  dps: 27947.07435
+  tps: 24067.20811
  }
 }
 dps_results: {
  key: "TestFury-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 26708.97886
-  tps: 23029.01355
+  dps: 27777.33802
+  tps: 23947.60428
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FallofMortality-59500"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FallofMortality-65124"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 26498.04725
-  tps: 22688.58779
+  dps: 27557.96914
+  tps: 23593.48769
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 26943.61414
-  tps: 22940.5188
+  dps: 28021.35871
+  tps: 23855.5927
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 26791.32724
-  tps: 23038.37682
+  dps: 27862.98033
+  tps: 23957.32244
  }
 }
 dps_results: {
  key: "TestFury-AllItems-FluidDeath-58181"
  value: {
-  dps: 26631.4481
-  tps: 22811.90701
+  dps: 27696.70602
+  tps: 23721.72385
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 26708.97886
-  tps: 23029.01355
+  dps: 27777.33802
+  tps: 23947.60428
  }
 }
 dps_results: {
  key: "TestFury-AllItems-GaleofShadows-56138"
  value: {
-  dps: 25812.59779
-  tps: 22104.91551
+  dps: 26845.1017
+  tps: 22986.4808
  }
 }
 dps_results: {
  key: "TestFury-AllItems-GaleofShadows-56462"
  value: {
-  dps: 25741.86422
-  tps: 22000.75538
+  dps: 26771.53879
+  tps: 22878.17432
  }
 }
 dps_results: {
  key: "TestFury-AllItems-GearDetector-61462"
  value: {
-  dps: 25944.2355
-  tps: 22214.17943
+  dps: 26982.00492
+  tps: 23100.14767
  }
 }
 dps_results: {
  key: "TestFury-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 25799.38537
-  tps: 22008.25121
+  dps: 26831.36079
+  tps: 22886.06016
  }
 }
 dps_results: {
  key: "TestFury-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 26399.62086
-  tps: 22639.90773
+  dps: 27455.6057
+  tps: 23542.93758
  }
 }
 dps_results: {
  key: "TestFury-AllItems-HarmlightToken-63839"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 26268.0805
-  tps: 22375.91948
+  dps: 27318.80372
+  tps: 23268.42245
  }
 }
 dps_results: {
  key: "TestFury-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-HeartofRage-59224"
  value: {
-  dps: 27036.91745
-  tps: 23285.47552
+  dps: 28118.39415
+  tps: 24214.32473
  }
 }
 dps_results: {
  key: "TestFury-AllItems-HeartofSolace-55868"
  value: {
-  dps: 25812.59779
-  tps: 22104.91551
+  dps: 26845.1017
+  tps: 22986.4808
  }
 }
 dps_results: {
  key: "TestFury-AllItems-HeartofSolace-56393"
  value: {
-  dps: 26876.02597
-  tps: 23036.53537
+  dps: 27951.06701
+  tps: 23955.38551
  }
 }
 dps_results: {
  key: "TestFury-AllItems-HeartofThunder-55845"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-HeartofThunder-56370"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 25826.12369
-  tps: 22142.44887
+  dps: 26859.16863
+  tps: 23025.61096
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Heartpierce-50641"
  value: {
-  dps: 27188.37566
-  tps: 23437.51925
+  dps: 28275.91069
+  tps: 24372.45021
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 26809.81942
-  tps: 23066.16246
+  dps: 27882.21219
+  tps: 23986.23573
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 27248.10106
-  tps: 23129.82038
+  dps: 28338.0251
+  tps: 24052.44542
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 27248.10106
-  tps: 23129.82038
+  dps: 28338.0251
+  tps: 24052.44542
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 25710.97251
-  tps: 21975.12596
+  dps: 26739.41142
+  tps: 22851.58796
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 25776.9774
-  tps: 22007.76027
+  dps: 26808.05649
+  tps: 22885.52383
  }
 }
 dps_results: {
  key: "TestFury-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 25651.76819
-  tps: 21962.06693
+  dps: 26677.83891
+  tps: 22837.98553
  }
 }
 dps_results: {
  key: "TestFury-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 25972.57381
-  tps: 22233.12341
+  dps: 27011.47677
+  tps: 23119.87007
  }
 }
 dps_results: {
  key: "TestFury-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 26385.50698
-  tps: 22682.06119
+  dps: 27440.92726
+  tps: 23586.67674
  }
 }
 dps_results: {
  key: "TestFury-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 26383.28827
-  tps: 22611.00851
+  dps: 27438.6198
+  tps: 23512.84552
  }
 }
 dps_results: {
  key: "TestFury-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 26355.38022
-  tps: 22507.10936
+  dps: 27409.59543
+  tps: 23404.83173
  }
 }
 dps_results: {
  key: "TestFury-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 26355.38022
-  tps: 22507.10936
+  dps: 27409.59543
+  tps: 23404.83173
  }
 }
 dps_results: {
  key: "TestFury-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 25743.96323
-  tps: 22055.81407
+  dps: 26773.72175
+  tps: 22935.44098
  }
 }
 dps_results: {
  key: "TestFury-AllItems-LastWord-50708"
  value: {
-  dps: 27188.37566
-  tps: 23437.51925
+  dps: 28275.91069
+  tps: 24372.45021
  }
 }
 dps_results: {
  key: "TestFury-AllItems-LeadenDespair-55816"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-LeadenDespair-56347"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 26262.19012
-  tps: 22568.39474
+  dps: 27312.67772
+  tps: 23468.54244
  }
 }
 dps_results: {
  key: "TestFury-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 26396.33959
-  tps: 22620.15131
+  dps: 27452.19317
+  tps: 23522.38711
  }
 }
 dps_results: {
  key: "TestFury-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 27058.87797
-  tps: 23128.04746
+  dps: 28141.23308
+  tps: 24050.51717
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 26489.83037
-  tps: 22769.36092
+  dps: 27549.42359
+  tps: 23677.56554
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 26736.58439
-  tps: 22986.08211
+  dps: 27806.04777
+  tps: 23902.95558
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 26421.57717
-  tps: 22524.02825
+  dps: 27478.44025
+  tps: 23422.44102
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 26583.58752
-  tps: 22659.01541
+  dps: 27646.93102
+  tps: 23562.82559
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 26469.18297
-  tps: 22690.47755
+  dps: 27527.95029
+  tps: 23595.48465
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 26903.95303
-  tps: 23093.86617
+  dps: 27980.11115
+  tps: 24014.98918
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 25919.90849
-  tps: 22077.54866
+  dps: 26956.70483
+  tps: 22958.08282
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 25919.90849
-  tps: 22077.54866
+  dps: 26956.70483
+  tps: 22958.08282
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MoltenGiantBattleplate"
  value: {
-  dps: 23257.8858
-  tps: 19698.1768
+  dps: 24188.20123
+  tps: 20483.85503
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MoltenGiantWarplate"
  value: {
-  dps: 28023.77475
-  tps: 23989.30873
+  dps: 29126.37039
+  tps: 24928.06902
  }
 }
 dps_results: {
  key: "TestFury-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 25743.83676
-  tps: 21836.08275
+  dps: 26773.59023
+  tps: 22706.98833
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 26484.43806
-  tps: 22633.12126
+  dps: 27543.81558
+  tps: 23535.91045
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 25764.62657
-  tps: 21991.99915
+  dps: 26795.21163
+  tps: 22869.13349
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 25577.56881
-  tps: 21853.74969
+  dps: 26600.67156
+  tps: 22725.35077
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 25653.95531
-  tps: 21913.28295
+  dps: 26680.11353
+  tps: 22787.24148
  }
 }
 dps_results: {
  key: "TestFury-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 26708.97886
-  tps: 23029.01355
+  dps: 27777.33802
+  tps: 23947.60428
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 26535.05525
-  tps: 22724.47972
+  dps: 27596.45747
+  tps: 23630.79383
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 26909.45025
-  tps: 23024.30986
+  dps: 27985.82826
+  tps: 23942.56908
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Rainsong-55854"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Rainsong-56377"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 27188.37566
-  tps: 23437.51925
+  dps: 28275.91069
+  tps: 24372.45021
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 27015.63851
-  tps: 23288.5948
+  dps: 28096.26405
+  tps: 24217.56878
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 26932.78971
-  tps: 23082.02791
+  dps: 28010.1013
+  tps: 24002.68992
  }
 }
 dps_results: {
  key: "TestFury-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 27011.29083
-  tps: 23187.59448
+  dps: 28091.74246
+  tps: 24112.46662
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 25938.08036
-  tps: 22120.59123
+  dps: 26975.60357
+  tps: 23002.86639
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SeaStar-55256"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SeaStar-56290"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Shadowmourne-49623"
  value: {
-  dps: 27188.37566
-  tps: 23437.51925
+  dps: 28275.91069
+  tps: 24372.45021
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ShardofWoe-60233"
  value: {
-  dps: 26163.73189
-  tps: 22301.10251
+  dps: 27210.28116
+  tps: 23190.52701
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 26421.44168
-  tps: 22615.8806
+  dps: 27478.29934
+  tps: 23517.93943
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 26154.81275
-  tps: 22250.25622
+  dps: 27201.00526
+  tps: 23137.70021
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 26178.83825
-  tps: 22275.16535
+  dps: 27225.99178
+  tps: 23163.63887
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Sorrowsong-55879"
  value: {
-  dps: 25710.97251
-  tps: 21975.12596
+  dps: 26739.41142
+  tps: 22851.58796
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Sorrowsong-56400"
  value: {
-  dps: 25776.9774
-  tps: 22007.76027
+  dps: 26808.05649
+  tps: 22885.52383
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 26465.32687
-  tps: 22662.25707
+  dps: 27523.93994
+  tps: 23566.12825
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SoulCasket-58183"
  value: {
-  dps: 25919.90849
-  tps: 22077.54866
+  dps: 26956.70483
+  tps: 22958.08282
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-StumpofTime-62465"
  value: {
-  dps: 25852.06781
-  tps: 22093.96151
+  dps: 26886.15052
+  tps: 22975.06779
  }
 }
 dps_results: {
  key: "TestFury-AllItems-StumpofTime-62470"
  value: {
-  dps: 25852.06781
-  tps: 22093.96151
+  dps: 26886.15052
+  tps: 22975.06779
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 26526.83925
-  tps: 22650.59117
+  dps: 27587.91282
+  tps: 23554.0253
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TearofBlood-55819"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TearofBlood-56351"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 25650.80933
-  tps: 21938.49102
+  dps: 26676.84171
+  tps: 22813.47079
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 25776.9774
-  tps: 22007.76027
+  dps: 26808.05649
+  tps: 22885.52383
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 26319.17023
-  tps: 22431.87333
+  dps: 27371.93704
+  tps: 23326.59707
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 26373.02653
-  tps: 22533.34434
+  dps: 27427.94759
+  tps: 23432.12663
  }
 }
 dps_results: {
  key: "TestFury-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 26727.1018
-  tps: 23009.75179
+  dps: 27796.18587
+  tps: 23927.51984
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 24481.25051
-  tps: 21028.80888
+  dps: 25460.50053
+  tps: 21867.41606
  }
 }
 dps_results: {
  key: "TestFury-AllItems-UnheededWarning-59520"
  value: {
-  dps: 26634.18736
-  tps: 22757.71661
+  dps: 27699.55486
+  tps: 23665.48285
  }
 }
 dps_results: {
  key: "TestFury-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 26134.25601
-  tps: 22270.52209
+  dps: 27179.62625
+  tps: 23158.8002
  }
 }
 dps_results: {
  key: "TestFury-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 26134.25601
-  tps: 22270.52209
+  dps: 27179.62625
+  tps: 23158.8002
  }
 }
 dps_results: {
  key: "TestFury-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 26134.25601
-  tps: 22270.52209
+  dps: 27179.62625
+  tps: 23158.8002
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 24123.94676
-  tps: 20766.99652
+  dps: 25088.90463
+  tps: 21595.1179
  }
 }
 dps_results: {
  key: "TestFury-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 26081.734
-  tps: 22292.91837
+  dps: 27125.00336
+  tps: 23182.0824
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 26622.57994
-  tps: 22735.12405
+  dps: 27687.48314
+  tps: 23641.98384
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 25915.91354
-  tps: 22233.31707
+  dps: 26952.55008
+  tps: 23119.98991
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 25854.66685
-  tps: 22180.65312
+  dps: 26888.85353
+  tps: 23065.22515
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 26272.26108
-  tps: 22524.00801
+  dps: 27323.15153
+  tps: 23422.41767
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 25731.94302
-  tps: 22103.71727
+  dps: 26761.22074
+  tps: 22985.29615
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 25943.2689
-  tps: 22124.55846
+  dps: 26980.99966
+  tps: 23006.97531
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 25816.79595
-  tps: 22090.63972
+  dps: 26849.46779
+  tps: 22971.72653
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 26504.00437
-  tps: 22696.66294
+  dps: 27564.16454
+  tps: 23601.98428
  }
 }
 dps_results: {
  key: "TestFury-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 25347.11149
-  tps: 21716.47342
+  dps: 26360.99595
+  tps: 22582.58718
  }
 }
 dps_results: {
  key: "TestFury-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 25651.30442
-  tps: 21922.44771
+  dps: 26677.3566
+  tps: 22796.79289
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 25618.51345
-  tps: 21847.35428
+  dps: 26643.25399
+  tps: 22718.7015
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 25618.51345
-  tps: 21847.35428
+  dps: 26643.25399
+  tps: 22718.7015
  }
 }
 dps_results: {
  key: "TestFury-Average-Default"
  value: {
-  dps: 27382.6482
-  tps: 23563.68981
+  dps: 28477.95413
+  tps: 24503.65674
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-p1_fury_smf-Basic-fury-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 31467.46556
-  tps: 27718.0178
+  dps: 32559.06475
+  tps: 28654.59134
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-p1_fury_smf-Basic-fury-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26844.84941
-  tps: 23149.25988
+  dps: 27918.64338
+  tps: 24072.67579
  }
 }
 dps_results: {
  key: "TestFury-Settings-Human-p1_fury_smf-Basic-fury-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 34138.07252
-  tps: 29510.33353
+  dps: 35503.59542
+  tps: 30687.84914
  }
 }
 dps_results: {
@@ -1368,22 +1368,22 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Orc-p1_fury_smf-Basic-fury-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 31970.6409
-  tps: 28230.97724
+  dps: 33075.50303
+  tps: 29181.19325
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-p1_fury_smf-Basic-fury-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 27188.37566
-  tps: 23437.51925
+  dps: 28275.91069
+  tps: 24372.45021
  }
 }
 dps_results: {
  key: "TestFury-Settings-Orc-p1_fury_smf-Basic-fury-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 34778.20631
-  tps: 30098.3856
+  dps: 36169.33456
+  tps: 31299.4233
  }
 }
 dps_results: {
@@ -1410,7 +1410,7 @@ dps_results: {
 dps_results: {
  key: "TestFury-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 25230.82249
-  tps: 21530.80939
+  dps: 26240.05539
+  tps: 22389.5437
  }
 }

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -37,1311 +37,1311 @@ character_stats_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 4913.97754
-  tps: 29525.01032
+  dps: 5110.53665
+  tps: 30658.14467
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 4982.44285
-  tps: 29860.94391
+  dps: 5181.74056
+  tps: 31005.6922
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 5017.13971
-  tps: 30105.77498
+  dps: 5217.8253
+  tps: 31259.56826
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 4986.36232
-  tps: 29921.81931
+  dps: 5185.81682
+  tps: 31070.82602
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 5004.21208
-  tps: 30019.57114
+  dps: 5204.38056
+  tps: 31172.48792
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BindingPromise-67037"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlackBruise-50692"
  value: {
-  dps: 4405.70235
-  tps: 26913.51935
+  dps: 4581.93044
+  tps: 27942.45657
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 4978.30152
-  tps: 29874.44497
+  dps: 5177.43358
+  tps: 31021.55671
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 4957.63123
-  tps: 29768.84852
+  dps: 5155.93648
+  tps: 30911.7364
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 5117.14775
-  tps: 30761.50475
+  dps: 5321.83366
+  tps: 31942.95359
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BottledLightning-66879"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 4871.47712
-  tps: 28705.17863
+  dps: 5066.3362
+  tps: 29806.47676
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 4895.58041
-  tps: 29429.37927
+  dps: 5091.40363
+  tps: 30558.68838
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 4916.06042
-  tps: 29535.42469
+  dps: 5112.70284
+  tps: 30668.97562
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ColossalDragonplateArmor"
  value: {
-  dps: 4791.98817
-  tps: 28780.68507
+  dps: 4983.6677
+  tps: 29883.15011
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ColossalDragonplateBattlegear"
  value: {
-  dps: 5729.17179
-  tps: 34284.34317
+  dps: 5958.33866
+  tps: 35598.75576
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CrushingWeight-59506"
  value: {
-  dps: 5209.94563
-  tps: 31184.58466
+  dps: 5418.34345
+  tps: 32382.81446
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CrushingWeight-65118"
  value: {
-  dps: 5310.40289
-  tps: 31729.39291
+  dps: 5522.819
+  tps: 32948.7507
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 5292.48249
-  tps: 31651.49341
+  dps: 5496.42163
+  tps: 32828.98805
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 5128.01199
-  tps: 30620.37953
+  dps: 5325.37231
+  tps: 31757.86861
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 5036.35869
-  tps: 30175.19974
+  dps: 5237.81304
+  tps: 31334.28121
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 4891.18061
-  tps: 29392.94832
+  dps: 5086.82784
+  tps: 30520.80019
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 4923.28744
-  tps: 29503.9061
+  dps: 5120.21894
+  tps: 30636.24119
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EarthenBattleplate"
  value: {
-  dps: 4921.4686
-  tps: 29524.26821
+  dps: 5118.32734
+  tps: 30656.3644
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EarthenWarplate"
  value: {
-  dps: 5400.67059
-  tps: 32271.30104
+  dps: 5616.69741
+  tps: 33507.95897
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 4891.18061
-  tps: 29392.94832
+  dps: 5086.82784
+  tps: 30520.80019
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 5093.40126
-  tps: 30507.37351
+  dps: 5297.13732
+  tps: 31679.80239
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 5122.05638
-  tps: 30664.75419
+  dps: 5326.93863
+  tps: 31843.47829
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FallofMortality-59500"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FallofMortality-65124"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 5017.13971
-  tps: 30105.77498
+  dps: 5217.8253
+  tps: 31259.56826
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FluidDeath-58181"
  value: {
-  dps: 5177.78505
-  tps: 30999.11775
+  dps: 5384.89645
+  tps: 32187.9061
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 4986.36232
-  tps: 29921.81931
+  dps: 5185.81682
+  tps: 31070.82602
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GaleofShadows-56138"
  value: {
-  dps: 4987.13883
-  tps: 29922.47095
+  dps: 5186.62439
+  tps: 31069.64313
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GaleofShadows-56462"
  value: {
-  dps: 4936.72009
-  tps: 29574.37446
+  dps: 5134.1889
+  tps: 30708.40225
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GearDetector-61462"
  value: {
-  dps: 4970.60811
-  tps: 29767.6163
+  dps: 5169.43244
+  tps: 30910.03875
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 4952.15604
-  tps: 29727.56574
+  dps: 5150.24228
+  tps: 30868.80231
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 5003.79817
-  tps: 30008.50198
+  dps: 5203.9501
+  tps: 31160.976
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HarmlightToken-63839"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 5060.29578
-  tps: 30425.59382
+  dps: 5262.70761
+  tps: 31593.866
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HeartofRage-59224"
  value: {
-  dps: 5337.91979
-  tps: 32138.49431
+  dps: 5551.43658
+  tps: 33371.73546
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HeartofRage-65072"
  value: {
-  dps: 5426.06786
-  tps: 32608.74824
+  dps: 5643.11057
+  tps: 33860.08675
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HeartofSolace-55868"
  value: {
-  dps: 5166.60244
-  tps: 30997.80756
+  dps: 5373.26654
+  tps: 32187.14225
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HeartofSolace-56393"
  value: {
-  dps: 5209.73505
-  tps: 31209.17575
+  dps: 5418.12445
+  tps: 32407.38184
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HeartofThunder-55845"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HeartofThunder-56370"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 4965.53314
-  tps: 29801.26607
+  dps: 5164.15447
+  tps: 30945.45066
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Heartpierce-50641"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 4891.18061
-  tps: 29392.94832
+  dps: 5086.82784
+  tps: 30520.80019
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 5067.12472
-  tps: 30321.17026
+  dps: 5269.80971
+  tps: 31484.99478
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 5112.65153
-  tps: 30637.03672
+  dps: 5317.15759
+  tps: 31812.08047
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 4927.99579
-  tps: 29555.11766
+  dps: 5125.11562
+  tps: 30689.49115
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 4927.99579
-  tps: 29555.11766
+  dps: 5125.11562
+  tps: 30689.49115
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-LastWord-50708"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-LeadenDespair-55816"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-LeadenDespair-56347"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 5058.10191
-  tps: 30308.86015
+  dps: 5260.42598
+  tps: 31471.30929
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 5122.30131
-  tps: 30740.72741
+  dps: 5327.19336
+  tps: 31919.78557
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 5380.13182
-  tps: 32263.29019
+  dps: 5595.33709
+  tps: 33501.08775
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 4961.14933
-  tps: 29744.3888
+  dps: 5159.59531
+  tps: 30884.80255
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 5041.49897
-  tps: 30297.56497
+  dps: 5243.15893
+  tps: 31458.89664
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 5074.82029
-  tps: 30512.87089
+  dps: 5277.8131
+  tps: 31684.56605
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 5101.44856
-  tps: 30672.87887
+  dps: 5305.5065
+  tps: 31850.84947
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 4945.69293
-  tps: 29637.66715
+  dps: 5143.52065
+  tps: 30774.42287
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 5017.13971
-  tps: 30105.77498
+  dps: 5217.8253
+  tps: 31259.56826
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MoltenGiantBattleplate"
  value: {
-  dps: 5281.72712
-  tps: 31465.11786
+  dps: 5492.9962
+  tps: 32673.18582
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MoltenGiantWarplate"
  value: {
-  dps: 5974.73427
-  tps: 35747.29961
+  dps: 6213.72364
+  tps: 37119.64821
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 5028.01908
-  tps: 30231.64475
+  dps: 5229.13985
+  tps: 31392.31035
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 4925.32928
-  tps: 29581.72721
+  dps: 5122.34245
+  tps: 30717.13024
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 5070.16701
-  tps: 30356.19259
+  dps: 5272.97369
+  tps: 31522.115
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 5075.31899
-  tps: 30303.67508
+  dps: 5278.33175
+  tps: 31467.26154
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Rainsong-55854"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Rainsong-56377"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 4939.36744
-  tps: 29692.4533
+  dps: 5136.94214
+  tps: 30832.08103
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 4895.58041
-  tps: 29429.37927
+  dps: 5091.40363
+  tps: 30558.68838
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 5162.46595
-  tps: 30927.02036
+  dps: 5368.96459
+  tps: 32113.56075
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 5221.58305
-  tps: 31310.16474
+  dps: 5430.44638
+  tps: 32511.26459
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 4926.07771
-  tps: 29587.06827
+  dps: 5123.12081
+  tps: 30722.68494
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SeaStar-55256"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SeaStar-56290"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Shadowmourne-49623"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShardofWoe-60233"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 5074.22852
-  tps: 30467.24292
+  dps: 5277.19766
+  tps: 31636.72539
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 4931.12085
-  tps: 29615.48186
+  dps: 5128.36568
+  tps: 30752.23507
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 4943.31358
-  tps: 29679.88726
+  dps: 5141.04613
+  tps: 30819.21668
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Sorrowsong-55879"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Sorrowsong-56400"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 4982.44285
-  tps: 29860.94391
+  dps: 5181.74056
+  tps: 31005.6922
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SoulCasket-58183"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StumpofTime-62465"
  value: {
-  dps: 5067.13734
-  tps: 30390.56006
+  dps: 5269.82283
+  tps: 31555.00611
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StumpofTime-62470"
  value: {
-  dps: 5067.13734
-  tps: 30390.56006
+  dps: 5269.82283
+  tps: 31555.00611
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 5061.28623
-  tps: 30364.83943
+  dps: 5263.73768
+  tps: 31530.49469
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TearofBlood-55819"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TearofBlood-56351"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 4949.18915
-  tps: 29712.70761
+  dps: 5147.15672
+  tps: 30853.34985
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 4960.28835
-  tps: 29774.5321
+  dps: 5158.69988
+  tps: 30917.64732
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 4939.66969
-  tps: 29598.67416
+  dps: 5137.25648
+  tps: 30733.77071
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-UnheededWarning-59520"
  value: {
-  dps: 5083.40106
-  tps: 30515.133
+  dps: 5286.7371
+  tps: 31687.40616
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 3905.30346
-  tps: 24445.82649
+  dps: 4061.5156
+  tps: 25372.95298
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 5049.78093
-  tps: 30340.93695
+  dps: 5251.77217
+  tps: 31503.44292
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 4973.9847
-  tps: 29750.97098
+  dps: 5172.94409
+  tps: 30892.06345
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 4993.7268
-  tps: 29962.09669
+  dps: 5193.47587
+  tps: 31112.71449
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 5051.69063
-  tps: 30398.69899
+  dps: 5253.75825
+  tps: 31563.49786
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 4962.69224
-  tps: 29777.58741
+  dps: 5161.19993
+  tps: 30920.82484
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 5127.58134
-  tps: 30823.08696
+  dps: 5332.68459
+  tps: 32006.95122
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 4871.47712
-  tps: 29290.9918
+  dps: 5066.3362
+  tps: 30414.76541
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Average-Default"
  value: {
-  dps: 13043.06331
-  tps: 75043.80158
+  dps: 13564.78584
+  tps: 77995.84005
   dtps: 8028.45683
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p1_bis-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 31262.74219
-  tps: 173767.66284
+  dps: 31467.60855
+  tps: 174930.73051
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p1_bis-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 5470.11189
-  tps: 32996.33254
+  dps: 5688.91637
+  tps: 34260.47993
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p1_bis-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 5925.00321
-  tps: 35386.41259
+  dps: 6162.00334
+  tps: 36742.43509
  }
 }
 dps_results: {
@@ -1368,22 +1368,22 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p1_bis-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 31239.45744
-  tps: 173601.77505
+  dps: 31444.02111
+  tps: 174762.63458
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p1_bis-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 5462.72726
-  tps: 32956.50128
+  dps: 5681.23635
+  tps: 34219.671
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p1_bis-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 5896.23537
-  tps: 35239.30414
+  dps: 6132.08479
+  tps: 36590.29456
  }
 }
 dps_results: {
@@ -1410,8 +1410,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 13914.79956
-  tps: 80471.13536
+  dps: 14471.39154
+  tps: 83633.07376
   dtps: 7433.41955
  }
 }


### PR DESCRIPTION
fix blood frenzy being overwritten by other bleed effects and losing the phys vuln debuff part

![image](https://github.com/wowsims/cata/assets/16014057/5143302c-6ce2-4d02-b7da-64a0952aa7e8)
