### PR TITLE
[UI] Disabled Wowhead import/export

### DIFF
--- a/ui/core/components/sim_header.tsx
+++ b/ui/core/components/sim_header.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import tippy, { ReferenceElement as TippyReferenceElement } from 'tippy.js';
 import { ref } from 'tsx-vanilla';
 
@@ -89,25 +90,31 @@ export class SimHeader extends Component {
 		this.simTabsContainer.appendChild(tab.navItem);
 	}
 
-	addImportLink(label: string, importer: Importer, hideInRaidSim?: boolean) {
-		this.addImportExportLink('.import-dropdown', label, importer, hideInRaidSim);
+	addImportLink(label: string, importer: Importer, hideInRaidSim?: boolean, isUnsupported = false) {
+		this.addImportExportLink('.import-dropdown', label, importer, hideInRaidSim, isUnsupported);
 	}
-	addExportLink(label: string, exporter: Exporter, hideInRaidSim?: boolean) {
-		this.addImportExportLink('.export-dropdown', label, exporter, hideInRaidSim);
+	addExportLink(label: string, exporter: Exporter, hideInRaidSim?: boolean, isUnsupported = false) {
+		this.addImportExportLink('.export-dropdown', label, exporter, hideInRaidSim, isUnsupported);
 	}
-	private addImportExportLink(cssClass: string, label: string, importerExporter: Importer | Exporter, _hideInRaidSim?: boolean) {
+	private addImportExportLink(cssClass: string, label: string, importerExporter: Importer | Exporter, _hideInRaidSim?: boolean, isUnsupported?: boolean) {
 		const dropdownElem = this.rootElem.querySelector<HTMLElement>(cssClass)!;
 		const menuElem = dropdownElem.querySelector<HTMLElement>('.dropdown-menu')!;
-		const linkRef = ref<HTMLButtonElement>();
+		const buttonRef = ref<HTMLButtonElement>();
 
 		menuElem.appendChild(
 			<li>
-				<button ref={linkRef} className="dropdown-item">
+				<button ref={buttonRef} className={clsx('dropdown-item', isUnsupported && 'disabled')}>
 					{label}
 				</button>
 			</li>,
 		);
-		linkRef.value?.addEventListener('click', () => importerExporter.open());
+		if (buttonRef.value) {
+			if (isUnsupported) {
+				tippy(buttonRef.value, { content: 'Currently unsupported' });
+				return;
+			}
+			buttonRef.value.addEventListener('click', () => importerExporter.open());
+		}
 	}
 
 	private addToolbarLink({ parent, tooltip, classes, onclick, text, ...itemArgs }: ToolbarLinkArgs): HTMLElement {

--- a/ui/core/individual_sim_ui.tsx
+++ b/ui/core/individual_sim_ui.tsx
@@ -457,12 +457,12 @@ export abstract class IndividualSimUI<SpecType extends Spec> extends SimUI {
 	private addTopbarComponents() {
 		this.simHeader.addImportLink('JSON', new Importers.IndividualJsonImporter(this.rootElem, this), true);
 		this.simHeader.addImportLink('60U Cata', new Importers.Individual60UImporter(this.rootElem, this), true);
-		this.simHeader.addImportLink('WoWHead', new Importers.IndividualWowheadGearPlannerImporter(this.rootElem, this), false);
+		this.simHeader.addImportLink('WoWHead', new Importers.IndividualWowheadGearPlannerImporter(this.rootElem, this), false, true);
 		this.simHeader.addImportLink('Addon', new Importers.IndividualAddonImporter(this.rootElem, this), true);
 
 		this.simHeader.addExportLink('Link', new Exporters.IndividualLinkExporter(this.rootElem, this), false);
 		this.simHeader.addExportLink('JSON', new Exporters.IndividualJsonExporter(this.rootElem, this), true);
-		this.simHeader.addExportLink('WoWHead', new Exporters.IndividualWowheadGearPlannerExporter(this.rootElem, this), false);
+		this.simHeader.addExportLink('WoWHead', new Exporters.IndividualWowheadGearPlannerExporter(this.rootElem, this), false, true);
 		this.simHeader.addExportLink('60U Cata EP', new Exporters.Individual60UEPExporter(this.rootElem, this), false);
 		this.simHeader.addExportLink('Pawn EP', new Exporters.IndividualPawnEPExporter(this.rootElem, this), false);
 		this.simHeader.addExportLink('CLI', new Exporters.IndividualCLIExporter(this.rootElem, this), true);

--- a/ui/scss/core/sim_ui/_header.scss
+++ b/ui/scss/core/sim_ui/_header.scss
@@ -77,6 +77,15 @@
 				color: var(--bs-white);
 			}
 		}
+
+		.dropdown-item {
+			&.disabled {
+				pointer-events: auto;
+				cursor: not-allowed;
+				color: var(--bs-dropdown-link-color);
+				opacity: 0.5;
+			}
+		}
 	}
 
 	.sim-toolbar {


### PR DESCRIPTION
We've not made the current import/export Wowhead tool compatible with their new gearplanner, so it's best to disable it for now so we don't get user reports about broken functionalities.

![image](https://github.com/wowsims/cata/assets/1216787/29acf6e2-af30-4f46-9606-79ba43b8337a)
