### PR TITLE
[Warrior] remove unused ui elements

### DIFF
--- a/proto/warrior.proto
+++ b/proto/warrior.proto
@@ -116,16 +116,8 @@ enum WarriorMinorGlyph {
 	GlyphOfShatteringThrow = 206953;
 }
 
-enum WarriorShout {
-	WarriorShoutNone = 0;
-	WarriorShoutBattle = 1;
-	WarriorShoutCommanding = 2;
-}
-
 message WarriorOptions {
 	double starting_rage = 1;
-	WarriorShout shout = 2;
-	bool use_shattering_throw = 3;
 }
 
 message ArmsWarrior {
@@ -133,9 +125,7 @@ message ArmsWarrior {
 
 	message Options {
 		WarriorOptions class_options = 1;
-		bool use_recklessness = 2;
-		bool stance_snapshot = 3;
-		bool disable_expertise_gemming = 4;
+		bool stance_snapshot = 2;
 	}
 	Options options = 1;
 }
@@ -145,10 +135,8 @@ message FuryWarrior {
 
 	message Options {
 		WarriorOptions class_options = 1;
-		bool use_recklessness = 2;
-		bool stance_snapshot = 3;
-		bool disable_expertise_gemming = 4;
-		WarriorSyncType sync_type = 5;
+		bool stance_snapshot = 2;
+		WarriorSyncType sync_type = 3;
 	}
 	Options options = 1;
 }
@@ -163,7 +151,6 @@ message ProtectionWarrior {
 
 	message Options {
 		WarriorOptions class_options = 1;
-		bool use_recklessness = 2;
 	}
 	Options options = 1;
 }

--- a/sim/warrior/fury/fury_test.go
+++ b/sim/warrior/fury/fury_test.go
@@ -69,11 +69,8 @@ var PlayerOptionsFury = &proto.Player_FuryWarrior{
 	FuryWarrior: &proto.FuryWarrior{
 		Options: &proto.FuryWarrior_Options{
 			ClassOptions: &proto.WarriorOptions{
-				StartingRage:       50,
-				UseShatteringThrow: true,
-				Shout:              proto.WarriorShout_WarriorShoutBattle,
+				StartingRage: 50,
 			},
-			UseRecklessness: true,
 		},
 	},
 }

--- a/sim/warrior/protection/protection_test.go
+++ b/sim/warrior/protection/protection_test.go
@@ -62,9 +62,7 @@ var PlayerOptionsBasic = &proto.Player_ProtectionWarrior{
 	ProtectionWarrior: &proto.ProtectionWarrior{
 		Options: &proto.ProtectionWarrior_Options{
 			ClassOptions: &proto.WarriorOptions{
-				StartingRage:       0,
-				Shout:              proto.WarriorShout_WarriorShoutCommanding,
-				UseShatteringThrow: false,
+				StartingRage: 0,
 			},
 		},
 	},

--- a/ui/raid/raid_stats.tsx
+++ b/ui/raid/raid_stats.tsx
@@ -10,7 +10,6 @@ import { HunterOptions_PetType as HunterPetType } from '../core/proto/hunter.js'
 import { PaladinAura } from '../core/proto/paladin.js';
 import { AirTotem, EarthTotem, FireTotem, WaterTotem } from '../core/proto/shaman.js';
 import { WarlockOptions_Summon as WarlockSummon } from '../core/proto/warlock.js';
-import { WarriorShout } from '../core/proto/warrior.js';
 import { ActionId } from '../core/proto_utils/action_id.js';
 import { ClassSpecs, SpecTalents, textCssClassForClass } from '../core/proto_utils/utils.js';
 import { Raid } from '../core/raid.js';

--- a/ui/warrior/arms/presets.ts
+++ b/ui/warrior/arms/presets.ts
@@ -1,7 +1,7 @@
 import * as PresetUtils from '../../core/preset_utils';
 import { Consumes, Flask, Food, Glyphs, Potions, Profession, PseudoStat, Stat, TinkerHands } from '../../core/proto/common';
 import { SavedTalents } from '../../core/proto/ui';
-import { ArmsWarrior_Options as WarriorOptions, WarriorMajorGlyph, WarriorMinorGlyph, WarriorPrimeGlyph, WarriorShout } from '../../core/proto/warrior';
+import { ArmsWarrior_Options as WarriorOptions, WarriorMajorGlyph, WarriorMinorGlyph, WarriorPrimeGlyph } from '../../core/proto/warrior';
 import { Stats } from '../../core/proto_utils/stats';
 import ArmsApl from './apls/arms.apl.json';
 import P1ArmsBisGear from './gear_sets/p1_arms_bis.gear.json';
@@ -61,11 +61,7 @@ export const ArmsTalents = {
 export const DefaultOptions = WarriorOptions.create({
 	classOptions: {
 		startingRage: 0,
-		useShatteringThrow: true,
-		shout: WarriorShout.WarriorShoutCommanding,
 	},
-	useRecklessness: true,
-	disableExpertiseGemming: false,
 });
 
 export const DefaultConsumes = Consumes.create({

--- a/ui/warrior/arms/sim.ts
+++ b/ui/warrior/arms/sim.ts
@@ -103,7 +103,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecArmsWarrior, {
 	},
 
 	// IconInputs to include in the 'Player' section on the settings tab.
-	playerIconInputs: [WarriorInputs.ShoutPicker(), WarriorInputs.Recklessness(), WarriorInputs.ShatteringThrow()],
+	playerIconInputs: [],
 	// Buff and Debuff inputs to include/exclude, overriding the EP-based defaults.
 	includeBuffDebuffInputs: [
 		// just for Bryntroll
@@ -115,7 +115,6 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecArmsWarrior, {
 		inputs: [
 			WarriorInputs.StartingRage(),
 			WarriorInputs.StanceSnapshot(),
-			WarriorInputs.DisableExpertiseGemming(),
 			OtherInputs.InputDelay,
 			OtherInputs.TankAssignment,
 			OtherInputs.InFrontOfTarget,

--- a/ui/warrior/fury/presets.ts
+++ b/ui/warrior/fury/presets.ts
@@ -2,7 +2,7 @@ import { Player } from '../../core/player';
 import * as PresetUtils from '../../core/preset_utils';
 import { Consumes, Faction, Flask, Food, Glyphs, HandType, ItemSlot, Potions, Profession, PseudoStat, Spec, Stat, TinkerHands } from '../../core/proto/common';
 import { SavedTalents } from '../../core/proto/ui';
-import { FuryWarrior_Options as WarriorOptions, WarriorMajorGlyph, WarriorMinorGlyph, WarriorPrimeGlyph, WarriorShout } from '../../core/proto/warrior';
+import { FuryWarrior_Options as WarriorOptions, WarriorMajorGlyph, WarriorMinorGlyph, WarriorPrimeGlyph } from '../../core/proto/warrior';
 import { Stats } from '../../core/proto_utils/stats';
 import { SpecType } from '../../core/proto_utils/utils';
 import FuryApl from './apls/fury.apl.json';
@@ -126,11 +126,7 @@ export const FuryTGTalents = {
 export const DefaultOptions = WarriorOptions.create({
 	classOptions: {
 		startingRage: 0,
-		useShatteringThrow: true,
-		shout: WarriorShout.WarriorShoutCommanding,
 	},
-	useRecklessness: true,
-	disableExpertiseGemming: false,
 	syncType: 0,
 });
 

--- a/ui/warrior/fury/sim.ts
+++ b/ui/warrior/fury/sim.ts
@@ -104,7 +104,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFuryWarrior, {
 	},
 
 	// IconInputs to include in the 'Player' section on the settings tab.
-	playerIconInputs: [WarriorInputs.ShoutPicker(), WarriorInputs.Recklessness(), WarriorInputs.ShatteringThrow()],
+	playerIconInputs: [],
 	// Buff and Debuff inputs to include/exclude, overriding the EP-based defaults.
 	includeBuffDebuffInputs: [
 		// just for Bryntroll
@@ -117,7 +117,6 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFuryWarrior, {
 			FuryInputs.SyncTypeInput,
 			WarriorInputs.StartingRage(),
 			WarriorInputs.StanceSnapshot(),
-			WarriorInputs.DisableExpertiseGemming(),
 			OtherInputs.InputDelay,
 			OtherInputs.TankAssignment,
 			OtherInputs.InFrontOfTarget,

--- a/ui/warrior/inputs.ts
+++ b/ui/warrior/inputs.ts
@@ -1,6 +1,5 @@
 import * as InputHelpers from '../core/components/input_helpers';
 import { Spec } from '../core/proto/common';
-import { WarriorShout } from '../core/proto/warrior';
 import { ActionId } from '../core/proto_utils/action_id';
 import { WarriorSpecs } from '../core/proto_utils/utils';
 
@@ -14,29 +13,7 @@ export const StartingRage = <SpecType extends WarriorSpecs>() =>
 		labelTooltip: 'Initial rage at the start of each iteration.',
 	});
 
-export const ShoutPicker = <SpecType extends WarriorSpecs>() =>
-	InputHelpers.makeClassOptionsEnumIconInput<SpecType, WarriorShout>({
-		fieldName: 'shout',
-		values: [
-			{ color: 'c79c6e', value: WarriorShout.WarriorShoutNone },
-			{ actionId: ActionId.fromSpellId(2048), value: WarriorShout.WarriorShoutBattle },
-			{ actionId: ActionId.fromSpellId(469), value: WarriorShout.WarriorShoutCommanding },
-		],
-	});
-
-export const ShatteringThrow = <SpecType extends WarriorSpecs>() =>
-	InputHelpers.makeClassOptionsBooleanIconInput<SpecType>({
-		fieldName: 'useShatteringThrow',
-		id: ActionId.fromSpellId(64382),
-	});
-
 // Arms/Fury only
-
-export const Recklessness = <SpecType extends Spec.SpecArmsWarrior | Spec.SpecFuryWarrior | Spec.SpecProtectionWarrior>() =>
-	InputHelpers.makeSpecOptionsBooleanIconInput<SpecType>({
-		fieldName: 'useRecklessness',
-		id: ActionId.fromSpellId(1719),
-	});
 
 export const StanceSnapshot = <SpecType extends Spec.SpecArmsWarrior | Spec.SpecFuryWarrior>() =>
 	InputHelpers.makeSpecOptionsBooleanInput<SpecType>({
@@ -45,11 +22,3 @@ export const StanceSnapshot = <SpecType extends Spec.SpecArmsWarrior | Spec.Spec
 		labelTooltip: 'Ability that is cast at the same time as stance swap will benefit from the bonus of the stance before the swap.',
 	});
 
-// Allows for auto gemming whilst ignoring expertise cap
-// (Useful for Arms)
-export const DisableExpertiseGemming = <SpecType extends Spec.SpecArmsWarrior | Spec.SpecFuryWarrior>() =>
-	InputHelpers.makeSpecOptionsBooleanInput<SpecType>({
-		fieldName: 'disableExpertiseGemming',
-		label: 'Disable expertise gemming',
-		labelTooltip: 'Disables auto gemming for expertise',
-	});

--- a/ui/warrior/protection/presets.ts
+++ b/ui/warrior/protection/presets.ts
@@ -20,7 +20,6 @@ import {
 	WarriorMajorGlyph,
 	WarriorMinorGlyph,
 	WarriorPrimeGlyph,
-	WarriorShout,
 } from '../../core/proto/warrior.js';
 import { Stats } from '../../core/proto_utils/stats';
 import DefaultApl from './apls/default.apl.json';
@@ -83,8 +82,6 @@ export const StandardTalents = {
 
 export const DefaultOptions = ProtectionWarriorOptions.create({
 	classOptions: {
-		shout: WarriorShout.WarriorShoutCommanding,
-		useShatteringThrow: false,
 		startingRage: 0,
 	},
 });

--- a/ui/warrior/protection/sim.ts
+++ b/ui/warrior/protection/sim.ts
@@ -104,7 +104,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecProtectionWarrior, {
 	},
 
 	// IconInputs to include in the 'Player' section on the settings tab.
-	playerIconInputs: [ProtectionWarriorInputs.ShoutPicker(), ProtectionWarriorInputs.ShatteringThrow(), ProtectionWarriorInputs.Recklessness()],
+	playerIconInputs: [],
 	// Buff and Debuff inputs to include/exclude, overriding the EP-based defaults.
 	includeBuffDebuffInputs: [BuffDebuffInputs.StaminaBuff],
 	excludeBuffDebuffInputs: [],


### PR DESCRIPTION
With the addition of APL rotations, there is no need for the old ui options. They were not being used already, it just cleans up the ui.