### PR TITLE
Add breakpoint display

### DIFF
--- a/ui/core/components/suggest_reforges_action.tsx
+++ b/ui/core/components/suggest_reforges_action.tsx
@@ -213,7 +213,7 @@ export class ReforgeOptimizer {
 									<td className="text-end">{statCapTypeNames.get(capType)}</td>
 								</tr>
 								<tr>
-									<th>Rating</th>
+									<th><em>Rating</em></th>
 									<th className="text-end">
 										<em>%</em>
 									</th>

--- a/ui/core/components/suggest_reforges_action.tsx
+++ b/ui/core/components/suggest_reforges_action.tsx
@@ -203,7 +203,7 @@ export class ReforgeOptimizer {
 	buildReforgeButtonTooltip() {
 		return (
 			<>
-				<p>The following soft caps / breakpoints have been implemented for this spec:</p>
+				<p>The following breakpoints have been implemented for this spec:</p>
 				<table className="w-100">
 					<tbody>
 						{this.softCapsConfig?.map(({ stat, breakpoints, capType, postCapEPs }, index) => (
@@ -213,9 +213,7 @@ export class ReforgeOptimizer {
 									<td className="text-end">{statCapTypeNames.get(capType)}</td>
 								</tr>
 								<tr>
-									<th className="fw-medium">
-										Rating
-									</th>
+									<th>Rating</th>
 									<th className="text-end">
 										<em>%</em>
 									</th>

--- a/ui/core/components/suggest_reforges_action.tsx
+++ b/ui/core/components/suggest_reforges_action.tsx
@@ -9,7 +9,7 @@ import { Player } from '../player';
 import { Class, ItemSlot, Spec, Stat } from '../proto/common';
 import { StatCapConfig, StatCapType } from '../proto/ui';
 import { Gear } from '../proto_utils/gear';
-import { getClassStatName } from '../proto_utils/names';
+import { getClassStatName, statCapTypeNames } from '../proto_utils/names';
 import { statPercentageOrPointsToNumber, Stats, statToPercentageOrPoints } from '../proto_utils/stats';
 import { SpecTalents } from '../proto_utils/utils';
 import { Sim } from '../sim';
@@ -150,9 +150,11 @@ export class ReforgeOptimizer {
 
 		if (!!this.softCapsConfig?.length)
 			tippy(startReforgeOptimizationButton, {
+				theme: 'suggest-reforges-softcaps',
 				content: this.buildReforgeButtonTooltip(),
 				placement: 'bottom',
 				maxWidth: 310,
+				interactive: true,
 			});
 
 		tippy(contextMenuButton, {
@@ -201,8 +203,47 @@ export class ReforgeOptimizer {
 	buildReforgeButtonTooltip() {
 		return (
 			<>
-				The following soft caps / breakpoints have been implemented for this spec:
-				<ul className="mt-1 mb-0">{this.softCapsConfig?.map(({ stat }) => <li>{getClassStatName(stat, this.player.getClass())}</li>)}</ul>
+				<p>The following soft caps / breakpoints have been implemented for this spec:</p>
+				<table className="w-100">
+					<tbody>
+						{this.softCapsConfig?.map(({ stat, breakpoints, capType, postCapEPs }, index) => (
+							<>
+								<tr>
+									<th colSpan={2}>{getClassStatName(stat, this.player.getClass())}</th>
+									<td className="text-end">{statCapTypeNames.get(capType)}</td>
+								</tr>
+								<tr>
+									<th className="fw-medium">
+										Rating
+									</th>
+									<th className="text-end">
+										<em>%</em>
+									</th>
+									<th className="text-end">
+										<em>Post cap EP</em>
+									</th>
+								</tr>
+								{breakpoints.map((breakpoint, breakpointIndex) => (
+									<tr>
+										<td>{Math.round(breakpoint)}</td>
+										<td className="text-end">{statToPercentageOrPoints(stat, breakpoint, new Stats()).toFixed(2)}</td>
+										<td className="text-end">{postCapEPs[breakpointIndex]}</td>
+									</tr>
+								))}
+								{index !== this.softCapsConfig.length - 1 && (
+									<>
+										<tr>
+											<td colSpan={2} className="border-bottom pb-2"></td>
+										</tr>
+										<tr>
+											<td colSpan={2} className="pb-2"></td>
+										</tr>
+									</>
+								)}
+							</>
+						))}
+					</tbody>
+				</table>
 			</>
 		);
 	}

--- a/ui/core/proto_utils/names.ts
+++ b/ui/core/proto_utils/names.ts
@@ -1,6 +1,6 @@
 import { ResourceType } from '../proto/api.js';
 import { ArmorType, Class, ItemSlot, Profession, PseudoStat, Race, RangedWeaponType, Spec, Stat, WeaponType } from '../proto/common.js';
-import { DungeonDifficulty, RaidFilterOption, RepFaction, RepLevel, SourceFilterOption } from '../proto/ui.js';
+import { DungeonDifficulty, RaidFilterOption, RepFaction, RepLevel, SourceFilterOption, StatCapType } from '../proto/ui.js';
 
 export const armorTypeNames: Map<ArmorType, string> = new Map([
 	[ArmorType.ArmorTypeUnknown, 'Unknown'],
@@ -193,11 +193,7 @@ export const shortSecondaryStatNames: Map<Stat, string> = new Map([
 	[Stat.StatParry, 'Parry'],
 ]);
 
-export const pseudoStatOrder: Array<PseudoStat> = [
-	PseudoStat.PseudoStatMainHandDps,
-	PseudoStat.PseudoStatOffHandDps,
-	PseudoStat.PseudoStatRangedDps,
-];
+export const pseudoStatOrder: Array<PseudoStat> = [PseudoStat.PseudoStatMainHandDps, PseudoStat.PseudoStatOffHandDps, PseudoStat.PseudoStatRangedDps];
 export const pseudoStatNames: Map<PseudoStat, string> = new Map([
 	[PseudoStat.PseudoStatMainHandDps, 'Main Hand DPS'],
 	[PseudoStat.PseudoStatOffHandDps, 'Off Hand DPS'],
@@ -338,8 +334,8 @@ export const REP_FACTION_NAMES: Record<RepFaction, string> = {
 	[RepFaction.RepFactionDragonmawClan]: 'Dragonmaw Clan',
 	[RepFaction.RepFactionRamkahen]: 'Ramkahen',
 	[RepFaction.RepFactionWildhammerClan]: 'Wildhammer Clan',
-	[RepFaction.RepFactionBaradinsWardens]: 'Baradin\'s Wardens',
-	[RepFaction.RepFactionHellscreamsReach]: 'Hellscream\'s Reach',
+	[RepFaction.RepFactionBaradinsWardens]: "Baradin's Wardens",
+	[RepFaction.RepFactionHellscreamsReach]: "Hellscream's Reach",
 	[RepFaction.RepFactionAvengersOfHyjal]: 'Avengers of Hyjal',
 };
 
@@ -354,7 +350,7 @@ export const REP_FACTION_QUARTERMASTERS: Record<RepFaction, number> = {
 	[RepFaction.RepFactionBaradinsWardens]: 47328,
 	[RepFaction.RepFactionHellscreamsReach]: 48531,
 	[RepFaction.RepFactionAvengersOfHyjal]: 54401,
-}
+};
 
 export const masterySpellNames: Map<Spec, string> = new Map([
 	[Spec.SpecAssassinationRogue, 'Potent Poisons'],
@@ -422,4 +418,9 @@ export const masterySpellIDs: Map<Spec, number> = new Map([
 	[Spec.SpecAfflictionWarlock, 77215],
 	[Spec.SpecDemonologyWarlock, 77219],
 	[Spec.SpecDestructionWarlock, 77220],
+]);
+export const statCapTypeNames = new Map<StatCapType, string>([
+	[StatCapType.TypeHardCap, 'Hard cap'],
+	[StatCapType.TypeSoftCap, 'Soft cap'],
+	[StatCapType.TypeThreshold, 'Threshold'],
 ]);

--- a/ui/core/proto_utils/stats.ts
+++ b/ui/core/proto_utils/stats.ts
@@ -1,5 +1,4 @@
 import * as Mechanics from '../constants/mechanics.js';
-import { Player } from '../player';
 import { Class, PseudoStat, Stat, UnitStats } from '../proto/common.js';
 import { getEnumValues } from '../utils.js';
 import { getClassStatName, pseudoStatNames } from './names.js';

--- a/ui/mage/fire/sim.ts
+++ b/ui/mage/fire/sim.ts
@@ -93,7 +93,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFireMage, {
 				stat: Stat.StatSpellHaste,
 				breakpoints,
 				capType: StatCapType.TypeSoftCap,
-				postCapEPs: [0.96, 0.86, 0.77, 0.77, 1.17, 0.76, 0.65],
+				postCapEPs: [0.86, 0.77, 0.77, 1.17, 0.76, 0.65, 0.64],
 			};
 
 			return [hasteSoftCapConfig];

--- a/ui/scss/core/components/_suggest_reforges_action.scss
+++ b/ui/scss/core/components/_suggest_reforges_action.scss
@@ -5,6 +5,11 @@
 		margin-bottom: 0;
 	}
 }
+.tippy-box[data-theme='suggest-reforges-softcaps'] {
+	max-height: 40vh;
+	overflow: auto;
+}
+
 .suggest-reforges-settings-group {
 	--settings-button-width: 36px;
 	position: relative;


### PR DESCRIPTION
Added a table to display the different breakpoints that are configured for a spec that has them. Highly requested by users that like to see how these are configured.

<img width="235" alt="Screenshot 2024-06-28 at 17 54 44" src="https://github.com/wowsims/cata/assets/1216787/07e45b8d-598f-4dfd-82bb-6542054c485f">
