### PR TITLE
Remove random suffix and reforge from 60U

### DIFF
--- a/ui/core/components/importers.tsx
+++ b/ui/core/components/importers.tsx
@@ -285,10 +285,12 @@ export class Individual60UImporter<SpecType extends Spec> extends Importer {
 			if (itemJson.gems) {
 				itemSpec.gems = (itemJson.gems as Array<any>).filter(gemJson => gemJson?.id).map(gemJson => gemJson.id);
 			}
+			if (itemJson.suffixId) {
+				itemSpec.randomSuffix = itemJson.suffixId;
+			}
 			if (itemJson.reforge?.id) {
 				itemSpec.reforging = itemJson.reforge.id;
 			}
-
 			equipmentSpec.items.push(itemSpec);
 		});
 

--- a/ui/core/components/importers.tsx
+++ b/ui/core/components/importers.tsx
@@ -275,6 +275,8 @@ export class Individual60UImporter<SpecType extends Spec> extends Importer {
 			talentsStr = talentSpellIdsToTalentString(charClass, talentIds);
 		}
 
+		let hasRemovedRandomSuffix = false;
+		const modifiedItemNames: string[] = [];
 		const equipmentSpec = EquipmentSpec.create();
 		(importJson.items as Array<any>).forEach(itemJson => {
 			const itemSpec = ItemSpec.create();
@@ -285,8 +287,16 @@ export class Individual60UImporter<SpecType extends Spec> extends Importer {
 			if (itemJson.gems) {
 				itemSpec.gems = (itemJson.gems as Array<any>).filter(gemJson => gemJson?.id).map(gemJson => gemJson.id);
 			}
+
+			// As long as 60U exports the wrong suffixes we should
+			// inform the user that they need to manually add them.
+			// Due to this we also remove the reforge on the item.
 			if (itemJson.suffixId) {
-				itemSpec.randomSuffix = itemJson.suffixId;
+				hasRemovedRandomSuffix = true;
+				if (itemJson.reforge?.id) {
+					itemJson.reforge.id = null;
+				}
+				modifiedItemNames.push(itemJson.name);
 			}
 			if (itemJson.reforge?.id) {
 				itemSpec.reforging = itemJson.reforge.id;
@@ -297,6 +307,25 @@ export class Individual60UImporter<SpecType extends Spec> extends Importer {
 		this.simUI.sim.db.lookupEquipmentSpec(equipmentSpec);
 
 		this.finishIndividualImport(this.simUI, charClass, race, equipmentSpec, talentsStr, null, []);
+
+		if (hasRemovedRandomSuffix && modifiedItemNames.length) {
+			new Toast({
+				variant: 'warning',
+				body: (
+					<>
+						<p>60U currently exports the wrong Random Suffixes. We have removed the random suffix on the following item(s):</p>
+						<ul>
+							{modifiedItemNames.map(itemName => (
+								<li>
+									<strong>{itemName}</strong>
+								</li>
+							))}
+						</ul>
+					</>
+				),
+				delay: 8000,
+			});
+		}
 	}
 }
 


### PR DESCRIPTION
Added https://github.com/wowsims/cata/issues/785 to improve random suffix handling by allowing to migrate them to the proper versions if they are applicable to an item.

When importing from 60U the wrong random suffix will be given. I remove the suffix + reforge to prevent errors. When this happens we inform the user:
![image](https://github.com/wowsims/cata/assets/1216787/af0db1a5-6fca-4fad-8003-401c728937da)
