### PR TITLE
lots of bug fixes for the batch sim

### DIFF
--- a/sim/core/bulksim.go
+++ b/sim/core/bulksim.go
@@ -728,6 +728,7 @@ type SubstitutionComboChecker map[string]struct{}
 
 func (ic *SubstitutionComboChecker) HasCombo(replacements equipmentSubstitution) bool {
 	key := replacements.CanonicalHash()
+	fmt.Println(key)
 	if key == "" {
 		// Invalid combo.
 		return true

--- a/sim/core/bulksim.go
+++ b/sim/core/bulksim.go
@@ -537,10 +537,14 @@ func generateAllEquipmentSubstitutions(_ context.Context, baseItems []*proto.Ite
 
 		// Organize everything by slot.
 		itemsBySlot := make([][]*proto.ItemSpec, 17)
-		for _, is := range distinctItemSlotCombos {
-			itemsBySlot[is.Slot] = append(itemsBySlot[is.Slot], is.Item)
+		for _, spec := range distinctItemSlotCombos {
+			itemsBySlot[spec.Slot] = append(itemsBySlot[spec.Slot], spec.Item)
 		}
-		itemsBySlot[proto.ItemSlot_ItemSlotOffHand] = append(itemsBySlot[proto.ItemSlot_ItemSlotOffHand], nil)
+
+		// Add a blank offhand to be paired with a two-handed weapon if any weapons were selected
+		if len(itemsBySlot[proto.ItemSlot_ItemSlotMainHand]) > 0 {
+			itemsBySlot[proto.ItemSlot_ItemSlotOffHand] = append(itemsBySlot[proto.ItemSlot_ItemSlotOffHand], nil)
+		}
 
 		if !combinations {
 			// seenCombos lets us deduplicate trinket/ring combos.

--- a/sim/core/bulksim.go
+++ b/sim/core/bulksim.go
@@ -504,12 +504,6 @@ func isValidEquipment(equipment *proto.EquipmentSpec, isFuryWarrior bool) bool {
 		return false
 	}
 
-	// Don't allow a blank off-hand if the player is a Fury warrior
-	// Don't allow a blank off-hand if the main-hand is not a two-hander
-	if (isFuryWarrior || !usesTwoHander) && !usesOffHand {
-		return false
-	}
-
 	// Validate trinkets for duplicate IDs
 	if equipment.Items[proto.ItemSlot_ItemSlotTrinket1].Id == equipment.Items[proto.ItemSlot_ItemSlotTrinket2].Id && equipment.Items[proto.ItemSlot_ItemSlotTrinket1].Id != 0 {
 		return false

--- a/sim/core/bulksim_test.go
+++ b/sim/core/bulksim_test.go
@@ -60,7 +60,7 @@ func TestIsValidEquipment(t *testing.T) {
 		want          bool
 	}{
 		{
-			comment:       "simple equipment set with just one mainhand weapon is valid",
+			comment:       "simple equipment set with a main-hand weapon and off-hand is valid",
 			spec:          createEquipmentFromItems(starshardEdge1, bookOfBindingWill),
 			isFuryWarrior: false,
 			want:          true,
@@ -70,12 +70,6 @@ func TestIsValidEquipment(t *testing.T) {
 			spec:          createEquipmentFromItems(ironmender),
 			isFuryWarrior: false,
 			want:          true,
-		},
-		{
-			comment:       "simple equipment set with just one mainhand weapon is not valid",
-			spec:          createEquipmentFromItems(starshardEdge1),
-			isFuryWarrior: false,
-			want:          false,
 		},
 		{
 			comment:       "cannot equip offhand and two-hander if player is not a fury warrior",

--- a/sim/core/bulksim_test.go
+++ b/sim/core/bulksim_test.go
@@ -148,6 +148,7 @@ func TestGenerateAllEquipmentSubstitutions(t *testing.T) {
 	type args struct {
 		combinations           bool
 		distinctItemSlotCombos []*itemWithSlot
+		isFuryWarrior          bool
 	}
 	tests := []struct {
 		name string
@@ -159,6 +160,7 @@ func TestGenerateAllEquipmentSubstitutions(t *testing.T) {
 			args: args{
 				combinations:           true,
 				distinctItemSlotCombos: []*itemWithSlot{},
+				isFuryWarrior:          false,
 			},
 			want: []*equipmentSubstitution{
 				{},
@@ -171,6 +173,7 @@ func TestGenerateAllEquipmentSubstitutions(t *testing.T) {
 				distinctItemSlotCombos: []*itemWithSlot{
 					{Item: item1, Slot: proto.ItemSlot_ItemSlotHead},
 				},
+				isFuryWarrior: false,
 			},
 			want: []*equipmentSubstitution{
 				{},
@@ -187,6 +190,7 @@ func TestGenerateAllEquipmentSubstitutions(t *testing.T) {
 					{Item: item1, Slot: proto.ItemSlot_ItemSlotHead},
 					{Item: item2, Slot: proto.ItemSlot_ItemSlotShoulder},
 				},
+				isFuryWarrior: false,
 			},
 			want: []*equipmentSubstitution{
 				{},
@@ -212,6 +216,7 @@ func TestGenerateAllEquipmentSubstitutions(t *testing.T) {
 					{Item: item2, Slot: proto.ItemSlot_ItemSlotTrinket1},
 					{Item: item2, Slot: proto.ItemSlot_ItemSlotTrinket2},
 				},
+				isFuryWarrior: false,
 			},
 			want: []*equipmentSubstitution{
 				{},
@@ -257,6 +262,7 @@ func TestGenerateAllEquipmentSubstitutions(t *testing.T) {
 					{Item: item2, Slot: proto.ItemSlot_ItemSlotTrinket1},
 					{Item: item2, Slot: proto.ItemSlot_ItemSlotTrinket2},
 				},
+				isFuryWarrior: false,
 			},
 			want: []*equipmentSubstitution{
 				{},
@@ -336,6 +342,7 @@ func TestGenerateAllEquipmentSubstitutions(t *testing.T) {
 					{Item: item3, Slot: proto.ItemSlot_ItemSlotFinger1},
 					{Item: item3, Slot: proto.ItemSlot_ItemSlotFinger2},
 				},
+				isFuryWarrior: false,
 			},
 			want: []*equipmentSubstitution{
 				{},
@@ -358,6 +365,7 @@ func TestGenerateAllEquipmentSubstitutions(t *testing.T) {
 					{Item: item2, Slot: proto.ItemSlot_ItemSlotFinger1},
 					{Item: item2, Slot: proto.ItemSlot_ItemSlotFinger2},
 				},
+				isFuryWarrior: false,
 			},
 			want: []*equipmentSubstitution{
 				{},
@@ -391,6 +399,7 @@ func TestGenerateAllEquipmentSubstitutions(t *testing.T) {
 					{Item: item2, Slot: proto.ItemSlot_ItemSlotOffHand},
 					{Item: item3, Slot: proto.ItemSlot_ItemSlotMainHand},
 				},
+				isFuryWarrior: false,
 			},
 			want: []*equipmentSubstitution{
 				{},
@@ -406,10 +415,6 @@ func TestGenerateAllEquipmentSubstitutions(t *testing.T) {
 					{Item: item2, Slot: proto.ItemSlot_ItemSlotOffHand},
 				}},
 				{Items: []*itemWithSlot{
-					{Item: item1, Slot: proto.ItemSlot_ItemSlotMainHand},
-					{Item: nil, Slot: proto.ItemSlot_ItemSlotOffHand},
-				}},
-				{Items: []*itemWithSlot{
 					{Item: item2, Slot: proto.ItemSlot_ItemSlotMainHand},
 				}},
 				{Items: []*itemWithSlot{
@@ -419,10 +424,6 @@ func TestGenerateAllEquipmentSubstitutions(t *testing.T) {
 				{Items: []*itemWithSlot{
 					{Item: item2, Slot: proto.ItemSlot_ItemSlotMainHand},
 					{Item: item2, Slot: proto.ItemSlot_ItemSlotOffHand},
-				}},
-				{Items: []*itemWithSlot{
-					{Item: item2, Slot: proto.ItemSlot_ItemSlotMainHand},
-					{Item: nil, Slot: proto.ItemSlot_ItemSlotOffHand},
 				}},
 				{Items: []*itemWithSlot{
 					{Item: item3, Slot: proto.ItemSlot_ItemSlotMainHand},
@@ -436,28 +437,33 @@ func TestGenerateAllEquipmentSubstitutions(t *testing.T) {
 					{Item: item2, Slot: proto.ItemSlot_ItemSlotOffHand},
 				}},
 				{Items: []*itemWithSlot{
-					{Item: item3, Slot: proto.ItemSlot_ItemSlotMainHand},
-					{Item: nil, Slot: proto.ItemSlot_ItemSlotOffHand},
-				}},
-				{Items: []*itemWithSlot{
 					{Item: item1, Slot: proto.ItemSlot_ItemSlotOffHand},
 				}},
 				{Items: []*itemWithSlot{
 					{Item: item2, Slot: proto.ItemSlot_ItemSlotOffHand},
-				}},
-				{Items: []*itemWithSlot{
-					{Item: nil, Slot: proto.ItemSlot_ItemSlotOffHand},
 				}},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			results := generateAllEquipmentSubstitutions(context.Background(), baseItems, tt.args.combinations, tt.args.distinctItemSlotCombos)
+			results := generateAllEquipmentSubstitutions(context.Background(), baseItems, tt.args.combinations, tt.args.distinctItemSlotCombos, tt.args.isFuryWarrior)
 
 			idx := 0
 			for got := range results {
 				wanted := tt.want[idx]
+
+				// Uncomment this for easier debugging:
+				// fmt.Println("Expected:")
+				// for _, item := range wanted.Items {
+				// 	fmt.Println(item)
+				// }
+				// fmt.Println("Got:")
+				// for _, item := range got.Items {
+				// 	fmt.Println(item)
+				// }
+				// fmt.Println("===============")
+
 				if len(got.Items) != len(wanted.Items) {
 					t.Errorf("%s generateAllEquipmentSubstitutions(%d) has incorrect number of items, expected: %d, got: %d", tt.name, idx, len(wanted.Items), len(got.Items))
 				}

--- a/sim/core/database.go
+++ b/sim/core/database.go
@@ -560,12 +560,16 @@ var itemTypeToSlotsMap = map[proto.ItemType][]proto.ItemSlot{
 	// ItemType_ItemTypeWeapon is excluded intentionally - the slot cannot be decided based on type alone for weapons.
 }
 
-func eligibleSlotsForItem(item Item) []proto.ItemSlot {
+func eligibleSlotsForItem(item Item, isFuryWarrior bool) []proto.ItemSlot {
 	if slots, ok := itemTypeToSlotsMap[item.Type]; ok {
 		return slots
 	}
 
 	if item.Type == proto.ItemType_ItemTypeWeapon {
+		if isFuryWarrior {
+			return []proto.ItemSlot{proto.ItemSlot_ItemSlotMainHand, proto.ItemSlot_ItemSlotOffHand}
+		}
+
 		switch item.HandType {
 		case proto.HandType_HandTypeTwoHand, proto.HandType_HandTypeMainHand:
 			return []proto.ItemSlot{proto.ItemSlot_ItemSlotMainHand}

--- a/ui/core/components/gear_picker/gear_picker.tsx
+++ b/ui/core/components/gear_picker/gear_picker.tsx
@@ -88,13 +88,13 @@ export class ItemRenderer extends Component {
 			<>
 				<div className="item-picker-icon-wrapper">
 					<span className="item-picker-ilvl" ref={ilvlElem} />
-					<a ref={iconElem} className="item-picker-icon" href="javascript:void(0)" attributes={{ role: 'button' }}></a>
+					<a ref={iconElem} className="item-picker-icon" href="javascript:void(0)" attributes={{ role: 'button' }} />
 					<div ref={sce} className="item-picker-sockets-container"></div>
 				</div>
 				<div className="item-picker-labels-container">
-					<a ref={nameElem} className="item-picker-name-container" href="javascript:void(0)" attributes={{ role: 'button' }}></a>
-					<a ref={enchantElem} className="item-picker-enchant hide" href="javascript:void(0)" attributes={{ role: 'button' }}></a>
-					<a ref={reforgeElem} className="item-picker-reforge hide" href="javascript:void(0)" attributes={{ role: 'button' }}></a>
+					<a ref={nameElem} className="item-picker-name-container" href="javascript:void(0)" attributes={{ role: 'button' }} />
+					<a ref={enchantElem} className="item-picker-enchant hide" href="javascript:void(0)" attributes={{ role: 'button' }} />
+					<a ref={reforgeElem} className="item-picker-reforge hide" href="javascript:void(0)" attributes={{ role: 'button' }} />
 				</div>
 			</>,
 		);
@@ -107,7 +107,7 @@ export class ItemRenderer extends Component {
 		this.socketsContainerElem = sce.value!;
 	}
 
-	clear() {
+	clear(slot: ItemSlot) {
 		this.nameElem.removeAttribute('data-wowhead');
 		this.nameElem.removeAttribute('href');
 		this.iconElem.removeAttribute('data-wowhead');
@@ -117,7 +117,7 @@ export class ItemRenderer extends Component {
 		this.enchantElem.classList.add('hide');
 		this.reforgeElem.classList.add('hide');
 
-		this.iconElem.style.backgroundImage = '';
+		this.iconElem.style.backgroundImage = `url('${getEmptySlotIconUrl(slot)}')`;
 
 		this.enchantElem.innerText = '';
 		this.reforgeElem.innerText = '';
@@ -129,17 +129,16 @@ export class ItemRenderer extends Component {
 	}
 
 	update(newItem: EquippedItem) {
-		this.nameElem.replaceChildren(<span className="item-picker-name">{newItem.item.name}</span>);
+		const nameSpan = <span className="item-picker-name">{newItem.item.name}</span>;
+		this.nameElem.replaceChildren(nameSpan);
 		this.ilvlElem.textContent = newItem.item.ilvl.toString();
 
 		if (newItem.randomSuffix) {
-			this.nameElem.textContent += ' ' + newItem.randomSuffix.name;
+			nameSpan.textContent += ' ' + newItem.randomSuffix.name;
 		}
 
 		if (newItem.item.heroic) {
-			this.nameElem.insertAdjacentElement('beforeend', createHeroicLabel());
-		} else {
-			this.nameElem.querySelector('.heroic-label')?.remove();
+			this.nameElem.appendChild(createHeroicLabel());
 		}
 
 		if (newItem.reforge) {
@@ -296,7 +295,7 @@ export class ItemPicker extends Component {
 
 	set item(newItem: EquippedItem | null) {
 		// Clear everything first
-		this.itemElem.clear();
+		this.itemElem.clear(this.slot);
 		// Clear quick swap gems array since gem sockets are rerendered every time
 		this.quickSwapGemPopover = [];
 		this.itemElem.nameElem.textContent = slotNames.get(this.slot) ?? '';
@@ -304,8 +303,6 @@ export class ItemPicker extends Component {
 
 		if (!!newItem) {
 			this.itemElem.update(newItem);
-		} else {
-			this.itemElem.iconElem.style.backgroundImage = `url('${getEmptySlotIconUrl(this.slot)}')`;
 		}
 
 		this._equippedItem = newItem;

--- a/ui/core/components/individual_sim_ui/bulk/bulk_item_picker.tsx
+++ b/ui/core/components/individual_sim_ui/bulk/bulk_item_picker.tsx
@@ -2,6 +2,7 @@ import tippy from 'tippy.js';
 import { ref } from 'tsx-vanilla';
 
 import { IndividualSimUI } from '../../../individual_sim_ui';
+import { ItemSlot } from '../../../proto/common';
 import { EquippedItem } from '../../../proto_utils/equipped_item';
 import { getEligibleItemSlots } from '../../../proto_utils/utils';
 import { TypedEvent } from '../../../typed_event';
@@ -10,11 +11,13 @@ import { ItemRenderer } from '../../gear_picker/gear_picker';
 import { GearData } from '../../gear_picker/item_list';
 import { SelectorModalTabs } from '../../gear_picker/selector_modal';
 import { BulkTab } from '../bulk_tab';
+import { BulkSimItemSlot } from './utils';
 
 export default class BulkItemPicker extends Component {
 	private readonly itemElem: ItemRenderer;
 	readonly simUI: IndividualSimUI<any>;
 	readonly bulkUI: BulkTab;
+	readonly bulkSlot: BulkSimItemSlot;
 	// If less than 0, the item is currently equipped and not stored in the batch sim's item array
 	readonly index: number;
 	protected item: EquippedItem;
@@ -24,11 +27,12 @@ export default class BulkItemPicker extends Component {
 	public abortController: AbortController;
 	public signal: AbortSignal;
 
-	constructor(parent: HTMLElement, simUI: IndividualSimUI<any>, bulkUI: BulkTab, item: EquippedItem, index: number) {
+	constructor(parent: HTMLElement, simUI: IndividualSimUI<any>, bulkUI: BulkTab, item: EquippedItem, bulkSlot: BulkSimItemSlot, index: number) {
 		super(parent, 'bulk-item-picker');
 
 		this.simUI = simUI;
 		this.bulkUI = bulkUI;
+		this.bulkSlot = bulkSlot;
 		this.index = index;
 		this.item = item;
 		this.itemElem = new ItemRenderer(parent, this.rootElem, simUI.player);
@@ -48,7 +52,7 @@ export default class BulkItemPicker extends Component {
 	}
 
 	setItem(newItem: EquippedItem) {
-		this.itemElem.clear();
+		this.itemElem.clear(ItemSlot.ItemSlotHead);
 		this.itemElem.update(newItem);
 		this.item = newItem;
 		this.setupHandlers();
@@ -144,7 +148,7 @@ export default class BulkItemPicker extends Component {
 
 		const copyBtn = copyBtnRef.value!;
 		tippy(copyBtn, { content: 'Make an editable copy of this item.' });
-		const copyItem = () => this.bulkUI.addItem(this.item.asSpec());
+		const copyItem = () => this.bulkUI.addItemToSlot(this.item.asSpec(), this.bulkSlot);
 		copyBtn.addEventListener('click', copyItem);
 		this.addOnDisposeCallback(() => copyBtn.removeEventListener('click', copyItem));
 

--- a/ui/core/components/individual_sim_ui/bulk/bulk_item_picker_group.tsx
+++ b/ui/core/components/individual_sim_ui/bulk/bulk_item_picker_group.tsx
@@ -9,17 +9,17 @@ import { BulkSimItemSlot, bulkSimSlotNames } from './utils';
 export default class BulkItemPickerGroup extends ContentBlock {
 	readonly simUI: IndividualSimUI<any>;
 	readonly bulkUI: BulkTab;
-	readonly slot: BulkSimItemSlot;
+	readonly bulkSlot: BulkSimItemSlot;
 
 	readonly pickers: Map<number, BulkItemPicker> = new Map();
 
-	constructor(parent: HTMLElement, simUI: IndividualSimUI<any>, bulkUI: BulkTab, slot: BulkSimItemSlot) {
-		const slotName = bulkSimSlotNames.get(slot)!;
+	constructor(parent: HTMLElement, simUI: IndividualSimUI<any>, bulkUI: BulkTab, bulkSlot: BulkSimItemSlot) {
+		const slotName = bulkSimSlotNames.get(bulkSlot)!;
 		super(parent, 'bulk-item-picker-group-root', { header: { title: slotName } });
 		this.rootElem.classList.add(`gear-group-${slotName.split(' ').join('-')}`);
 		this.simUI = simUI;
 		this.bulkUI = bulkUI;
-		this.slot = slot;
+		this.bulkSlot = bulkSlot;
 
 		this.addEmptyElement();
 	}
@@ -33,7 +33,7 @@ export default class BulkItemPickerGroup extends ContentBlock {
 			this.pickers.delete(idx);
 		}
 
-		this.pickers.set(idx, new BulkItemPicker(this.bodyElement, this.simUI, this.bulkUI, item, idx));
+		this.pickers.set(idx, new BulkItemPicker(this.bodyElement, this.simUI, this.bulkUI, item, this.bulkSlot, idx));
 	}
 
 	update(idx: number, newItem: EquippedItem) {

--- a/ui/core/components/individual_sim_ui/bulk/bulk_item_picker_group.tsx
+++ b/ui/core/components/individual_sim_ui/bulk/bulk_item_picker_group.tsx
@@ -24,6 +24,10 @@ export default class BulkItemPickerGroup extends ContentBlock {
 		this.addEmptyElement();
 	}
 
+	has(idx: number) {
+		return !!this.pickers.get(idx);
+	}
+
 	add(idx: number, item: EquippedItem) {
 		if (!this.pickers.size) this.bodyElement.replaceChildren();
 

--- a/ui/core/components/individual_sim_ui/bulk/bulk_item_search.tsx
+++ b/ui/core/components/individual_sim_ui/bulk/bulk_item_search.tsx
@@ -221,10 +221,11 @@ export default class BulkItemSearch extends ContentBlock {
 			<>
 				{items}
 				{matchCount > MAX_SEARCH_RESULTS && (
-					<li className="bulk-item-search-item bulk-item-search-more-items-note">
-						Showing {MAX_SEARCH_RESULTS} of {matchCount} total matches.
+					<li className="bulk-item-search-item bulk-item-search-results-note">
+						Showing {MAX_SEARCH_RESULTS} of {matchCount} total results.
 					</li>
 				)}
+				{matchCount === 0 && <li className="bulk-item-search-item bulk-item-search-results-note">No results found.</li>}
 			</>,
 		);
 

--- a/ui/core/components/individual_sim_ui/bulk/bulk_sim_results_renderer.tsx
+++ b/ui/core/components/individual_sim_ui/bulk/bulk_sim_results_renderer.tsx
@@ -59,9 +59,12 @@ export default class BulkSimResultRenderer extends Component {
 		if (!!result.itemsAdded?.length) {
 			equipButtonRef.value?.addEventListener('click', () => {
 				result.itemsAdded.forEach(itemAdded => {
-					const item = simUI.sim.db.lookupItemSpec(itemAdded.item!);
-					simUI.player.equipItem(TypedEvent.nextEventID(), itemAdded.slot, item);
-					simUI.simHeader.activateTab('gear-tab');
+					// This could be blank for a blank off-hand paired with a two-handed weapon
+					if (itemAdded.item) {
+						const item = simUI.sim.db.lookupItemSpec(itemAdded.item);
+						simUI.player.equipItem(TypedEvent.nextEventID(), itemAdded.slot, item);
+						simUI.simHeader.activateTab('gear-tab');
+					}
 				});
 				new Toast({
 					variant: 'success',

--- a/ui/core/components/individual_sim_ui/bulk/utils.ts
+++ b/ui/core/components/individual_sim_ui/bulk/utils.ts
@@ -1,4 +1,5 @@
 import { ItemSlot } from '../../../proto/common';
+import { getEnumValues } from '../../../utils';
 
 // Combines Fingers 1 and 2 and Trinket 1 and 2 into single groups
 export enum BulkSimItemSlot {
@@ -16,8 +17,21 @@ export enum BulkSimItemSlot {
 	ItemSlotTrinket,
 	ItemSlotMainHand,
 	ItemSlotOffHand,
+	ItemSlotHandWeapon, // Weapon grouping slot for specs that can dual-wield
 	ItemSlotRanged,
 }
+
+// Return all eligible bulk item slots.
+// If the player can dual-wield, exclude main-hand/off-hand in favor of the grouped weapons slot
+// Otherwise include main-hand/off-hand instead of the grouped weapons slot
+export const getBulkItemSlots = (canDualWield: boolean) => {
+	const allSlots = getEnumValues<BulkSimItemSlot>(BulkSimItemSlot);
+	if (canDualWield) {
+		return allSlots.filter(bulkSlot => ![BulkSimItemSlot.ItemSlotMainHand, BulkSimItemSlot.ItemSlotOffHand].includes(bulkSlot));
+	} else {
+		return allSlots.filter(bulkSlot => bulkSlot !== BulkSimItemSlot.ItemSlotHandWeapon);
+	}
+};
 
 export const bulkSimSlotNames: Map<BulkSimItemSlot, string> = new Map([
 	[BulkSimItemSlot.ItemSlotHead, 'Head'],
@@ -34,6 +48,7 @@ export const bulkSimSlotNames: Map<BulkSimItemSlot, string> = new Map([
 	[BulkSimItemSlot.ItemSlotTrinket, 'Trinkets'],
 	[BulkSimItemSlot.ItemSlotMainHand, 'Main Hand'],
 	[BulkSimItemSlot.ItemSlotOffHand, 'Off Hand'],
+	[BulkSimItemSlot.ItemSlotHandWeapon, 'Weapons'],
 	[BulkSimItemSlot.ItemSlotRanged, 'Ranged'],
 ]);
 
@@ -56,3 +71,10 @@ export const itemSlotToBulkSimItemSlot: Map<ItemSlot, BulkSimItemSlot> = new Map
 	[ItemSlot.ItemSlotOffHand, BulkSimItemSlot.ItemSlotOffHand],
 	[ItemSlot.ItemSlotRanged, BulkSimItemSlot.ItemSlotRanged],
 ]);
+
+export const getBulkItemSlotFromSlot = (slot: ItemSlot, canDualWield: boolean): BulkSimItemSlot => {
+	if (canDualWield && [ItemSlot.ItemSlotMainHand, ItemSlot.ItemSlotOffHand].includes(slot)) {
+		return BulkSimItemSlot.ItemSlotHandWeapon;
+	}
+	return itemSlotToBulkSimItemSlot.get(slot)!;
+};

--- a/ui/core/components/individual_sim_ui/bulk_tab.tsx
+++ b/ui/core/components/individual_sim_ui/bulk_tab.tsx
@@ -171,14 +171,22 @@ export class BulkTab extends SimTab {
 			this.loadSettings();
 
 			const loadEquippedItems = () => {
+				// Clear all previously equipped items from the pickers
+				for (const group of this.pickerGroups.values()) {
+					if (group.has(-1)) {
+						group.remove(-1);
+					}
+					if (group.has(-2)) {
+						group.remove(-2);
+					}
+				}
+
 				this.simUI.player.getEquippedItems().forEach((equippedItem, slot) => {
 					const bulkSlot = getBulkItemSlotFromSlot(slot, this.playerCanDualWield);
 					const group = this.pickerGroups.get(bulkSlot)!;
 					const idx = this.isSecondaryItemSlot(slot) ? -2 : -1;
 					if (equippedItem) {
 						group.add(idx, equippedItem);
-					} else {
-						group.remove(idx);
 					}
 				});
 			};

--- a/ui/core/proto_utils/utils.ts
+++ b/ui/core/proto_utils/utils.ts
@@ -1739,18 +1739,20 @@ const itemTypeToSlotsMap: Partial<Record<ItemType, Array<ItemSlot>>> = {
 	[ItemType.ItemTypeRanged]: [ItemSlot.ItemSlotRanged],
 };
 
-export function getEligibleItemSlots(item: Item): Array<ItemSlot> {
+export function getEligibleItemSlots(item: Item, isFuryWarrior?: boolean): Array<ItemSlot> {
 	if (itemTypeToSlotsMap[item.type]) {
 		return itemTypeToSlotsMap[item.type]!;
 	}
 
 	if (item.type == ItemType.ItemTypeWeapon) {
+		if (isFuryWarrior) {
+			return [ItemSlot.ItemSlotMainHand, ItemSlot.ItemSlotOffHand];
+		}
+
 		if (item.handType == HandType.HandTypeMainHand) {
 			return [ItemSlot.ItemSlotMainHand];
 		} else if (item.handType == HandType.HandTypeOffHand) {
 			return [ItemSlot.ItemSlotOffHand];
-			// Missing HandTypeTwoHand
-			// We allow 2H weapons to be wielded in mainhand and offhand for Fury Warriors
 		} else {
 			return [ItemSlot.ItemSlotMainHand, ItemSlot.ItemSlotOffHand];
 		}

--- a/ui/core/sim.ts
+++ b/ui/core/sim.ts
@@ -269,6 +269,7 @@ export class Sim {
 			return result;
 		} catch (error) {
 			if (error instanceof SimError) throw error;
+			console.log(error);
 			throw new Error('Something went wrong running your raid sim. Reload the page and try again.');
 		}
 	}

--- a/ui/scss/core/components/individual_sim_ui/bulk/_bulk_item_search.scss
+++ b/ui/scss/core/components/individual_sim_ui/bulk/_bulk_item_search.scss
@@ -39,6 +39,7 @@
 		left: var(--spacer-3);
 		right: var(--spacer-3);
 		grid-template-columns: repeat(var(--bulk-gear-search-results-column-count), 1fr);
+		z-index: 10; // Needs to be greater than 1 but less than the header z-index
 
 		@include media-breakpoint-up(md) {
 			--bulk-gear-search-results-column-count: 2;
@@ -55,6 +56,7 @@
 	.bulk-item-search-item {
 		display: flex;
 		width: 100%;
+		height: 100%;
 		padding: var(--spacer-2);
 		border: var(--border-default);
 		white-space: normal;
@@ -73,9 +75,10 @@
 		height: 100%;
 	}
 
-	.bulk-item-search-more-items-note {
+	.bulk-item-search-results-note {
 		border: none;
-		grid-column: 1 / var(--bulk-gear-search-results-column-count);
+		grid-column: 1 / calc(var(--bulk-gear-search-results-column-count) + 1);
+		justify-content: center;
 	}
 
 	.bulk-gear-search-ilvl-filters {


### PR DESCRIPTION
Resolves https://github.com/wowsims/cata/issues/709

- For dual wield classes, group weapons into a single bulk slot
- Fix bugs with 2h weapon combinations allowing offhands
- Allow fury warriors to batch sim 2hs in either hand
- Fill in shared slots (ring, trinket, weapon) in results for easier understanding
- I hate combination calculations