### PR TITLE
[UI] Disable Reforge Optimizer stat inputs

### DIFF
--- a/ui/core/components/input.tsx
+++ b/ui/core/components/input.tsx
@@ -1,4 +1,4 @@
-import tippy from 'tippy.js';
+import tippy, { Content as TippyContent } from 'tippy.js';
 
 import { EventID, TypedEvent } from '../typed_event.js';
 import { existsInDOM } from '../utils';
@@ -9,7 +9,7 @@ import { Component } from './component.js';
  */
 export interface InputConfig<ModObject, T, V = T> {
 	label?: string;
-	labelTooltip?: string;
+	labelTooltip?: TippyContent;
 	inline?: boolean;
 	id?: string;
 	extraCssClasses?: Array<string>;

--- a/ui/core/components/suggest_reforges_action.tsx
+++ b/ui/core/components/suggest_reforges_action.tsx
@@ -186,7 +186,7 @@ export class ReforgeOptimizer {
 			onShow: instance => {
 				const useCustomEPValuesInput = new BooleanPicker(null, this.player, {
 					id: 'reforge-optimizer-enable-custom-ep-weights',
-					label: 'Enable custom EP Weights',
+					label: 'Use custom EP Weights',
 					inline: true,
 					changedEvent: () => this.sim.useCustomEPValuesChangeEmitter,
 					getValue: () => this.sim.getUseCustomEPValues(),
@@ -198,7 +198,7 @@ export class ReforgeOptimizer {
 				if (!!this.softCapsConfig?.length) {
 					useSoftCapBreakpointsInput = new BooleanPicker(null, this.player, {
 						id: 'reforge-optimizer-enable-soft-cap-breakpoints',
-						label: 'Enable soft cap breakpoints',
+						label: 'Use soft cap breakpoints',
 						labelTooltip: this.buildReforgeButtonTooltip(),
 						inline: true,
 						changedEvent: () => this.sim.useSoftCapBreakpointsChangeEmitter,

--- a/ui/core/components/suggest_reforges_action.tsx
+++ b/ui/core/components/suggest_reforges_action.tsx
@@ -122,12 +122,12 @@ export class ReforgeOptimizer {
 			),
 		};
 
-		const [_startReforgeOptimizationButton, contextMenuButton] = simUI.addActionGroup([startReforgeOptimizationEntry, contextMenuEntry], {
+		const [startReforgeOptimizationButton, contextMenuButton] = simUI.addActionGroup([startReforgeOptimizationEntry, contextMenuEntry], {
 			cssClass: 'suggest-reforges-settings-group d-flex',
 		});
 
 		if (!!this.softCapsConfig?.length)
-			tippy(_startReforgeOptimizationButton, {
+			tippy(startReforgeOptimizationButton, {
 				content: this.buildReforgeButtonTooltip(),
 				placement: 'bottom',
 				maxWidth: 310,
@@ -199,6 +199,7 @@ export class ReforgeOptimizer {
 					useSoftCapBreakpointsInput = new BooleanPicker(null, this.player, {
 						id: 'reforge-optimizer-enable-soft-cap-breakpoints',
 						label: 'Enable soft cap breakpoints',
+						labelTooltip: this.buildReforgeButtonTooltip(),
 						inline: true,
 						changedEvent: () => this.sim.useSoftCapBreakpointsChangeEmitter,
 						getValue: () => this.sim.getUseSoftCapBreakpoints(),

--- a/ui/core/components/suggest_reforges_action.tsx
+++ b/ui/core/components/suggest_reforges_action.tsx
@@ -238,7 +238,7 @@ export class ReforgeOptimizer {
 			showZeroes: false,
 			positive: true,
 			extraCssClasses: ['mb-0'],
-			changedEvent: _ => this.player.statCapsChangeEmitter,
+			changedEvent: _ => TypedEvent.onAny([this.sim.useSoftCapBreakpointsChangeEmitter, this.player.statCapsChangeEmitter]),
 		};
 
 		const tableRef = ref<HTMLTableElement>();
@@ -278,6 +278,7 @@ export class ReforgeOptimizer {
 						const ratingPicker = new NumberPicker(null, this.player, {
 							...numberPickerSharedConfig,
 							id: `character-bonus-stat-${stat}-rating`,
+							enableWhen: () => this.isAllowedToOverrideStatCaps || !this.softCapsConfig.some(config => config.stat === stat),
 							getValue: () => {
 								let statValue = this.statCaps.getStat(stat);
 								if (stat === Stat.StatMastery) statValue = this.toVisualBaseMasteryRating(statValue);
@@ -294,6 +295,7 @@ export class ReforgeOptimizer {
 						const percentagePicker = new NumberPicker(null, this.player, {
 							...numberPickerSharedConfig,
 							id: `character-bonus-stat-${stat}-percentage`,
+							enableWhen: () => this.isAllowedToOverrideStatCaps || !this.softCapsConfig.some(config => config.stat === stat),
 							getValue: () => {
 								const statValue = this.statCaps.getStat(stat);
 								let statInPercentageOrPoints = statToPercentageOrPoints(stat, statValue, stats);
@@ -404,6 +406,20 @@ export class ReforgeOptimizer {
 		);
 	}
 
+	get isAllowedToOverrideStatCaps() {
+		return !(this.sim.getUseSoftCapBreakpoints() && this.softCapsConfig);
+	}
+
+	get statsToCompute() {
+		let statCaps = this.statCaps;
+		if (!this.isAllowedToOverrideStatCaps)
+			this.softCapsConfig.forEach(({ stat }) => {
+				statCaps = statCaps.withStat(stat, 0);
+			});
+
+		return statCaps;
+	}
+
 	async optimizeReforges() {
 		if (isDevMode()) console.log('Starting Reforge optimization...');
 
@@ -411,9 +427,9 @@ export class ReforgeOptimizer {
 		if (isDevMode()) console.log('Clearing existing Reforges...');
 		const baseGear = this.player.getGear().withoutReforges(this.player.canDualWield2H());
 		const baseStats = await this.updateGear(baseGear);
-
+		const statsToCompute = this.statsToCompute;
 		// Compute effective stat caps for just the Reforge contribution
-		const reforgeCaps = baseStats.computeStatCapsDelta(this.statCaps);
+		const reforgeCaps = baseStats.computeStatCapsDelta(statsToCompute);
 		if (isDevMode()) {
 			console.log('Stat caps for Reforge contribution:');
 			console.log(reforgeCaps);
@@ -442,10 +458,10 @@ export class ReforgeOptimizer {
 	computeReforgeSoftCaps(baseStats: Stats): StatCapConfig[] {
 		const reforgeSoftCaps: StatCapConfig[] = [];
 
-		if (this.sim.getUseSoftCapBreakpoints() && this.softCapsConfig) {
+		if (!this.isAllowedToOverrideStatCaps) {
 			this.softCapsConfig
 				.slice()
-				.filter(config => this.statCaps.getStat(config.stat) == 0)
+				.filter(config => this.statsToCompute.getStat(config.stat) == 0)
 				.forEach(config => {
 					let weights = config.postCapEPs.slice();
 					const relativeBreakpoints = [];


### PR DESCRIPTION
Disabled inputs when user has soft breakpoints enabled and will set the computed (hard cap) stat to 0 so we don't get hardcap + breakpoint conflicts. This to prevent user error/questions on what is happening.

![image](https://github.com/wowsims/cata/assets/1216787/2f4533c3-9178-4e66-91db-34e2fac29e98)
![image](https://github.com/wowsims/cata/assets/1216787/b5cadab9-f7fb-4046-823b-dbdad1a3f71d)
![image](https://github.com/wowsims/cata/assets/1216787/7e56e032-f47e-4da1-8ccd-6d33b2d23265)
