### PR TITLE
[UI] Flip dodge/parry visual values

### DIFF
--- a/ui/core/proto_utils/stats.ts
+++ b/ui/core/proto_utils/stats.ts
@@ -274,10 +274,10 @@ export const statToPercentageOrPoints = (stat: Stat, value: number, stats: Stats
 			statInPercentage = value / Mechanics.BLOCK_RATING_PER_BLOCK_CHANCE + 5.0;
 			break;
 		case Stat.StatDodge:
-			statInPercentage = stats.getPseudoStat(PseudoStat.PseudoStatDodge) / 100;
+			statInPercentage = stats.getPseudoStat(PseudoStat.PseudoStatDodge) * 100;
 			break;
 		case Stat.StatParry:
-			statInPercentage = stats.getPseudoStat(PseudoStat.PseudoStatParry) / 100;
+			statInPercentage = stats.getPseudoStat(PseudoStat.PseudoStatParry) * 100;
 			break;
 		case Stat.StatResilience:
 			statInPercentage = value / Mechanics.RESILIENCE_RATING_PER_CRIT_REDUCTION_CHANCE;
@@ -318,10 +318,10 @@ export const statPercentageOrPointsToNumber = (stat: Stat, value: number, stats:
 			statInPoints = value * Mechanics.BLOCK_RATING_PER_BLOCK_CHANCE - 5.0;
 			break;
 		case Stat.StatDodge:
-			statInPoints = stats.getPseudoStat(PseudoStat.PseudoStatDodge) * 100;
+			statInPoints = stats.getPseudoStat(PseudoStat.PseudoStatDodge) / 100;
 			break;
 		case Stat.StatParry:
-			statInPoints = stats.getPseudoStat(PseudoStat.PseudoStatParry) * 100;
+			statInPoints = stats.getPseudoStat(PseudoStat.PseudoStatParry) / 100;
 			break;
 		case Stat.StatResilience:
 			statInPoints = value * Mechanics.RESILIENCE_RATING_PER_CRIT_REDUCTION_CHANCE;


### PR DESCRIPTION
Wrongfully changed `*` and `/` when doing the reforge optimizer stuff. For pseudoStats it needs to be reversed.