### PR TITLE
Guardian EP Update

### DIFF
--- a/ui/druid/guardian/presets.ts
+++ b/ui/druid/guardian/presets.ts
@@ -37,8 +37,8 @@ export const ROTATION_DEFAULT = PresetUtils.makePresetAPLRotation('APL Default',
 export const ROTATION_PRESET_SIMPLE = PresetUtils.makePresetSimpleRotation('Simple Default', Spec.SpecGuardianDruid, DefaultSimpleRotation);
 
 // Preset options for EP weights
-export const P1_EP_PRESET = PresetUtils.makePresetEpWeights(
-	'P1',
+export const SURVIVAL_EP_PRESET = PresetUtils.makePresetEpWeights(
+	'Survival',
 	Stats.fromMap(
 		{
 			[Stat.StatHealth]: 0.04,
@@ -58,6 +58,30 @@ export const P1_EP_PRESET = PresetUtils.makePresetEpWeights(
 		},
 		{
 			[PseudoStat.PseudoStatMainHandDps]: 0.0,
+		},
+	),
+);
+
+export const BALANCED_EP_PRESET = PresetUtils.makePresetEpWeights(
+	'Balanced',
+	Stats.fromMap(
+		{
+			[Stat.StatHealth]: 0.02,
+			[Stat.StatStamina]: 0.76,
+			[Stat.StatAgility]: 1.0,
+			[Stat.StatArmor]: 0.62,
+			[Stat.StatBonusArmor]: 0.14,
+			[Stat.StatDodge]: 0.59,
+			[Stat.StatMastery]: 0.20,
+			[Stat.StatStrength]: 0.21,
+			[Stat.StatAttackPower]: 0.20,
+			[Stat.StatMeleeHit]: 0.60,
+			[Stat.StatExpertise]: 0.93,
+			[Stat.StatMeleeCrit]: 0.25,
+			[Stat.StatMeleeHaste]: 0.03,
+		},
+		{
+			[PseudoStat.PseudoStatMainHandDps]: 0.23,
 		},
 	),
 );

--- a/ui/druid/guardian/sim.ts
+++ b/ui/druid/guardian/sim.ts
@@ -9,6 +9,7 @@ import { APLAction, APLListItem, APLPrepullAction, APLRotation, APLRotation_Type
 import { Cooldowns, Debuffs, Faction, IndividualBuffs, PartyBuffs, PseudoStat, Race, RaidBuffs, Spec, Stat } from '../../core/proto/common.js';
 import { GuardianDruid_Rotation as DruidRotation } from '../../core/proto/druid.js';
 import * as AplUtils from '../../core/proto_utils/apl_utils.js';
+import { StatCapType } from '../../core/proto/ui';
 import { Stats } from '../../core/proto_utils/stats.js';
 import * as DruidInputs from './inputs.js';
 import * as Presets from './presets.js';
@@ -64,14 +65,27 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecGuardianDruid, {
 		// Default equipped gear.
 		gear: Presets.PRERAID_PRESET.gear,
 		// Default EP weights for sorting gear in the gear picker.
-		epWeights: Presets.P1_EP_PRESET.epWeights,
+		epWeights: Presets.SURVIVAL_EP_PRESET.epWeights,
 		// Default stat caps for the Reforge Optimizer
 		statCaps: (() => {
-			const meleeHitCap = new Stats().withStat(Stat.StatMeleeHit, 5 * Mechanics.MELEE_HIT_RATING_PER_HIT_CHANCE);
-			const spellHitCap = new Stats().withStat(Stat.StatSpellHit, 4 * Mechanics.SPELL_HIT_RATING_PER_HIT_CHANCE);
-			const expCap = new Stats().withStat(Stat.StatExpertise, 5 * 4 * Mechanics.EXPERTISE_PER_QUARTER_PERCENT_REDUCTION);
+			return new Stats().withStat(Stat.StatSpellHit, 4 * Mechanics.SPELL_HIT_RATING_PER_HIT_CHANCE);
+		})(),
+		softCapBreakpoints: (() => {
+			const expertiseSoftCapConfig = {
+				stat: Stat.StatExpertise,
+				breakpoints: [6.5 * 4 * Mechanics.EXPERTISE_PER_QUARTER_PERCENT_REDUCTION, 14 * 4 * Mechanics.EXPERTISE_PER_QUARTER_PERCENT_REDUCTION],
+				capType: StatCapType.TypeSoftCap,
+				postCapEPs: [0.47, 0],
+			};
 
-			return meleeHitCap.add(spellHitCap).add(expCap);
+			const hitSoftCapConfig = {
+				stat: Stat.StatMeleeHit,
+				breakpoints: [5.5 * Mechanics.MELEE_HIT_RATING_PER_HIT_CHANCE, 8 * Mechanics.MELEE_HIT_RATING_PER_HIT_CHANCE, 17 * Mechanics.SPELL_HIT_RATING_PER_HIT_CHANCE],
+				capType: StatCapType.TypeSoftCap,
+				postCapEPs: [0.47, 0.14, 0],
+			};
+
+			return [expertiseSoftCapConfig, hitSoftCapConfig];
 		})(),
 		// Default consumes settings.
 		consumes: Presets.DefaultConsumes,
@@ -131,7 +145,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecGuardianDruid, {
 	},
 
 	presets: {
-		epWeights: [Presets.P1_EP_PRESET],
+		epWeights: [Presets.SURVIVAL_EP_PRESET, Presets.BALANCED_EP_PRESET],
 		// Preset talents that the user can quickly select.
 		talents: [Presets.StandardTalents],
 		// Preset rotations that the user can quickly select.


### PR DESCRIPTION
Added Balanced EP preset to complement existing default Survival preset, and added soft caps configuration with efficient breakpoints to target for offensively skewed setups.

 On branch guardian
 Changes to be committed:
	modified:   ui/druid/guardian/presets.ts
	modified:   ui/druid/guardian/sim.ts