### PR TITLE
Makefile edit for FreeBSD support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,8 @@ sim/web/__debug_bin
 
 # temporary files
 *.results.tmp
+temp.json
+
 #.dockerignore
 /cata/
 *.code-workspace

--- a/makefile
+++ b/makefile
@@ -95,8 +95,8 @@ ui/%/index.html: ui/index_template.html
 .PHONY: package.json
 
 package.json:
-# Checks if the system is FreeBSD and jq is installed. This is due to the need to switch out the rollup package for vite.
-ifeq ($(shell uname -s), FreeBSD)
+# Checks if the system is FreeBSD and jq is installed. This is due to the need to switch out the vite package for rollup on FreeBSD.
+ifeq ($(shell uname -s), Linux)
 	@if ! command -v jq > /dev/null; then \
 		echo "jq is not installed. Please install jq to proceed."; \
 		exit 1; \

--- a/makefile
+++ b/makefile
@@ -92,6 +92,25 @@ ui/core/proto/api.ts: proto/*.proto node_modules
 ui/%/index.html: ui/index_template.html
 	cat ui/index_template.html | sed -e 's/@@CLASS@@/$(shell dirname $(@D) | xargs basename)/g' -e 's/@@SPEC@@/$(shell basename $(@D))/g' > $@
 
+.PHONY: package.json
+
+package.json:
+# Checks if the system is FreeBSD and jq is installed. This is due to the need to switch out the rollup package for vite.
+ifeq ($(shell uname -s), FreeBSD)
+	@if ! command -v jq > /dev/null; then \
+		echo "jq is not installed. Please install jq to proceed."; \
+		exit 1; \
+	fi; \
+	\
+	echo "Checking and updating package.json for FreeBSD..."; \
+	\
+	if ! grep -q '"overrides"' package.json; then \
+		jq '. + { "overrides": { "vite": { "rollup": "npm:@rollup/wasm-node@4.13.0" } } }' package.json > temp.json && mv temp.json package.json && npm install; \
+	else \
+		jq '.overrides += { "vite": { "rollup": "npm:@rollup/wasm-node@4.13.0" } }' package.json > temp.json && mv temp.json package.json && npm install; \
+	fi
+endif
+
 package-lock.json:
 	npm install
 


### PR DESCRIPTION
Make file edit to check if there was a change on package.json and if the user is running FreeBSD. If they are it will use rollup instead of Vite due to incompatibilities. It will run `npm install` after to fix any lock file inconsistencies. 

I chose `jq` instead of any build in util like `sed` etc because `jq` is structure aware instead of straight text find and replace.

addresses #586 