### PR TITLE
[Balance] Enable mastery snapshotting + Innervate

### DIFF
--- a/proto/druid.proto
+++ b/proto/druid.proto
@@ -138,6 +138,8 @@ message BalanceDruid {
   message Options {
     DruidOptions class_options = 1;
 	float okf_uptime = 2;
+	bool start_in_solar = 3;
+	int32 mastery_snapshot = 4;
   }
   Options options = 3;
 }

--- a/sim/core/buffs.go
+++ b/sim/core/buffs.go
@@ -1670,7 +1670,7 @@ func registerInnervateCD(agent Agent, numInnervates int32) {
 	character := agent.GetCharacter()
 	character.Env.RegisterPostFinalizeEffect(func() {
 		innervateThreshold = InnervateManaThreshold(character)
-		innervateAura = InnervateAura(character, -1, false)
+		innervateAura = InnervateAura(character, -1, 0.05)
 	})
 
 	registerExternalConsecutiveCDApproximation(
@@ -1693,7 +1693,7 @@ func registerInnervateCD(agent Agent, numInnervates int32) {
 		numInnervates)
 }
 
-func InnervateAura(character *Character, actionTag int32, isSelfCast bool) *Aura {
+func InnervateAura(character *Character, actionTag int32, reg float64) *Aura {
 	actionID := ActionID{SpellID: 29166, Tag: actionTag}
 	manaMetrics := character.NewManaMetrics(actionID)
 	return character.GetOrRegisterAura(Aura{
@@ -1702,7 +1702,6 @@ func InnervateAura(character *Character, actionTag int32, isSelfCast bool) *Aura
 		ActionID: actionID,
 		Duration: InnervateDuration,
 		OnGain: func(aura *Aura, sim *Simulation) {
-			reg := TernaryFloat64(isSelfCast, 0.2, 0.05)
 			manaPerTick := aura.Unit.MaxMana() * reg / 10.0
 			StartPeriodicAction(sim, PeriodicActionOptions{
 				Period:   InnervateDuration / 10,

--- a/sim/core/buffs.go
+++ b/sim/core/buffs.go
@@ -1655,7 +1655,7 @@ func InnervateManaThreshold(character *Character) float64 {
 		// Mages burn mana really fast so they need a higher threshold.
 		return character.MaxMana() * 0.7
 	} else {
-		return 1000
+		return 5000
 	}
 }
 

--- a/sim/druid/balance/balance.go
+++ b/sim/druid/balance/balance.go
@@ -106,4 +106,8 @@ func (moonkin *BalanceDruid) ApplyTalents() {
 func (moonkin *BalanceDruid) Reset(sim *core.Simulation) {
 	moonkin.Druid.Reset(sim)
 	//moonkin.RebirthTiming = moonkin.Env.BaseDuration.Seconds() * sim.RandomFloat("Rebirth Timing")
+
+	if moonkin.Options.StartInSolar {
+		moonkin.Druid.ForceSolarEclipse(sim, float64(moonkin.Options.MasterySnapshot))
+	}
 }

--- a/sim/druid/druid.go
+++ b/sim/druid/druid.go
@@ -267,7 +267,7 @@ func (druid *Druid) Initialize() {
 	// }
 	druid.registerFaerieFireSpell()
 	// druid.registerRebirthSpell()
-	// druid.registerInnervateCD()
+	druid.registerInnervateCD()
 	// druid.registerFakeGotw()
 	druid.applyOmenOfClarity()
 }

--- a/sim/druid/druid.go
+++ b/sim/druid/druid.go
@@ -328,14 +328,22 @@ func (druid *Druid) RegisterFeralTankSpells() {
 }
 
 func (druid *Druid) Reset(_ *core.Simulation) {
-
 	druid.eclipseEnergyBar.reset()
 	druid.BleedsActive = 0
 	druid.form = druid.StartingForm
 	druid.disabledMCDs = []*core.MajorCooldown{}
 	druid.RebirthUsed = false
-	// druid.LunarICD.Timer.Reset()
-	// druid.SolarICD.Timer.Reset()
+}
+
+func (druid *Druid) ForceSolarEclipse(sim *core.Simulation, mastery float64){
+	mastery -= druid.GetStat(stats.Mastery)
+	if mastery > 0 {
+		druid.AddStatDynamic(sim, stats.Mastery, mastery)
+	}
+	druid.eclipseEnergyBar.ForceEclipse(SolarEclipse, sim)
+	if mastery > 0 {
+		druid.AddStatDynamic(sim, stats.Mastery, -mastery)
+	}
 }
 
 func New(char *core.Character, form DruidForm, selfBuffs SelfBuffs, talents string) *Druid {

--- a/sim/druid/eclipse.go
+++ b/sim/druid/eclipse.go
@@ -201,6 +201,18 @@ func (eb *eclipseEnergyBar) addLunarEnergy(amount float64, sim *core.Simulation,
 	metrics.AddEvent(amount, gain)
 }
 
+func (eb *eclipseEnergyBar) ForceEclipse(eclipse Eclipse, sim *core.Simulation) {
+	eb.reset()
+
+	if eclipse == SolarEclipse {
+		eb.solarEnergy = 100
+	} else if eclipse == LunarEclipse {
+		eb.lunarEnergy = 100
+	}
+
+	eb.SetEclipse(eclipse, sim)
+}
+
 func (eb *eclipseEnergyBar) SetEclipse(eclipse Eclipse, sim *core.Simulation) {
 	if eb.currentEclipse == eclipse {
 		return

--- a/sim/druid/innervate.go
+++ b/sim/druid/innervate.go
@@ -7,43 +7,18 @@ import (
 // Returns the time to wait before the next action, or 0 if innervate is on CD
 // or disabled.
 func (druid *Druid) registerInnervateCD() {
-	innervateTarget := druid.GetUnit(druid.SelfBuffs.InnervateTarget)
-	if innervateTarget == nil {
-		return
-	}
-	innervateTargetChar := druid.Env.Raid.GetPlayerFromUnit(innervateTarget).GetCharacter()
-
 	actionID := core.ActionID{SpellID: 29166, Tag: druid.Index}
 	var innervateSpell *DruidSpell
 
 	innervateCD := core.InnervateCD
 
+	amount := 0.2 + float64(druid.Talents.Dreamstate) * 0.15
+
 	var innervateAura *core.Aura
-	var innervateManaThreshold float64
-	druid.RegisterResetEffect(func(sim *core.Simulation) {
-		if innervateTarget == &druid.Unit {
-			if druid.StartingForm.Matches(Cat) {
-				// double shift + innervate cost.
-				// Prevents not having enough mana to shift back into form if more powershift are executed
-				innervateManaThreshold = druid.CatForm.DefaultCast.Cost*2 + innervateSpell.DefaultCast.Cost
-			} else {
-				// Threshold can be lower when casting on self because its never mid-cast.
-				innervateManaThreshold = 500
-			}
-		} else {
-			innervateManaThreshold = core.InnervateManaThreshold(innervateTargetChar)
-		}
-		innervateAura = core.InnervateAura(innervateTargetChar, actionID.Tag)
-	})
+	innervateAura = core.InnervateAura(druid.GetCharacter(), actionID.Tag, amount)
 
 	innervateSpell = druid.RegisterSpell(Humanoid|Moonkin|Tree, core.SpellConfig{
 		ActionID: actionID,
-		Flags:    SpellFlagOmenTrigger,
-
-		ManaCost: core.ManaCostOptions{
-			BaseCost:   0.04,
-			Multiplier: 1,
-		},
 		Cast: core.CastConfig{
 			DefaultCast: core.Cast{
 				GCD: core.GCDDefault,
@@ -53,12 +28,10 @@ func (druid *Druid) registerInnervateCD() {
 				Duration: innervateCD,
 			},
 		},
-
 		ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
 			// If target already has another innervate, don't cast.
-			return innervateTarget.HasActiveAuraWithTag(core.InnervateAuraTag)
+			return !druid.HasActiveAuraWithTag(core.InnervateAuraTag)
 		},
-
 		ApplyEffects: func(sim *core.Simulation, _ *core.Unit, _ *core.Spell) {
 			innervateAura.Activate(sim)
 		},
@@ -72,7 +45,7 @@ func (druid *Druid) registerInnervateCD() {
 			// innervate gives so much mana that it can cause Super Mana Potion or Dark Rune usages
 			// to be delayed, if they come off CD soon after innervate. This delay is minimized by
 			// activating innervate from the smallest amount of mana possible.
-			return innervateTarget.CurrentMana() <= innervateManaThreshold
+			return druid.CurrentMana() <= 5000
 		},
 	})
 }

--- a/ui/druid/balance/inputs.ts
+++ b/ui/druid/balance/inputs.ts
@@ -1,4 +1,5 @@
 import * as InputHelpers from '../../core/components/input_helpers.js';
+import { Player } from '../../core/player.js';
 import { Spec } from '../../core/proto/common.js';
 
 // Configuration for spec-specific UI elements on the settings tab.
@@ -9,4 +10,17 @@ export const OkfUptime = InputHelpers.makeSpecOptionsNumberInput<Spec.SpecBalanc
 	label: 'Owlkin Frenzy Uptime (%)',
 	labelTooltip: 'Percentage of fight uptime for Owlkin Frenzy',
 	percent: true,
+});
+
+export const StartInSolar = InputHelpers.makeSpecOptionsBooleanInput<Spec.SpecBalanceDruid>({
+	fieldName: 'startInSolar',
+	label: 'Start in Solar Eclipse',
+	labelTooltip: 'Starts the fight in solar eclipse at full energy',
+});
+
+export const MasterySnapshot = InputHelpers.makeSpecOptionsNumberInput<Spec.SpecBalanceDruid>({
+	fieldName: 'masterySnapshot',
+	label: 'Mastery snapshot amount (rating)',
+	labelTooltip: 'Mastery amount to use when starting in Solar Eclipse',
+	showWhen: (player: Player<Spec.SpecBalanceDruid>) => player.getSpecOptions().startInSolar,
 });

--- a/ui/druid/balance/sim.ts
+++ b/ui/druid/balance/sim.ts
@@ -91,7 +91,8 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecBalanceDruid, {
 	excludeBuffDebuffInputs: [],
 	// Inputs to include in the 'Other' section on the settings tab.
 	otherInputs: {
-		inputs: [BalanceInputs.OkfUptime, OtherInputs.TankAssignment, OtherInputs.InputDelay, OtherInputs.DistanceFromTarget, OtherInputs.DarkIntentUptime],
+		inputs: [BalanceInputs.OkfUptime, BalanceInputs.StartInSolar, BalanceInputs.MasterySnapshot, OtherInputs.TankAssignment,
+			     OtherInputs.InputDelay, OtherInputs.DistanceFromTarget, OtherInputs.DarkIntentUptime],
 	},
 	encounterPicker: {
 		// Whether to include 'Execute Duration (%)' in the 'Encounter' section of the settings tab.


### PR DESCRIPTION
Ability to start in solar eclipse
Ability to specify a mastery amount for the initial solar eclipse
Enable self innervate (some stuff about innervate target didn't seem to be working so it's just innervate self for now, not like there's much of a reason to innervate someone else anymore...)