### PR TITLE
Reduce font sizes on larger displays to improve scaling

### DIFF
--- a/ui/scss/shared/_global.scss
+++ b/ui/scss/shared/_global.scss
@@ -8,11 +8,11 @@
 
 	// We want to apply only to 1440p monitors, NOT 1080p Ultrawide
 	@media (min-width: map-get($grid-breakpoints, 1440p)) and (max-aspect-ratio: 16/9) {
-		--bs-body-font-size: 24px;
+		--bs-body-font-size: 20px;
 	}
 
 	@include media-breakpoint-up(4k) {
-		--bs-body-font-size: 32px;
+		--bs-body-font-size: 24px;
 	}
 
 	@include media-breakpoint-up(lg) {


### PR DESCRIPTION
Fixes https://github.com/wowsims/cata/issues/439

Adjusted the font sizes to not make the Sim tool scale proportionally with larger displays, but rather scale it a bit more to stay legible whilst enjoying more screen space.

**Current**
![image](https://github.com/wowsims/cata/assets/1216787/8087197a-9c41-4fd8-9ded-b3f1066ce144)
![image](https://github.com/wowsims/cata/assets/1216787/6778dd87-e6cf-45c1-8270-9cfe6bd752f0)

**Adjusted**
![image](https://github.com/wowsims/cata/assets/1216787/9b60a444-1c8c-459e-b4a4-57b84b0df9db)
![image](https://github.com/wowsims/cata/assets/1216787/2d646f9e-8e20-48fe-8140-84b54b29fa0b)
