### PR TITLE
Get engine and volta props aligned with .nvmrc

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
 	"version": "0.1.0",
 	"private": true,
 	"engines": {
-		"node": ">=18"
+		"node": ">=20"
 	},
 	"volta": {
-		"node": ">=18"
+		"node": "20.11.1"
 	},
 	"scripts": {
 		"build": "bazel build //...",


### PR DESCRIPTION
Volta can only recognize specific versions and `engine` should at least be 20 if that's what every nvm user gets :)