### PR TITLE
Feature/disable UI for unlaunched sims

### DIFF
--- a/ui/core/components/gear_picker/item_list.tsx
+++ b/ui/core/components/gear_picker/item_list.tsx
@@ -568,7 +568,7 @@ export default class ItemList<T extends ItemListType> {
 			this.bindToggleCompare(compareContainer.value!);
 			const simUI = this.simUI instanceof IndividualSimUI ? this.simUI : null;
 			if (simUI) {
-				const checkHasItem = () => simUI.bt.hasItem(ItemSpec.create({ id: itemData.id }));
+				const checkHasItem = () => simUI.bt?.hasItem(ItemSpec.create({ id: itemData.id }));
 				const toggleCompareButtonState = () => {
 					const hasItem = checkHasItem();
 					batchSimTooltip.setContent(hasItem ? 'Remove from Batch Sim' : 'Add to Batch Sim');
@@ -576,13 +576,13 @@ export default class ItemList<T extends ItemListType> {
 				};
 
 				toggleCompareButtonState();
-				simUI.bt.itemsChangedEmitter.on(() => {
+				simUI.bt?.itemsChangedEmitter.on(() => {
 					toggleCompareButtonState();
 				});
 
 				compareButton.value!.addEventListener('click', () => {
 					const hasItem = checkHasItem();
-					simUI.bt[hasItem ? 'removeItem' : 'addItem'](ItemSpec.create({ id: itemData.id }));
+					simUI.bt?.[hasItem ? 'removeItem' : 'addItem'](ItemSpec.create({ id: itemData.id }));
 
 					new Toast({
 						delay: 1000,

--- a/ui/core/player_specs/druid.ts
+++ b/ui/core/player_specs/druid.ts
@@ -116,7 +116,7 @@ export class RestorationDruid extends PlayerSpec<Spec.SpecRestorationDruid> {
 	static specID = Spec.SpecRestorationDruid as Spec.SpecRestorationDruid;
 	static classID = Class.ClassDruid as Class.ClassDruid;
 	static friendlyName = 'Restoration';
-	static simLink = getSpecSiteUrl('druid', 'Restoration');
+	static simLink = getSpecSiteUrl('druid', 'restoration');
 
 	static isTankSpec = false;
 	static isHealingSpec = true;

--- a/ui/scss/core/sim_ui/_shared.scss
+++ b/ui/scss/core/sim_ui/_shared.scss
@@ -68,6 +68,9 @@ th {
 }
 
 .sim-ui--is-unlaunched {
+	.import-export {
+		display: none !important;
+	}
 	.sim-sidebar {
 		.sim-sidebar-actions > *:not(.sim-ui-unlaunched-container),
 		.sim-sidebar-results {
@@ -77,6 +80,8 @@ th {
 }
 
 .sim-ui-unlaunched-container {
+	max-width: 400px;
+
 	i {
 		color: var(--bs-danger);
 	}


### PR DESCRIPTION
- Stop the Sim UI from initializing for unlaunched sims when the client is not in dev mode. (local sim releases would still load the unlaunched sims) This will hopefully stop people from reporting issues that happen when the actual Sim UI is loading (HPala for example)
- Fix `R` in resto sim link

![image](https://github.com/wowsims/cata/assets/1216787/0c19d636-0032-4297-827a-106c409b1099)
