### PR TITLE
[MM] Fix Piercing Shots damage

### DIFF
--- a/sim/hunter/marksmanship/TestMM.results
+++ b/sim/hunter/marksmanship/TestMM.results
@@ -37,1457 +37,1457 @@ character_stats_results: {
 dps_results: {
  key: "TestMM-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 23922.05674
-  tps: 21596.86224
+  dps: 22137.58222
+  tps: 19812.38772
  }
 }
 dps_results: {
  key: "TestMM-AllItems-AgonyandTorment"
  value: {
-  dps: 23561.03116
-  tps: 21313.41882
+  dps: 21772.52031
+  tps: 19524.90798
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
-  dps: 20279.60358
-  tps: 18325.3942
+  dps: 18932.42188
+  tps: 16978.2125
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 22556.52786
-  tps: 20359.91423
+  dps: 21023.01631
+  tps: 18826.40268
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 22556.52786
-  tps: 20359.91423
+  dps: 21023.01631
+  tps: 18826.40268
  }
 }
 dps_results: {
  key: "TestMM-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 23406.13646
-  tps: 21097.21995
+  dps: 21681.49423
+  tps: 19372.57771
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 22311.50592
-  tps: 20138.12071
+  dps: 20804.45047
+  tps: 18631.06526
   hps: 94.58123
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 22809.05551
-  tps: 20608.83259
+  dps: 21215.58752
+  tps: 19015.36461
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 22848.42666
-  tps: 20644.97411
+  dps: 21251.47167
+  tps: 19048.01913
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BindingPromise-67037"
  value: {
-  dps: 22311.47946
-  tps: 20138.00966
+  dps: 20804.38157
+  tps: 18630.91177
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlackBruise-50692"
  value: {
-  dps: 22378.19509
-  tps: 20176.9116
+  dps: 20762.33701
+  tps: 18561.05353
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 22991.14144
-  tps: 20782.7752
+  dps: 21461.55365
+  tps: 19253.1874
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 22447.69065
-  tps: 20277.0948
+  dps: 21001.63264
+  tps: 18831.03678
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 22553.54358
-  tps: 20375.3079
+  dps: 21109.87219
+  tps: 18931.63651
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 23328.25657
-  tps: 21069.02424
+  dps: 21737.76289
+  tps: 19478.53056
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 22437.85691
-  tps: 20264.38711
+  dps: 20930.75902
+  tps: 18757.28922
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 22738.08008
-  tps: 20538.4875
+  dps: 21145.00968
+  tps: 18945.4171
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 22311.47946
-  tps: 20138.00966
+  dps: 20804.38157
+  tps: 18630.91177
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 22311.47946
-  tps: 20138.00966
+  dps: 20804.38157
+  tps: 18630.91177
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 23221.34099
-  tps: 20955.2099
+  dps: 21616.84764
+  tps: 19350.71654
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 22328.01112
-  tps: 20154.54132
+  dps: 20820.91323
+  tps: 18647.44343
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BottledLightning-66879"
  value: {
-  dps: 22416.96445
-  tps: 20237.15467
+  dps: 20887.30193
+  tps: 18707.49215
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 23406.13646
-  tps: 20675.27555
+  dps: 21681.49423
+  tps: 18985.12616
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 23922.05674
-  tps: 21596.86224
+  dps: 22137.58222
+  tps: 19812.38772
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 23784.28995
-  tps: 21475.37343
+  dps: 22007.90845
+  tps: 19698.99193
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 23841.19223
-  tps: 21527.04537
+  dps: 22052.90526
+  tps: 19738.7584
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CrushingWeight-59506"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CrushingWeight-65118"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 22311.47946
-  tps: 20138.00966
+  dps: 20804.38157
+  tps: 18630.91177
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 22823.72497
-  tps: 20665.40244
+  dps: 21290.61183
+  tps: 19132.2893
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 23721.55122
-  tps: 21471.79475
+  dps: 22114.09441
+  tps: 19864.33794
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 22654.96288
-  tps: 20472.60473
+  dps: 21198.59938
+  tps: 19016.24123
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 23031.64997
-  tps: 20794.21432
+  dps: 21390.43303
+  tps: 19152.99739
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 23460.66376
-  tps: 21146.5169
+  dps: 21724.46283
+  tps: 19410.31596
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 22414.10932
-  tps: 20217.38991
+  dps: 20929.92157
+  tps: 18733.20215
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 23406.13646
-  tps: 21097.21995
+  dps: 21681.49423
+  tps: 19372.57771
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 23406.13646
-  tps: 21097.21995
+  dps: 21681.49423
+  tps: 19372.57771
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 23460.66376
-  tps: 21146.5169
+  dps: 21724.46283
+  tps: 19410.31596
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 23699.91377
-  tps: 21395.42047
+  dps: 22020.4686
+  tps: 19715.97529
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 23822.53284
-  tps: 21506.03179
+  dps: 22163.83845
+  tps: 19847.3374
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 23406.13646
-  tps: 21097.21995
+  dps: 21681.49423
+  tps: 19372.57771
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FallofMortality-59500"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FallofMortality-65124"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 23401.21838
-  tps: 21131.6836
+  dps: 21792.12404
+  tps: 19522.58927
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 22311.47946
-  tps: 20138.00966
+  dps: 20804.38157
+  tps: 18630.91177
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 22429.95709
-  tps: 20256.48729
+  dps: 20922.8592
+  tps: 18749.3894
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 22553.54358
-  tps: 20375.3079
+  dps: 21109.87219
+  tps: 18931.63651
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 23405.10227
-  tps: 21110.67072
+  dps: 21708.18486
+  tps: 19413.75331
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FluidDeath-58181"
  value: {
-  dps: 23607.18454
-  tps: 21299.19575
+  dps: 21985.30988
+  tps: 19677.32109
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 23406.13646
-  tps: 21097.21995
+  dps: 21681.49423
+  tps: 19372.57771
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 22751.24755
-  tps: 20551.02463
+  dps: 21157.77956
+  tps: 18957.55664
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GaleofShadows-56138"
  value: {
-  dps: 22562.87994
-  tps: 20352.64083
+  dps: 21058.28078
+  tps: 18848.04167
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GaleofShadows-56462"
  value: {
-  dps: 22532.9484
-  tps: 20348.50404
+  dps: 21022.10075
+  tps: 18837.65638
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GearDetector-61462"
  value: {
-  dps: 23098.17349
-  tps: 20860.74194
+  dps: 21474.05895
+  tps: 19236.6274
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 20996.07023
-  tps: 18935.53783
+  dps: 19663.47014
+  tps: 17602.93774
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 22311.47946
-  tps: 20138.00966
+  dps: 20804.38157
+  tps: 18630.91177
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 23038.26618
-  tps: 20793.17973
+  dps: 21436.54974
+  tps: 19191.4633
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 23379.35376
-  tps: 21099.08408
+  dps: 21725.38532
+  tps: 19445.11564
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HarmlightToken-63839"
  value: {
-  dps: 22317.44761
-  tps: 20144.02894
+  dps: 20810.34439
+  tps: 18636.92572
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 22312.85937
-  tps: 20139.38958
+  dps: 20805.76148
+  tps: 18632.29169
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 22313.03858
-  tps: 20139.56879
+  dps: 20805.94069
+  tps: 18632.4709
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofRage-59224"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofRage-65072"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofSolace-55868"
  value: {
-  dps: 22558.02834
-  tps: 20347.78923
+  dps: 21053.42919
+  tps: 18843.19008
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofSolace-56393"
  value: {
-  dps: 22527.4966
-  tps: 20343.05223
+  dps: 21016.64895
+  tps: 18832.20458
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofThunder-55845"
  value: {
-  dps: 22311.47946
-  tps: 20138.00966
+  dps: 20804.38157
+  tps: 18630.91177
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofThunder-56370"
  value: {
-  dps: 22311.47946
-  tps: 20138.00966
+  dps: 20804.38157
+  tps: 18630.91177
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 23121.21513
-  tps: 20870.78709
+  dps: 21518.52225
+  tps: 19268.09421
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Heartpierce-50641"
  value: {
-  dps: 24078.63389
-  tps: 21739.35575
+  dps: 22268.13997
+  tps: 19928.86183
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 23460.66376
-  tps: 21146.5169
+  dps: 21724.46283
+  tps: 19410.31596
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 22650.6154
-  tps: 20468.17107
+  dps: 21194.17815
+  tps: 19011.73383
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 22650.6154
-  tps: 20468.17107
+  dps: 21194.17815
+  tps: 19011.73383
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 22447.71031
-  tps: 20277.11446
+  dps: 21001.65229
+  tps: 18831.05644
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 22553.56324
-  tps: 20375.32756
+  dps: 21109.89185
+  tps: 18931.65617
  }
 }
 dps_results: {
  key: "TestMM-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 22311.47946
-  tps: 20138.00966
+  dps: 20804.38157
+  tps: 18630.91177
  }
 }
 dps_results: {
  key: "TestMM-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 22573.39202
-  tps: 20417.39885
+  dps: 21081.62136
+  tps: 18925.62818
  }
 }
 dps_results: {
  key: "TestMM-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 22991.14144
-  tps: 20782.7752
+  dps: 21461.55365
+  tps: 19253.1874
  }
 }
 dps_results: {
  key: "TestMM-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 23437.78569
-  tps: 21157.92885
+  dps: 21761.31436
+  tps: 19481.45752
  }
 }
 dps_results: {
  key: "TestMM-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 22406.25823
-  tps: 20209.44623
+  dps: 20913.75763
+  tps: 18716.94563
  }
 }
 dps_results: {
  key: "TestMM-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 22406.25823
-  tps: 20209.44623
+  dps: 20913.75763
+  tps: 18716.94563
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 22680.35736
-  tps: 20507.93184
+  dps: 21123.83003
+  tps: 18951.40451
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LastWord-50708"
  value: {
-  dps: 23922.05674
-  tps: 21596.86224
+  dps: 22137.58222
+  tps: 19812.38772
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LeadenDespair-55816"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LeadenDespair-56347"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 23259.00606
-  tps: 20996.00261
+  dps: 21604.31593
+  tps: 19341.31248
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 23431.10422
-  tps: 21155.90891
+  dps: 21749.02789
+  tps: 19473.83258
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 22556.52786
-  tps: 20359.91423
+  dps: 21023.01631
+  tps: 18826.40268
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Lightning-ChargedBattlegear"
  value: {
-  dps: 23561.7705
-  tps: 21369.12733
+  dps: 21841.48072
+  tps: 19648.83755
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 22311.26814
-  tps: 20140.13674
+  dps: 20804.62791
+  tps: 18633.49651
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 22311.26814
-  tps: 20140.13674
+  dps: 20804.62791
+  tps: 18633.49651
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 22545.16193
-  tps: 20384.16772
+  dps: 21026.56504
+  tps: 18865.57084
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 22607.94134
-  tps: 20458.20259
+  dps: 21083.57929
+  tps: 18933.84053
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 22547.33628
-  tps: 20352.93219
+  dps: 21015.70096
+  tps: 18821.29687
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 22547.33628
-  tps: 20352.93219
+  dps: 21015.70096
+  tps: 18821.29687
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 22650.63506
-  tps: 20468.19073
+  dps: 21194.19781
+  tps: 19011.75349
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 22650.63506
-  tps: 20468.19073
+  dps: 21194.19781
+  tps: 19011.75349
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 22697.63733
-  tps: 20520.6342
+  dps: 21137.04464
+  tps: 18960.04151
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 22541.24369
-  tps: 20356.51525
+  dps: 20980.10294
+  tps: 18795.3745
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 22554.53374
-  tps: 20365.15293
+  dps: 21009.72419
+  tps: 18820.34338
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 23406.13646
-  tps: 21097.21995
+  dps: 21681.49423
+  tps: 19372.57771
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 23916.02004
-  tps: 21606.86788
+  dps: 22144.46693
+  tps: 19835.31478
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 24129.99418
-  tps: 21823.21399
+  dps: 22351.7644
+  tps: 20044.98421
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Rainsong-55854"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Rainsong-56377"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 23784.28995
-  tps: 21475.37343
+  dps: 22007.90845
+  tps: 19698.99193
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 23784.28995
-  tps: 21475.37343
+  dps: 22007.90845
+  tps: 19698.99193
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 22556.52786
-  tps: 20359.91423
+  dps: 21023.01631
+  tps: 18826.40268
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 22556.52786
-  tps: 20359.91423
+  dps: 21023.01631
+  tps: 18826.40268
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 22988.17278
-  tps: 20745.53
+  dps: 21420.1186
+  tps: 19177.47581
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SeaStar-55256"
  value: {
-  dps: 22375.07414
-  tps: 20201.60434
+  dps: 20867.97625
+  tps: 18694.50645
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SeaStar-56290"
  value: {
-  dps: 22429.95709
-  tps: 20256.48729
+  dps: 20922.8592
+  tps: 18749.3894
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Shadowmourne-49623"
  value: {
-  dps: 24222.53084
-  tps: 21850.72245
+  dps: 22417.73441
+  tps: 20045.92602
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ShardofWoe-60233"
  value: {
-  dps: 22759.72533
-  tps: 20540.92298
+  dps: 21161.91641
+  tps: 18943.11406
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 22311.47946
-  tps: 20138.00966
+  dps: 20804.38157
+  tps: 18630.91177
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 23371.4303
-  tps: 21123.27649
+  dps: 21782.2959
+  tps: 19534.14209
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 23500.86545
-  tps: 21258.25225
+  dps: 21879.03372
+  tps: 19636.42052
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Sorrowsong-55879"
  value: {
-  dps: 22447.69065
-  tps: 20277.0948
+  dps: 21001.63264
+  tps: 18831.03678
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Sorrowsong-56400"
  value: {
-  dps: 22553.54358
-  tps: 20375.3079
+  dps: 21109.87219
+  tps: 18931.63651
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 22547.33628
-  tps: 20352.93219
+  dps: 21015.70096
+  tps: 18821.29687
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SoulCasket-58183"
  value: {
-  dps: 22835.52625
-  tps: 20653.08192
+  dps: 21379.089
+  tps: 19196.64467
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 22341.15526
-  tps: 20167.30788
+  dps: 20817.48847
+  tps: 18643.64108
  }
 }
 dps_results: {
  key: "TestMM-AllItems-StumpofTime-62465"
  value: {
-  dps: 22572.24819
-  tps: 20375.63456
+  dps: 21038.73664
+  tps: 18842.12301
  }
 }
 dps_results: {
  key: "TestMM-AllItems-StumpofTime-62470"
  value: {
-  dps: 22585.32271
-  tps: 20388.70907
+  dps: 21051.81116
+  tps: 18855.19753
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 22186.05966
-  tps: 20017.12049
+  dps: 20717.34634
+  tps: 18548.40717
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TearofBlood-55819"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TearofBlood-56351"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 22506.43311
-  tps: 20351.23833
+  dps: 21019.36212
+  tps: 18864.16734
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 22557.59323
-  tps: 20379.35755
+  dps: 21113.92184
+  tps: 18935.68616
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 22284.24134
-  tps: 20104.76121
+  dps: 20808.47701
+  tps: 18628.99687
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 23303.04408
-  tps: 21048.36262
+  dps: 21768.33267
+  tps: 19513.65121
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 23540.88795
-  tps: 21267.39315
+  dps: 22000.44539
+  tps: 19726.95059
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 22642.67216
-  tps: 20457.83353
+  dps: 21108.89824
+  tps: 18924.05962
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 21783.64593
-  tps: 19678.55808
+  dps: 20286.71682
+  tps: 18181.62897
  }
 }
 dps_results: {
  key: "TestMM-AllItems-UnheededWarning-59520"
  value: {
-  dps: 23234.89867
-  tps: 20966.42911
+  dps: 21648.13355
+  tps: 19379.66399
  }
 }
 dps_results: {
  key: "TestMM-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 23609.74074
-  tps: 21340.81721
+  dps: 22053.35564
+  tps: 19784.43212
  }
 }
 dps_results: {
  key: "TestMM-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 23609.74074
-  tps: 21340.81721
+  dps: 22053.35564
+  tps: 19784.43212
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 22761.31159
-  tps: 20589.27336
+  dps: 21163.42769
+  tps: 18991.38947
  }
 }
 dps_results: {
  key: "TestMM-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 22311.47946
-  tps: 20138.00966
+  dps: 20804.38157
+  tps: 18630.91177
  }
 }
 dps_results: {
  key: "TestMM-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 22311.47946
-  tps: 20138.00966
+  dps: 20804.38157
+  tps: 18630.91177
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 23233.20363
-  tps: 20980.06838
+  dps: 21644.38118
+  tps: 19391.24593
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 22444.92517
-  tps: 20271.45537
+  dps: 20937.82728
+  tps: 18764.35748
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 22556.54751
-  tps: 20359.93388
+  dps: 21023.03597
+  tps: 18826.42233
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 22576.82134
-  tps: 20365.99067
+  dps: 21063.42693
+  tps: 18852.59626
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 22772.34605
-  tps: 20570.87198
+  dps: 21175.98771
+  tps: 18974.51364
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 22311.47946
-  tps: 20138.00966
+  dps: 20804.38157
+  tps: 18630.91177
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 22702.51115
-  tps: 20526.2417
+  dps: 21244.46268
+  tps: 19068.19323
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 22311.47946
-  tps: 20138.00966
+  dps: 20804.38157
+  tps: 18630.91177
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 23383.81082
-  tps: 21098.97385
+  dps: 21740.12197
+  tps: 19455.285
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 22317.83937
-  tps: 20144.36957
+  dps: 20810.74148
+  tps: 18637.27168
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 22311.4598
-  tps: 20137.99
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
  key: "TestMM-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 22445.42806
-  tps: 20287.30183
+  dps: 20961.52074
+  tps: 18803.39451
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 22512.65615
-  tps: 20339.61772
+  dps: 20990.0371
+  tps: 18816.99867
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 22512.65615
-  tps: 20339.61772
+  dps: 20990.0371
+  tps: 18816.99867
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 22157.83668
-  tps: 19855.04462
+  dps: 20525.26226
+  tps: 18222.4702
  }
 }
 dps_results: {
  key: "TestMM-Average-Default"
  value: {
-  dps: 23890.21011
-  tps: 21563.80421
+  dps: 22164.88994
+  tps: 19838.48404
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-FullBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 25217.70055
-  tps: 23025.40606
+  dps: 23458.30599
+  tps: 21266.0115
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-FullBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 23750.0677
-  tps: 21559.97037
+  dps: 21977.75324
+  tps: 19787.65591
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 28883.94106
-  tps: 25984.93596
+  dps: 27821.63862
+  tps: 24922.63352
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-NoBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 16664.83899
-  tps: 15098.17149
+  dps: 16175.58134
+  tps: 14608.91384
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-NoBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 15678.99471
-  tps: 14104.80991
+  dps: 15225.32356
+  tps: 13651.13875
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-NoBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 16741.71689
-  tps: 15016.07026
+  dps: 16513.16779
+  tps: 14787.52117
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm_advanced-FullBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 25217.70055
-  tps: 23025.40606
+  dps: 23458.30599
+  tps: 21266.0115
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm_advanced-FullBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 23750.0677
-  tps: 21559.97037
+  dps: 21977.75324
+  tps: 19787.65591
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm_advanced-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 28883.94106
-  tps: 25984.93596
+  dps: 27821.63862
+  tps: 24922.63352
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm_advanced-NoBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 16664.83899
-  tps: 15098.17149
+  dps: 16175.58134
+  tps: 14608.91384
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm_advanced-NoBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 15678.99471
-  tps: 14104.80991
+  dps: 15225.32356
+  tps: 13651.13875
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm_advanced-NoBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 16741.71689
-  tps: 15016.07026
+  dps: 16513.16779
+  tps: 14787.52117
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-FullBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 25465.96261
-  tps: 23138.60544
+  dps: 23694.88717
+  tps: 21367.53
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-FullBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 23922.05674
-  tps: 21596.86224
+  dps: 22137.58222
+  tps: 19812.38772
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 29393.79862
-  tps: 26292.91411
+  dps: 28312.61836
+  tps: 25211.73385
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-NoBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 16842.37561
-  tps: 15178.45487
+  dps: 16350.83191
+  tps: 14686.91117
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-NoBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 15845.78804
-  tps: 14173.43532
+  dps: 15389.63262
+  tps: 13717.2799
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-NoBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 17029.79362
-  tps: 15185.09575
+  dps: 16797.51706
+  tps: 14952.81919
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm_advanced-FullBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 25465.96261
-  tps: 23138.60544
+  dps: 23694.88717
+  tps: 21367.53
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm_advanced-FullBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 23922.05674
-  tps: 21596.86224
+  dps: 22137.58222
+  tps: 19812.38772
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm_advanced-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 29393.79862
-  tps: 26292.91411
+  dps: 28312.61836
+  tps: 25211.73385
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm_advanced-NoBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 16842.37561
-  tps: 15178.45487
+  dps: 16350.83191
+  tps: 14686.91117
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm_advanced-NoBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 15845.78804
-  tps: 14173.43532
+  dps: 15389.63262
+  tps: 13717.2799
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm_advanced-NoBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 17029.79362
-  tps: 15185.09575
+  dps: 16797.51706
+  tps: 14952.81919
  }
 }
 dps_results: {
  key: "TestMM-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 23580.01138
-  tps: 21284.60709
+  dps: 21826.91357
+  tps: 19531.50928
  }
 }

--- a/sim/hunter/mm_talents.go
+++ b/sim/hunter/mm_talents.go
@@ -206,7 +206,7 @@ func (hunter *Hunter) applyPiercingShots() {
 			dot := psSpell.Dot(result.Target)
 			newDamage := result.Damage * 0.1 * float64(hunter.Talents.PiercingShots)
 
-			dot.SnapshotBaseDamage = (dot.OutstandingDmg() + newDamage) / float64(dot.BaseTickCount)
+			dot.SnapshotBaseDamage = (dot.OutstandingDmg() + newDamage) / float64(dot.BaseTickCount+core.TernaryInt32(dot.IsActive(), 1, 0))
 			psSpell.Cast(sim, result.Target)
 		},
 	})


### PR DESCRIPTION
Should be calculated on 9 ticks due to rollover. It's not exactly as it happens in game, but the easier approx so far:
![image](https://github.com/wowsims/cata/assets/95472394/8d32f932-68a5-4b68-b6af-e850905cd4ee)
From Whist on the Hunter Discord:
the second piercing shot does 5808 damage, so the first tick does 5808/8=726, then the remaining 8 ticks do (5808-726) / 8 = 635