### PR TITLE
fix stump of time (alliance) to use the correct aura id

### DIFF
--- a/sim/common/cata/stat_bonus_procs.go
+++ b/sim/common/cata/stat_bonus_procs.go
@@ -555,7 +555,7 @@ func init() {
 	shared.NewProcStatBonusEffect(shared.ProcStatBonusEffect{
 		Name:       "Stump of Time (Aliance)",
 		ID:         62470,
-		AuraID:     91048,
+		AuraID:     91047,
 		Bonus:      stats.Stats{stats.SpellPower: 1926},
 		Duration:   time.Second * 15,
 		Callback:   core.CallbackOnSpellHitDealt | core.CallbackOnPeriodicDamageDealt,

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -1004,8 +1004,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-StumpofTime-62470"
  value: {
-  dps: 31210.66836
-  tps: 570.01881
+  dps: 31475.6141
+  tps: 568.48225
  }
 }
 dps_results: {


### PR DESCRIPTION
This also affected shaman tests because the shaman apl being used is keeping track of the [battle magic](https://www.wowhead.com/cata/spell=91047/battle-magic) aura, which wasn't the one being used in the [alliance version](https://www.wowhead.com/cata/spell=91048/item-proc-spell-power)