### PR TITLE
Auto-Reforge Improvements for Demonology Warlock

### DIFF
--- a/proto/common.proto
+++ b/proto/common.proto
@@ -150,6 +150,9 @@ enum PseudoStat {
 	PseudoStatBlockDamageReduction = 3;
 	PseudoStatDodge = 4;
 	PseudoStatParry = 5;
+	PseudoStatRangedSpeedMultiplier = 6;
+	PseudoStatMeleeSpeedMultiplier = 7;
+	PseudoStatCastSpeedMultiplier = 8;
 }
 
 message UnitStats {

--- a/proto/ui.proto
+++ b/proto/ui.proto
@@ -318,14 +318,46 @@ message IndividualSimSettings {
 	Stat heal_ref_stat = 13;
 	Stat tank_ref_stat = 14;
 	UnitStats stat_caps = 15;
-	repeated SoftCapBreakpoints soft_cap_breakpoints = 16;
+	repeated StatCapConfig soft_cap_breakpoints = 16;
 }
 
-message SoftCapBreakpoints {
+message StatCapConfig {
 	Stat stat = 1;
+
+	// Breakpoint values in ascending order
 	repeated double breakpoints = 2;
+
+	// Should be either TypeSoftCap or TypeThreshold currently
+	StatCapType cap_type = 3;
+
+	// postCapEPs[i] is the stat weight value when between breakpoints[i]
+	// and breakpoints[i+1]. Used only for TypeSoftCap and ignored for
+	// TypeThreshold.
+	repeated double post_cap_EPs = 4;
 }
 
+enum StatCapType {
+	TypeUnknown = 0;
+
+	// Unused currently, but may be able to combine hard cap + soft cap
+	// configuration in the future.
+	TypeHardCap = 1;
+
+	// Used for stats that exhibit significant EP changes after particular
+	// breakpoint values, but where the post-cap EP remains non-zero.
+	// Examples include Spell Haste for Demonology Warlocks and Expertise
+	// for tanks.
+	TypeSoftCap = 2;
+
+	// Used for stats that exhibit discontinuities in value at discrete
+	// thresholds due to in-game rounding effects etc., but where the
+	// average value of the stat from one breakpoint to the next does not
+	// vary significantly. The most relevant example in early Cata Classic
+	// is Mastery Rating for Affliction Warlock, Demonology Warlock,
+	// Arcane Mage, Fire Mage, and Balance Druid, which gets floored in-game
+	// to the nearest integer % damage threshold.
+	TypeThreshold = 3;
+}
 
 // Local storage data for gear settings.
 message SavedGearSet {

--- a/sim/core/character.go
+++ b/sim/core/character.go
@@ -256,15 +256,6 @@ func (character *Character) applyAllEffects(agent Agent, raidBuffs *proto.RaidBu
 			PseudoStats: character.GetPseudoStatsProto(),
 		}
 
-		meleeMulti := 1 + (base.Stats[stats.MeleeHaste] / (HasteRatingPerHastePercent * 100))
-		spellMulti := 1 + (base.Stats[stats.SpellHaste] / (HasteRatingPerHastePercent * 100))
-
-		if agent.GetCharacter().Class == proto.Class_ClassHunter {
-			base.Stats[stats.MeleeHaste] = (meleeMulti*character.PseudoStats.RangedSpeedMultiplier - 1) * 100 * HasteRatingPerHastePercent
-		} else {
-			base.Stats[stats.MeleeHaste] = (meleeMulti*character.PseudoStats.MeleeSpeedMultiplier - 1) * 100 * HasteRatingPerHastePercent
-		}
-		base.Stats[stats.SpellHaste] = (spellMulti*character.PseudoStats.CastSpeedMultiplier - 1) * 100 * HasteRatingPerHastePercent
 		return base
 	}
 
@@ -480,16 +471,6 @@ func (character *Character) FillPlayerStats(playerStats *proto.PlayerStats) {
 		PseudoStats: character.GetPseudoStatsProto(),
 	}
 
-	meleeMulti := 1 + (playerStats.FinalStats.Stats[stats.MeleeHaste] / (HasteRatingPerHastePercent * 100))
-	spellMulti := 1 + (playerStats.FinalStats.Stats[stats.SpellHaste] / (HasteRatingPerHastePercent * 100))
-	if character.Class == proto.Class_ClassHunter {
-		playerStats.FinalStats.Stats[stats.MeleeHaste] = (meleeMulti*character.PseudoStats.RangedSpeedMultiplier - 1) * 100 * HasteRatingPerHastePercent
-	} else {
-		playerStats.FinalStats.Stats[stats.MeleeHaste] = (meleeMulti*character.PseudoStats.MeleeSpeedMultiplier - 1) * 100 * HasteRatingPerHastePercent
-	}
-
-	playerStats.FinalStats.Stats[stats.SpellHaste] = (spellMulti*character.PseudoStats.CastSpeedMultiplier - 1) * 100 * HasteRatingPerHastePercent
-
 	character.clearBuildPhaseAuras(CharacterBuildPhaseAll)
 	playerStats.Sets = character.GetActiveSetBonusNames()
 
@@ -644,6 +625,11 @@ func (character *Character) GetPseudoStatsProto() []float64 {
 		// Base values are modified by Enemy attackTables, but we display for LVL 80 enemy as paperdoll default
 		proto.PseudoStat_PseudoStatDodge: character.PseudoStats.BaseDodge + character.GetDiminishedDodgeChance(),
 		proto.PseudoStat_PseudoStatParry: character.PseudoStats.BaseParry + character.GetDiminishedParryChance(),
+
+		// Used by UI to incorporate multiplicative Haste buffs into final character stats display.
+		proto.PseudoStat_PseudoStatRangedSpeedMultiplier: character.PseudoStats.RangedSpeedMultiplier,
+		proto.PseudoStat_PseudoStatMeleeSpeedMultiplier:  character.PseudoStats.MeleeSpeedMultiplier,
+		proto.PseudoStat_PseudoStatCastSpeedMultiplier:   character.PseudoStats.CastSpeedMultiplier,
 	}
 }
 

--- a/sim/death_knight/blood/TestBlood.results
+++ b/sim/death_knight/blood/TestBlood.results
@@ -10,12 +10,12 @@ character_stats_results: {
   final_stats: 326
   final_stats: 1894.01166
   final_stats: 1390.68024
-  final_stats: 758.9358
+  final_stats: 113
   final_stats: 0
   final_stats: 13710.90658
   final_stats: 972
   final_stats: 1909.76106
-  final_stats: 1404.8716
+  final_stats: 113
   final_stats: 502.16318
   final_stats: 0
   final_stats: 24758.85984

--- a/sim/death_knight/frost/TestFrost.results
+++ b/sim/death_knight/frost/TestFrost.results
@@ -10,12 +10,12 @@ character_stats_results: {
   final_stats: 326
   final_stats: 1617.01166
   final_stats: 2697.4837
-  final_stats: 2977.67347
+  final_stats: 2226.0835
   final_stats: 0
   final_stats: 16413.98592
   final_stats: 695
   final_stats: 3228.15115
-  final_stats: 8028.35811
+  final_stats: 2226.0835
   final_stats: 655
   final_stats: 0
   final_stats: 21136

--- a/sim/death_knight/unholy/TestUnholy.results
+++ b/sim/death_knight/unholy/TestUnholy.results
@@ -10,12 +10,12 @@ character_stats_results: {
   final_stats: 326
   final_stats: 1889.01166
   final_stats: 2975.76374
-  final_stats: 3027.02347
+  final_stats: 2273.0835
   final_stats: 0
   final_stats: 19589.88885
   final_stats: 967
   final_stats: 3510.2934
-  final_stats: 3780.96345
+  final_stats: 2273.0835
   final_stats: 381
   final_stats: 0
   final_stats: 21044

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -10,12 +10,12 @@ character_stats_results: {
   final_stats: 1257.75
   final_stats: 962
   final_stats: 2897.39222
-  final_stats: 1013.0358
+  final_stats: 355
   final_stats: 0
   final_stats: 19891.245
   final_stats: 962
   final_stats: 7607.89071
-  final_stats: 1671.0716
+  final_stats: 355
   final_stats: 779
   final_stats: 27020.53455
   final_stats: 9951

--- a/sim/druid/guardian/TestGuardian.results
+++ b/sim/druid/guardian/TestGuardian.results
@@ -10,12 +10,12 @@ character_stats_results: {
   final_stats: 1257.75
   final_stats: 182
   final_stats: 2971.10676
-  final_stats: 965.7858
+  final_stats: 310
   final_stats: 0
   final_stats: 13520.25
   final_stats: 182
   final_stats: 6184.13635
-  final_stats: 1621.5716
+  final_stats: 310
   final_stats: 83
   final_stats: 26617.3503
   final_stats: 46177.25153

--- a/sim/hunter/beast_mastery/TestBM.results
+++ b/sim/hunter/beast_mastery/TestBM.results
@@ -10,12 +10,12 @@ character_stats_results: {
   final_stats: 326
   final_stats: 962
   final_stats: 2800.4002
-  final_stats: 1482.3858
+  final_stats: 802
   final_stats: 0
   final_stats: 17922.0288
   final_stats: 962
   final_stats: 5623.72809
-  final_stats: 2611.82623
+  final_stats: 802
   final_stats: 0
   final_stats: 0
   final_stats: 14342

--- a/sim/hunter/marksmanship/TestMM.results
+++ b/sim/hunter/marksmanship/TestMM.results
@@ -10,12 +10,12 @@ character_stats_results: {
   final_stats: 326
   final_stats: 962
   final_stats: 2800.4002
-  final_stats: 1482.3858
+  final_stats: 802
   final_stats: 0
   final_stats: 13786.176
   final_stats: 962
   final_stats: 5623.72809
-  final_stats: 2611.82623
+  final_stats: 802
   final_stats: 0
   final_stats: 0
   final_stats: 14342

--- a/sim/hunter/survival/TestSV.results
+++ b/sim/hunter/survival/TestSV.results
@@ -10,12 +10,12 @@ character_stats_results: {
   final_stats: 326
   final_stats: 962
   final_stats: 2800.4002
-  final_stats: 1482.3858
+  final_stats: 802
   final_stats: 0
   final_stats: 15418.31347
   final_stats: 962
   final_stats: 6001.68224
-  final_stats: 2611.82623
+  final_stats: 802
   final_stats: 0
   final_stats: 0
   final_stats: 14342

--- a/sim/mage/arcane/TestArcane.results
+++ b/sim/mage/arcane/TestArcane.results
@@ -10,12 +10,12 @@ character_stats_results: {
   final_stats: 1196.9
   final_stats: 1754.178
   final_stats: 3556.97522
-  final_stats: 2396.61024
+  final_stats: 1250.9888
   final_stats: 0
   final_stats: 0
   final_stats: 1754.178
   final_stats: 2410.63346
-  final_stats: 2656.65928
+  final_stats: 1250.9888
   final_stats: 0
   final_stats: 108670.40511
   final_stats: 8479

--- a/sim/mage/fire/TestFire.results
+++ b/sim/mage/fire/TestFire.results
@@ -10,12 +10,12 @@ character_stats_results: {
   final_stats: 1196.9
   final_stats: 1749.178
   final_stats: 3753.72036
-  final_stats: 3093.10835
+  final_stats: 1895
   final_stats: 0
   final_stats: 0
   final_stats: 1749.178
   final_stats: 2756.81146
-  final_stats: 3365.0716
+  final_stats: 1895
   final_stats: 0
   final_stats: 100335.24051
   final_stats: 8479

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -10,12 +10,12 @@ character_stats_results: {
   final_stats: 1497.1
   final_stats: 1781.04912
   final_stats: 3014.2972
-  final_stats: 1239.8358
+  final_stats: 571
   final_stats: 0
   final_stats: 15303.8495
   final_stats: 961.4832
   final_stats: 3112.93438
-  final_stats: 1908.6716
+  final_stats: 571
   final_stats: 484
   final_stats: 27299.75
   final_stats: 21168

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -10,12 +10,12 @@ character_stats_results: {
   final_stats: 1355.5
   final_stats: 1760.0784
   final_stats: 3286.36903
-  final_stats: 3980.02314
+  final_stats: 2715.0784
   final_stats: 0
   final_stats: 0
   final_stats: 86
   final_stats: 2129.88325
-  final_stats: 4267.15784
+  final_stats: 2715.0784
   final_stats: 0
   final_stats: 106333.22474
   final_stats: 13603.2

--- a/sim/rogue/assassination/TestAssassination.results
+++ b/sim/rogue/assassination/TestAssassination.results
@@ -10,12 +10,12 @@ character_stats_results: {
   final_stats: 326
   final_stats: 1684.78296
   final_stats: 1756.4002
-  final_stats: 1923.48524
+  final_stats: 1222.0947
   final_stats: 0
   final_stats: 16527.97475
   final_stats: 1755.4352
   final_stats: 5234.79719
-  final_stats: 2624.87577
+  final_stats: 1222.0947
   final_stats: 66
   final_stats: 0
   final_stats: 10889

--- a/sim/rogue/combat/TestCombat.results
+++ b/sim/rogue/combat/TestCombat.results
@@ -10,12 +10,12 @@ character_stats_results: {
   final_stats: 326
   final_stats: 1634.67444
   final_stats: 1595.4002
-  final_stats: 2241.7227
+  final_stats: 1525.178
   final_stats: 0
   final_stats: 22593.63906
   final_stats: 1740.6528
   final_stats: 5043.22757
-  final_stats: 3904.1064
+  final_stats: 1525.178
   final_stats: 795
   final_stats: 0
   final_stats: 10889

--- a/sim/rogue/subtlety/TestSubtlety.results
+++ b/sim/rogue/subtlety/TestSubtlety.results
@@ -10,12 +10,12 @@ character_stats_results: {
   final_stats: 326
   final_stats: 1461.78296
   final_stats: 2401.5285
-  final_stats: 2735.17052
+  final_stats: 1995.1283
   final_stats: 0
   final_stats: 20929.34546
   final_stats: 1532.4352
   final_stats: 6899.15114
-  final_stats: 3475.21273
+  final_stats: 1995.1283
   final_stats: 586
   final_stats: 0
   final_stats: 10857

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -10,12 +10,12 @@ character_stats_results: {
   final_stats: 1497.5
   final_stats: 1742
   final_stats: 3951.82041
-  final_stats: 3073.1358
+  final_stats: 2317
   final_stats: 0
   final_stats: 1808.52
   final_stats: 347
   final_stats: 2966.9919
-  final_stats: 3829.2716
+  final_stats: 2317
   final_stats: 0
   final_stats: 108608.4625
   final_stats: 15396

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -10,12 +10,12 @@ character_stats_results: {
   final_stats: 1497.5
   final_stats: 1836.44574
   final_stats: 2702.73189
-  final_stats: 1613.68284
+  final_stats: 927.0448
   final_stats: 0
   final_stats: 15897.26481
   final_stats: 2553.7616
   final_stats: 6172.18873
-  final_stats: 2300.32088
+  final_stats: 927.0448
   final_stats: 782.21758
   final_stats: 27780.25
   final_stats: 15326

--- a/sim/warlock/affliction/TestAffliction.results
+++ b/sim/warlock/affliction/TestAffliction.results
@@ -10,12 +10,12 @@ character_stats_results: {
   final_stats: 1353.65
   final_stats: 1748.1332
   final_stats: 3681.32011
-  final_stats: 2950.33284
+  final_stats: 2200.0448
   final_stats: 0
   final_stats: 788.1
   final_stats: 1748.1332
   final_stats: 2355.51726
-  final_stats: 3700.62088
+  final_stats: 2200.0448
   final_stats: 0
   final_stats: 105570.50301
   final_stats: 8479

--- a/sim/warlock/demonology/TestDemonology.results
+++ b/sim/warlock/demonology/TestDemonology.results
@@ -10,12 +10,12 @@ character_stats_results: {
   final_stats: 1353.65
   final_stats: 1743.178
   final_stats: 3459.27531
-  final_stats: 2459.9358
+  final_stats: 1733
   final_stats: 0
   final_stats: 788.1
   final_stats: 1743.178
   final_stats: 2133.47246
-  final_stats: 3186.8716
+  final_stats: 1733
   final_stats: 0
   final_stats: 105570.50301
   final_stats: 8479

--- a/sim/warlock/destruction/TestDestruction.results
+++ b/sim/warlock/destruction/TestDestruction.results
@@ -10,12 +10,12 @@ character_stats_results: {
   final_stats: 1353.65
   final_stats: 1749.178
   final_stats: 3548.28495
-  final_stats: 3012.2358
+  final_stats: 2259
   final_stats: 0
   final_stats: 788.1
   final_stats: 1749.178
   final_stats: 2219.51726
-  final_stats: 3765.4716
+  final_stats: 2259
   final_stats: 0
   final_stats: 105735.87801
   final_stats: 8479

--- a/sim/warrior/arms/TestArms.results
+++ b/sim/warrior/arms/TestArms.results
@@ -10,12 +10,12 @@ character_stats_results: {
   final_stats: 326
   final_stats: 961.0896
   final_stats: 3542.4898
-  final_stats: 1341.6858
+  final_stats: 668
   final_stats: 0
   final_stats: 15428.50362
   final_stats: 961.0896
   final_stats: 4074.26039
-  final_stats: 2015.3716
+  final_stats: 668
   final_stats: 783
   final_stats: 0
   final_stats: 21168

--- a/sim/warrior/fury/TestFury.results
+++ b/sim/warrior/fury/TestFury.results
@@ -10,12 +10,12 @@ character_stats_results: {
   final_stats: 326
   final_stats: 1200.0448
   final_stats: 2974.445
-  final_stats: 2015.7858
+  final_stats: 1310
   final_stats: 0
   final_stats: 15061.85481
   final_stats: 1560.3712
   final_stats: 3864.77567
-  final_stats: 2721.5716
+  final_stats: 1310
   final_stats: 963
   final_stats: 0
   final_stats: 21208

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -10,12 +10,12 @@ character_stats_results: {
   final_stats: 326
   final_stats: 175
   final_stats: 1013.4002
-  final_stats: 640.2858
+  final_stats: 0
   final_stats: 0
   final_stats: 11405.28
   final_stats: 175
   final_stats: 1623.12265
-  final_stats: 1280.5716
+  final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 33491

--- a/ui/core/components/character_stats.tsx
+++ b/ui/core/components/character_stats.tsx
@@ -4,7 +4,7 @@ import { ref } from 'tsx-vanilla';
 
 import * as Mechanics from '../constants/mechanics.js';
 import { Player } from '../player.js';
-import { Stat } from '../proto/common.js';
+import { Class, PseudoStat, Stat } from '../proto/common.js';
 import { ActionId } from '../proto_utils/action_id';
 import { getClassStatName, masterySpellIDs, masterySpellNames, statOrder } from '../proto_utils/names.js';
 import { Stats, statToPercentageOrPoints } from '../proto_utils/stats.js';
@@ -137,6 +137,14 @@ export class CharacterStats extends Component {
 				});
 			}
 		}
+
+		// Apply multiplicative Haste buffs to the final displayed value
+		const baseMeleeHasteMultiplier = 1 + finalStats.getStat(Stat.StatMeleeHaste) / (Mechanics.HASTE_RATING_PER_HASTE_PERCENT * 100);
+		const meleeHasteBuffsMultiplier = (this.player.getClass() == Class.ClassHunter) ? finalStats.getPseudoStat(PseudoStat.PseudoStatRangedSpeedMultiplier) : finalStats.getPseudoStat(PseudoStat.PseudoStatMeleeSpeedMultiplier);
+		finalStats = finalStats.withStat(Stat.StatMeleeHaste, (baseMeleeHasteMultiplier * meleeHasteBuffsMultiplier - 1) * 100 * Mechanics.HASTE_RATING_PER_HASTE_PERCENT);
+		const baseSpellHasteMultiplier = 1 + finalStats.getStat(Stat.StatSpellHaste) / (Mechanics.HASTE_RATING_PER_HASTE_PERCENT * 100);
+		const spellHasteBuffsMultiplier = finalStats.getPseudoStat(PseudoStat.PseudoStatCastSpeedMultiplier);
+		finalStats = finalStats.withStat(Stat.StatSpellHaste, (baseSpellHasteMultiplier * spellHasteBuffsMultiplier - 1) * 100 * Mechanics.HASTE_RATING_PER_HASTE_PERCENT);
 
 		const masteryPoints =
 			this.player.getBaseMastery() + (playerStats.finalStats?.stats[Stat.StatMastery] || 0) / Mechanics.MASTERY_RATING_PER_MASTERY_POINT;

--- a/ui/core/components/suggest_reforges_action.tsx
+++ b/ui/core/components/suggest_reforges_action.tsx
@@ -7,7 +7,7 @@ import * as Mechanics from '../constants/mechanics.js';
 import { IndividualSimUI } from '../individual_sim_ui';
 import { Player } from '../player';
 import { ItemSlot, Spec, Stat } from '../proto/common';
-import { SoftCapBreakpoints } from '../proto/ui';
+import { StatCapConfig, StatCapType } from '../proto/ui';
 import { Gear } from '../proto_utils/gear';
 import { getClassStatName } from '../proto_utils/names';
 import { statPercentageOrPointsToNumber, Stats, statToPercentageOrPoints } from '../proto_utils/stats';
@@ -63,7 +63,7 @@ export class ReforgeOptimizer {
 	protected readonly defaults: IndividualSimUI<any>['individualConfig']['defaults'];
 	protected _statCaps: Stats;
 	protected updateGearStatsModifier: ReforgeOptimizerOptions['updateGearStatsModifier'];
-	protected softCapsConfig: SoftCapBreakpoints[];
+	protected softCapsConfig: StatCapConfig[];
 
 	constructor(simUI: IndividualSimUI<any>, options?: ReforgeOptimizerOptions) {
 		this.simUI = simUI;
@@ -413,7 +413,7 @@ export class ReforgeOptimizer {
 		const constraints = this.buildYalpsConstraints(baseGear);
 
 		// Solve in multiple passes to enforce caps
-		await this.solveModel(baseGear, reforgeCaps, reforgeSoftCaps, variables, constraints);
+		await this.solveModel(baseGear, this.preCapEPs, reforgeCaps, reforgeSoftCaps, variables, constraints);
 	}
 
 	async updateGear(gear: Gear): Promise<Stats> {
@@ -425,24 +425,36 @@ export class ReforgeOptimizer {
 		return baseStats;
 	}
 
-	computeReforgeSoftCaps(baseStats: Stats): SoftCapBreakpoints[] {
-		const reforgeSoftCaps: SoftCapBreakpoints[] = [];
+	computeReforgeSoftCaps(baseStats: Stats): StatCapConfig[] {
+		const reforgeSoftCaps: StatCapConfig[] = [];
 
 		if (this.sim.getUseSoftCapBreakpoints() && this.softCapsConfig) {
 			this.softCapsConfig
 				.slice()
-				.reverse()
 				.filter(config => this.statCaps.getStat(config.stat) == 0)
 				.forEach(config => {
+					let weights = config.postCapEPs.slice();
 					const relativeBreakpoints = [];
 
 					for (const breakpoint of config.breakpoints) {
 						relativeBreakpoints.push(breakpoint - baseStats.getStat(config.stat));
 					}
 
+					// For stats that are configured as thresholds rather than
+					// soft caps, reverse the order of evaluation of the
+					// breakpoints so that the largest relevant threshold is
+					// always targeted. Likewise, make sure that post-cap EPs
+					// are always 0 for these stats.
+					if (config.capType == StatCapType.TypeThreshold) {
+						relativeBreakpoints.reverse();
+						weights = Array(relativeBreakpoints.length).fill(0);
+					}
+
 					reforgeSoftCaps.push({
 						stat: config.stat,
-						breakpoints: relativeBreakpoints.sort((a, b) => b - a),
+						breakpoints: relativeBreakpoints,
+						capType: config.capType,
+						postCapEPs: weights,
 					});
 				});
 		}
@@ -518,9 +530,13 @@ export class ReforgeOptimizer {
 		return constraints;
 	}
 
-	async solveModel(gear: Gear, reforgeCaps: Stats, reforgeSoftCaps: SoftCapBreakpoints[], variables: YalpsVariables, constraints: YalpsConstraints) {
+	async solveModel(gear: Gear, weights: Stats, reforgeCaps: Stats, reforgeSoftCaps: StatCapConfig[], variables: YalpsVariables, constraints: YalpsConstraints) {
 		// Calculate EP scores for each Reforge option
-		const updatedVariables = this.updateReforgeScores(variables, constraints);
+		if (isDevMode()) {
+			console.log('Stat weights for this iteration:');
+			console.log(weights);
+		}
+		const updatedVariables = this.updateReforgeScores(variables, weights);
 		if (isDevMode()) {
 			console.log('Optimization variables and constraints for this iteration:');
 			console.log(updatedVariables);
@@ -551,18 +567,18 @@ export class ReforgeOptimizer {
 		// Check if any unconstrained stats exceeded their specified cap.
 		// If so, add these stats to the constraint list and re-run the solver.
 		// If no unconstrained caps were exceeded, then we're done.
-		const [anyCapsExceeded, updatedConstraints] = this.checkCaps(solution, reforgeCaps, reforgeSoftCaps, updatedVariables, constraints);
+		const [anyCapsExceeded, updatedConstraints, updatedWeights] = this.checkCaps(solution, reforgeCaps, reforgeSoftCaps, updatedVariables, constraints, weights);
 
 		if (!anyCapsExceeded) {
 			if (isDevMode()) console.log('Reforge optimization has finished!');
 		} else {
 			if (isDevMode()) console.log('One or more stat caps were exceeded, starting constrained iteration...');
 			await sleep(100);
-			await this.solveModel(gear, reforgeCaps, reforgeSoftCaps, updatedVariables, updatedConstraints);
+			await this.solveModel(gear, updatedWeights, reforgeCaps, reforgeSoftCaps, updatedVariables, updatedConstraints);
 		}
 	}
 
-	updateReforgeScores(variables: YalpsVariables, constraints: YalpsConstraints): YalpsVariables {
+	updateReforgeScores(variables: YalpsVariables, weights: Stats): YalpsVariables {
 		const updatedVariables = new Map<string, YalpsCoefficients>();
 
 		for (const [variableKey, coefficients] of variables.entries()) {
@@ -572,12 +588,14 @@ export class ReforgeOptimizer {
 			for (const [coefficientKey, value] of coefficients.entries()) {
 				updatedCoefficients.set(coefficientKey, value);
 
-				// Determine whether the key corresponds to a stat change.
-				// If so, check whether the stat has already been constrained to be capped in a previous iteration.
-				// Apply stored EP only for unconstrained stats.
-				if (coefficientKey.includes('Stat') && !constraints.has(coefficientKey)) {
+				// Determine whether the key corresponds to a stat change. If
+				// so, apply current EP for that stat. It is assumed that the
+				// supplied weights have already been updated to post-cap
+				// values for any stats that were constrained to be capped in
+				// a previous iteration.
+				if (coefficientKey.includes('Stat')) {
 					const statKey = (Stat as any)[coefficientKey] as Stat;
-					score += this.preCapEPs.getStat(statKey) * value;
+					score += weights.getStat(statKey) * value;
 				}
 			}
 
@@ -612,10 +630,11 @@ export class ReforgeOptimizer {
 	checkCaps(
 		solution: Solution,
 		reforgeCaps: Stats,
-		reforgeSoftCaps: SoftCapBreakpoints[],
+		reforgeSoftCaps: StatCapConfig[],
 		variables: YalpsVariables,
 		constraints: YalpsConstraints,
-	): [boolean, YalpsConstraints] {
+		currentWeights: Stats,
+	): [boolean, YalpsConstraints, Stats] {
 		// First add up the total stat changes from the solution
 		let reforgeStatContribution = new Stats();
 
@@ -636,6 +655,7 @@ export class ReforgeOptimizer {
 		// Then check whether any unconstrained stats exceed their cap
 		let anyCapsExceeded = false;
 		const updatedConstraints = new Map<string, Constraint>(constraints);
+		let updatedWeights = currentWeights;
 
 		for (const [statKey, value] of reforgeStatContribution.asArray().entries()) {
 			const cap = reforgeCaps.getStat(statKey);
@@ -645,26 +665,48 @@ export class ReforgeOptimizer {
 				updatedConstraints.set(statName, greaterEq(cap));
 				anyCapsExceeded = true;
 				if (isDevMode()) console.log('Cap exceeded for: %s', statName);
+
+				// Set EP to 0 for hard capped stats
+				updatedWeights = updatedWeights.withStat(statKey, 0);
 			}
 		}
 
 		// If hard caps are all taken care of, then deal with any remaining soft cap breakpoints
-		if (!anyCapsExceeded && reforgeSoftCaps.length > 0) {
-			const nextSoftCap = reforgeSoftCaps.pop()!;
-			const statName = Stat[nextSoftCap.stat];
-			const currentValue = reforgeStatContribution.getStat(nextSoftCap.stat);
+		while (!anyCapsExceeded && reforgeSoftCaps.length > 0) {
+			const nextSoftCap = reforgeSoftCaps[0];
+			const statKey = nextSoftCap.stat;
+			const statName = Stat[statKey];
+			const currentValue = reforgeStatContribution.getStat(statKey);
 
+			let idx = 0;
 			for (const breakpoint of nextSoftCap.breakpoints) {
 				if (currentValue > breakpoint) {
 					updatedConstraints.set(statName, greaterEq(breakpoint));
+					updatedWeights = updatedWeights.withStat(statKey, nextSoftCap.postCapEPs[idx]);
 					anyCapsExceeded = true;
 					if (isDevMode()) console.log('Breakpoint exceeded for: %s', statName);
 					break;
 				}
+
+				idx++;
+			}
+
+			// For true soft cap stats (evaluated in ascending order), remove any breakpoint that was
+			// exceeded from the configuration. If no breakpoints were exceeded or there are none
+			// remaining, then remove the entry completely from reforgeSoftCaps. In contrast, for threshold
+			// stats (evaluated in descending order), always remove the entry completely after the first
+			// pass.
+			if (nextSoftCap.capType == StatCapType.TypeSoftCap) {
+				nextSoftCap.breakpoints = nextSoftCap.breakpoints.slice(idx + 1);
+				nextSoftCap.postCapEPs = nextSoftCap.postCapEPs.slice(idx + 1);
+			}
+
+			if ((nextSoftCap.capType == StatCapType.TypeThreshold) || (nextSoftCap.breakpoints.length == 0)) {
+				reforgeSoftCaps.shift();
 			}
 		}
 
-		return [anyCapsExceeded, updatedConstraints];
+		return [anyCapsExceeded, updatedConstraints, updatedWeights];
 	}
 
 	private get baseMastery() {

--- a/ui/core/components/suggest_reforges_action.tsx
+++ b/ui/core/components/suggest_reforges_action.tsx
@@ -536,7 +536,7 @@ export class ReforgeOptimizer {
 			binaries: true,
 		};
 		const options: Options = {
-			timeout: 15000,
+			timeout: 60000,
 			maxIterations: Infinity,
 			tolerance: 0.01,
 		};

--- a/ui/core/individual_sim_ui.tsx
+++ b/ui/core/individual_sim_ui.tsx
@@ -41,7 +41,7 @@ import {
 	Spec,
 	Stat,
 } from './proto/common';
-import { IndividualSimSettings, SavedTalents, SoftCapBreakpoints } from './proto/ui';
+import { IndividualSimSettings, SavedTalents, StatCapConfig } from './proto/ui';
 import { getMetaGemConditionDescription } from './proto_utils/gems';
 import { armorTypeNames, professionNames } from './proto_utils/names';
 import { Stats } from './proto_utils/stats';
@@ -130,7 +130,7 @@ export interface IndividualSimUIConfig<SpecType extends Spec> extends PlayerConf
 		 * while ignoring any others. Then the solution is used to identify the closest
 		 * breakpoint for the second listed stat (if present), etc.
 		 */
-		softCapBreakpoints?: SoftCapBreakpoints[];
+		softCapBreakpoints?: StatCapConfig[];
 		consumes: Consumes;
 		talents: SavedTalents;
 		specOptions: SpecOptions<SpecType>;

--- a/ui/core/player.ts
+++ b/ui/core/player.ts
@@ -38,7 +38,7 @@ import {
 import {
 	DungeonDifficulty,
 	RaidFilterOption,
-	SoftCapBreakpoints,
+	StatCapConfig,
 	SourceFilterOption,
 	UIEnchant as Enchant,
 	UIGem as Gem,
@@ -277,7 +277,7 @@ export class Player<SpecType extends Spec> {
 	private epRatios: Array<number> = new Array<number>(Player.numEpRatios).fill(0);
 	private epWeights: Stats = new Stats();
 	private statCaps: Stats = new Stats();
-	private softCapBreakpoints: SoftCapBreakpoints[] = [];
+	private softCapBreakpoints: StatCapConfig[] = [];
 	private currentStats: PlayerStats = PlayerStats.create();
 	private metadata: UnitMetadata = new UnitMetadata();
 	private petMetadatas: UnitMetadataList = new UnitMetadataList();
@@ -516,11 +516,11 @@ export class Player<SpecType extends Spec> {
 		this.statCapsChangeEmitter.emit(eventID);
 	}
 
-	getSoftCapBreakpoints(): SoftCapBreakpoints[] {
+	getSoftCapBreakpoints(): StatCapConfig[] {
 		return this.softCapBreakpoints;
 	}
 
-	setSoftCapBreakpoints(eventID: EventID, newSoftCapBreakpoints: SoftCapBreakpoints[]) {
+	setSoftCapBreakpoints(eventID: EventID, newSoftCapBreakpoints: StatCapConfig[]) {
 		this.softCapBreakpoints = newSoftCapBreakpoints;
 		this.softCapBreakpointsChangeEmitter.emit(eventID);
 	}

--- a/ui/warlock/affliction/sim.ts
+++ b/ui/warlock/affliction/sim.ts
@@ -7,6 +7,7 @@ import { Player } from '../../core/player';
 import { PlayerClasses } from '../../core/player_classes';
 import { APLRotation } from '../../core/proto/apl';
 import { Faction, ItemSlot, PartyBuffs, Race, Spec, Stat } from '../../core/proto/common';
+import { StatCapType } from '../../core/proto/ui';
 import { Stats } from '../../core/proto_utils/stats';
 import * as WarlockInputs from '../inputs';
 import * as Presets from './presets';
@@ -56,7 +57,12 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecAfflictionWarlock, {
 				masteryRatingBreakpoints.push((masteryPercent / 1.63) * Mechanics.MASTERY_RATING_PER_MASTERY_POINT);
 			}
 
-			const masterySoftCapConfig = { stat: Stat.StatMastery, breakpoints: masteryRatingBreakpoints };
+			const masterySoftCapConfig = {
+				stat: Stat.StatMastery,
+				breakpoints: masteryRatingBreakpoints,
+				capType: StatCapType.TypeThreshold,
+				postCapEPs: Array(masteryRatingBreakpoints.length).fill(0),
+			};
 
 			return [masterySoftCapConfig];
 		})(),

--- a/ui/warlock/demonology/presets.ts
+++ b/ui/warlock/demonology/presets.ts
@@ -30,12 +30,12 @@ export const APL_Default = PresetUtils.makePresetAPLRotation('Demo', DefaultApl)
 export const P1_EP_PRESET = PresetUtils.makePresetEpWeights(
 	'P1',
 	Stats.fromMap({
-		[Stat.StatIntellect]: 1.28,
+		[Stat.StatIntellect]: 1.27,
 		[Stat.StatSpellPower]: 1.0,
-		[Stat.StatSpellHit]: 0.9,
-		[Stat.StatSpellCrit]: 0.57,
-		[Stat.StatSpellHaste]: 0.74,
-		[Stat.StatMastery]: 0.79,
+		[Stat.StatSpellHit]: 0.92,
+		[Stat.StatSpellCrit]: 0.51,
+		[Stat.StatSpellHaste]: 2.75,
+		[Stat.StatMastery]: 0.76,
 	}),
 );
 

--- a/ui/warlock/demonology/sim.ts
+++ b/ui/warlock/demonology/sim.ts
@@ -7,6 +7,7 @@ import { Player } from '../../core/player';
 import { PlayerClasses } from '../../core/player_classes';
 import { APLRotation } from '../../core/proto/apl';
 import { Faction, ItemSlot, PartyBuffs, Race, Spec, Stat } from '../../core/proto/common';
+import { StatCapType } from '../../core/proto/ui';
 import { Stats } from '../../core/proto_utils/stats';
 import * as WarlockInputs from '../inputs';
 import * as Presets from './presets';
@@ -56,10 +57,21 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecDemonologyWarlock, {
 				masteryRatingBreakpoints.push((masteryPercent / 2.3) * Mechanics.MASTERY_RATING_PER_MASTERY_POINT);
 			}
 
-			const masterySoftCapConfig = { stat: Stat.StatMastery, breakpoints: masteryRatingBreakpoints };
+			const masterySoftCapConfig = {
+				stat: Stat.StatMastery,
+				breakpoints: masteryRatingBreakpoints,
+				capType: StatCapType.TypeThreshold,
+				postCapEPs: Array(masteryRatingBreakpoints.length).fill(0),
+			};
 
-			const hasteSoftCapConfig = { stat: Stat.StatSpellHaste, breakpoints: [1007, 1993] };
-			return [masterySoftCapConfig, hasteSoftCapConfig];
+			const hasteSoftCapConfig = {
+				stat: Stat.StatSpellHaste,
+				breakpoints: [1007, 1993],
+				capType: StatCapType.TypeSoftCap,
+				postCapEPs: [0.64, 0.61],
+			};
+
+			return [hasteSoftCapConfig, masterySoftCapConfig];
 		})(),
 		// Default consumes settings.
 		consumes: Presets.DefaultConsumes,


### PR DESCRIPTION
- Refactored back-end character stats calculation to no longer incorporate multiplicative Haste buffs into the final Haste value, and moved this calculation to the front-end stats display instead.
- Increased timeout for Reforge optimizer to 1 minute in order to guarantee convergence for harder Warlock gear sets with Mastery breakpoints.
- Fixed Demonology Warlock preset EPs to use full pre-cap Haste value.
- Added support for specifying post-cap EPs in soft caps configuration, and updated Demonology Reforger accordingly.