### PR TITLE
[Batch Sim] Calculate combinations/iterations from the back-end's real calculations

### DIFF
--- a/proto/api.proto
+++ b/proto/api.proto
@@ -500,7 +500,7 @@ message BulkSettings {
 
 message BulkSimResult {
     repeated BulkComboResult results = 1;
-		BulkComboResult equipped_gear_result = 2;
+	BulkComboResult equipped_gear_result = 2;
     string error_result = 3; // only set if sim failed.
 }
 
@@ -513,4 +513,16 @@ message BulkComboResult {
 message ItemSpecWithSlot {
     ItemSpec item = 1;
     ItemSlot slot = 2;
+}
+
+// RPC: BulkSimCombos
+message BulkSimCombosRequest {
+	RaidSimRequest base_settings = 1;
+    BulkSettings bulk_settings = 2;
+}
+
+message BulkSimCombosResult {
+	int32 num_combinations = 1;
+	int32 num_iterations = 2;
+    string error_result = 3; // only set if sim failed.
 }

--- a/sim/core/api.go
+++ b/sim/core/api.go
@@ -60,3 +60,11 @@ func RunBulkSim(request *proto.BulkSimRequest) *proto.BulkSimResult {
 func RunBulkSimAsync(ctx context.Context, request *proto.BulkSimRequest, progress chan *proto.ProgressMetrics) {
 	go BulkSim(ctx, request, progress)
 }
+
+func RunBulkCombos(ctx context.Context, request *proto.BulkSimCombosRequest) *proto.BulkSimCombosResult {
+	bulkSimReq := &proto.BulkSimCombosRequest{
+		BaseSettings: request.BaseSettings,
+		BulkSettings: request.BulkSettings,
+	}
+	return BulkSimCombos(ctx, bulkSimReq)
+}

--- a/sim/core/bulksim.go
+++ b/sim/core/bulksim.go
@@ -55,6 +55,49 @@ func BulkSim(ctx context.Context, request *proto.BulkSimRequest, progress chan *
 	return result
 }
 
+func BulkSimCombos(ctx context.Context, req *proto.BulkSimCombosRequest) *proto.BulkSimCombosResult {
+	// Bulk simming is only supported for the single-player use (i.e. not whole raid-wide simming).
+	// Verify that we have exactly 1 player.
+	var playerCount int
+	var player *proto.Player
+	for _, p := range req.BaseSettings.GetRaid().GetParties() {
+		for _, pl := range p.GetPlayers() {
+			// TODO(Riotdog-GehennasEU): Better way to check if a player is valid/set?
+			if pl.Name != "" {
+				player = pl
+				playerCount++
+			}
+		}
+	}
+	if playerCount != 1 || player == nil {
+		return &proto.BulkSimCombosResult{
+			ErrorResult: fmt.Sprintf("bulksim: expected exactly 1 player, found %d", playerCount),
+		}
+	}
+
+	if player.GetDatabase() != nil {
+		addToDatabase(player.GetDatabase())
+	}
+	// reduce to just base party.
+	req.BaseSettings.Raid.Parties = []*proto.Party{req.BaseSettings.Raid.Parties[0]}
+	// clean to reduce memory
+	player.Database = nil
+
+	validCombos, iterations, err := buildCombos(ctx, req.BaseSettings, req.BulkSettings, player)
+	if err != nil {
+		return &proto.BulkSimCombosResult{
+			ErrorResult: err.Error(),
+		}
+	}
+
+	result := &proto.BulkSimCombosResult{
+		NumCombinations: int32(len(validCombos)),
+		NumIterations:   int32(len(validCombos)) * iterations,
+	}
+
+	return result
+}
+
 type singleBulkSim struct {
 	req *proto.RaidSimRequest
 	cl  *raidSimRequestChangeLog
@@ -96,121 +139,14 @@ func (b *bulkSimRunner) Run(pctx context.Context, progress chan *proto.ProgressM
 	// clean to reduce memory
 	player.Database = nil
 
-	// Gemming for now can happen before slots are decided.
-	// We might have to add logic after slot decisions if we want to enforce keeping meta gem active.
-
-	if b.Request.BulkSettings.AutoGem {
-		for _, replaceItem := range b.Request.BulkSettings.Items {
-			itemData := ItemsByID[replaceItem.Id]
-			if len(itemData.GemSockets) == 0 && itemData.Type != proto.ItemType_ItemTypeWaist {
-				continue
-			}
-
-			sockets := make([]int32, len(itemData.GemSockets))
-			if len(sockets) < len(replaceItem.Gems) {
-				// this means the extra gem was specified, just add an extra element
-				sockets = append(sockets, 0)
-			}
-			// now copy over what we have from inputs.
-			copy(sockets, replaceItem.Gems)
-			if itemData.Type == proto.ItemType_ItemTypeWaist {
-				// Assume waist always has the eternal belt buckle and add extra red gem.
-				// TODO: is there a better way to do this?
-				// Should we have a 'prismatic' standard gem in the defaults?
-				if len(sockets) == len(itemData.GemSockets) {
-					sockets = append(sockets, b.Request.BulkSettings.DefaultRedGem)
-				} else if len(sockets) > len(itemData.GemSockets) && sockets[len(sockets)-1] == 0 {
-					sockets[len(sockets)-1] = b.Request.BulkSettings.DefaultRedGem
-				}
-			}
-
-			for i, color := range itemData.GemSockets {
-				if sockets[i] > 0 {
-					// This means gem was already specified, skip autogem
-					continue
-				}
-				if ColorIntersects(color, proto.GemColor_GemColorRed) {
-					sockets[i] = b.Request.BulkSettings.DefaultRedGem
-				} else if ColorIntersects(color, proto.GemColor_GemColorYellow) {
-					sockets[i] = b.Request.BulkSettings.DefaultYellowGem
-				} else if ColorIntersects(color, proto.GemColor_GemColorBlue) {
-					sockets[i] = b.Request.BulkSettings.DefaultBlueGem
-				} else if ColorIntersects(color, proto.GemColor_GemColorMeta) {
-					sockets[i] = b.Request.BulkSettings.DefaultMetaGem
-				}
-			}
-			replaceItem.Gems = sockets
-		}
+	originalIterations := b.Request.BulkSettings.GetIterationsPerCombo()
+	if originalIterations <= 0 {
+		originalIterations = defaultIterationsPerCombo
 	}
 
-	iterations := b.Request.GetBulkSettings().GetIterationsPerCombo()
-	if iterations <= 0 {
-		iterations = defaultIterationsPerCombo
-	}
-
-	items := b.Request.GetBulkSettings().GetItems()
-	isFuryWarrior := player.GetFuryWarrior() != nil
-	// numItems := len(items)
-	// if b.Request.BulkSettings.Combinations && numItems > maxItemCount {
-	// 	return nil, fmt.Errorf("too many items specified (%d > %d), not computationally feasible", numItems, maxItemCount)
-	// }
-
-	// Create all distinct combinations of (item, slot). For example, let's say the only item we
-	// want to bulk sim is a one-handed item that can be worn both as an off-hand or a main-hand weapon.
-	// For each slot, we will create one itemWithSlot pair, so (item, off-hand) and (item, main-hand).
-	// We verify later that we are not emitting any invalid equipment set.
-	var distinctItemSlotCombos []*itemWithSlot
-	for index, is := range items {
-		item, ok := ItemsByID[is.Id]
-		if !ok {
-			return nil, fmt.Errorf("unknown item with id %d in bulk settings", is.Id)
-		}
-		for _, slot := range eligibleSlotsForItem(item, isFuryWarrior) {
-			distinctItemSlotCombos = append(distinctItemSlotCombos, &itemWithSlot{
-				Item:  is,
-				Slot:  slot,
-				Index: index,
-			})
-		}
-	}
-	baseItems := player.Equipment.Items
-
-	allCombos := generateAllEquipmentSubstitutions(ctx, baseItems, b.Request.BulkSettings.Combinations, distinctItemSlotCombos, isFuryWarrior)
-
-	var validCombos []singleBulkSim
-	count := 0
-	for sub := range allCombos {
-		count++
-		if count > 1000000 {
-			panic("over 1 million combos, abandoning attempt")
-		}
-
-		substitutedRequest, changeLog := createNewRequestWithSubstitution(b.Request.BaseSettings, sub, b.Request.BulkSettings.AutoEnchant, isFuryWarrior)
-		if isValidEquipment(substitutedRequest.Raid.Parties[0].Players[0].Equipment, isFuryWarrior) {
-			// Need to sim base dps of gear loudout
-			validCombos = append(validCombos, singleBulkSim{req: substitutedRequest, cl: changeLog, eq: sub})
-			// Todo(Netzone-GehennasEU): Make this its own step?
-			if !b.Request.BulkSettings.SimTalents {
-
-			} else {
-				var talentsToSim = b.Request.BulkSettings.GetTalentsToSim()
-
-				if len(talentsToSim) > 0 {
-					for _, talent := range talentsToSim {
-						sr := goproto.Clone(substitutedRequest).(*proto.RaidSimRequest)
-						cl := *changeLog
-						if sr.Raid.Parties[0].Players[0].TalentsString == talent.TalentsString && goproto.Equal(talent.Glyphs, sr.Raid.Parties[0].Players[0].Glyphs) {
-							continue
-						}
-
-						sr.Raid.Parties[0].Players[0].TalentsString = talent.TalentsString
-						sr.Raid.Parties[0].Players[0].Glyphs = talent.Glyphs
-						cl.TalentLoadout = talent
-						validCombos = append(validCombos, singleBulkSim{req: sr, cl: &cl, eq: sub})
-					}
-				}
-			}
-		}
+	validCombos, newIters, err := buildCombos(ctx, b.Request.BaseSettings, b.Request.BulkSettings, player)
+	if err != nil {
+		return nil, err
 	}
 
 	// TODO(Riotdog-GehennasEU): Make this configurable?
@@ -218,23 +154,6 @@ func (b *bulkSimRunner) Run(pctx context.Context, progress chan *proto.ProgressM
 
 	var rankedResults []*itemSubstitutionSimResult
 	var baseResult *itemSubstitutionSimResult
-	newIters := int64(iterations)
-	if b.Request.BulkSettings.FastMode {
-		newIters /= 10
-
-		// In fast mode try to keep starting iterations between 50 and 1000.
-		if newIters < 50 {
-			newIters = 50
-		}
-		if newIters > 1000 {
-			newIters = 1000
-		}
-	}
-
-	maxIterations := newIters * int64(len(validCombos))
-	if maxIterations > math.MaxInt32 {
-		return nil, fmt.Errorf("number of total iterations %d too large", maxIterations)
-	}
 
 	for {
 		var tempBase *itemSubstitutionSimResult
@@ -256,7 +175,7 @@ func (b *bulkSimRunner) Run(pctx context.Context, progress chan *proto.ProgressM
 		}
 
 		// we have reached max accuracy now
-		if newIters >= int64(iterations) {
+		if newIters >= originalIterations {
 			break
 		}
 
@@ -316,7 +235,7 @@ func (b *bulkSimRunner) Run(pctx context.Context, progress chan *proto.ProgressM
 	return result, nil
 }
 
-func (b *bulkSimRunner) getRankedResults(pctx context.Context, validCombos []singleBulkSim, iterations int64, progress chan *proto.ProgressMetrics) ([]*itemSubstitutionSimResult, *itemSubstitutionSimResult, error) {
+func (b *bulkSimRunner) getRankedResults(pctx context.Context, validCombos []singleBulkSim, iterations int32, progress chan *proto.ProgressMetrics) ([]*itemSubstitutionSimResult, *itemSubstitutionSimResult, error) {
 	concurrency := runtime.NumCPU() + 1
 	if concurrency <= 0 {
 		concurrency = 2
@@ -330,7 +249,7 @@ func (b *bulkSimRunner) getRankedResults(pctx context.Context, validCombos []sin
 	results := make(chan *itemSubstitutionSimResult, 10)
 
 	numCombinations := int32(len(validCombos))
-	totalIterationsUpperBound := int64(numCombinations) * iterations
+	totalIterationsUpperBound := numCombinations * iterations
 
 	var totalCompletedIterations int32
 	var totalCompletedSims int32
@@ -411,6 +330,142 @@ func (b *bulkSimRunner) getRankedResults(pctx context.Context, validCombos []sin
 		return rankedResults[i].Score() > rankedResults[j].Score()
 	})
 	return rankedResults, baseResult, nil
+}
+
+func buildCombos(ctx context.Context, baseSettings *proto.RaidSimRequest, bulkSettings *proto.BulkSettings, player *proto.Player) ([]singleBulkSim, int32, error) {
+	// Gemming for now can happen before slots are decided.
+	// We might have to add logic after slot decisions if we want to enforce keeping meta gem active.
+	if bulkSettings.AutoGem {
+		for _, replaceItem := range bulkSettings.Items {
+			itemData := ItemsByID[replaceItem.Id]
+			if len(itemData.GemSockets) == 0 && itemData.Type != proto.ItemType_ItemTypeWaist {
+				continue
+			}
+
+			sockets := make([]int32, len(itemData.GemSockets))
+			if len(sockets) < len(replaceItem.Gems) {
+				// this means the extra gem was specified, just add an extra element
+				sockets = append(sockets, 0)
+			}
+			// now copy over what we have from inputs.
+			copy(sockets, replaceItem.Gems)
+			if itemData.Type == proto.ItemType_ItemTypeWaist {
+				// Assume waist always has the eternal belt buckle and add extra red gem.
+				// TODO: is there a better way to do this?
+				// Should we have a 'prismatic' standard gem in the defaults?
+				if len(sockets) == len(itemData.GemSockets) {
+					sockets = append(sockets, bulkSettings.DefaultRedGem)
+				} else if len(sockets) > len(itemData.GemSockets) && sockets[len(sockets)-1] == 0 {
+					sockets[len(sockets)-1] = bulkSettings.DefaultRedGem
+				}
+			}
+
+			for i, color := range itemData.GemSockets {
+				if sockets[i] > 0 {
+					// This means gem was already specified, skip autogem
+					continue
+				}
+				if ColorIntersects(color, proto.GemColor_GemColorRed) {
+					sockets[i] = bulkSettings.DefaultRedGem
+				} else if ColorIntersects(color, proto.GemColor_GemColorYellow) {
+					sockets[i] = bulkSettings.DefaultYellowGem
+				} else if ColorIntersects(color, proto.GemColor_GemColorBlue) {
+					sockets[i] = bulkSettings.DefaultBlueGem
+				} else if ColorIntersects(color, proto.GemColor_GemColorMeta) {
+					sockets[i] = bulkSettings.DefaultMetaGem
+				}
+			}
+			replaceItem.Gems = sockets
+		}
+	}
+
+	iterations := bulkSettings.GetIterationsPerCombo()
+	if iterations <= 0 {
+		iterations = defaultIterationsPerCombo
+	}
+
+	items := bulkSettings.GetItems()
+	isFuryWarrior := player.GetFuryWarrior() != nil
+	// numItems := len(items)
+	// if b.Request.BulkSettings.Combinations && numItems > maxItemCount {
+	// 	return nil, fmt.Errorf("too many items specified (%d > %d), not computationally feasible", numItems, maxItemCount)
+	// }
+
+	// Create all distinct combinations of (item, slot). For example, let's say the only item we
+	// want to bulk sim is a one-handed item that can be worn both as an off-hand or a main-hand weapon.
+	// For each slot, we will create one itemWithSlot pair, so (item, off-hand) and (item, main-hand).
+	// We verify later that we are not emitting any invalid equipment set.
+	var distinctItemSlotCombos []*itemWithSlot
+	for index, is := range items {
+		item, ok := ItemsByID[is.Id]
+		if !ok {
+			return nil, 0, fmt.Errorf("unknown item with id %d in bulk settings", is.Id)
+		}
+		for _, slot := range eligibleSlotsForItem(item, isFuryWarrior) {
+			distinctItemSlotCombos = append(distinctItemSlotCombos, &itemWithSlot{
+				Item:  is,
+				Slot:  slot,
+				Index: index,
+			})
+		}
+	}
+	baseItems := player.Equipment.Items
+
+	allCombos := generateAllEquipmentSubstitutions(ctx, baseItems, bulkSettings.Combinations, distinctItemSlotCombos, isFuryWarrior)
+
+	var validCombos []singleBulkSim
+	count := 0
+	for sub := range allCombos {
+		count++
+		if count > 1000000 {
+			panic("over 1 million combos, abandoning attempt")
+		}
+
+		substitutedRequest, changeLog := createNewRequestWithSubstitution(baseSettings, sub, bulkSettings.AutoEnchant, isFuryWarrior)
+		if isValidEquipment(substitutedRequest.Raid.Parties[0].Players[0].Equipment, isFuryWarrior) {
+			// Need to sim base dps of gear loudout
+			validCombos = append(validCombos, singleBulkSim{req: substitutedRequest, cl: changeLog, eq: sub})
+			// Todo(Netzone-GehennasEU): Make this its own step?
+			if !bulkSettings.SimTalents {
+
+			} else {
+				var talentsToSim = bulkSettings.GetTalentsToSim()
+
+				if len(talentsToSim) > 0 {
+					for _, talent := range talentsToSim {
+						sr := goproto.Clone(substitutedRequest).(*proto.RaidSimRequest)
+						cl := *changeLog
+						if sr.Raid.Parties[0].Players[0].TalentsString == talent.TalentsString && goproto.Equal(talent.Glyphs, sr.Raid.Parties[0].Players[0].Glyphs) {
+							continue
+						}
+
+						sr.Raid.Parties[0].Players[0].TalentsString = talent.TalentsString
+						sr.Raid.Parties[0].Players[0].Glyphs = talent.Glyphs
+						cl.TalentLoadout = talent
+						validCombos = append(validCombos, singleBulkSim{req: sr, cl: &cl, eq: sub})
+					}
+				}
+			}
+		}
+	}
+
+	// In fast mode try to keep starting iterations between 1000 and 2000
+	if bulkSettings.FastMode {
+		iterations /= 10
+
+		if iterations < 1000 {
+			iterations = 1000
+		} else if iterations > 2000 {
+			iterations = 2000
+		}
+	}
+
+	maxIterations := int64(iterations) * int64(len(validCombos))
+	if maxIterations > math.MaxInt32 {
+		return nil, 0, fmt.Errorf("number of total iterations %d too large", maxIterations)
+	}
+
+	return validCombos, iterations, nil
 }
 
 // itemSubstitutionSimResult stores the request and response of a simulation, along with the used

--- a/sim/wasm/main.go
+++ b/sim/wasm/main.go
@@ -31,6 +31,7 @@ func main() {
 	js.Global().Set("statWeights", js.FuncOf(statWeights))
 	js.Global().Set("statWeightsAsync", js.FuncOf(statWeightsAsync))
 	js.Global().Set("bulkSimAsync", js.FuncOf(bulkSimAsync))
+	js.Global().Set("bulkSimCombos", js.FuncOf(bulkSimCombos))
 	js.Global().Call("wasmready")
 	<-c
 }
@@ -212,6 +213,21 @@ func bulkSimAsync(this js.Value, args []js.Value) interface{} {
 	// for now just use context.Background() until we can figure out the best way to handle
 	// allowing front end to cancel.
 	core.RunBulkSimAsync(context.Background(), rsr, reporter)
+
+	result := processAsyncProgress(args[1], reporter)
+	return result
+}
+
+func bulkSimCombos(this js.Value, args []js.Value) interface{} {
+	rsr := &proto.BulkSimCombosRequest{}
+	if err := googleProto.Unmarshal(getArgsBinary(args[0]), rsr); err != nil {
+		log.Printf("Failed to parse request: %s", err)
+		return nil
+	}
+	reporter := make(chan *proto.ProgressMetrics, 100)
+	// for now just use context.Background() until we can figure out the best way to handle
+	// allowing front end to cancel.
+	core.RunBulkCombos(context.Background(), rsr)
 
 	result := processAsyncProgress(args[1], reporter)
 	return result

--- a/sim/web/main.go
+++ b/sim/web/main.go
@@ -100,7 +100,12 @@ var handlers = map[string]apiHandler{
 	"/computeStats": {msg: func() googleProto.Message { return &proto.ComputeStatsRequest{} }, handle: func(msg googleProto.Message) googleProto.Message {
 		return core.ComputeStats(msg.(*proto.ComputeStatsRequest))
 	}},
-}
+	"/bulkSimCombos": {msg: func() googleProto.Message { return &proto.BulkSimCombosRequest{} }, handle: func(msg googleProto.Message) googleProto.Message {
+		// TODO: we can use context's to cancel stuff.
+		// We should have all the async APIs take in context and let it be cancelled via its async ID.
+		return core.RunBulkCombos(context.Background(), msg.(*proto.BulkSimCombosRequest))
+	},
+	}}
 
 var asyncAPIHandlers = map[string]asyncAPIHandler{
 	"/raidSimAsync": {msg: func() googleProto.Message { return &proto.RaidSimRequest{} }, handle: func(msg googleProto.Message, reporter chan *proto.ProgressMetrics) {

--- a/ui/core/worker_pool.ts
+++ b/ui/core/worker_pool.ts
@@ -1,6 +1,8 @@
 import { SimRequest, WorkerReceiveMessage, WorkerSendMessage } from '../worker/types';
 import { REPO_NAME } from './constants/other.js';
 import {
+	BulkSimCombosRequest,
+	BulkSimCombosResult,
 	BulkSimRequest,
 	BulkSimResult,
 	ComputeStatsRequest,
@@ -70,6 +72,17 @@ export class WorkerPool {
 		const resultJson = BulkSimResult.toJson(result.finalBulkResult!) as any;
 		console.log('bulk sim result: ' + JSON.stringify(resultJson));
 		return result.finalBulkResult!;
+	}
+
+	// Calculate combos and return counts
+	async bulkSimCombosAsync(request: BulkSimCombosRequest): Promise<BulkSimCombosResult> {
+		console.log('bulk sim combinations request: ' + BulkSimCombosRequest.toJsonString(request, { enumAsInteger: true }));
+		const worker = this.getLeastBusyWorker();
+		const id = worker.makeTaskId();
+
+		// Now start the async sim
+		const resultData = await worker.doApiCall(SimRequest.bulkSimCombos, BulkSimCombosRequest.toBinary(request), id);
+		return BulkSimCombosResult.fromBinary(resultData);
 	}
 
 	async raidSimAsync(request: RaidSimRequest, onProgress: WorkerProgressCallback): Promise<RaidSimResult> {

--- a/ui/worker/sim_worker.ts
+++ b/ui/worker/sim_worker.ts
@@ -7,6 +7,7 @@ type SimRequestSync = (data: Uint8Array) => Uint8Array;
 declare global {
 	function wasmready(): void;
 	const bulkSimAsync: SimRequestAsync;
+	const bulkSimCombos: SimRequestSync;
 	const computeStats: SimRequestSync;
 	const computeStatsJson: SimRequestSync;
 	const raidSim: SimRequestSync;
@@ -21,6 +22,7 @@ declare global {
 globalThis.wasmready = function () {
 	new WorkerInterface({
 		bulkSimAsync: (data, progress) => bulkSimAsync(data, progress),
+		bulkSimCombos: data => bulkSimCombos(data),
 		computeStats: computeStats,
 		computeStatsJson: computeStatsJson,
 		raidSim: raidSim,

--- a/ui/worker/types.ts
+++ b/ui/worker/types.ts
@@ -3,6 +3,7 @@
  */
 export enum SimRequest {
 	bulkSimAsync = 'bulkSimAsync',
+	bulkSimCombos = 'bulkSimCombos',
 	computeStats = 'computeStats',
 	computeStatsJson = 'computeStatsJson',
 	raidSim = 'raidSim',

--- a/ui/worker/worker_http.ts
+++ b/ui/worker/worker_http.ts
@@ -42,6 +42,7 @@ export const setupHttpWorker = (baseURL: string) => {
 
 	new WorkerInterface({
 		bulkSimAsync: asyncHandler,
+		bulkSimCombos: syncHandler,
 		computeStats: syncHandler,
 		computeStatsJson: syncHandler,
 		raidSim: syncHandler,


### PR DESCRIPTION
Creates a new RPC `BulkSimCombos` that runs the Batch sim's valid combination generation and returns the number of combos and iterations that a real bulk sim would run. I extracted the logic for the combination/iteration calculation into a shared function to be able to do it without running a full bulk sim. When users make changes that would affect the numbers of combinations/iterations, the UI makes a request to the back-end to get updated numbers