### PR TITLE
[Shaman] Fix flametongue imbue being affected by reforges

### DIFF
--- a/sim/shaman/enhancement/enhancement.go
+++ b/sim/shaman/enhancement/enhancement.go
@@ -102,10 +102,7 @@ func (enh *EnhancementShaman) Initialize() {
 	enh.RegisterWindfuryImbue(enh.getImbueProcMask(proto.ShamanImbue_WindfuryWeapon))
 
 	if enh.ItemSwap.IsEnabled() {
-		mh := enh.ItemSwap.GetItem(proto.ItemSlot_ItemSlotMainHand)
-		enh.ApplyFlametongueImbueToItem(mh)
-		oh := enh.ItemSwap.GetItem(proto.ItemSlot_ItemSlotOffHand)
-		enh.ApplyFlametongueImbueToItem(oh)
+		enh.ApplyFlametongueImbueSwap(enh.getImbueProcMask(proto.ShamanImbue_FlametongueWeapon))
 		enh.RegisterOnItemSwap(func(_ *core.Simulation) {
 			enh.ApplySyncType(proto.ShamanSyncType_Auto)
 		})

--- a/sim/shaman/weapon_imbues.go
+++ b/sim/shaman/weapon_imbues.go
@@ -153,6 +153,16 @@ func (shaman *Shaman) ApplyFlametongueImbueToItem(item *core.Item) {
 	}
 
 	enchantID := 5
+	//flametongue imbue does not stack
+	if (shaman.HasMHWeapon() && shaman.GetMHWeapon().TempEnchant == int32(enchantID)) || (shaman.HasOHWeapon() && shaman.GetOHWeapon().TempEnchant == int32(enchantID)) {
+		item.TempEnchant = int32(enchantID)
+		return
+
+	}
+	if shaman.ItemSwap.IsEnabled() && (shaman.ItemSwap.GetItem(proto.ItemSlot_ItemSlotMainHand).TempEnchant == int32(enchantID) || shaman.ItemSwap.GetItem(proto.ItemSlot_ItemSlotOffHand).TempEnchant == int32(enchantID)) {
+		item.TempEnchant = int32(enchantID)
+		return
+	}
 	magicDamageBonus := 1.0 + (0.05 * (1 + 0.2*float64(shaman.Talents.ElementalWeapons)))
 
 	shaman.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexFire] *= magicDamageBonus
@@ -161,7 +171,7 @@ func (shaman *Shaman) ApplyFlametongueImbueToItem(item *core.Item) {
 
 	if shaman.HasPrimeGlyph(proto.ShamanPrimeGlyph_GlyphOfFlametongueWeapon) {
 		newStats := stats.Stats{stats.SpellCrit: 2 * core.CritRatingPerCritChance}
-		item.Stats = item.Stats.Add(newStats)
+		shaman.AddStats(newStats)
 	}
 
 	item.TempEnchant = int32(enchantID)
@@ -174,6 +184,16 @@ func (shaman *Shaman) ApplyFlametongueImbue(procMask core.ProcMask) {
 
 	if procMask.Matches(core.ProcMaskMeleeOH) && shaman.HasOHWeapon() {
 		shaman.ApplyFlametongueImbueToItem(shaman.OffHand())
+	}
+}
+
+func (shaman *Shaman) ApplyFlametongueImbueSwap(procMask core.ProcMask) {
+	if procMask.Matches(core.ProcMaskMeleeMH) && shaman.ItemSwap.IsEnabled() {
+		shaman.ApplyFlametongueImbueToItem(shaman.ItemSwap.GetItem(proto.ItemSlot_ItemSlotMainHand))
+	}
+
+	if procMask.Matches(core.ProcMaskMeleeOH) && shaman.ItemSwap.IsEnabled() {
+		shaman.ApplyFlametongueImbueToItem(shaman.ItemSwap.GetItem(proto.ItemSlot_ItemSlotOffHand))
 	}
 }
 


### PR DESCRIPTION
Also added a test to not have it stack with itself when imbued on both weapon

Not sure why enh tests are not failing