### PR TITLE
fix: Update sixtyupgrades URLs to use Cata URL instead of Wotlk URL

### DIFF
--- a/ui/core/components/exporters.tsx
+++ b/ui/core/components/exporters.tsx
@@ -337,7 +337,7 @@ export class Individual80UEPExporter<SpecType extends Spec> extends Exporter {
 	private readonly simUI: IndividualSimUI<SpecType>;
 
 	constructor(parent: HTMLElement, simUI: IndividualSimUI<SpecType>) {
-		super(parent, simUI, { title: '80Upgrades EP Export', allowDownload: true });
+		super(parent, simUI, { title: '85Upgrades EP Export', allowDownload: true });
 		this.simUI = simUI;
 	}
 
@@ -368,7 +368,7 @@ export class Individual80UEPExporter<SpecType extends Spec> extends Exporter {
 		});
 
 		return (
-			`https://eightyupgrades.com/ep/import?name=${encodeURIComponent(`${player.getPlayerSpec().friendlyName} WoWSims Weights`)}` +
+			`https://sixtyupgrades.com/cata/ep/import?name=${encodeURIComponent(`${player.getPlayerSpec().friendlyName} WoWSims Weights`)}` +
 			Object.keys(namesToWeights)
 				.map(statName => `&${statName}=${namesToWeights[statName].toFixed(3)}`)
 				.join('')

--- a/ui/core/individual_sim_ui.tsx
+++ b/ui/core/individual_sim_ui.tsx
@@ -1,5 +1,3 @@
-
-
 import { CharacterStats, StatMods, StatWrites } from './components/character_stats';
 import { ContentBlock } from './components/content_block';
 import { EmbeddedDetailedResults } from './components/detailed_results';
@@ -436,14 +434,14 @@ export abstract class IndividualSimUI<SpecType extends Spec> extends SimUI {
 
 	private addTopbarComponents() {
 		this.simHeader.addImportLink('JSON', new Importers.IndividualJsonImporter(this.rootElem, this), true);
-		this.simHeader.addImportLink('80U', new Importers.Individual80UImporter(this.rootElem, this), true);
+		this.simHeader.addImportLink('85U', new Importers.Individual80UImporter(this.rootElem, this), true);
 		this.simHeader.addImportLink('WoWHead', new Importers.IndividualWowheadGearPlannerImporter(this.rootElem, this), false);
 		this.simHeader.addImportLink('Addon', new Importers.IndividualAddonImporter(this.rootElem, this), true);
 
 		this.simHeader.addExportLink('Link', new Exporters.IndividualLinkExporter(this.rootElem, this), false);
 		this.simHeader.addExportLink('JSON', new Exporters.IndividualJsonExporter(this.rootElem, this), true);
 		this.simHeader.addExportLink('WoWHead', new Exporters.IndividualWowheadGearPlannerExporter(this.rootElem, this), false);
-		this.simHeader.addExportLink('80U EP', new Exporters.Individual80UEPExporter(this.rootElem, this), false);
+		this.simHeader.addExportLink('85U EP', new Exporters.Individual80UEPExporter(this.rootElem, this), false);
 		this.simHeader.addExportLink('Pawn EP', new Exporters.IndividualPawnEPExporter(this.rootElem, this), false);
 		this.simHeader.addExportLink('CLI', new Exporters.IndividualCLIExporter(this.rootElem, this), true);
 	}


### PR DESCRIPTION
Updated export link so that it now correctly goes to https://sixtyupgrades.com/cata/.. instead of the wotlk site.
from issue: https://github.com/wowsims/cata/issues/557
