### PR TITLE
Fix bug preventing the gear picker dialog from loading when importing…

### DIFF
--- a/ui/core/player.ts
+++ b/ui/core/player.ts
@@ -1137,7 +1137,7 @@ export class Player<SpecType extends Spec> {
 		let maxSuffixEP = 0;
 
 		if (item.randomSuffixOptions.length > 0) {
-			const suffixEPs = item.randomSuffixOptions.map(id => this.computeRandomSuffixEP(this.sim.db.getRandomSuffixById(id)!));
+			const suffixEPs = item.randomSuffixOptions.map(id => this.computeRandomSuffixEP(this.sim.db.getRandomSuffixById(id)! || 0));
 			maxSuffixEP = (Math.max(...suffixEPs) * item.randPropPoints) / 10000;
 		}
 


### PR DESCRIPTION
… items that cause the leftovers db to be loaded.

Closes issue #496.