### PR TITLE
[UI] Bulk responsive fixes

### DIFF
--- a/ui/core/components/individual_sim_ui/bulk_tab.tsx
+++ b/ui/core/components/individual_sim_ui/bulk_tab.tsx
@@ -796,7 +796,7 @@ export class BulkTab extends SimTab {
 				</span>
 				{this.showIterationsWarning() && (
 					<button className="warning link-warning" ref={warningRef}>
-						<i className="fas fa-exclamation-triangle fa-2x ms-2" />
+						<i className="fas fa-exclamation-triangle fa-2x" />
 					</button>
 				)}
 			</>
@@ -807,6 +807,16 @@ export class BulkTab extends SimTab {
 				content: `Simming over ${WEB_ITERATIONS_LIMIT} iterations in the web sim will take a long time or may not run at all.
 					For larger batch sims we recommend using Fast Mode or downloading the executable and running on your machine.`,
 				placement: 'left',
+				popperOptions: {
+					modifiers: [
+						{
+							name: 'flip',
+							options: {
+								fallbackPlacements: ['auto'],
+							},
+						},
+					],
+				},
 			});
 		}
 

--- a/ui/scss/core/components/individual_sim_ui/_bulk_tab.scss
+++ b/ui/scss/core/components/individual_sim_ui/_bulk_tab.scss
@@ -10,58 +10,52 @@
 		}
 	}
 
-	#bulkSetupTab {
-		gap: var(--gap-width);
-
-		&.active {
-			display: grid;
-		}
-
-		.bulk-gear-actions {
-			display: flex;
-			grid-auto-flow: column;
-			gap: var(--block-spacer);
-		}
-
-		.bulk-gear-combo {
-			display: grid;
-			grid-template-columns: repeat(3, minmax(0, 1fr));
-			grid-template-rows: auto;
-			gap: calc(2 * var(--gap-width)) var(--gap-width);
-		}
-	}
-
 	.bulk-settings-outer-container {
 		position: sticky;
 		top: var(--sim-header-height);
 		padding-top: var(--gap-width);
+	}
 
-		.bulk-settings-container {
-			padding: var(--spacer-3);
-			border: var(--border-default);
-			display: grid;
-			gap: var(--gap-width);
-			background: var(--bs-body-bg);
+	.bulk-settings-container {
+		padding: var(--spacer-3);
+		border: var(--border-default);
+		display: grid;
+		gap: var(--gap-width);
+		background: var(--bs-body-bg);
+	}
 
-			.bulk-combinations-count {
-				margin-bottom: 0;
-				display: flex;
-				align-items: center;
+	.bulk-combinations-count {
+		margin-bottom: 0;
+		display: flex;
+		align-items: center;
+		gap: var(--spacer-2);
 
-				small {
-					font-size: var(--bs-body-font-size);
-				}
+		@include media-breakpoint-between(xl, xxl) {
+			flex-wrap: wrap;
+		}
+
+		small {
+			font-size: var(--bs-body-font-size);
+		}
+
+		.warning {
+			@include media-breakpoint-between(xl, xxl) {
+				order: -1;
 			}
+		}
+	}
 
-			.bulk-boolean-settings-container {
-				display: grid;
-				grid-template-columns: repeat(2, 1fr);
-				gap: var(--block-spacer);
+	.bulk-boolean-settings-container {
+		display: grid;
+		grid-template-columns: repeat(2, 1fr);
+		gap: var(--block-spacer);
 
-				.boolean-picker-root {
-					margin-bottom: 0;
-				}
-			}
+		@include media-breakpoint-between(xl, xxxl) {
+			grid-template-columns: 1fr;
+		}
+
+		.boolean-picker-root {
+			margin-bottom: 0;
 		}
 	}
 
@@ -127,6 +121,37 @@
 					text-overflow: ellipsis;
 				}
 			}
+		}
+	}
+}
+
+#bulkSetupTab {
+	gap: var(--gap-width);
+
+	&.active {
+		display: grid;
+	}
+
+	.bulk-gear-actions {
+		display: flex;
+		grid-auto-flow: column;
+		gap: var(--block-spacer);
+	}
+
+	.bulk-gear-combo {
+		--bulk-gear-combo-column-count: 1;
+		--bulk-gear-combo-gap-width: calc(var(--gap-width)) var(--gap-width);
+		display: grid;
+		gap: var(--bulk-gear-combo-gap-width);
+		grid-template-columns: repeat(var(--bulk-gear-combo-column-count), minmax(0, 1fr));
+		grid-template-rows: auto;
+
+		@include media-breakpoint-up(sm) {
+			--bulk-gear-combo-gap-width: calc(2 * var(--gap-width)) var(--gap-width);
+			--bulk-gear-combo-column-count: 2;
+		}
+		@include media-breakpoint-up(xl) {
+			--bulk-gear-combo-column-count: 3;
 		}
 	}
 }

--- a/ui/scss/core/components/individual_sim_ui/bulk/_bulk_item_search.scss
+++ b/ui/scss/core/components/individual_sim_ui/bulk/_bulk_item_search.scss
@@ -11,69 +11,85 @@
 	}
 
 	.bulk-gear-search-container {
+		position: relative;
 		display: grid;
+		gap: var(--gap-width);
 		padding: var(--spacer-3);
 		border: var(--border-default);
 		background: var(--bs-body-bg);
-		grid-template-columns: 1fr 1fr 2fr;
-		gap: var(--gap-width);
-		position: relative;
+		grid-template-columns: 1fr 1fr;
+		@include media-breakpoint-up(md) {
+			grid-template-columns: 1fr 1fr 2fr;
+		}
+	}
 
-		.cancel-bulk-gear-search-btn {
-			padding: $input-padding-y $input-padding-x;
-			display: flex;
-			align-items: center;
-			background-color: $input-bg;
-			border: 1px solid $input-border-color;
+	.cancel-bulk-gear-search-btn {
+		padding: $input-padding-y $input-padding-x;
+		display: flex;
+		align-items: center;
+		background-color: $input-bg;
+		border: 1px solid $input-border-color;
+	}
+
+	.bulk-gear-search-results {
+		--bulk-gear-search-results-column-count: 1;
+		gap: var(--spacer-2);
+		top: 100%;
+		padding: var(--spacer-2);
+		left: var(--spacer-3);
+		right: var(--spacer-3);
+		grid-template-columns: repeat(var(--bulk-gear-search-results-column-count), 1fr);
+
+		@include media-breakpoint-up(md) {
+			--bulk-gear-search-results-column-count: 2;
+		}
+		@include media-breakpoint-up(lg) {
+			--bulk-gear-search-results-column-count: 3;
 		}
 
-		.bulk-gear-search-results {
-			top: 100%;
-			padding: var(--spacer-2);
+		&.show {
+			display: grid;
+		}
+	}
 
-			&.show {
-				display: grid;
-				grid-template-columns: repeat(3, 1fr);
-				gap: var(--spacer-2);
-			}
+	.bulk-item-search-item {
+		display: flex;
+		width: 100%;
+		padding: var(--spacer-2);
+		border: var(--border-default);
+		white-space: normal;
+	}
 
-			.bulk-item-search-item {
-				display: flex;
-				padding: var(--spacer-2);
-				border: var(--border-default);
+	.bulk-item-search-item-icon-wrapper {
+		flex-shrink: 0;
+		width: var(--icon-size-md);
+		height: var(--icon-size-md);
+		border: var(--border-default);
+	}
 
-				.bulk-item-search-item-icon-wrapper {
-					width: var(--icon-size-md);
-					height: var(--icon-size-md);
-					border: var(--border-default);
+	.bulk-item-search-item-icon {
+		@include wowhead-background-icon;
+		width: 100%;
+		height: 100%;
+	}
 
-					.bulk-item-search-item-icon {
-						@include wowhead-background-icon;
-						width: 100%;
-						height: 100%;
-					}
-				}
-			}
+	.bulk-item-search-more-items-note {
+		border: none;
+		grid-column: 1 / var(--bulk-gear-search-results-column-count);
+	}
 
-			.bulk-item-search-more-items-note {
-				border: none;
-				grid-column: 1 / 4;
-			}
+	.bulk-gear-search-ilvl-filters {
+		display: flex;
+		align-items: center;
+
+		.number-picker-root {
+			margin-bottom: 0;
 		}
 
-		.bulk-gear-search-ilvl-filters {
-			display: flex;
-			align-items: center;
-
-			.number-picker-root {
-				margin-bottom: 0;
-			}
-
-			.ilvl-filters-separator {
-				margin-left: var(--block-spacer);
-				margin-right: var(--block-spacer);
-				margin-top: var(--block-spacer);
-			}
+		.ilvl-filters-separator {
+			margin-left: var(--block-spacer);
+			margin-right: var(--block-spacer);
+			margin-top: var(--block-spacer);
 		}
 	}
 }


### PR DESCRIPTION
- Fixes mobile view overflows
- Fixes on screens smaller than ~1500px where the search results container would overflow
  - Current: https://i.imgur.com/BEJF3U3.png
  - Fixed: https://i.imgur.com/zyklmzV.png
- Made results and item list columns scale based on breakpoints
  - Mobile: 1
  - Tablet: 2
  - Desktop: 3
  - Now also follow the width of the parent
- Iterations warning box in sidebar no longer overflows the sidebar
- Boolean inputs columns now are responsive and no longer overflow the sidebar
- Re-ordered some of the deeply nested specific selectors