### PR TITLE
[Warrior] arms mastery fix

### DIFF
--- a/sim/warrior/arms/TestArms.results
+++ b/sim/warrior/arms/TestArms.results
@@ -37,1373 +37,1373 @@ character_stats_results: {
 dps_results: {
  key: "TestArms-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 33044.64917
-  tps: 22143.29742
+  dps: 33047.51233
+  tps: 22038.51413
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 32481.29202
-  tps: 21761.08519
+  dps: 32469.11482
+  tps: 21695.32084
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
   hps: 96.7093
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 31685.67343
-  tps: 21283.05415
+  dps: 31678.92258
+  tps: 21222.70376
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 31782.30873
-  tps: 21365.70351
+  dps: 31794.80855
+  tps: 21267.23645
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BindingPromise-67037"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 31849.03152
-  tps: 21317.88922
+  dps: 31902.28812
+  tps: 21423.2221
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 31591.78037
-  tps: 21159.46774
+  dps: 31682.88117
+  tps: 21272.10736
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 31507.35118
-  tps: 21067.59787
+  dps: 31727.40586
+  tps: 21373.14028
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 31688.54608
-  tps: 21319.69001
+  dps: 31804.31389
+  tps: 21197.16509
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 32232.5099
-  tps: 21627.51616
+  dps: 32268.03636
+  tps: 21541.41788
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 31665.25179
-  tps: 21263.19188
+  dps: 31658.43378
+  tps: 21205.38972
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 31554.08383
-  tps: 21179.80014
+  dps: 31604.17275
+  tps: 21172.51363
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 32118.93882
-  tps: 21579.93312
+  dps: 32122.71445
+  tps: 21469.31008
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BottledLightning-66879"
  value: {
-  dps: 31285.6218
-  tps: 21024.37954
+  dps: 31380.19481
+  tps: 20963.58559
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 32481.29202
-  tps: 21326.00052
+  dps: 32469.11482
+  tps: 21261.55098
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 33692.40832
-  tps: 22552.29516
+  dps: 33673.04592
+  tps: 22482.3553
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 32944.32475
-  tps: 22057.54825
+  dps: 32929.94612
+  tps: 21992.15723
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 33068.08667
-  tps: 22160.84247
+  dps: 33086.70753
+  tps: 22063.54806
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ColossalDragonplateArmor"
  value: {
-  dps: 27076.48261
-  tps: 18385.2125
+  dps: 27371.85575
+  tps: 18533.25515
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ColossalDragonplateBattlegear"
  value: {
-  dps: 30328.1029
-  tps: 20756.80845
+  dps: 30384.09191
+  tps: 20430.6029
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CrushingWeight-59506"
  value: {
-  dps: 32397.87403
-  tps: 21648.34107
+  dps: 32797.52036
+  tps: 21909.36276
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CrushingWeight-65118"
  value: {
-  dps: 32702.45827
-  tps: 21916.94242
+  dps: 32416.79153
+  tps: 21752.59396
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 32787.71133
-  tps: 22275.82651
+  dps: 32653.09536
+  tps: 21988.25709
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 32308.24641
-  tps: 21962.67668
+  dps: 32136.99844
+  tps: 21691.73515
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 32009.96405
-  tps: 21460.49018
+  dps: 31628.9766
+  tps: 21240.06385
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 32230.72524
-  tps: 21614.66839
+  dps: 31733.5873
+  tps: 21180.65722
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 32599.94036
-  tps: 21860.33624
+  dps: 32619.39853
+  tps: 21763.86989
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 31484.602
-  tps: 21024.66449
+  dps: 31408.0513
+  tps: 21029.0153
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EarthenBattleplate"
  value: {
-  dps: 27018.836
-  tps: 18199.56965
+  dps: 27047.61507
+  tps: 18310.32717
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EarthenWarplate"
  value: {
-  dps: 29849.08142
-  tps: 20077.90675
+  dps: 29843.69383
+  tps: 20078.71455
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 32481.29202
-  tps: 21761.08519
+  dps: 32469.11482
+  tps: 21695.32084
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 32481.29202
-  tps: 21761.08519
+  dps: 32469.11482
+  tps: 21695.32084
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 32599.94036
-  tps: 21860.33624
+  dps: 32619.39853
+  tps: 21763.86989
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 32314.15659
-  tps: 21735.77563
+  dps: 32300.37909
+  tps: 21572.20917
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 32341.3797
-  tps: 21767.31625
+  dps: 32373.4269
+  tps: 21706.52918
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 32481.29202
-  tps: 21761.08519
+  dps: 32469.11482
+  tps: 21695.32084
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FallofMortality-59500"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FallofMortality-65124"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 31536.67599
-  tps: 21213.79831
+  dps: 31733.42747
+  tps: 21182.59752
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 32595.97575
-  tps: 21772.91286
+  dps: 32827.02348
+  tps: 22079.35683
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 32632.27909
-  tps: 21918.76029
+  dps: 32701.17983
+  tps: 21712.69739
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FluidDeath-58181"
  value: {
-  dps: 31641.69905
-  tps: 21250.11245
+  dps: 31628.17568
+  tps: 21164.64317
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 32481.29202
-  tps: 21761.08519
+  dps: 32469.11482
+  tps: 21695.32084
  }
 }
 dps_results: {
  key: "TestArms-AllItems-GaleofShadows-56138"
  value: {
-  dps: 31366.21323
-  tps: 21097.96001
+  dps: 31445.57064
+  tps: 20968.51955
  }
 }
 dps_results: {
  key: "TestArms-AllItems-GaleofShadows-56462"
  value: {
-  dps: 31454.59814
-  tps: 21218.17407
+  dps: 31424.88223
+  tps: 21018.71134
  }
 }
 dps_results: {
  key: "TestArms-AllItems-GearDetector-61462"
  value: {
-  dps: 31661.22509
-  tps: 21171.01386
+  dps: 31703.20278
+  tps: 21206.83273
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Gladiator'sBattlegear"
  value: {
-  dps: 26552.74889
-  tps: 17757.77613
+  dps: 26625.93339
+  tps: 17754.88114
  }
 }
 dps_results: {
  key: "TestArms-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 31623.97212
-  tps: 21232.65549
+  dps: 31570.6243
+  tps: 21092.96477
  }
 }
 dps_results: {
  key: "TestArms-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 31896.09518
-  tps: 21424.98537
+  dps: 31879.25798
+  tps: 21305.56309
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HarmlightToken-63839"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 32115.84691
-  tps: 21569.89147
+  dps: 32252.13067
+  tps: 21724.82599
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartofRage-59224"
  value: {
-  dps: 32331.89473
-  tps: 21791.24194
+  dps: 32368.57965
+  tps: 21690.5943
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartofSolace-55868"
  value: {
-  dps: 31366.21323
-  tps: 21097.96001
+  dps: 31445.57064
+  tps: 20968.51955
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartofSolace-56393"
  value: {
-  dps: 32559.32849
-  tps: 22025.97483
+  dps: 32522.2573
+  tps: 21813.41904
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartofThunder-55845"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartofThunder-56370"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 31795.81592
-  tps: 21325.49547
+  dps: 31657.95752
+  tps: 21158.7528
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 32599.94036
-  tps: 21860.33624
+  dps: 32619.39853
+  tps: 21763.86989
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 33239.14316
-  tps: 22258.37174
+  dps: 32844.86406
+  tps: 22030.60341
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 33239.14316
-  tps: 22258.37174
+  dps: 32844.86406
+  tps: 22030.60341
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 31591.78037
-  tps: 21159.46774
+  dps: 31682.88117
+  tps: 21272.10736
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 31507.35118
-  tps: 21067.59787
+  dps: 31727.40586
+  tps: 21373.14028
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 31561.06131
-  tps: 21149.93312
+  dps: 31537.08054
+  tps: 21182.21471
  }
 }
 dps_results: {
  key: "TestArms-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 31849.03152
-  tps: 21317.88922
+  dps: 31902.28812
+  tps: 21423.2221
  }
 }
 dps_results: {
  key: "TestArms-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 31512.17543
-  tps: 21195.38419
+  dps: 31608.14072
+  tps: 21128.45505
  }
 }
 dps_results: {
  key: "TestArms-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 31546.14816
-  tps: 21203.77417
+  dps: 31633.29647
+  tps: 21126.01833
  }
 }
 dps_results: {
  key: "TestArms-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 31902.42033
-  tps: 21366.94705
+  dps: 31989.07941
+  tps: 21361.54589
  }
 }
 dps_results: {
  key: "TestArms-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 31902.42033
-  tps: 21366.94705
+  dps: 31989.07941
+  tps: 21361.54589
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 31467.02381
-  tps: 20890.99983
+  dps: 31425.42383
+  tps: 20969.18153
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LastWord-50708"
  value: {
-  dps: 33471.05315
-  tps: 22405.68349
+  dps: 33452.87079
+  tps: 22337.23346
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LeadenDespair-55816"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LeadenDespair-56347"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 31553.11776
-  tps: 21178.19846
+  dps: 31581.63073
+  tps: 21056.09849
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 31537.70599
-  tps: 21205.71889
+  dps: 31682.11196
+  tps: 21101.37128
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 32256.66247
-  tps: 21655.07397
+  dps: 32278.69258
+  tps: 21555.55896
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 31811.98566
-  tps: 21359.77523
+  dps: 31829.42867
+  tps: 21253.76106
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 32043.03009
-  tps: 21512.27412
+  dps: 32057.35806
+  tps: 21401.46808
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 32201.3286
-  tps: 21644.2073
+  dps: 32477.63371
+  tps: 21866.46324
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 32223.74497
-  tps: 21764.15424
+  dps: 32541.09525
+  tps: 21848.70744
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 31607.34632
-  tps: 21224.70479
+  dps: 31627.54835
+  tps: 21122.93485
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 32043.03009
-  tps: 21512.27412
+  dps: 32057.35806
+  tps: 21401.46808
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 32009.96405
-  tps: 21460.49018
+  dps: 31628.9766
+  tps: 21240.06385
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 32009.96405
-  tps: 21460.49018
+  dps: 31628.9766
+  tps: 21240.06385
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MoltenGiantBattleplate"
  value: {
-  dps: 27776.28768
-  tps: 18779.72151
+  dps: 27830.37674
+  tps: 18774.24331
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MoltenGiantWarplate"
  value: {
-  dps: 31960.44555
-  tps: 21897.26791
+  dps: 32061.58345
+  tps: 21837.39822
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 31596.28737
-  tps: 21274.7808
+  dps: 31774.10627
+  tps: 21451.31307
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 32119.22787
-  tps: 21594.56571
+  dps: 32302.98438
+  tps: 21550.82587
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 31432.69371
-  tps: 21100.28311
+  dps: 31454.64484
+  tps: 21045.29118
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 31363.83298
-  tps: 20998.80397
+  dps: 31347.78562
+  tps: 21116.49204
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 31736.42687
-  tps: 21288.66721
+  dps: 31744.75426
+  tps: 21363.98487
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 32481.29202
-  tps: 21761.08519
+  dps: 32469.11482
+  tps: 21695.32084
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 32094.23078
-  tps: 21441.04837
+  dps: 31971.70288
+  tps: 21366.12676
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 32342.7392
-  tps: 21577.55552
+  dps: 32002.02379
+  tps: 21451.34202
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Rainsong-55854"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Rainsong-56377"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 33113.34781
-  tps: 22169.33207
+  dps: 33097.84315
+  tps: 22102.91328
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 32944.32475
-  tps: 22057.54825
+  dps: 32929.94612
+  tps: 21992.15723
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 32005.43686
-  tps: 21499.75937
+  dps: 32028.19762
+  tps: 21401.69938
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 32149.76482
-  tps: 21593.80127
+  dps: 32149.18221
+  tps: 21480.4719
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 31741.26731
-  tps: 21347.71963
+  dps: 31895.05152
+  tps: 21485.61761
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SeaStar-55256"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SeaStar-56290"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Shadowmourne-49623"
  value: {
-  dps: 34877.70828
-  tps: 23362.42363
+  dps: 35053.65881
+  tps: 23459.37963
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ShardofWoe-60233"
  value: {
-  dps: 31467.39504
-  tps: 21114.4156
+  dps: 31471.54992
+  tps: 21031.31586
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 32110.04043
-  tps: 21468.27092
+  dps: 31975.45764
+  tps: 21476.89498
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 31934.22701
-  tps: 21562.75937
+  dps: 31869.39332
+  tps: 21506.52995
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 32008.74567
-  tps: 21618.02009
+  dps: 32236.05028
+  tps: 21712.80448
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Sorrowsong-55879"
  value: {
-  dps: 31591.78037
-  tps: 21159.46774
+  dps: 31682.88117
+  tps: 21272.10736
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Sorrowsong-56400"
  value: {
-  dps: 31507.35118
-  tps: 21067.59787
+  dps: 31727.40586
+  tps: 21373.14028
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 31607.34632
-  tps: 21224.70479
+  dps: 31627.54835
+  tps: 21122.93485
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SoulCasket-58183"
  value: {
-  dps: 32009.96405
-  tps: 21460.49018
+  dps: 31628.9766
+  tps: 21240.06385
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StumpofTime-62465"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StumpofTime-62470"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 31772.42697
-  tps: 21352.69943
+  dps: 32160.68069
+  tps: 21559.80671
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TearofBlood-55819"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TearofBlood-56351"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 31643.93069
-  tps: 21157.31048
+  dps: 31623.31226
+  tps: 21232.28099
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 31507.35118
-  tps: 21067.59787
+  dps: 31727.40586
+  tps: 21373.14028
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 32073.32315
-  tps: 21484.51025
+  dps: 32113.81973
+  tps: 21580.07413
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 32064.22654
-  tps: 21452.1047
+  dps: 32204.77341
+  tps: 21731.12784
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 32277.82075
-  tps: 21732.72072
+  dps: 31912.03944
+  tps: 21554.57998
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-UnheededWarning-59520"
  value: {
-  dps: 32101.42997
-  tps: 21554.6048
+  dps: 32091.20528
+  tps: 21475.88636
  }
 }
 dps_results: {
  key: "TestArms-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 32504.93452
-  tps: 21779.03156
+  dps: 32193.01939
+  tps: 21602.45686
  }
 }
 dps_results: {
  key: "TestArms-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 32504.93452
-  tps: 21779.03156
+  dps: 32193.01939
+  tps: 21602.45686
  }
 }
 dps_results: {
  key: "TestArms-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 32504.93452
-  tps: 21779.03156
+  dps: 32193.01939
+  tps: 21602.45686
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 18179.14799
-  tps: 11318.36406
+  dps: 18482.06665
+  tps: 11723.91224
  }
 }
 dps_results: {
  key: "TestArms-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 31628.93567
-  tps: 21269.56897
+  dps: 31836.23255
+  tps: 21226.00668
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 32295.70967
-  tps: 21668.68134
+  dps: 32331.71236
+  tps: 21582.87374
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 31096.9302
-  tps: 20879.93121
+  dps: 31430.65695
+  tps: 21149.95249
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 31753.05913
-  tps: 21342.49709
+  dps: 31741.01502
+  tps: 21229.56792
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 32057.62621
-  tps: 21493.27644
+  dps: 31844.29274
+  tps: 21313.45887
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 31542.58631
-  tps: 21207.89403
+  dps: 31668.08671
+  tps: 21248.26189
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 32170.7118
-  tps: 21619.90306
+  dps: 32197.32594
+  tps: 21529.54345
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 31102.34922
-  tps: 20891.38579
+  dps: 31129.35982
+  tps: 20800.0895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 31602.61232
-  tps: 21169.92409
+  dps: 31653.73669
+  tps: 21244.96683
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 31293.81172
-  tps: 21079.95069
+  dps: 31390.97142
+  tps: 21097.7021
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 31293.81172
-  tps: 21079.95069
+  dps: 31390.97142
+  tps: 21097.7021
  }
 }
 dps_results: {
  key: "TestArms-Average-Default"
  value: {
-  dps: 33195.70523
-  tps: 22136.10505
+  dps: 33129.51025
+  tps: 22058.39391
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p1_arms_bis-Basic-arms-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 68570.21183
-  tps: 35919.55476
+  dps: 68445.08112
+  tps: 35723.60395
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p1_arms_bis-Basic-arms-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 33113.34781
-  tps: 22169.33207
+  dps: 33097.84315
+  tps: 22102.91328
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p1_arms_bis-Basic-arms-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 39872.02485
-  tps: 27773.01461
+  dps: 39546.23247
+  tps: 27475.60787
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p1_arms_bis-Basic-arms-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 48311.32068
-  tps: 24092.79519
+  dps: 48452.00856
+  tps: 24217.64609
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p1_arms_bis-Basic-arms-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 23215.3021
-  tps: 15420.18554
+  dps: 23050.34229
+  tps: 15229.42133
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p1_arms_bis-Basic-arms-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 26424.29526
-  tps: 17826.02991
+  dps: 26538.74336
+  tps: 18002.8701
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p1_arms_bis-Basic-arms-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 68541.20494
-  tps: 35735.79272
+  dps: 68695.15056
+  tps: 35668.131
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p1_arms_bis-Basic-arms-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 33196.98372
-  tps: 22251.91624
+  dps: 33283.87297
+  tps: 22178.11505
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p1_arms_bis-Basic-arms-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 39744.97531
-  tps: 27650.27179
+  dps: 39451.04607
+  tps: 27380.39153
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p1_arms_bis-Basic-arms-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 48483.52629
-  tps: 24049.14139
+  dps: 48554.31769
+  tps: 24116.26269
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p1_arms_bis-Basic-arms-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 23304.7361
-  tps: 15516.29534
+  dps: 23036.16592
+  tps: 15306.92447
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p1_arms_bis-Basic-arms-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 26438.66884
-  tps: 17875.73159
+  dps: 26476.88038
+  tps: 18006.03146
  }
 }
 dps_results: {
  key: "TestArms-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 30209.76144
-  tps: 20485.8012
+  dps: 30255.59211
+  tps: 20433.65994
  }
 }

--- a/sim/warrior/arms/arms.go
+++ b/sim/warrior/arms/arms.go
@@ -106,7 +106,7 @@ func (war *ArmsWarrior) RegisterMastery() {
 		BonusCoefficient: 1.0,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			baseDamage := spell.Unit.MHWeaponDamage(sim, spell.MeleeAttackPower())
+			baseDamage := spell.Unit.MHNormalizedWeaponDamage(sim, spell.MeleeAttackPower())
 			spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMeleeSpecialHitAndCrit)
 		},
 	}
@@ -119,7 +119,7 @@ func (war *ArmsWarrior) RegisterMastery() {
 		Callback: core.CallbackOnSpellHitDealt,
 		Outcome:  core.OutcomeLanded,
 		ProcMask: core.ProcMaskMelee,
-		ICD:      500 * time.Millisecond,
+		ICD:      100 * time.Millisecond,
 		ExtraCondition: func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) bool {
 			// Implement the proc in here so we can get the most up to date proc chance from mastery
 			return sim.Proc(war.GetMasteryProcChance(), "Strikes of Opportunity")


### PR DESCRIPTION
- update arms mastery to use normalized weapon damage and 100ms icd
https://www.wowhead.com/cata/spell=76858/opportunity-strike
https://www.wowhead.com/cata/spell=76838/strikes-of-opportunity
log with 2 mastery proc within 126 ms
![image](https://github.com/wowsims/cata/assets/16014057/113020ac-b862-4a21-9a22-bc7d75363479)

