### PR TITLE
[UI] Reforge Optimiser stat input changes

### DIFF
--- a/proto/ui.proto
+++ b/proto/ui.proto
@@ -296,6 +296,7 @@ message SimSettings {
 	bool show_quick_swap = 12;
 	bool show_ep_values = 11;
 	bool use_custom_ep_values = 13;
+	bool use_soft_cap_breakpoints = 14;
 	string language = 9;
 	Faction faction = 6;
 	DatabaseFilters filters = 10;

--- a/ui/core/components/suggest_reforges_action.tsx
+++ b/ui/core/components/suggest_reforges_action.tsx
@@ -185,17 +185,19 @@ export class ReforgeOptimizer {
 						this.sim.setUseCustomEPValues(eventID, newValue);
 					},
 				});
-
-				const useSoftCapBreakpointsInput = new BooleanPicker(null, this.player, {
-					id: 'reforge-optimizer-enable-soft-cap-breakpoints',
-					label: 'Enable soft cap breakpoints',
-					inline: true,
-					changedEvent: () => this.sim.useSoftCapBreakpointsChangeEmitter,
-					getValue: () => this.sim.getUseSoftCapBreakpoints(),
-					setValue: (eventID, _player, newValue) => {
-						this.sim.setUseSoftCapBreakpoints(eventID, newValue);
-					},
-				});
+				let useSoftCapBreakpointsInput: BooleanPicker<Player<any>> | null = null;
+				if (!!this.softCapsConfig?.length) {
+					useSoftCapBreakpointsInput = new BooleanPicker(null, this.player, {
+						id: 'reforge-optimizer-enable-soft-cap-breakpoints',
+						label: 'Enable soft cap breakpoints',
+						inline: true,
+						changedEvent: () => this.sim.useSoftCapBreakpointsChangeEmitter,
+						getValue: () => this.sim.getUseSoftCapBreakpoints(),
+						setValue: (eventID, _player, newValue) => {
+							this.sim.setUseSoftCapBreakpoints(eventID, newValue);
+						},
+					});
+				}
 
 				const descriptionRef = ref<HTMLParagraphElement>();
 				instance.setContent(
@@ -210,7 +212,7 @@ export class ReforgeOptimizer {
 							useCustomEPValuesInput: useCustomEPValuesInput,
 							description: descriptionRef.value!,
 						})}
-						{useSoftCapBreakpointsInput.rootElem}
+						{useSoftCapBreakpointsInput?.rootElem}
 						{this.buildEPWeightsToggle({ useCustomEPValuesInput: useCustomEPValuesInput })}
 					</>,
 				);

--- a/ui/core/components/suggest_reforges_action.tsx
+++ b/ui/core/components/suggest_reforges_action.tsx
@@ -37,6 +37,7 @@ const EXCLUDED_STATS = [
 	Stat.StatSpellPenetration,
 	Stat.StatSpirit,
 	Stat.StatMana,
+	Stat.StatMP5,
 ];
 
 export type ReforgeOptimizerOptions = {

--- a/ui/core/components/suggest_reforges_action.tsx
+++ b/ui/core/components/suggest_reforges_action.tsx
@@ -383,7 +383,7 @@ export class ReforgeOptimizer {
 	computeReforgeSoftCaps(baseStats: Stats): SoftCapBreakpoints[] {
 		const reforgeSoftCaps: SoftCapBreakpoints[] = [];
 
-		if (this.softCapsConfig) {
+		if (this.sim.getUseSoftCapBreakpoints() && this.softCapsConfig) {
 			this.softCapsConfig
 				.slice()
 				.reverse()

--- a/ui/core/player.ts
+++ b/ui/core/player.ts
@@ -299,7 +299,7 @@ export class Player<SpecType extends Spec> {
 	readonly healingModelChangeEmitter = new TypedEvent<void>('PlayerHealingModel');
 	readonly epWeightsChangeEmitter = new TypedEvent<void>('PlayerEpWeights');
 	readonly statCapsChangeEmitter = new TypedEvent<void>('StatCaps');
-	readonly softCapBreakpointsChangeEmitter = new TypedEvent<void>('StatCaps');
+	readonly softCapBreakpointsChangeEmitter = new TypedEvent<void>('SoftCapBreakpoints');
 	readonly miscOptionsChangeEmitter = new TypedEvent<void>('PlayerMiscOptions');
 
 	readonly currentStatsEmitter = new TypedEvent<void>('PlayerCurrentStats');

--- a/ui/core/proto_utils/stats.ts
+++ b/ui/core/proto_utils/stats.ts
@@ -1,4 +1,5 @@
 import * as Mechanics from '../constants/mechanics.js';
+import { Player } from '../player';
 import { Class, PseudoStat, Stat, UnitStats } from '../proto/common.js';
 import { getEnumValues } from '../utils.js';
 import { getClassStatName, pseudoStatNames } from './names.js';
@@ -288,7 +289,7 @@ export const statToPercentageOrPoints = (stat: Stat, value: number, stats: Stats
 			statInPercentage = value;
 			break;
 	}
-	return Number(statInPercentage.toFixed(2));
+	return statInPercentage;
 };
 
 export const statPercentageOrPointsToNumber = (stat: Stat, value: number, stats: Stats) => {

--- a/ui/core/sim.ts
+++ b/ui/core/sim.ts
@@ -80,6 +80,7 @@ export class Sim {
 	private showQuickSwap = false;
 	private showEPValues = false;
 	private useCustomEPValues = false;
+	private useSoftCapBreakpoints = true;
 	private language = '';
 
 	readonly type: SimType;
@@ -101,6 +102,7 @@ export class Sim {
 	readonly showQuickSwapChangeEmitter = new TypedEvent<void>();
 	readonly showEPValuesChangeEmitter = new TypedEvent<void>();
 	readonly useCustomEPValuesChangeEmitter = new TypedEvent<void>();
+	readonly useSoftCapBreakpointsChangeEmitter = new TypedEvent<void>();
 	readonly languageChangeEmitter = new TypedEvent<void>();
 	readonly crashEmitter = new TypedEvent<SimError>();
 
@@ -150,6 +152,7 @@ export class Sim {
 			this.showQuickSwapChangeEmitter,
 			this.showEPValuesChangeEmitter,
 			this.useCustomEPValuesChangeEmitter,
+			this.useSoftCapBreakpointsChangeEmitter,
 			this.languageChangeEmitter,
 		]);
 
@@ -570,6 +573,16 @@ export class Sim {
 		}
 	}
 
+	getUseSoftCapBreakpoints(): boolean {
+		return this.useSoftCapBreakpoints;
+	}
+	setUseSoftCapBreakpoints(eventID: EventID, newUseSoftCapBreakpoints: boolean) {
+		if (newUseSoftCapBreakpoints !== this.useSoftCapBreakpoints) {
+			this.useSoftCapBreakpoints = newUseSoftCapBreakpoints;
+			this.useSoftCapBreakpointsChangeEmitter.emit(eventID);
+		}
+	}
+
 	getLanguage(): string {
 		return this.language;
 	}
@@ -627,6 +640,7 @@ export class Sim {
 			showQuickSwap: this.getShowQuickSwap(),
 			showEpValues: this.getShowEPValues(),
 			useCustomEpValues: this.getUseCustomEPValues(),
+			useSoftCapBreakpoints: this.getUseSoftCapBreakpoints(),
 			language: this.getLanguage(),
 			faction: this.getFaction(),
 			filters: filters,
@@ -645,6 +659,7 @@ export class Sim {
 			this.setShowQuickSwap(eventID, proto.showQuickSwap);
 			this.setShowEPValues(eventID, proto.showEpValues);
 			this.setUseCustomEPValues(eventID, proto.useCustomEpValues);
+			this.setUseSoftCapBreakpoints(eventID, proto.useSoftCapBreakpoints);
 			this.setLanguage(eventID, proto.language);
 			this.setFaction(eventID, proto.faction || Faction.Alliance);
 

--- a/ui/core/sim.ts
+++ b/ui/core/sim.ts
@@ -701,6 +701,7 @@ export class Sim {
 				language: this.getLanguage(), // Don't change language.
 				filters: Sim.defaultFilters(),
 				showEpValues: false,
+				useSoftCapBreakpoints: true,
 			}),
 		);
 	}

--- a/ui/scss/core/components/_suggest_reforges_action.scss
+++ b/ui/scss/core/components/_suggest_reforges_action.scss
@@ -15,6 +15,48 @@
 	padding-right: calc(var(--btn-padding-x) + var(--settings-button-width));
 }
 
+.reforge-optimizer-stat-cap-table {
+	border-collapse: collapse;
+	border-spacing: 0;
+	padding: 0;
+
+	tr {
+		td,
+		th {
+			padding-bottom: var(--spacer-1);
+		}
+	}
+
+	th,
+	td {
+		padding: 0;
+		&:not(:first-child):not(:only-child) {
+			padding-left: calc(var(--spacer-1) / 2);
+		}
+		&:not(:last-child):not(:only-child) {
+			padding-right: calc(var(--spacer-1) / 2);
+		}
+		&:first-child:not(:only-child) {
+			padding-right: var(--spacer-2);
+		}
+	}
+
+	tbody {
+		td:nth-child(2) {
+			width: 75px;
+		}
+		td:nth-child(3) {
+			width: 60px;
+		}
+	}
+
+	.form-control {
+		padding-left: var(--spacer-2);
+		padding-right: var(--spacer-2);
+		text-align: right;
+	}
+}
+
 .suggest-reforges-button-settings {
 	position: absolute;
 	top: 0;

--- a/ui/scss/core/components/_suggest_reforges_action.scss
+++ b/ui/scss/core/components/_suggest_reforges_action.scss
@@ -1,5 +1,5 @@
 .tippy-box[data-theme='reforge-optimiser-popover'] {
-	min-width: 200px;
+	min-width: 240px;
 
 	.saved-data-manager-root {
 		margin-bottom: 0;
@@ -55,6 +55,10 @@
 		padding-right: var(--spacer-2);
 		text-align: right;
 	}
+}
+
+.reforge-optimizer-stat-cap-item-label {
+	white-space: nowrap;
 }
 
 .suggest-reforges-button-settings {


### PR DESCRIPTION
- Added option to toggle soft cap breakpoints (enabled by default) and only shows for classes that have this available/configured
- Changed to double inputs to allow for simultaneous rating and percentage editing
- Mastery will now always be either Rating or % (not points)

![image](https://github.com/wowsims/cata/assets/1216787/49d13912-a6b1-469e-9005-69ebfb6d2e74)
![image](https://github.com/wowsims/cata/assets/1216787/45b59cd7-3f4e-413a-a7de-6cb3f0c68e38)
