### PR TITLE
[FIX] getSpec lookups

### DIFF
--- a/ui/core/components/encounter_picker.ts
+++ b/ui/core/components/encounter_picker.ts
@@ -114,7 +114,7 @@ export class EncounterPicker extends Component {
 			//	});
 			//}
 
-			if (simUI.isIndividualSim() && (simUI as IndividualSimUI<any>).player.getSpec().isHealingSpec) {
+			if (simUI.isIndividualSim() && (simUI as IndividualSimUI<any>).player.getPlayerSpec().isHealingSpec) {
 				new NumberPicker(this.rootElem, simUI.sim.raid, {
 					id: 'encounter-num-allies',
 					label: 'Num Allies',
@@ -127,7 +127,7 @@ export class EncounterPicker extends Component {
 				});
 			}
 
-			if (simUI.isIndividualSim() && (simUI as IndividualSimUI<any>).player.getSpec().isTankSpec) {
+			if (simUI.isIndividualSim() && (simUI as IndividualSimUI<any>).player.getPlayerSpec().isTankSpec) {
 				new NumberPicker(this.rootElem, modEncounter, {
 					id: 'encounter-min-base-damage',
 					label: 'Min Base Damage',

--- a/ui/core/components/gear_picker/filters_menu.tsx
+++ b/ui/core/components/gear_picker/filters_menu.tsx
@@ -194,7 +194,8 @@ export class FiltersMenu extends BaseModal {
 					sim.setFilters(eventID, filters);
 				},
 			});
-			if (player.getSpec().canDualWield) {
+
+			if (player.getPlayerSpec().canDualWield) {
 				new NumberPicker<Sim>(weaponSpeedSection, player.sim, {
 					id: 'filters-min-oh-weapon-speed',
 					label: 'Min OH Speed',

--- a/ui/scss/core/components/gear_picker/_filters_menu.scss
+++ b/ui/scss/core/components/gear_picker/_filters_menu.scss
@@ -1,4 +1,8 @@
 .filters-menu {
+	.modal-body {
+		overflow: auto;
+	}
+
 	.menu-section {
 		display: flex;
 		@include media-breakpoint-down(sm) {


### PR DESCRIPTION
Fixes: https://github.com/wowsims/cata/issues/608

Some `getSpec` lookups werent migrated properly to `getPlayerSpec`, resulting in some Spec inputs missing for;
- Offhand options
- Tank-only options
- Healer-only options

![image](https://github.com/wowsims/cata/assets/1216787/9b24fbb0-4ba9-4cb0-a4cd-de58ce69f43f)
![image](https://github.com/wowsims/cata/assets/1216787/cff46f0e-e80e-47e7-9490-550ee5efc05e)
