### PR TITLE
Move breakpoints to ui settings and add tooltip

### DIFF
--- a/proto/ui.proto
+++ b/proto/ui.proto
@@ -317,7 +317,14 @@ message IndividualSimSettings {
 	Stat heal_ref_stat = 13;
 	Stat tank_ref_stat = 14;
 	UnitStats stat_caps = 15;
+	repeated SoftCapBreakpoints soft_cap_breakpoints = 16;
 }
+
+message SoftCapBreakpoints {
+	Stat stat = 1;
+	repeated double breakpoints = 2;
+}
+
 
 // Local storage data for gear settings.
 message SavedGearSet {

--- a/ui/core/components/suggest_reforges_action.tsx
+++ b/ui/core/components/suggest_reforges_action.tsx
@@ -119,7 +119,7 @@ export class ReforgeOptimizer {
 			tippy(_startReforgeOptimizationButton, {
 				content: this.buildReforgeButtonTooltip(),
 				placement: 'bottom',
-				maxWidth: 270,
+				maxWidth: 310,
 			});
 
 		tippy(contextMenuButton, {
@@ -160,8 +160,8 @@ export class ReforgeOptimizer {
 	buildReforgeButtonTooltip() {
 		return (
 			<>
-				The following soft caps/breakpoints have been implemented for this spec:
-				<ul className="mb-0">{this.softCapsConfig?.map(({ stat }) => <li>{getClassStatName(stat, this.player.getClass())}</li>)}</ul>
+				The following soft caps / breakpoints have been implemented for this spec:
+				<ul className="mt-1 mb-0">{this.softCapsConfig?.map(({ stat }) => <li>{getClassStatName(stat, this.player.getClass())}</li>)}</ul>
 			</>
 		);
 	}

--- a/ui/core/components/suggest_reforges_action.tsx
+++ b/ui/core/components/suggest_reforges_action.tsx
@@ -7,6 +7,7 @@ import * as Mechanics from '../constants/mechanics.js';
 import { IndividualSimUI } from '../individual_sim_ui';
 import { Player } from '../player';
 import { ItemSlot, Spec, Stat } from '../proto/common';
+import { SoftCapBreakpoints } from '../proto/ui';
 import { Gear } from '../proto_utils/gear';
 import { getClassStatName } from '../proto_utils/names';
 import { statPercentageOrPointsToNumber, Stats, statToPercentageOrPoints } from '../proto_utils/stats';
@@ -37,26 +38,10 @@ const EXCLUDED_STATS = [
 	Stat.StatMana,
 ];
 
-interface SoftCapBreakpoints {
-	stat: Stat;
-	breakpoints: number[];
-}
-
 export type ReforgeOptimizerOptions = {
 	// Allows you to modify the stats before they are returned for the calculations
 	// For example: Adding class specific Glyphs/Talents that are not added by the backend
 	updateGearStatsModifier?: (baseStats: Stats) => Stats;
-
-	// Allows specification of soft cap breakpoints for one or more stats. These
-	// function differently from the hard caps taken from the sim UI in a few ways:
-	// Firstly, the specified breakpoints are lower priority than hard caps, and
-	// evaluated only after the hard cap constraints have been solved first. Secondly,
-	// these constraints are evaluated in the order specified by the configuration
-	// Array rather than all at once. So once the hard caps have been respected, the
-	// closest breakpoint for the *first* listed soft capped stat is optimized against
-	// while ignoring any others. Then the solution is used to identify the closest
-	// breakpoint for the second listed stat (if present), etc.
-	softCapsConfig?: SoftCapBreakpoints[];
 };
 
 export class ReforgeOptimizer {
@@ -67,7 +52,7 @@ export class ReforgeOptimizer {
 	protected readonly defaults: IndividualSimUI<any>['individualConfig']['defaults'];
 	protected _statCaps: Stats;
 	protected updateGearStatsModifier: ReforgeOptimizerOptions['updateGearStatsModifier'];
-	protected softCapsConfig: ReforgeOptimizerOptions['softCapsConfig'];
+	protected softCapsConfig: SoftCapBreakpoints[];
 
 	constructor(simUI: IndividualSimUI<any>, options?: ReforgeOptimizerOptions) {
 		this.simUI = simUI;
@@ -76,9 +61,9 @@ export class ReforgeOptimizer {
 		this.sim = simUI.sim;
 		this.defaults = simUI.individualConfig.defaults;
 		this.updateGearStatsModifier = options?.updateGearStatsModifier;
-		this.softCapsConfig = options?.softCapsConfig;
-		// For now only gets the first entry because of breakpoints support
+		this.softCapsConfig = this.defaults.softCapBreakpoints || [];
 		this._statCaps = this.statCaps;
+
 		const startReforgeOptimizationEntry: ActionGroupItem = {
 			label: 'Suggest Reforges',
 			cssClass: 'suggest-reforges-action-button flex-grow-1',
@@ -130,7 +115,15 @@ export class ReforgeOptimizer {
 			cssClass: 'suggest-reforges-settings-group d-flex',
 		});
 
+		if (!!this.softCapsConfig?.length)
+			tippy(_startReforgeOptimizationButton, {
+				content: this.buildReforgeButtonTooltip(),
+				placement: 'bottom',
+				maxWidth: 270,
+			});
+
 		tippy(contextMenuButton, {
+			placement: 'bottom',
 			content: 'Change Reforge Optimizer settings',
 		});
 
@@ -162,6 +155,15 @@ export class ReforgeOptimizer {
 		}
 
 		return weights;
+	}
+
+	buildReforgeButtonTooltip() {
+		return (
+			<>
+				The following soft caps/breakpoints have been implemented for this spec:
+				<ul className="mb-0">{this.softCapsConfig?.map(({ stat }) => <li>{getClassStatName(stat, this.player.getClass())}</li>)}</ul>
+			</>
+		);
 	}
 
 	buildContextMenu(button: HTMLButtonElement) {
@@ -316,18 +318,21 @@ export class ReforgeOptimizer {
 		const reforgeSoftCaps: SoftCapBreakpoints[] = [];
 
 		if (this.softCapsConfig) {
-			this.softCapsConfig.slice().reverse().forEach((config) => {
-				const relativeBreakpoints = [];
+			this.softCapsConfig
+				.slice()
+				.reverse()
+				.forEach(config => {
+					const relativeBreakpoints = [];
 
-				for (const breakpoint of config.breakpoints) {
-					relativeBreakpoints.push(breakpoint - baseStats.getStat(config.stat));
-				}
+					for (const breakpoint of config.breakpoints) {
+						relativeBreakpoints.push(breakpoint - baseStats.getStat(config.stat));
+					}
 
-				reforgeSoftCaps.push({
-					stat: config.stat,
-					breakpoints: relativeBreakpoints.sort((a, b) => b - a),
+					reforgeSoftCaps.push({
+						stat: config.stat,
+						breakpoints: relativeBreakpoints.sort((a, b) => b - a),
+					});
 				});
-			});
 		}
 
 		return reforgeSoftCaps;
@@ -368,7 +373,7 @@ export class ReforgeOptimizer {
 		let appliedStat = stat;
 		let appliedAmount = amount;
 
-		if ((stat == Stat.StatSpirit) && this.isHybridCaster) {
+		if (stat == Stat.StatSpirit && this.isHybridCaster) {
 			appliedStat = Stat.StatSpellHit;
 
 			switch (this.player.getSpec()) {
@@ -492,7 +497,13 @@ export class ReforgeOptimizer {
 		await this.updateGear(updatedGear);
 	}
 
-	checkCaps(solution: Solution, reforgeCaps: Stats, reforgeSoftCaps: SoftCapBreakpoints[], variables: YalpsVariables, constraints: YalpsConstraints): [boolean, YalpsConstraints] {
+	checkCaps(
+		solution: Solution,
+		reforgeCaps: Stats,
+		reforgeSoftCaps: SoftCapBreakpoints[],
+		variables: YalpsVariables,
+		constraints: YalpsConstraints,
+	): [boolean, YalpsConstraints] {
 		// First add up the total stat changes from the solution
 		let reforgeStatContribution = new Stats();
 
@@ -526,7 +537,7 @@ export class ReforgeOptimizer {
 		}
 
 		// If hard caps are all taken care of, then deal with any remaining soft cap breakpoints
-		if (!anyCapsExceeded && (reforgeSoftCaps.length > 0)) {
+		if (!anyCapsExceeded && reforgeSoftCaps.length > 0) {
 			const nextSoftCap = reforgeSoftCaps.pop()!;
 			const statName = Stat[nextSoftCap.stat];
 			const currentValue = reforgeStatContribution.getStat(nextSoftCap.stat);

--- a/ui/core/player.ts
+++ b/ui/core/player.ts
@@ -38,6 +38,7 @@ import {
 import {
 	DungeonDifficulty,
 	RaidFilterOption,
+	SoftCapBreakpoints,
 	SourceFilterOption,
 	UIEnchant as Enchant,
 	UIGem as Gem,
@@ -276,6 +277,7 @@ export class Player<SpecType extends Spec> {
 	private epRatios: Array<number> = new Array<number>(Player.numEpRatios).fill(0);
 	private epWeights: Stats = new Stats();
 	private statCaps: Stats = new Stats();
+	private softCapBreakpoints: SoftCapBreakpoints[] = [];
 	private currentStats: PlayerStats = PlayerStats.create();
 	private metadata: UnitMetadata = new UnitMetadata();
 	private petMetadatas: UnitMetadataList = new UnitMetadataList();
@@ -297,6 +299,7 @@ export class Player<SpecType extends Spec> {
 	readonly healingModelChangeEmitter = new TypedEvent<void>('PlayerHealingModel');
 	readonly epWeightsChangeEmitter = new TypedEvent<void>('PlayerEpWeights');
 	readonly statCapsChangeEmitter = new TypedEvent<void>('StatCaps');
+	readonly softCapBreakpointsChangeEmitter = new TypedEvent<void>('StatCaps');
 	readonly miscOptionsChangeEmitter = new TypedEvent<void>('PlayerMiscOptions');
 
 	readonly currentStatsEmitter = new TypedEvent<void>('PlayerCurrentStats');
@@ -511,6 +514,15 @@ export class Player<SpecType extends Spec> {
 	setStatCaps(eventID: EventID, newStatCaps: Stats) {
 		this.statCaps = newStatCaps;
 		this.statCapsChangeEmitter.emit(eventID);
+	}
+
+	getSoftCapBreakpoints(): SoftCapBreakpoints[] {
+		return this.softCapBreakpoints;
+	}
+
+	setSoftCapBreakpoints(eventID: EventID, newSoftCapBreakpoints: SoftCapBreakpoints[]) {
+		this.softCapBreakpoints = newSoftCapBreakpoints;
+		this.softCapBreakpointsChangeEmitter.emit(eventID);
 	}
 
 	getDefaultEpRatios(isTankSpec: boolean, isHealingSpec: boolean): Array<number> {

--- a/ui/warlock/demonology/sim.ts
+++ b/ui/warlock/demonology/sim.ts
@@ -52,6 +52,20 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecDemonologyWarlock, {
 		statCaps: (() => {
 			return new Stats().withStat(Stat.StatSpellHit, 17 * Mechanics.SPELL_HIT_RATING_PER_HIT_CHANCE);
 		})(),
+		// Default soft caps for the Reforge optimizer
+		softCapBreakpoints: (() => {
+			// Set up Mastery breakpoints for integer % damage increments.
+			// These should be removed once the bugfix to make Mastery
+			// continuous goes live!
+			const masteryRatingBreakpoints = [];
+
+			for (let masteryPercent = 19; masteryPercent <= 200; masteryPercent++) {
+				masteryRatingBreakpoints.push((masteryPercent / 2.3) * Mechanics.MASTERY_RATING_PER_MASTERY_POINT);
+			}
+
+			const masterySoftCapConfig = { stat: Stat.StatMastery, breakpoints: masteryRatingBreakpoints };
+			return [masterySoftCapConfig];
+		})(),
 		// Default consumes settings.
 		consumes: Presets.DefaultConsumes,
 
@@ -154,17 +168,7 @@ export class DemonologyWarlockSimUI extends IndividualSimUI<Spec.SpecDemonologyW
 	constructor(parentElem: HTMLElement, player: Player<Spec.SpecDemonologyWarlock>) {
 		super(parentElem, player, SPEC_CONFIG);
 		player.sim.waitForInit().then(() => {
-			// Set up Mastery breakpoints for integer % damage increments.
-			// These should be removed once the bugfix to make Mastery
-			// continuous goes live!
-			const masteryRatingBreakpoints = [];
-
-			for (let masteryPercent = 19; masteryPercent <= 200; masteryPercent++) {
-				masteryRatingBreakpoints.push(masteryPercent / 2.3 * Mechanics.MASTERY_RATING_PER_MASTERY_POINT);
-			}
-
-			const masterySoftCapConfig = {stat: Stat.StatMastery, breakpoints: masteryRatingBreakpoints};
-			new ReforgeOptimizer(this, {softCapsConfig: [masterySoftCapConfig]});
+			new ReforgeOptimizer(this);
 		});
 	}
 }


### PR DESCRIPTION
- Move soft cap breakpoints to the Sim UI settings for potential CLI usage
- Make soft cap breakpoints part of Sim UI spec defaults
- Add tooltip that will show if a specific spec has implemented certain stat breakpoints

![image](https://github.com/wowsims/cata/assets/1216787/5ffdbaa0-348f-47b0-8a0a-bd62623e908c)
