### PR TITLE
[FIX] Removing of Random Suffix and Reforge

### DIFF
--- a/ui/core/components/gear_picker/gear_picker.tsx
+++ b/ui/core/components/gear_picker/gear_picker.tsx
@@ -845,7 +845,8 @@ export class SelectorModal extends BaseModal {
 			equippedToItemFn: (equippedItem: EquippedItem | null) => equippedItem?.randomSuffix,
 			onRemove: (eventID: number) => {
 				const equippedItem = gearData.getEquippedItem();
-				if (equippedItem) gearData.equipItem(eventID, equippedItem.withRandomSuffix(null));
+				if (equippedItem) gearData.equipItem(eventID, equippedItem.withItem(equippedItem.item).withRandomSuffix(null));
+				this.removeTabs(SelectorModalTabs.Reforging);
 			},
 		});
 	}
@@ -892,7 +893,7 @@ export class SelectorModal extends BaseModal {
 				equippedItem?.reforge ? this.player.getReforgeData(equippedItem, equippedItem.reforge) : null,
 			onRemove: (eventID: number) => {
 				const equippedItem = gearData.getEquippedItem();
-				if (equippedItem) gearData.equipItem(eventID, equippedItem.withItem(equippedItem.item));
+				if (equippedItem) gearData.equipItem(eventID, equippedItem.withItem(equippedItem.item).withRandomSuffix(equippedItem._randomSuffix));
 			},
 		});
 	}
@@ -1278,6 +1279,9 @@ export class ItemList<T extends ItemListType> {
 					break;
 				case SelectorModalTabs.Reforging:
 					removeButton.textContent = 'Remove Reforge';
+					break;
+				case SelectorModalTabs.RandomSuffixes:
+					removeButton.textContent = 'Remove Random Suffix';
 					break;
 				case SelectorModalTabs.Gem1:
 				case SelectorModalTabs.Gem2:


### PR DESCRIPTION
- Now keeps `randomSuffix` when removing a reforge of a `randomSuffix` item
- Now removes reforge and reforge tab when removing `randomSuffix`
- Added correct button state for `Remove Random Suffix` tab 