### PR TITLE
Implement t12 procs

### DIFF
--- a/sim/common/cata/damage_procs.go
+++ b/sim/common/cata/damage_procs.go
@@ -80,9 +80,6 @@ func init() {
 				dummyAura.AddStack(sim)
 
 				if sim.Proc(procChance, "Variable Pulse Lightning Capacitor") {
-					if dummyAura.GetStacks() == 0 {
-						return
-					}
 					lightningSpell.Cast(sim, result.Target)
 					dummyAura.SetStacks(sim, 0)
 				}
@@ -128,9 +125,6 @@ func init() {
 				dummyAura.AddStack(sim)
 
 				if sim.Proc(procChance, "Variable Pulse Lightning Capacitor Heroic") {
-					if dummyAura.GetStacks() == 0 {
-						return
-					}
 					lightningSpell.Cast(sim, result.Target)
 					dummyAura.SetStacks(sim, 0)
 				}

--- a/sim/common/cata/damage_procs.go
+++ b/sim/common/cata/damage_procs.go
@@ -1,6 +1,8 @@
 package cata
 
 import (
+	"time"
+
 	"github.com/wowsims/cata/sim/common/shared"
 	"github.com/wowsims/cata/sim/core"
 )
@@ -39,4 +41,101 @@ func init() {
 			Callback: core.CallbackOnSpellHitDealt,
 		},
 	})
+
+	core.NewItemEffect(68925, func(agent core.Agent) {
+		character := agent.GetCharacter()
+		procChance := 0.3 //TODO: placeholder, get real proc chance
+		dummyAura := character.GetOrRegisterAura(core.Aura{
+			Label:     "Electrical Charge",
+			ActionID:  core.ActionID{SpellID: 96890},
+			Duration:  core.NeverExpires,
+			MaxStacks: 10,
+		})
+
+		lightningSpell := character.RegisterSpell(core.SpellConfig{
+			ActionID:         core.ActionID{SpellID: 96891},
+			SpellSchool:      core.SpellSchoolNature,
+			ProcMask:         core.ProcMaskEmpty,
+			Flags:            core.SpellFlagNoOnDamageDealt,
+			DamageMultiplier: 1,
+			CritMultiplier:   character.DefaultSpellCritMultiplier(),
+			ThreatMultiplier: 1,
+
+			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
+				baseDamage := sim.Roll(985, 1266) * float64(dummyAura.GetStacks())
+				spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMagicHitAndCrit)
+			},
+		})
+
+		core.MakePermanent(core.MakeProcTriggerAura(&character.Unit, core.ProcTrigger{
+			Name:       "Electrical Charge Aura",
+			ActionID:   core.ActionID{ItemID: 68925},
+			Callback:   core.CallbackOnSpellHitDealt,
+			ProcMask:   core.ProcMaskSpellOrProc,
+			ProcChance: 1,
+			Outcome:    core.OutcomeCrit,
+			ICD:        time.Millisecond * 2500,
+			Handler: func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				dummyAura.Activate(sim)
+				dummyAura.AddStack(sim)
+
+				if sim.Proc(procChance, "Variable Pulse Lightning Capacitor") {
+					if dummyAura.GetStacks() == 0 {
+						return
+					}
+					lightningSpell.Cast(sim, result.Target)
+					dummyAura.SetStacks(sim, 0)
+				}
+			},
+		}))
+	})
+
+	core.NewItemEffect(69110, func(agent core.Agent) {
+		character := agent.GetCharacter()
+		procChance := 0.3 //TODO: placeholder, get real proc chance
+		dummyAura := character.GetOrRegisterAura(core.Aura{
+			Label:     "Electrical Charge",
+			ActionID:  core.ActionID{SpellID: 96890},
+			Duration:  core.NeverExpires,
+			MaxStacks: 10,
+		})
+
+		lightningSpell := character.RegisterSpell(core.SpellConfig{
+			ActionID:         core.ActionID{SpellID: 96891},
+			SpellSchool:      core.SpellSchoolNature,
+			ProcMask:         core.ProcMaskEmpty,
+			Flags:            core.SpellFlagNoOnDamageDealt,
+			DamageMultiplier: 1,
+			CritMultiplier:   character.DefaultSpellCritMultiplier(),
+			ThreatMultiplier: 1,
+
+			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
+				baseDamage := sim.Roll(2889, 3713) * float64(dummyAura.GetStacks())
+				spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMagicHitAndCrit)
+			},
+		})
+
+		core.MakePermanent(core.MakeProcTriggerAura(&character.Unit, core.ProcTrigger{
+			Name:       "Electrical Charge Aura",
+			ActionID:   core.ActionID{ItemID: 69110},
+			Callback:   core.CallbackOnSpellHitDealt,
+			ProcMask:   core.ProcMaskSpellOrProc,
+			ProcChance: 1,
+			Outcome:    core.OutcomeCrit,
+			ICD:        time.Millisecond * 2500,
+			Handler: func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				dummyAura.Activate(sim)
+				dummyAura.AddStack(sim)
+
+				if sim.Proc(procChance, "Variable Pulse Lightning Capacitor Heroic") {
+					if dummyAura.GetStacks() == 0 {
+						return
+					}
+					lightningSpell.Cast(sim, result.Target)
+					dummyAura.SetStacks(sim, 0)
+				}
+			},
+		}))
+	})
+
 }

--- a/sim/common/cata/other_effects.go
+++ b/sim/common/cata/other_effects.go
@@ -674,4 +674,90 @@ func init() {
 			},
 		})
 	})
+
+	core.NewItemEffect(68994, func(agent core.Agent) {
+		character := agent.GetCharacter()
+
+		bonusStats := 1624.0
+		procAuraCrit := character.NewTemporaryStatsAura("Matrix Restabilizer Crit Proc", core.ActionID{SpellID: 96978}, stats.Stats{stats.MeleeCrit: bonusStats, stats.SpellCrit: bonusStats}, time.Second*30)
+		procAuraHaste := character.NewTemporaryStatsAura("Matrix Restabilizer Haste Proc", core.ActionID{SpellID: 96977}, stats.Stats{stats.MeleeHaste: bonusStats, stats.SpellHaste: bonusStats}, time.Second*30)
+		procAuraMastery := character.NewTemporaryStatsAura("Matrix Restabilizer Mastery Proc", core.ActionID{SpellID: 96979}, stats.Stats{stats.Mastery: bonusStats}, time.Second*30)
+
+		icd := core.Cooldown{
+			Timer:    character.NewTimer(),
+			Duration: time.Second * 105,
+		}
+
+		procAuraCrit.Icd = &icd
+		procAuraHaste.Icd = &icd
+		procAuraMastery.Icd = &icd
+
+		core.MakeProcTriggerAura(&character.Unit, core.ProcTrigger{
+			Name:       "Matrix Restabilizer Trigger",
+			Callback:   core.CallbackOnSpellHitDealt,
+			ProcMask:   core.ProcMaskMeleeOrRanged,
+			ProcChance: 0.2,
+			ActionID:   core.ActionID{ItemID: 68994},
+			Harmful:    true,
+			Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellResult) {
+				if icd.IsReady(sim) {
+					statType := character.GetHighestStat([]stats.Stat{stats.MeleeCrit, stats.SpellCrit, stats.MeleeHaste, stats.SpellHaste, stats.Mastery})
+					switch statType {
+					case stats.MeleeCrit, stats.SpellCrit:
+						procAuraCrit.Activate(sim)
+					case stats.MeleeHaste, stats.SpellHaste:
+						procAuraHaste.Activate(sim)
+					case stats.Mastery:
+						procAuraMastery.Activate(sim)
+					default:
+						panic("unexpected statType")
+					}
+					icd.Use(sim)
+				}
+			},
+		})
+	})
+
+	core.NewItemEffect(69150, func(agent core.Agent) {
+		character := agent.GetCharacter()
+
+		bonusStats := 1834.0
+		procAuraCrit := character.NewTemporaryStatsAura("Matrix Restabilizer Crit Proc (Heroic)", core.ActionID{SpellID: 97140}, stats.Stats{stats.MeleeCrit: bonusStats, stats.SpellCrit: bonusStats}, time.Second*30)
+		procAuraHaste := character.NewTemporaryStatsAura("Matrix Restabilizer Haste Proc (Heroic)", core.ActionID{SpellID: 97139}, stats.Stats{stats.MeleeHaste: bonusStats, stats.SpellHaste: bonusStats}, time.Second*30)
+		procAuraMastery := character.NewTemporaryStatsAura("Matrix Restabilizer Mastery Proc (Heroic)", core.ActionID{SpellID: 97141}, stats.Stats{stats.Mastery: bonusStats}, time.Second*30)
+
+		icd := core.Cooldown{
+			Timer:    character.NewTimer(),
+			Duration: time.Second * 105,
+		}
+
+		procAuraCrit.Icd = &icd
+		procAuraHaste.Icd = &icd
+		procAuraMastery.Icd = &icd
+
+		core.MakeProcTriggerAura(&character.Unit, core.ProcTrigger{
+			Name:       "Matrix Restabilizer Trigger (Heroic)",
+			Callback:   core.CallbackOnSpellHitDealt,
+			ProcMask:   core.ProcMaskMeleeOrRanged,
+			ProcChance: 0.2,
+			ActionID:   core.ActionID{ItemID: 69150},
+			Harmful:    true,
+			Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellResult) {
+				if icd.IsReady(sim) {
+					statType := character.GetHighestStat([]stats.Stat{stats.MeleeCrit, stats.SpellCrit, stats.MeleeHaste, stats.SpellHaste, stats.Mastery})
+					switch statType {
+					case stats.MeleeCrit, stats.SpellCrit:
+						procAuraCrit.Activate(sim)
+					case stats.MeleeHaste, stats.SpellHaste:
+						procAuraHaste.Activate(sim)
+					case stats.Mastery:
+						procAuraMastery.Activate(sim)
+					default:
+						panic("unexpected statType")
+					}
+					icd.Use(sim)
+				}
+			},
+		})
+	})
 }

--- a/sim/common/cata/other_effects.go
+++ b/sim/common/cata/other_effects.go
@@ -524,4 +524,154 @@ func init() {
 			Type:     core.CooldownTypeMana,
 		})
 	})
+
+	core.NewItemEffect(68972, func(agent core.Agent) {
+		character := agent.GetCharacter()
+
+		dummyAura := character.RegisterAura(core.Aura{
+			Label:     "Titanic Power",
+			ActionID:  core.ActionID{SpellID: 96923},
+			Duration:  time.Second * 30,
+			MaxStacks: 5,
+		})
+
+		core.MakePermanent(core.MakeProcTriggerAura(&character.Unit, core.ProcTrigger{
+			Name:       "Titanic Power Aura",
+			ActionID:   core.ActionID{ItemID: 68972},
+			Callback:   core.CallbackOnSpellHitDealt,
+			ProcMask:   core.ProcMaskMelee,
+			ProcChance: 1,
+			Outcome:    core.OutcomeCrit,
+			Handler: func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				dummyAura.Activate(sim)
+				dummyAura.AddStack(sim)
+			},
+		}))
+
+		statBonus := float64(508 * dummyAura.MaxStacks)
+		buffAuraCrit := character.NewTemporaryStatsAura("Blessing of the Shaper Crit", core.ActionID{SpellID: 96928}, stats.Stats{stats.MeleeCrit: statBonus, stats.SpellCrit: statBonus}, time.Second*15)
+		buffAuraHaste := character.NewTemporaryStatsAura("Blessing of the Shaper Haste", core.ActionID{SpellID: 96927}, stats.Stats{stats.MeleeHaste: statBonus, stats.SpellHaste: statBonus}, time.Second*15)
+		buffAuraMastery := character.NewTemporaryStatsAura("Blessing of the Shaper Mastery", core.ActionID{SpellID: 96929}, stats.Stats{stats.Mastery: statBonus}, time.Second*15)
+
+		sharedCD := character.GetOffensiveTrinketCD()
+		trinketSpell := character.RegisterSpell(core.SpellConfig{
+			ActionID:    core.ActionID{ItemID: 68972},
+			SpellSchool: core.SpellSchoolPhysical,
+			ProcMask:    core.ProcMaskEmpty,
+			Flags:       core.SpellFlagNoOnCastComplete,
+			Cast: core.CastConfig{
+				SharedCD: core.Cooldown{
+					Timer:    sharedCD,
+					Duration: time.Second * 15,
+				},
+				CD: core.Cooldown{
+					Timer:    character.NewTimer(),
+					Duration: time.Minute * 2,
+				},
+			},
+
+			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
+				statType := character.GetHighestStat([]stats.Stat{stats.MeleeCrit, stats.SpellCrit, stats.MeleeHaste, stats.SpellHaste, stats.Mastery})
+				switch statType {
+				case stats.MeleeCrit, stats.SpellCrit:
+					buffAuraCrit.Activate(sim)
+				case stats.MeleeHaste, stats.SpellHaste:
+					buffAuraHaste.Activate(sim)
+				case stats.Mastery:
+					buffAuraMastery.Activate(sim)
+				default:
+					panic("unexpected statType")
+				}
+				dummyAura.Deactivate(sim)
+			},
+			ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
+				return dummyAura.GetStacks() == 5
+			},
+		})
+
+		character.AddMajorCooldown(core.MajorCooldown{
+			Spell:    trinketSpell,
+			Priority: core.CooldownPriorityDefault,
+			Type:     core.CooldownTypeDPS,
+			ShouldActivate: func(s *core.Simulation, c *core.Character) bool {
+				return dummyAura.GetStacks() == 5
+			},
+		})
+	})
+
+	core.NewItemEffect(69113, func(agent core.Agent) {
+		character := agent.GetCharacter()
+
+		dummyAura := character.RegisterAura(core.Aura{
+			Label:     "Titanic Power (Heroic)",
+			ActionID:  core.ActionID{SpellID: 96923},
+			Duration:  time.Second * 30,
+			MaxStacks: 5,
+		})
+
+		core.MakePermanent(core.MakeProcTriggerAura(&character.Unit, core.ProcTrigger{
+			Name:       "Titanic Power Aura (Heroic)",
+			ActionID:   core.ActionID{ItemID: 69113},
+			Callback:   core.CallbackOnSpellHitDealt,
+			ProcMask:   core.ProcMaskMelee,
+			ProcChance: 1,
+			Outcome:    core.OutcomeCrit,
+			Handler: func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+				dummyAura.Activate(sim)
+				dummyAura.AddStack(sim)
+			},
+		}))
+
+		// TODO: discuss the following scenario:
+		// the trinket should allow to activate at any number of stacks, should we allow this behaviour at all to the users?
+		// would also mean that we need the temporary aura to be created on the fly after an environment is finalized
+		statBonus := float64(575 * dummyAura.MaxStacks)
+		buffAuraCrit := character.NewTemporaryStatsAura("Blessing of the Shaper Crit (Heroic)", core.ActionID{SpellID: 96928}, stats.Stats{stats.MeleeCrit: statBonus, stats.SpellCrit: statBonus}, time.Second*15)
+		buffAuraHaste := character.NewTemporaryStatsAura("Blessing of the Shaper Haste (Heroic)", core.ActionID{SpellID: 96927}, stats.Stats{stats.MeleeHaste: statBonus, stats.SpellHaste: statBonus}, time.Second*15)
+		buffAuraMastery := character.NewTemporaryStatsAura("Blessing of the Shaper Mastery (Heroic)", core.ActionID{SpellID: 96929}, stats.Stats{stats.Mastery: statBonus}, time.Second*15)
+
+		sharedCD := character.GetOffensiveTrinketCD()
+		trinketSpell := character.RegisterSpell(core.SpellConfig{
+			ActionID:    core.ActionID{ItemID: 69113},
+			SpellSchool: core.SpellSchoolPhysical,
+			ProcMask:    core.ProcMaskEmpty,
+			Flags:       core.SpellFlagNoOnCastComplete,
+			Cast: core.CastConfig{
+				SharedCD: core.Cooldown{
+					Timer:    sharedCD,
+					Duration: time.Second * 15,
+				},
+				CD: core.Cooldown{
+					Timer:    character.NewTimer(),
+					Duration: time.Minute * 2,
+				},
+			},
+			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
+				statType := character.GetHighestStat([]stats.Stat{stats.MeleeCrit, stats.SpellCrit, stats.MeleeHaste, stats.SpellHaste, stats.Mastery})
+				switch statType {
+				case stats.MeleeCrit, stats.SpellCrit:
+					buffAuraCrit.Activate(sim)
+				case stats.MeleeHaste, stats.SpellHaste:
+					buffAuraHaste.Activate(sim)
+				case stats.Mastery:
+					buffAuraMastery.Activate(sim)
+				default:
+					panic("unexpected statType")
+				}
+				dummyAura.Deactivate(sim)
+			},
+			ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
+				return dummyAura.GetStacks() == 5
+			},
+		})
+
+		character.AddMajorCooldown(core.MajorCooldown{
+			Spell:    trinketSpell,
+			Priority: core.CooldownPriorityDefault,
+			Type:     core.CooldownTypeDPS,
+			ShouldActivate: func(s *core.Simulation, c *core.Character) bool {
+				return dummyAura.GetStacks() == 5
+			},
+		})
+	})
 }

--- a/sim/common/cata/stat_bonus_cds.go
+++ b/sim/common/cata/stat_bonus_cds.go
@@ -54,6 +54,7 @@ func init() {
 	shared.NewDodgeActive(59515, 1605, time.Second*20, time.Minute*2) // Vial of Stolen Memories
 	shared.NewDodgeActive(65109, 1812, time.Second*20, time.Minute*2) // Vial of Stolen Memories (Heroic)
 	shared.NewDodgeActive(70143, 1700, time.Second*20, time.Minute*2) // Moonwell Phial
+	shared.NewDodgeActive(71338, 1700, time.Second*20, time.Minute*2) // Brawler's Trophy
 
 	// SpellPower
 	shared.NewSpellPowerActive(61429, 970, time.Second*15, time.Second*90) // Insignia of the Earthen Lord

--- a/sim/common/cata/stat_bonus_cds.go
+++ b/sim/common/cata/stat_bonus_cds.go
@@ -13,8 +13,9 @@ func init() {
 	shared.NewHasteActive(60233, 1935, time.Second*10, time.Minute*1) // Shard of Woe
 
 	// CRIT
-	shared.NewCritActive(66879, 512, time.Second*20, time.Minute*2) // Bottled Lightning
-	shared.NewCritActive(61448, 970, time.Second*20, time.Minute*2) // Oremantle's Favor
+	shared.NewCritActive(66879, 512, time.Second*20, time.Minute*2)  // Bottled Lightning
+	shared.NewCritActive(61448, 970, time.Second*20, time.Minute*2)  // Oremantle's Favor
+	shared.NewCritActive(70144, 1700, time.Second*20, time.Minute*2) // Ricket's Magnetic Fireball
 
 	// STRENGTH
 	shared.NewStrengthActive(59685, 830, time.Second*10, time.Minute)     // Kvaldir Battle Standard - Alliance
@@ -29,6 +30,7 @@ func init() {
 	shared.NewStrengthActive(62464, 1605, time.Second*20, time.Minute*2)  // Impatience of Youth (Alliance)
 	shared.NewStrengthActive(62469, 1605, time.Second*20, time.Minute*2)  // Impatience of Youth (Horde)
 	shared.NewStrengthActive(61034, 1605, time.Second*20, time.Minute*2)  // Vicious Gladiator's Badge of Victory
+	shared.NewStrengthActive(69002, 1277, time.Second*15, time.Minute)    // Essence of the Eternal Flame
 
 	// AGILITY
 	shared.NewAgilityActive(63840, 1095, time.Second*15, time.Second*90) // Juju of Nimbleness
@@ -39,6 +41,7 @@ func init() {
 	shared.NewAgilityActive(62463, 1605, time.Second*20, time.Minute*2)  // Unsolvable Riddle (Horde)
 	shared.NewAgilityActive(68709, 1605, time.Second*20, time.Minute*2)  // Unsolvable Riddle (No Faction)
 	shared.NewAgilityActive(61033, 1605, time.Second*20, time.Minute*2)  // Vicious Gladiator's Badge of Conquest
+	shared.NewAgilityActive(69001, 1277, time.Second*15, time.Minute)    // Ancient Petrified Seed
 
 	// SPIRIT
 	shared.NewSpiritActive(67101, 555, time.Second*20, time.Minute*2)  // Unquenchable Flame
@@ -50,6 +53,7 @@ func init() {
 	shared.NewDodgeActive(52352, 1425, time.Second*20, time.Minute*2) // Figurine - Earthen Guardian
 	shared.NewDodgeActive(59515, 1605, time.Second*20, time.Minute*2) // Vial of Stolen Memories
 	shared.NewDodgeActive(65109, 1812, time.Second*20, time.Minute*2) // Vial of Stolen Memories (Heroic)
+	shared.NewDodgeActive(70143, 1700, time.Second*20, time.Minute*2) // Moonwell Phial
 
 	// SpellPower
 	shared.NewSpellPowerActive(61429, 970, time.Second*15, time.Second*90) // Insignia of the Earthen Lord
@@ -76,7 +80,9 @@ func init() {
 	shared.NewHealthActive(61027, 16196, time.Second*15, time.Minute*2) // Vicious Gladiator's Emblem of Accuracy
 
 	// INT
-	shared.NewIntActive(67118, 567, time.Second*20, time.Minute*2) // Electrospark Heartstarter
+	shared.NewIntActive(67118, 567, time.Second*20, time.Minute*2)   // Electrospark Heartstarter
+	shared.NewIntActive(68998, 1277, time.Second*15, time.Minute)    // Rune of Zeth
+	shared.NewIntActive(69000, 1149, time.Second*25, time.Second*90) // Fiery Quintessence
 
 	// MASTERY
 	shared.NewMasteryActive(63745, 1095, time.Second*15, time.Second*90) // Za'brox's Lucky Tooth - Alliance

--- a/sim/common/cata/stat_bonus_procs.go
+++ b/sim/common/cata/stat_bonus_procs.go
@@ -921,6 +921,32 @@ func init() {
 		ProcChance: 0.1,
 		ICD:        time.Second * 45,
 	})
+
+	shared.NewProcStatBonusEffect(shared.ProcStatBonusEffect{
+		Name:       "The Hungerer",
+		ID:         68927,
+		AuraID:     96911,
+		Bonus:      stats.Stats{stats.MeleeHaste: 1532, stats.SpellHaste: 1532},
+		Duration:   time.Second * 15,
+		Callback:   core.CallbackOnSpellHitDealt,
+		ProcMask:   core.ProcMaskMeleeOrRanged,
+		Outcome:    core.OutcomeLanded,
+		ProcChance: 1, //TODO: verify proc chance, seems wrong?
+		ICD:        time.Second * 60,
+	})
+
+	shared.NewProcStatBonusEffect(shared.ProcStatBonusEffect{
+		Name:       "The Hungerer Heroic",
+		ID:         69112,
+		AuraID:     97125,
+		Bonus:      stats.Stats{stats.MeleeHaste: 1730, stats.SpellHaste: 1730},
+		Duration:   time.Second * 15,
+		Callback:   core.CallbackOnSpellHitDealt,
+		ProcMask:   core.ProcMaskMeleeOrRanged,
+		Outcome:    core.OutcomeLanded,
+		ProcChance: 1, //TODO: verify proc chance, seems wrong?
+		ICD:        time.Second * 60,
+	})
 }
 
 var ItemSetAgonyAndTorment = core.NewItemSet(core.ItemSet{

--- a/sim/common/cata/stat_bonus_procs.go
+++ b/sim/common/cata/stat_bonus_procs.go
@@ -869,6 +869,19 @@ func init() {
 		ProcChance: 0.15,
 		ICD:        time.Second * 55,
 	})
+
+	shared.NewProcStatBonusEffect(shared.ProcStatBonusEffect{
+		Name:       "Dwyer's Caber",
+		ID:         70141,
+		AuraID:     100322,
+		Bonus:      stats.Stats{stats.MeleeCrit: 1020, stats.SpellCrit: 1020},
+		Duration:   time.Second * 20,
+		Callback:   core.CallbackOnSpellHitDealt,
+		ProcMask:   core.ProcMaskDirect,
+		Outcome:    core.OutcomeLanded,
+		ProcChance: 0.15,
+		ICD:        time.Second * 50,
+	})
 }
 
 var ItemSetAgonyAndTorment = core.NewItemSet(core.ItemSet{

--- a/sim/common/cata/stat_bonus_procs.go
+++ b/sim/common/cata/stat_bonus_procs.go
@@ -882,6 +882,45 @@ func init() {
 		ProcChance: 0.15,
 		ICD:        time.Second * 50,
 	})
+
+	shared.NewProcStatBonusEffect(shared.ProcStatBonusEffect{
+		Name:       "Coren's Chilled Chromium Coaster",
+		ID:         71335,
+		AuraID:     101287,
+		Bonus:      stats.Stats{stats.AttackPower: 4000, stats.RangedAttackPower: 4000},
+		Duration:   time.Second * 10,
+		Callback:   core.CallbackOnSpellHitDealt,
+		ProcMask:   core.ProcMaskMeleeOrRanged,
+		Outcome:    core.OutcomeCrit,
+		ProcChance: 0.1,
+		ICD:        time.Second * 50,
+	})
+
+	shared.NewProcStatBonusEffect(shared.ProcStatBonusEffect{
+		Name:       "Petrified Pickled Egg",
+		ID:         71336,
+		AuraID:     101289,
+		Bonus:      stats.Stats{stats.MeleeHaste: 2040, stats.SpellHaste: 2040},
+		Duration:   time.Second * 10,
+		Callback:   core.CallbackOnHealDealt | core.CallbackOnPeriodicHealDealt,
+		ProcMask:   core.ProcMaskSpellHealing,
+		Outcome:    core.OutcomeLanded,
+		ProcChance: 0.1,
+		ICD:        time.Second * 45,
+	})
+
+	shared.NewProcStatBonusEffect(shared.ProcStatBonusEffect{
+		Name:       "Mithril Stopwatch",
+		ID:         71337,
+		AuraID:     101291,
+		Bonus:      stats.Stats{stats.SpellPower: 2040},
+		Duration:   time.Second * 10,
+		Callback:   core.CallbackOnSpellHitDealt | core.CallbackOnPeriodicDamageDealt,
+		ProcMask:   core.ProcMaskSpellDamage,
+		Outcome:    core.OutcomeLanded,
+		ProcChance: 0.1,
+		ICD:        time.Second * 45,
+	})
 }
 
 var ItemSetAgonyAndTorment = core.NewItemSet(core.ItemSet{

--- a/sim/common/cata/stat_bonus_stacking.go
+++ b/sim/common/cata/stat_bonus_stacking.go
@@ -146,4 +146,32 @@ func init() {
 		Harmful:    false,
 		ProcChance: 1,
 	})
+
+	shared.NewStackingStatBonusEffect(shared.StackingStatBonusEffect{
+		Name:       "Necromantic Focus",
+		ID:         68982,
+		AuraID:     96962,
+		Bonus:      stats.Stats{stats.Mastery: 39},
+		MaxStacks:  10,
+		ProcMask:   core.ProcMaskSpellDamage,
+		Duration:   time.Second * 10,
+		Outcome:    core.OutcomeLanded,
+		Callback:   core.CallbackOnPeriodicDamageDealt,
+		Harmful:    false,
+		ProcChance: 1,
+	})
+
+	shared.NewStackingStatBonusEffect(shared.StackingStatBonusEffect{
+		Name:       "Necromantic Focus Heroic",
+		ID:         69139,
+		AuraID:     97131,
+		Bonus:      stats.Stats{stats.Mastery: 44},
+		MaxStacks:  10,
+		ProcMask:   core.ProcMaskSpellDamage,
+		Duration:   time.Second * 10,
+		Outcome:    core.OutcomeLanded,
+		Callback:   core.CallbackOnPeriodicDamageDealt,
+		Harmful:    false,
+		ProcChance: 1,
+	})
 }

--- a/sim/common/cata/stat_bonus_stacking.go
+++ b/sim/common/cata/stat_bonus_stacking.go
@@ -118,4 +118,32 @@ func init() {
 		Harmful:    false,
 		ProcChance: 1,
 	})
+
+	shared.NewStackingStatBonusEffect(shared.StackingStatBonusEffect{
+		Name:       "Vessel of Acceleration",
+		ID:         68995,
+		AuraID:     96980,
+		Bonus:      stats.Stats{stats.MeleeCrit: 82, stats.SpellCrit: 82},
+		MaxStacks:  5,
+		ProcMask:   core.ProcMaskMelee,
+		Duration:   time.Second * 20,
+		Outcome:    core.OutcomeCrit,
+		Callback:   core.CallbackOnSpellHitDealt,
+		Harmful:    false,
+		ProcChance: 1,
+	})
+
+	shared.NewStackingStatBonusEffect(shared.StackingStatBonusEffect{
+		Name:       "Vessel of Acceleration (Heroic)",
+		ID:         69167,
+		AuraID:     97142,
+		Bonus:      stats.Stats{stats.MeleeCrit: 92, stats.SpellCrit: 92},
+		MaxStacks:  5,
+		ProcMask:   core.ProcMaskMelee,
+		Duration:   time.Second * 20,
+		Outcome:    core.OutcomeCrit,
+		Callback:   core.CallbackOnSpellHitDealt,
+		Harmful:    false,
+		ProcChance: 1,
+	})
 }

--- a/sim/death_knight/blood/TestBlood.results
+++ b/sim/death_knight/blood/TestBlood.results
@@ -51,6 +51,14 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestBlood-AllItems-AncientPetrifiedSeed-69001"
+ value: {
+  dps: 13995.71959
+  tps: 67901.83019
+  hps: 3603.09015
+ }
+}
+dps_results: {
  key: "TestBlood-AllItems-Anhuur'sHymnal-55889"
  value: {
   dps: 13793.96328
@@ -63,6 +71,22 @@ dps_results: {
  value: {
   dps: 13793.96328
   tps: 66925.11387
+  hps: 3603.09015
+ }
+}
+dps_results: {
+ key: "TestBlood-AllItems-ApparatusofKhaz'goroth-68972"
+ value: {
+  dps: 14312.56604
+  tps: 69575.45094
+  hps: 3603.09015
+ }
+}
+dps_results: {
+ key: "TestBlood-AllItems-ApparatusofKhaz'goroth-69113"
+ value: {
+  dps: 14380.26875
+  tps: 69921.44795
   hps: 3603.09015
  }
 }
@@ -227,6 +251,14 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestBlood-AllItems-Brawler'sTrophy-71338"
+ value: {
+  dps: 13793.96328
+  tps: 66925.11387
+  hps: 3603.09015
+ }
+}
+dps_results: {
  key: "TestBlood-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
   dps: 14748.88352
@@ -248,6 +280,14 @@ dps_results: {
   dps: 13941.17967
   tps: 67727.19725
   hps: 3576.23938
+ }
+}
+dps_results: {
+ key: "TestBlood-AllItems-Coren'sChilledChromiumCoaster-71335"
+ value: {
+  dps: 14228.34764
+  tps: 69221.74539
+  hps: 3603.09015
  }
 }
 dps_results: {
@@ -347,6 +387,14 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestBlood-AllItems-Dwyer'sCaber-70141"
+ value: {
+  dps: 14487.98832
+  tps: 70535.94159
+  hps: 3603.09015
+ }
+}
+dps_results: {
  key: "TestBlood-AllItems-EffulgentShadowspiritDiamond"
  value: {
   dps: 13779.25393
@@ -395,6 +443,14 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestBlood-AllItems-EssenceoftheEternalFlame-69002"
+ value: {
+  dps: 14352.86478
+  tps: 69301.70696
+  hps: 3603.09015
+ }
+}
+dps_results: {
  key: "TestBlood-AllItems-EternalShadowspiritDiamond"
  value: {
   dps: 13779.25393
@@ -412,6 +468,14 @@ dps_results: {
 }
 dps_results: {
  key: "TestBlood-AllItems-FallofMortality-65124"
+ value: {
+  dps: 13793.96328
+  tps: 66925.11387
+  hps: 3603.09015
+ }
+}
+dps_results: {
+ key: "TestBlood-AllItems-FieryQuintessence-69000"
  value: {
   dps: 13793.96328
   tps: 66925.11387
@@ -859,6 +923,22 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestBlood-AllItems-MatrixRestabilizer-68994"
+ value: {
+  dps: 14333.79702
+  tps: 69805.38503
+  hps: 3603.09015
+ }
+}
+dps_results: {
+ key: "TestBlood-AllItems-MatrixRestabilizer-69150"
+ value: {
+  dps: 14394.34233
+  tps: 70100.84791
+  hps: 3603.09015
+ }
+}
+dps_results: {
  key: "TestBlood-AllItems-MightoftheOcean-55251"
  value: {
   dps: 14089.88333
@@ -883,7 +963,39 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestBlood-AllItems-MithrilStopwatch-71337"
+ value: {
+  dps: 14068.544
+  tps: 68376.61101
+  hps: 3603.09015
+ }
+}
+dps_results: {
  key: "TestBlood-AllItems-MoonwellChalice-70142"
+ value: {
+  dps: 13793.96328
+  tps: 66925.11387
+  hps: 3603.09015
+ }
+}
+dps_results: {
+ key: "TestBlood-AllItems-MoonwellPhial-70143"
+ value: {
+  dps: 13793.96328
+  tps: 66925.11387
+  hps: 3772.1505
+ }
+}
+dps_results: {
+ key: "TestBlood-AllItems-NecromanticFocus-68982"
+ value: {
+  dps: 13793.96328
+  tps: 66925.11387
+  hps: 3603.09015
+ }
+}
+dps_results: {
+ key: "TestBlood-AllItems-NecromanticFocus-69139"
  value: {
   dps: 13793.96328
   tps: 66925.11387
@@ -896,6 +1008,14 @@ dps_results: {
   dps: 14210.60269
   tps: 69015.04644
   hps: 3603.09015
+ }
+}
+dps_results: {
+ key: "TestBlood-AllItems-PetrifiedPickledEgg-71336"
+ value: {
+  dps: 14084.10194
+  tps: 68510.30806
+  hps: 3644.60268
  }
 }
 dps_results: {
@@ -987,6 +1107,14 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestBlood-AllItems-Ricket'sMagneticFireball-70144"
+ value: {
+  dps: 14256.21412
+  tps: 69255.79319
+  hps: 3603.09015
+ }
+}
+dps_results: {
  key: "TestBlood-AllItems-RightEyeofRajh-56100"
  value: {
   dps: 14088.72204
@@ -999,6 +1127,14 @@ dps_results: {
  value: {
   dps: 14084.83596
   tps: 68432.26839
+  hps: 3603.09015
+ }
+}
+dps_results: {
+ key: "TestBlood-AllItems-RuneofZeth-68998"
+ value: {
+  dps: 14090.71544
+  tps: 68487.52172
   hps: 3603.09015
  }
 }
@@ -1187,6 +1323,22 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestBlood-AllItems-TheHungerer-68927"
+ value: {
+  dps: 14583.744
+  tps: 70946.83906
+  hps: 3689.6599
+ }
+}
+dps_results: {
+ key: "TestBlood-AllItems-TheHungerer-69112"
+ value: {
+  dps: 14679.04793
+  tps: 71570.59395
+  hps: 3728.55604
+ }
+}
+dps_results: {
  key: "TestBlood-AllItems-Theralion'sMirror-59519"
  value: {
   dps: 13793.96328
@@ -1296,6 +1448,38 @@ dps_results: {
   dps: 8073.01299
   tps: 37631.73438
   hps: 3629.75731
+ }
+}
+dps_results: {
+ key: "TestBlood-AllItems-VariablePulseLightningCapacitor-68925"
+ value: {
+  dps: 13798.55561
+  tps: 66949.75354
+  hps: 3603.09015
+ }
+}
+dps_results: {
+ key: "TestBlood-AllItems-VariablePulseLightningCapacitor-69110"
+ value: {
+  dps: 13804.23147
+  tps: 66980.88542
+  hps: 3603.09015
+ }
+}
+dps_results: {
+ key: "TestBlood-AllItems-VesselofAcceleration-68995"
+ value: {
+  dps: 14570.30743
+  tps: 71013.574
+  hps: 3603.09015
+ }
+}
+dps_results: {
+ key: "TestBlood-AllItems-VesselofAcceleration-69167"
+ value: {
+  dps: 14668.08098
+  tps: 71527.32585
+  hps: 3603.09015
  }
 }
 dps_results: {

--- a/sim/death_knight/frost/TestFrost.results
+++ b/sim/death_knight/frost/TestFrost.results
@@ -51,6 +51,14 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFrost-AllItems-AncientPetrifiedSeed-69001"
+ value: {
+  dps: 21193.93931
+  tps: 19347.56594
+  hps: 215.12703
+ }
+}
+dps_results: {
  key: "TestFrost-AllItems-Anhuur'sHymnal-55889"
  value: {
   dps: 21004.67447
@@ -64,6 +72,22 @@ dps_results: {
   dps: 21078.49694
   tps: 19176.19355
   hps: 220.73294
+ }
+}
+dps_results: {
+ key: "TestFrost-AllItems-ApparatusofKhaz'goroth-68972"
+ value: {
+  dps: 22036.10262
+  tps: 20060.543
+  hps: 215.12703
+ }
+}
+dps_results: {
+ key: "TestFrost-AllItems-ApparatusofKhaz'goroth-69113"
+ value: {
+  dps: 22201.03467
+  tps: 20208.76484
+  hps: 215.12703
  }
 }
 dps_results: {
@@ -227,6 +251,14 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFrost-AllItems-Brawler'sTrophy-71338"
+ value: {
+  dps: 20745.1798
+  tps: 18901.58265
+  hps: 215.12703
+ }
+}
+dps_results: {
  key: "TestFrost-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
   dps: 22133.5881
@@ -248,6 +280,14 @@ dps_results: {
   dps: 22062.32402
   tps: 20006.44586
   hps: 222.13442
+ }
+}
+dps_results: {
+ key: "TestFrost-AllItems-Coren'sChilledChromiumCoaster-71335"
+ value: {
+  dps: 21505.95518
+  tps: 19628.07733
+  hps: 215.12703
  }
 }
 dps_results: {
@@ -347,6 +387,14 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFrost-AllItems-Dwyer'sCaber-70141"
+ value: {
+  dps: 21881.62928
+  tps: 19944.1471
+  hps: 215.12703
+ }
+}
+dps_results: {
  key: "TestFrost-AllItems-EffulgentShadowspiritDiamond"
  value: {
   dps: 21707.03316
@@ -395,6 +443,14 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFrost-AllItems-EssenceoftheEternalFlame-69002"
+ value: {
+  dps: 21823.15293
+  tps: 19969.68812
+  hps: 215.12703
+ }
+}
+dps_results: {
  key: "TestFrost-AllItems-EternalShadowspiritDiamond"
  value: {
   dps: 21707.03316
@@ -412,6 +468,14 @@ dps_results: {
 }
 dps_results: {
  key: "TestFrost-AllItems-FallofMortality-65124"
+ value: {
+  dps: 20745.1798
+  tps: 18901.58265
+  hps: 215.12703
+ }
+}
+dps_results: {
+ key: "TestFrost-AllItems-FieryQuintessence-69000"
  value: {
   dps: 20745.1798
   tps: 18901.58265
@@ -843,6 +907,22 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFrost-AllItems-MatrixRestabilizer-68994"
+ value: {
+  dps: 21354.69732
+  tps: 19430.27919
+  hps: 215.12703
+ }
+}
+dps_results: {
+ key: "TestFrost-AllItems-MatrixRestabilizer-69150"
+ value: {
+  dps: 21436.04584
+  tps: 19502.46051
+  hps: 215.12703
+ }
+}
+dps_results: {
  key: "TestFrost-AllItems-MightoftheOcean-55251"
  value: {
   dps: 21397.2305
@@ -875,10 +955,42 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFrost-AllItems-MithrilStopwatch-71337"
+ value: {
+  dps: 21042.40753
+  tps: 19164.52968
+  hps: 215.12703
+ }
+}
+dps_results: {
  key: "TestFrost-AllItems-MoonwellChalice-70142"
  value: {
   dps: 21040.75428
   tps: 19197.15713
+  hps: 215.12703
+ }
+}
+dps_results: {
+ key: "TestFrost-AllItems-MoonwellPhial-70143"
+ value: {
+  dps: 20745.1798
+  tps: 18901.58265
+  hps: 226.63492
+ }
+}
+dps_results: {
+ key: "TestFrost-AllItems-NecromanticFocus-68982"
+ value: {
+  dps: 21042.0645
+  tps: 19198.46735
+  hps: 215.12703
+ }
+}
+dps_results: {
+ key: "TestFrost-AllItems-NecromanticFocus-69139"
+ value: {
+  dps: 21080.12664
+  tps: 19236.52949
   hps: 215.12703
  }
 }
@@ -888,6 +1000,14 @@ dps_results: {
   dps: 21411.88604
   tps: 19511.25305
   hps: 215.12703
+ }
+}
+dps_results: {
+ key: "TestFrost-AllItems-PetrifiedPickledEgg-71336"
+ value: {
+  dps: 20789.85631
+  tps: 18970.93897
+  hps: 214.42629
  }
 }
 dps_results: {
@@ -979,6 +1099,14 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFrost-AllItems-Ricket'sMagneticFireball-70144"
+ value: {
+  dps: 21274.52588
+  tps: 19368.45941
+  hps: 215.12703
+ }
+}
+dps_results: {
  key: "TestFrost-AllItems-RightEyeofRajh-56100"
  value: {
   dps: 21640.92643
@@ -992,6 +1120,14 @@ dps_results: {
   dps: 21805.36057
   tps: 19884.15017
   hps: 220.73294
+ }
+}
+dps_results: {
+ key: "TestFrost-AllItems-RuneofZeth-68998"
+ value: {
+  dps: 21066.04715
+  tps: 19184.18457
+  hps: 215.12703
  }
 }
 dps_results: {
@@ -1187,6 +1323,22 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFrost-AllItems-TheHungerer-68927"
+ value: {
+  dps: 21272.08883
+  tps: 19363.22484
+  hps: 216.52851
+ }
+}
+dps_results: {
+ key: "TestFrost-AllItems-TheHungerer-69112"
+ value: {
+  dps: 21379.42495
+  tps: 19364.52378
+  hps: 220.0322
+ }
+}
+dps_results: {
  key: "TestFrost-AllItems-Theralion'sMirror-59519"
  value: {
   dps: 20931.82067
@@ -1296,6 +1448,38 @@ dps_results: {
   dps: 18309.28336
   tps: 16249.421
   hps: 216.35228
+ }
+}
+dps_results: {
+ key: "TestFrost-AllItems-VariablePulseLightningCapacitor-68925"
+ value: {
+  dps: 20778.22388
+  tps: 18939.79361
+  hps: 215.12703
+ }
+}
+dps_results: {
+ key: "TestFrost-AllItems-VariablePulseLightningCapacitor-69110"
+ value: {
+  dps: 20834.97419
+  tps: 19000.58033
+  hps: 215.82777
+ }
+}
+dps_results: {
+ key: "TestFrost-AllItems-VesselofAcceleration-68995"
+ value: {
+  dps: 21998.61235
+  tps: 20051.24989
+  hps: 215.12703
+ }
+}
+dps_results: {
+ key: "TestFrost-AllItems-VesselofAcceleration-69167"
+ value: {
+  dps: 22160.79326
+  tps: 20200.64854
+  hps: 215.12703
  }
 }
 dps_results: {

--- a/sim/death_knight/unholy/TestUnholy.results
+++ b/sim/death_knight/unholy/TestUnholy.results
@@ -51,6 +51,14 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestUnholy-AllItems-AncientPetrifiedSeed-69001"
+ value: {
+  dps: 30467.30966
+  tps: 22785.47421
+  hps: 473.88367
+ }
+}
+dps_results: {
  key: "TestUnholy-AllItems-Anhuur'sHymnal-55889"
  value: {
   dps: 29703.52326
@@ -63,6 +71,22 @@ dps_results: {
  value: {
   dps: 29703.52326
   tps: 22059.90612
+  hps: 473.88367
+ }
+}
+dps_results: {
+ key: "TestUnholy-AllItems-ApparatusofKhaz'goroth-68972"
+ value: {
+  dps: 31620.29273
+  tps: 23469.5494
+  hps: 473.88367
+ }
+}
+dps_results: {
+ key: "TestUnholy-AllItems-ApparatusofKhaz'goroth-69113"
+ value: {
+  dps: 31870.15156
+  tps: 23647.75155
   hps: 473.88367
  }
 }
@@ -227,6 +251,14 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestUnholy-AllItems-Brawler'sTrophy-71338"
+ value: {
+  dps: 29703.52326
+  tps: 22059.90612
+  hps: 473.88367
+ }
+}
+dps_results: {
  key: "TestUnholy-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
   dps: 33136.24307
@@ -248,6 +280,14 @@ dps_results: {
   dps: 31749.41801
   tps: 23461.75294
   hps: 489.35168
+ }
+}
+dps_results: {
+ key: "TestUnholy-AllItems-Coren'sChilledChromiumCoaster-71335"
+ value: {
+  dps: 30547.83685
+  tps: 22766.82822
+  hps: 473.88367
  }
 }
 dps_results: {
@@ -347,6 +387,14 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestUnholy-AllItems-Dwyer'sCaber-70141"
+ value: {
+  dps: 31585.93052
+  tps: 23432.81891
+  hps: 473.88367
+ }
+}
+dps_results: {
  key: "TestUnholy-AllItems-EffulgentShadowspiritDiamond"
  value: {
   dps: 31467.261
@@ -395,6 +443,14 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestUnholy-AllItems-EssenceoftheEternalFlame-69002"
+ value: {
+  dps: 31501.43239
+  tps: 23676.76729
+  hps: 473.88367
+ }
+}
+dps_results: {
  key: "TestUnholy-AllItems-EternalShadowspiritDiamond"
  value: {
   dps: 31467.261
@@ -412,6 +468,14 @@ dps_results: {
 }
 dps_results: {
  key: "TestUnholy-AllItems-FallofMortality-65124"
+ value: {
+  dps: 29703.52326
+  tps: 22059.90612
+  hps: 473.88367
+ }
+}
+dps_results: {
+ key: "TestUnholy-AllItems-FieryQuintessence-69000"
  value: {
   dps: 29703.52326
   tps: 22059.90612
@@ -843,6 +907,22 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestUnholy-AllItems-MatrixRestabilizer-68994"
+ value: {
+  dps: 30847.06645
+  tps: 22872.34421
+  hps: 473.88367
+ }
+}
+dps_results: {
+ key: "TestUnholy-AllItems-MatrixRestabilizer-69150"
+ value: {
+  dps: 30997.37264
+  tps: 23002.99428
+  hps: 473.88367
+ }
+}
+dps_results: {
  key: "TestUnholy-AllItems-MightoftheOcean-55251"
  value: {
   dps: 30271.69285
@@ -875,10 +955,42 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestUnholy-AllItems-MithrilStopwatch-71337"
+ value: {
+  dps: 30257.62333
+  tps: 22482.50059
+  hps: 473.88367
+ }
+}
+dps_results: {
  key: "TestUnholy-AllItems-MoonwellChalice-70142"
  value: {
   dps: 30210.22052
   tps: 22623.92123
+  hps: 473.88367
+ }
+}
+dps_results: {
+ key: "TestUnholy-AllItems-MoonwellPhial-70143"
+ value: {
+  dps: 29703.52326
+  tps: 22059.90612
+  hps: 499.14856
+ }
+}
+dps_results: {
+ key: "TestUnholy-AllItems-NecromanticFocus-68982"
+ value: {
+  dps: 30172.39829
+  tps: 22574.57355
+  hps: 473.88367
+ }
+}
+dps_results: {
+ key: "TestUnholy-AllItems-NecromanticFocus-69139"
+ value: {
+  dps: 30232.63499
+  tps: 22640.68107
   hps: 473.88367
  }
 }
@@ -888,6 +1000,14 @@ dps_results: {
   dps: 30760.48632
   tps: 22834.64931
   hps: 473.88367
+ }
+}
+dps_results: {
+ key: "TestUnholy-AllItems-PetrifiedPickledEgg-71336"
+ value: {
+  dps: 29888.45176
+  tps: 22182.65376
+  hps: 482.32077
  }
 }
 dps_results: {
@@ -979,6 +1099,14 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestUnholy-AllItems-Ricket'sMagneticFireball-70144"
+ value: {
+  dps: 30548.47256
+  tps: 22674.68768
+  hps: 473.88367
+ }
+}
+dps_results: {
  key: "TestUnholy-AllItems-RightEyeofRajh-56100"
  value: {
   dps: 30662.43529
@@ -991,6 +1119,14 @@ dps_results: {
  value: {
   dps: 30715.37881
   tps: 22763.64789
+  hps: 473.88367
+ }
+}
+dps_results: {
+ key: "TestUnholy-AllItems-RuneofZeth-68998"
+ value: {
+  dps: 30317.11586
+  tps: 22522.89975
   hps: 473.88367
  }
 }
@@ -1187,6 +1323,22 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestUnholy-AllItems-TheHungerer-68927"
+ value: {
+  dps: 30658.56473
+  tps: 22790.09212
+  hps: 490.75787
+ }
+}
+dps_results: {
+ key: "TestUnholy-AllItems-TheHungerer-69112"
+ value: {
+  dps: 30769.78247
+  tps: 22804.747
+  hps: 493.57023
+ }
+}
+dps_results: {
  key: "TestUnholy-AllItems-Theralion'sMirror-59519"
  value: {
   dps: 30184.99343
@@ -1295,6 +1447,38 @@ dps_results: {
  value: {
   dps: 22748.59433
   tps: 15877.04584
+ }
+}
+dps_results: {
+ key: "TestUnholy-AllItems-VariablePulseLightningCapacitor-68925"
+ value: {
+  dps: 29757.62305
+  tps: 22139.36776
+  hps: 473.88367
+ }
+}
+dps_results: {
+ key: "TestUnholy-AllItems-VariablePulseLightningCapacitor-69110"
+ value: {
+  dps: 29871.3464
+  tps: 22243.66805
+  hps: 473.88367
+ }
+}
+dps_results: {
+ key: "TestUnholy-AllItems-VesselofAcceleration-68995"
+ value: {
+  dps: 31723.3845
+  tps: 23533.27264
+  hps: 473.88367
+ }
+}
+dps_results: {
+ key: "TestUnholy-AllItems-VesselofAcceleration-69167"
+ value: {
+  dps: 31986.99423
+  tps: 23728.85359
+  hps: 473.88367
  }
 }
 dps_results: {

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -49,6 +49,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFeral-AllItems-AncientPetrifiedSeed-69001"
+ value: {
+  dps: 26987.87755
+  tps: 37763.08403
+ }
+}
+dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-55889"
  value: {
   dps: 24978.26492
@@ -60,6 +67,20 @@ dps_results: {
  value: {
   dps: 24978.26492
   tps: 35221.67672
+ }
+}
+dps_results: {
+ key: "TestFeral-AllItems-ApparatusofKhaz'goroth-68972"
+ value: {
+  dps: 26010.1643
+  tps: 36366.3176
+ }
+}
+dps_results: {
+ key: "TestFeral-AllItems-ApparatusofKhaz'goroth-69113"
+ value: {
+  dps: 26164.81896
+  tps: 36466.50154
  }
 }
 dps_results: {
@@ -204,6 +225,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFeral-AllItems-Brawler'sTrophy-71338"
+ value: {
+  dps: 24976.79848
+  tps: 35210.11948
+ }
+}
+dps_results: {
  key: "TestFeral-AllItems-BurningShadowspiritDiamond"
  value: {
   dps: 26452.65443
@@ -215,6 +243,13 @@ dps_results: {
  value: {
   dps: 26531.00678
   tps: 36854.6161
+ }
+}
+dps_results: {
+ key: "TestFeral-AllItems-Coren'sChilledChromiumCoaster-71335"
+ value: {
+  dps: 26274.92217
+  tps: 36928.41354
  }
 }
 dps_results: {
@@ -302,6 +337,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFeral-AllItems-Dwyer'sCaber-70141"
+ value: {
+  dps: 25957.5019
+  tps: 36373.2207
+ }
+}
+dps_results: {
  key: "TestFeral-AllItems-EffulgentShadowspiritDiamond"
  value: {
   dps: 26003.37097
@@ -344,6 +386,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFeral-AllItems-EssenceoftheEternalFlame-69002"
+ value: {
+  dps: 25996.8044
+  tps: 36620.70906
+ }
+}
+dps_results: {
  key: "TestFeral-AllItems-EternalShadowspiritDiamond"
  value: {
   dps: 26003.37097
@@ -362,6 +411,13 @@ dps_results: {
  value: {
   dps: 24977.3284
   tps: 35212.25856
+ }
+}
+dps_results: {
+ key: "TestFeral-AllItems-FieryQuintessence-69000"
+ value: {
+  dps: 24979.69419
+  tps: 35302.82355
  }
 }
 dps_results: {
@@ -736,6 +792,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFeral-AllItems-MatrixRestabilizer-68994"
+ value: {
+  dps: 27153.43487
+  tps: 38223.96494
+ }
+}
+dps_results: {
+ key: "TestFeral-AllItems-MatrixRestabilizer-69150"
+ value: {
+  dps: 27417.92519
+  tps: 38614.79024
+ }
+}
+dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-55251"
  value: {
   dps: 25255.91555
@@ -764,6 +834,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFeral-AllItems-MithrilStopwatch-71337"
+ value: {
+  dps: 25336.18048
+  tps: 35669.90361
+ }
+}
+dps_results: {
  key: "TestFeral-AllItems-MoonwellChalice-70142"
  value: {
   dps: 25430.74135
@@ -771,10 +848,38 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFeral-AllItems-MoonwellPhial-70143"
+ value: {
+  dps: 24976.79848
+  tps: 35210.11948
+ }
+}
+dps_results: {
+ key: "TestFeral-AllItems-NecromanticFocus-68982"
+ value: {
+  dps: 24977.3284
+  tps: 35212.2302
+ }
+}
+dps_results: {
+ key: "TestFeral-AllItems-NecromanticFocus-69139"
+ value: {
+  dps: 24977.3284
+  tps: 35212.15931
+ }
+}
+dps_results: {
  key: "TestFeral-AllItems-Oremantle'sFavor-61448"
  value: {
   dps: 25548.99903
   tps: 36042.78804
+ }
+}
+dps_results: {
+ key: "TestFeral-AllItems-PetrifiedPickledEgg-71336"
+ value: {
+  dps: 24977.3284
+  tps: 35212.29117
  }
 }
 dps_results: {
@@ -855,6 +960,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFeral-AllItems-Ricket'sMagneticFireball-70144"
+ value: {
+  dps: 26681.88242
+  tps: 37146.35174
+ }
+}
+dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56100"
  value: {
   dps: 25417.87208
@@ -866,6 +978,13 @@ dps_results: {
  value: {
   dps: 25488.34929
   tps: 35906.43349
+ }
+}
+dps_results: {
+ key: "TestFeral-AllItems-RuneofZeth-68998"
+ value: {
+  dps: 25402.32951
+  tps: 35754.56948
  }
 }
 dps_results: {
@@ -1044,6 +1163,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFeral-AllItems-TheHungerer-68927"
+ value: {
+  dps: 26852.42025
+  tps: 36173.39841
+ }
+}
+dps_results: {
+ key: "TestFeral-AllItems-TheHungerer-69112"
+ value: {
+  dps: 26995.42753
+  tps: 36802.58041
+ }
+}
+dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-59519"
  value: {
   dps: 25020.36798
@@ -1139,6 +1272,34 @@ dps_results: {
  value: {
   dps: 22253.96468
   tps: 31156.3609
+ }
+}
+dps_results: {
+ key: "TestFeral-AllItems-VariablePulseLightningCapacitor-68925"
+ value: {
+  dps: 24979.66148
+  tps: 35223.86716
+ }
+}
+dps_results: {
+ key: "TestFeral-AllItems-VariablePulseLightningCapacitor-69110"
+ value: {
+  dps: 24981.55439
+  tps: 35233.94999
+ }
+}
+dps_results: {
+ key: "TestFeral-AllItems-VesselofAcceleration-68995"
+ value: {
+  dps: 26025.45386
+  tps: 36671.52219
+ }
+}
+dps_results: {
+ key: "TestFeral-AllItems-VesselofAcceleration-69167"
+ value: {
+  dps: 26175.0842
+  tps: 36752.6595
  }
 }
 dps_results: {

--- a/sim/druid/guardian/TestGuardian.results
+++ b/sim/druid/guardian/TestGuardian.results
@@ -49,6 +49,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestGuardian-AllItems-AncientPetrifiedSeed-69001"
+ value: {
+  dps: 7874.90018
+  tps: 39439.88175
+ }
+}
+dps_results: {
  key: "TestGuardian-AllItems-Anhuur'sHymnal-55889"
  value: {
   dps: 7839.54716
@@ -60,6 +67,20 @@ dps_results: {
  value: {
   dps: 7866.23787
   tps: 39398.22308
+ }
+}
+dps_results: {
+ key: "TestGuardian-AllItems-ApparatusofKhaz'goroth-68972"
+ value: {
+  dps: 7800.83542
+  tps: 39070.13604
+ }
+}
+dps_results: {
+ key: "TestGuardian-AllItems-ApparatusofKhaz'goroth-69113"
+ value: {
+  dps: 7833.11618
+  tps: 39231.31568
  }
 }
 dps_results: {
@@ -204,6 +225,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestGuardian-AllItems-Brawler'sTrophy-71338"
+ value: {
+  dps: 7551.55167
+  tps: 37822.88171
+ }
+}
+dps_results: {
  key: "TestGuardian-AllItems-BurningShadowspiritDiamond"
  value: {
   dps: 7655.47217
@@ -215,6 +243,13 @@ dps_results: {
  value: {
   dps: 7682.28034
   tps: 38476.37233
+ }
+}
+dps_results: {
+ key: "TestGuardian-AllItems-Coren'sChilledChromiumCoaster-71335"
+ value: {
+  dps: 7844.56308
+  tps: 39288.27063
  }
 }
 dps_results: {
@@ -302,6 +337,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestGuardian-AllItems-Dwyer'sCaber-70141"
+ value: {
+  dps: 7795.82525
+  tps: 39045.26311
+ }
+}
+dps_results: {
  key: "TestGuardian-AllItems-EffulgentShadowspiritDiamond"
  value: {
   dps: 7551.55167
@@ -344,6 +386,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestGuardian-AllItems-EssenceoftheEternalFlame-69002"
+ value: {
+  dps: 7710.08407
+  tps: 38615.54368
+ }
+}
+dps_results: {
  key: "TestGuardian-AllItems-EternalShadowspiritDiamond"
  value: {
   dps: 7551.55167
@@ -362,6 +411,13 @@ dps_results: {
  value: {
   dps: 7521.82209
   tps: 37674.2363
+ }
+}
+dps_results: {
+ key: "TestGuardian-AllItems-FieryQuintessence-69000"
+ value: {
+  dps: 7527.05713
+  tps: 37779.37189
  }
 }
 dps_results: {
@@ -736,6 +792,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestGuardian-AllItems-MatrixRestabilizer-68994"
+ value: {
+  dps: 8178.6549
+  tps: 40959.72327
+ }
+}
+dps_results: {
+ key: "TestGuardian-AllItems-MatrixRestabilizer-69150"
+ value: {
+  dps: 8220.48321
+  tps: 41169.74958
+ }
+}
+dps_results: {
  key: "TestGuardian-AllItems-MightoftheOcean-55251"
  value: {
   dps: 7861.93121
@@ -764,7 +834,35 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestGuardian-AllItems-MithrilStopwatch-71337"
+ value: {
+  dps: 7622.04236
+  tps: 38175.66703
+ }
+}
+dps_results: {
  key: "TestGuardian-AllItems-MoonwellChalice-70142"
+ value: {
+  dps: 7521.82209
+  tps: 37674.2363
+ }
+}
+dps_results: {
+ key: "TestGuardian-AllItems-MoonwellPhial-70143"
+ value: {
+  dps: 7551.55167
+  tps: 37822.88171
+ }
+}
+dps_results: {
+ key: "TestGuardian-AllItems-NecromanticFocus-68982"
+ value: {
+  dps: 7521.82209
+  tps: 37674.2363
+ }
+}
+dps_results: {
+ key: "TestGuardian-AllItems-NecromanticFocus-69139"
  value: {
   dps: 7521.82209
   tps: 37674.2363
@@ -775,6 +873,13 @@ dps_results: {
  value: {
   dps: 7705.35396
   tps: 38592.38876
+ }
+}
+dps_results: {
+ key: "TestGuardian-AllItems-PetrifiedPickledEgg-71336"
+ value: {
+  dps: 7521.82209
+  tps: 37674.2363
  }
 }
 dps_results: {
@@ -855,6 +960,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestGuardian-AllItems-Ricket'sMagneticFireball-70144"
+ value: {
+  dps: 8072.43084
+  tps: 40428.63565
+ }
+}
+dps_results: {
  key: "TestGuardian-AllItems-RightEyeofRajh-56100"
  value: {
   dps: 7972.47549
@@ -866,6 +978,13 @@ dps_results: {
  value: {
   dps: 8011.5898
   tps: 40124.98277
+ }
+}
+dps_results: {
+ key: "TestGuardian-AllItems-RuneofZeth-68998"
+ value: {
+  dps: 7628.07943
+  tps: 38268.77505
  }
 }
 dps_results: {
@@ -1044,6 +1163,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestGuardian-AllItems-TheHungerer-68927"
+ value: {
+  dps: 7966.60474
+  tps: 39899.75453
+ }
+}
+dps_results: {
+ key: "TestGuardian-AllItems-TheHungerer-69112"
+ value: {
+  dps: 8073.84571
+  tps: 40435.7271
+ }
+}
+dps_results: {
  key: "TestGuardian-AllItems-Theralion'sMirror-59519"
  value: {
   dps: 7521.82209
@@ -1139,6 +1272,34 @@ dps_results: {
  value: {
   dps: 6439.7789
   tps: 32262.71365
+ }
+}
+dps_results: {
+ key: "TestGuardian-AllItems-VariablePulseLightningCapacitor-68925"
+ value: {
+  dps: 7515.9011
+  tps: 37644.53197
+ }
+}
+dps_results: {
+ key: "TestGuardian-AllItems-VariablePulseLightningCapacitor-69110"
+ value: {
+  dps: 7583.93862
+  tps: 37984.95102
+ }
+}
+dps_results: {
+ key: "TestGuardian-AllItems-VesselofAcceleration-68995"
+ value: {
+  dps: 7787.874
+  tps: 39005.12915
+ }
+}
+dps_results: {
+ key: "TestGuardian-AllItems-VesselofAcceleration-69167"
+ value: {
+  dps: 7812.50473
+  tps: 39128.66116
  }
 }
 dps_results: {

--- a/sim/hunter/beast_mastery/TestBM.results
+++ b/sim/hunter/beast_mastery/TestBM.results
@@ -63,6 +63,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestBM-AllItems-AncientPetrifiedSeed-69001"
+ value: {
+  dps: 21486.28136
+  tps: 17998.72356
+ }
+}
+dps_results: {
  key: "TestBM-AllItems-Anhuur'sHymnal-55889"
  value: {
   dps: 20602.26977
@@ -74,6 +81,20 @@ dps_results: {
  value: {
   dps: 20602.26977
   tps: 17319.59464
+ }
+}
+dps_results: {
+ key: "TestBM-AllItems-ApparatusofKhaz'goroth-68972"
+ value: {
+  dps: 20550.60396
+  tps: 17283.06451
+ }
+}
+dps_results: {
+ key: "TestBM-AllItems-ApparatusofKhaz'goroth-69113"
+ value: {
+  dps: 20540.04974
+  tps: 17269.8276
  }
 }
 dps_results: {
@@ -225,6 +246,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestBM-AllItems-Brawler'sTrophy-71338"
+ value: {
+  dps: 20397.33057
+  tps: 17164.01401
+ }
+}
+dps_results: {
  key: "TestBM-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
   dps: 21849.45721
@@ -243,6 +271,13 @@ dps_results: {
  value: {
   dps: 21710.91523
   tps: 18278.68687
+ }
+}
+dps_results: {
+ key: "TestBM-AllItems-Coren'sChilledChromiumCoaster-71335"
+ value: {
+  dps: 21214.41384
+  tps: 17830.83024
  }
 }
 dps_results: {
@@ -330,6 +365,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestBM-AllItems-Dwyer'sCaber-70141"
+ value: {
+  dps: 20844.29474
+  tps: 17540.88887
+ }
+}
+dps_results: {
  key: "TestBM-AllItems-EffulgentShadowspiritDiamond"
  value: {
   dps: 21305.2301
@@ -372,6 +414,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestBM-AllItems-EssenceoftheEternalFlame-69002"
+ value: {
+  dps: 20566.82396
+  tps: 17238.40157
+ }
+}
+dps_results: {
  key: "TestBM-AllItems-EternalShadowspiritDiamond"
  value: {
   dps: 21305.2301
@@ -390,6 +439,13 @@ dps_results: {
  value: {
   dps: 20397.33057
   tps: 17164.01401
+ }
+}
+dps_results: {
+ key: "TestBM-AllItems-FieryQuintessence-69000"
+ value: {
+  dps: 20377.53648
+  tps: 17129.79939
  }
 }
 dps_results: {
@@ -778,6 +834,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestBM-AllItems-MatrixRestabilizer-68994"
+ value: {
+  dps: 21840.8965
+  tps: 18340.19028
+ }
+}
+dps_results: {
+ key: "TestBM-AllItems-MatrixRestabilizer-69150"
+ value: {
+  dps: 22143.90793
+  tps: 18621.84085
+ }
+}
+dps_results: {
  key: "TestBM-AllItems-MightoftheOcean-55251"
  value: {
   dps: 20679.95719
@@ -806,6 +876,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestBM-AllItems-MithrilStopwatch-71337"
+ value: {
+  dps: 20698.54938
+  tps: 17411.14747
+ }
+}
+dps_results: {
  key: "TestBM-AllItems-MoonwellChalice-70142"
  value: {
   dps: 20539.63627
@@ -813,10 +890,38 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestBM-AllItems-MoonwellPhial-70143"
+ value: {
+  dps: 20397.33057
+  tps: 17164.01401
+ }
+}
+dps_results: {
+ key: "TestBM-AllItems-NecromanticFocus-68982"
+ value: {
+  dps: 20397.33057
+  tps: 17164.01401
+ }
+}
+dps_results: {
+ key: "TestBM-AllItems-NecromanticFocus-69139"
+ value: {
+  dps: 20397.33057
+  tps: 17164.01401
+ }
+}
+dps_results: {
  key: "TestBM-AllItems-Oremantle'sFavor-61448"
  value: {
   dps: 20573.57479
   tps: 17309.32432
+ }
+}
+dps_results: {
+ key: "TestBM-AllItems-PetrifiedPickledEgg-71336"
+ value: {
+  dps: 20397.33057
+  tps: 17164.01401
  }
 }
 dps_results: {
@@ -897,6 +1002,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestBM-AllItems-Ricket'sMagneticFireball-70144"
+ value: {
+  dps: 21661.94135
+  tps: 18236.63412
+ }
+}
+dps_results: {
  key: "TestBM-AllItems-RightEyeofRajh-56100"
  value: {
   dps: 20602.26977
@@ -908,6 +1020,13 @@ dps_results: {
  value: {
   dps: 20602.26977
   tps: 17319.59464
+ }
+}
+dps_results: {
+ key: "TestBM-AllItems-RuneofZeth-68998"
+ value: {
+  dps: 20774.18863
+  tps: 17478.84108
  }
 }
 dps_results: {
@@ -1079,6 +1198,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestBM-AllItems-TheHungerer-68927"
+ value: {
+  dps: 21667.36171
+  tps: 18201.90697
+ }
+}
+dps_results: {
+ key: "TestBM-AllItems-TheHungerer-69112"
+ value: {
+  dps: 22013.05363
+  tps: 18513.83239
+ }
+}
+dps_results: {
  key: "TestBM-AllItems-Theralion'sMirror-59519"
  value: {
   dps: 20397.33057
@@ -1167,6 +1300,34 @@ dps_results: {
  value: {
   dps: 20363.7901
   tps: 17165.43459
+ }
+}
+dps_results: {
+ key: "TestBM-AllItems-VariablePulseLightningCapacitor-68925"
+ value: {
+  dps: 20397.33057
+  tps: 17164.01401
+ }
+}
+dps_results: {
+ key: "TestBM-AllItems-VariablePulseLightningCapacitor-69110"
+ value: {
+  dps: 20397.33057
+  tps: 17164.01401
+ }
+}
+dps_results: {
+ key: "TestBM-AllItems-VesselofAcceleration-68995"
+ value: {
+  dps: 20492.76482
+  tps: 17238.60192
+ }
+}
+dps_results: {
+ key: "TestBM-AllItems-VesselofAcceleration-69167"
+ value: {
+  dps: 20495.07658
+  tps: 17241.67672
  }
 }
 dps_results: {

--- a/sim/hunter/marksmanship/TestMM.results
+++ b/sim/hunter/marksmanship/TestMM.results
@@ -63,6 +63,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestMM-AllItems-AncientPetrifiedSeed-69001"
+ value: {
+  dps: 22014.82609
+  tps: 19742.21812
+ }
+}
+dps_results: {
  key: "TestMM-AllItems-Anhuur'sHymnal-55889"
  value: {
   dps: 21023.01631
@@ -74,6 +81,20 @@ dps_results: {
  value: {
   dps: 21023.01631
   tps: 18826.40268
+ }
+}
+dps_results: {
+ key: "TestMM-AllItems-ApparatusofKhaz'goroth-68972"
+ value: {
+  dps: 20804.36191
+  tps: 18630.89211
+ }
+}
+dps_results: {
+ key: "TestMM-AllItems-ApparatusofKhaz'goroth-69113"
+ value: {
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
@@ -225,6 +246,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestMM-AllItems-Brawler'sTrophy-71338"
+ value: {
+  dps: 20804.38157
+  tps: 18630.91177
+ }
+}
+dps_results: {
  key: "TestMM-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
   dps: 22137.58222
@@ -243,6 +271,13 @@ dps_results: {
  value: {
   dps: 22052.90526
   tps: 19738.7584
+ }
+}
+dps_results: {
+ key: "TestMM-AllItems-Coren'sChilledChromiumCoaster-71335"
+ value: {
+  dps: 21715.66557
+  tps: 19449.28938
  }
 }
 dps_results: {
@@ -330,6 +365,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestMM-AllItems-Dwyer'sCaber-70141"
+ value: {
+  dps: 21228.59205
+  tps: 19022.13401
+ }
+}
+dps_results: {
  key: "TestMM-AllItems-EffulgentShadowspiritDiamond"
  value: {
   dps: 21681.49423
@@ -372,6 +414,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestMM-AllItems-EssenceoftheEternalFlame-69002"
+ value: {
+  dps: 21211.72465
+  tps: 19028.51013
+ }
+}
+dps_results: {
  key: "TestMM-AllItems-EternalShadowspiritDiamond"
  value: {
   dps: 21681.49423
@@ -390,6 +439,13 @@ dps_results: {
  value: {
   dps: 20804.36191
   tps: 18630.89211
+ }
+}
+dps_results: {
+ key: "TestMM-AllItems-FieryQuintessence-69000"
+ value: {
+  dps: 20792.04007
+  tps: 18635.83269
  }
 }
 dps_results: {
@@ -778,6 +834,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestMM-AllItems-MatrixRestabilizer-68994"
+ value: {
+  dps: 22430.55946
+  tps: 20080.82475
+ }
+}
+dps_results: {
+ key: "TestMM-AllItems-MatrixRestabilizer-69150"
+ value: {
+  dps: 22642.9727
+  tps: 20269.98581
+ }
+}
+dps_results: {
  key: "TestMM-AllItems-MightoftheOcean-55251"
  value: {
   dps: 21015.70096
@@ -806,6 +876,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestMM-AllItems-MithrilStopwatch-71337"
+ value: {
+  dps: 21194.34533
+  tps: 18992.87126
+ }
+}
+dps_results: {
  key: "TestMM-AllItems-MoonwellChalice-70142"
  value: {
   dps: 21137.04464
@@ -813,10 +890,38 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestMM-AllItems-MoonwellPhial-70143"
+ value: {
+  dps: 20804.38157
+  tps: 18630.91177
+ }
+}
+dps_results: {
+ key: "TestMM-AllItems-NecromanticFocus-68982"
+ value: {
+  dps: 20824.58323
+  tps: 18665.9753
+ }
+}
+dps_results: {
+ key: "TestMM-AllItems-NecromanticFocus-69139"
+ value: {
+  dps: 20837.58551
+  tps: 18681.70954
+ }
+}
+dps_results: {
  key: "TestMM-AllItems-Oremantle'sFavor-61448"
  value: {
   dps: 20980.10294
   tps: 18795.3745
+ }
+}
+dps_results: {
+ key: "TestMM-AllItems-PetrifiedPickledEgg-71336"
+ value: {
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {
@@ -897,6 +1002,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestMM-AllItems-Ricket'sMagneticFireball-70144"
+ value: {
+  dps: 22021.6851
+  tps: 19725.19256
+ }
+}
+dps_results: {
  key: "TestMM-AllItems-RightEyeofRajh-56100"
  value: {
   dps: 21023.01631
@@ -908,6 +1020,13 @@ dps_results: {
  value: {
   dps: 21023.01631
   tps: 18826.40268
+ }
+}
+dps_results: {
+ key: "TestMM-AllItems-RuneofZeth-68998"
+ value: {
+  dps: 21211.69014
+  tps: 19006.88497
  }
 }
 dps_results: {
@@ -1079,6 +1198,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestMM-AllItems-TheHungerer-68927"
+ value: {
+  dps: 22202.57102
+  tps: 19875.40843
+ }
+}
+dps_results: {
+ key: "TestMM-AllItems-TheHungerer-69112"
+ value: {
+  dps: 22577.79068
+  tps: 20205.49571
+ }
+}
+dps_results: {
  key: "TestMM-AllItems-Theralion'sMirror-59519"
  value: {
   dps: 20804.36191
@@ -1167,6 +1300,34 @@ dps_results: {
  value: {
   dps: 21163.42769
   tps: 18991.38947
+ }
+}
+dps_results: {
+ key: "TestMM-AllItems-VariablePulseLightningCapacitor-68925"
+ value: {
+  dps: 20804.76432
+  tps: 18631.39461
+ }
+}
+dps_results: {
+ key: "TestMM-AllItems-VariablePulseLightningCapacitor-69110"
+ value: {
+  dps: 20804.36191
+  tps: 18630.89211
+ }
+}
+dps_results: {
+ key: "TestMM-AllItems-VesselofAcceleration-68995"
+ value: {
+  dps: 20804.36191
+  tps: 18630.89211
+ }
+}
+dps_results: {
+ key: "TestMM-AllItems-VesselofAcceleration-69167"
+ value: {
+  dps: 20804.36191
+  tps: 18630.89211
  }
 }
 dps_results: {

--- a/sim/hunter/survival/TestSV.results
+++ b/sim/hunter/survival/TestSV.results
@@ -63,6 +63,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestSV-AllItems-AncientPetrifiedSeed-69001"
+ value: {
+  dps: 25861.76209
+  tps: 23402.66281
+ }
+}
+dps_results: {
  key: "TestSV-AllItems-Anhuur'sHymnal-55889"
  value: {
   dps: 24690.64504
@@ -74,6 +81,20 @@ dps_results: {
  value: {
   dps: 24690.64504
   tps: 22314.26094
+ }
+}
+dps_results: {
+ key: "TestSV-AllItems-ApparatusofKhaz'goroth-68972"
+ value: {
+  dps: 24446.92799
+  tps: 22092.58654
+ }
+}
+dps_results: {
+ key: "TestSV-AllItems-ApparatusofKhaz'goroth-69113"
+ value: {
+  dps: 24446.92799
+  tps: 22092.58654
  }
 }
 dps_results: {
@@ -225,6 +246,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestSV-AllItems-Brawler'sTrophy-71338"
+ value: {
+  dps: 24446.92799
+  tps: 22092.58654
+ }
+}
+dps_results: {
  key: "TestSV-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
   dps: 26099.8667
@@ -243,6 +271,13 @@ dps_results: {
  value: {
   dps: 25964.08857
   tps: 23455.9796
+ }
+}
+dps_results: {
+ key: "TestSV-AllItems-Coren'sChilledChromiumCoaster-71335"
+ value: {
+  dps: 25318.28486
+  tps: 22872.15448
  }
 }
 dps_results: {
@@ -330,6 +365,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestSV-AllItems-Dwyer'sCaber-70141"
+ value: {
+  dps: 24827.90407
+  tps: 22439.64688
+ }
+}
+dps_results: {
  key: "TestSV-AllItems-EffulgentShadowspiritDiamond"
  value: {
   dps: 25516.5496
@@ -372,6 +414,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestSV-AllItems-EssenceoftheEternalFlame-69002"
+ value: {
+  dps: 24784.90702
+  tps: 22430.00631
+ }
+}
+dps_results: {
  key: "TestSV-AllItems-EternalShadowspiritDiamond"
  value: {
   dps: 25516.5496
@@ -390,6 +439,13 @@ dps_results: {
  value: {
   dps: 24446.92799
   tps: 22092.58654
+ }
+}
+dps_results: {
+ key: "TestSV-AllItems-FieryQuintessence-69000"
+ value: {
+  dps: 24487.83521
+  tps: 22148.61001
  }
 }
 dps_results: {
@@ -778,6 +834,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestSV-AllItems-MatrixRestabilizer-68994"
+ value: {
+  dps: 26471.73035
+  tps: 23916.70162
+ }
+}
+dps_results: {
+ key: "TestSV-AllItems-MatrixRestabilizer-69150"
+ value: {
+  dps: 26699.1285
+  tps: 24119.41463
+ }
+}
+dps_results: {
  key: "TestSV-AllItems-MightoftheOcean-55251"
  value: {
   dps: 24711.3622
@@ -806,6 +876,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestSV-AllItems-MithrilStopwatch-71337"
+ value: {
+  dps: 24790.12934
+  tps: 22399.47681
+ }
+}
+dps_results: {
  key: "TestSV-AllItems-MoonwellChalice-70142"
  value: {
   dps: 24724.59453
@@ -813,10 +890,38 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestSV-AllItems-MoonwellPhial-70143"
+ value: {
+  dps: 24446.92799
+  tps: 22092.58654
+ }
+}
+dps_results: {
+ key: "TestSV-AllItems-NecromanticFocus-68982"
+ value: {
+  dps: 24476.69403
+  tps: 22122.35258
+ }
+}
+dps_results: {
+ key: "TestSV-AllItems-NecromanticFocus-69139"
+ value: {
+  dps: 24480.51019
+  tps: 22126.16874
+ }
+}
+dps_results: {
  key: "TestSV-AllItems-Oremantle'sFavor-61448"
  value: {
   dps: 24648.55863
   tps: 22278.55733
+ }
+}
+dps_results: {
+ key: "TestSV-AllItems-PetrifiedPickledEgg-71336"
+ value: {
+  dps: 24446.92799
+  tps: 22092.58654
  }
 }
 dps_results: {
@@ -897,6 +1002,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestSV-AllItems-Ricket'sMagneticFireball-70144"
+ value: {
+  dps: 25941.41127
+  tps: 23434.8727
+ }
+}
+dps_results: {
  key: "TestSV-AllItems-RightEyeofRajh-56100"
  value: {
   dps: 24690.64504
@@ -908,6 +1020,13 @@ dps_results: {
  value: {
   dps: 24690.64504
   tps: 22314.26094
+ }
+}
+dps_results: {
+ key: "TestSV-AllItems-RuneofZeth-68998"
+ value: {
+  dps: 24847.80589
+  tps: 22451.96875
  }
 }
 dps_results: {
@@ -1079,6 +1198,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestSV-AllItems-TheHungerer-68927"
+ value: {
+  dps: 26031.19427
+  tps: 23476.80882
+ }
+}
+dps_results: {
+ key: "TestSV-AllItems-TheHungerer-69112"
+ value: {
+  dps: 26259.62622
+  tps: 23707.97893
+ }
+}
+dps_results: {
  key: "TestSV-AllItems-Theralion'sMirror-59519"
  value: {
   dps: 24455.37028
@@ -1167,6 +1300,34 @@ dps_results: {
  value: {
   dps: 24269.52577
   tps: 21906.51044
+ }
+}
+dps_results: {
+ key: "TestSV-AllItems-VariablePulseLightningCapacitor-68925"
+ value: {
+  dps: 24447.96042
+  tps: 22093.592
+ }
+}
+dps_results: {
+ key: "TestSV-AllItems-VariablePulseLightningCapacitor-69110"
+ value: {
+  dps: 24450.44993
+  tps: 22096.00415
+ }
+}
+dps_results: {
+ key: "TestSV-AllItems-VesselofAcceleration-68995"
+ value: {
+  dps: 24448.87767
+  tps: 22094.53622
+ }
+}
+dps_results: {
+ key: "TestSV-AllItems-VesselofAcceleration-69167"
+ value: {
+  dps: 24448.87767
+  tps: 22094.53622
  }
 }
 dps_results: {

--- a/sim/mage/arcane/TestArcane.results
+++ b/sim/mage/arcane/TestArcane.results
@@ -49,6 +49,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestArcane-AllItems-AncientPetrifiedSeed-69001"
+ value: {
+  dps: 28269.96582
+  tps: 28420.96667
+ }
+}
+dps_results: {
  key: "TestArcane-AllItems-Anhuur'sHymnal-55889"
  value: {
   dps: 28802.76898
@@ -60,6 +67,20 @@ dps_results: {
  value: {
   dps: 28864.21557
   tps: 28988.57619
+ }
+}
+dps_results: {
+ key: "TestArcane-AllItems-ApparatusofKhaz'goroth-68972"
+ value: {
+  dps: 27722.46924
+  tps: 27857.88575
+ }
+}
+dps_results: {
+ key: "TestArcane-AllItems-ApparatusofKhaz'goroth-69113"
+ value: {
+  dps: 27722.46924
+  tps: 27857.88575
  }
 }
 dps_results: {
@@ -197,6 +218,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestArcane-AllItems-Brawler'sTrophy-71338"
+ value: {
+  dps: 27722.46924
+  tps: 27857.88575
+ }
+}
+dps_results: {
  key: "TestArcane-AllItems-BurningShadowspiritDiamond"
  value: {
   dps: 29703.22885
@@ -208,6 +236,13 @@ dps_results: {
  value: {
   dps: 29557.52341
   tps: 29654.40238
+ }
+}
+dps_results: {
+ key: "TestArcane-AllItems-Coren'sChilledChromiumCoaster-71335"
+ value: {
+  dps: 28169.64069
+  tps: 28316.66306
  }
 }
 dps_results: {
@@ -295,6 +330,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestArcane-AllItems-Dwyer'sCaber-70141"
+ value: {
+  dps: 28354.2387
+  tps: 28494.38352
+ }
+}
+dps_results: {
  key: "TestArcane-AllItems-EffulgentShadowspiritDiamond"
  value: {
   dps: 29019.40582
@@ -337,6 +379,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestArcane-AllItems-EssenceoftheEternalFlame-69002"
+ value: {
+  dps: 28269.96582
+  tps: 28420.96667
+ }
+}
+dps_results: {
  key: "TestArcane-AllItems-EternalShadowspiritDiamond"
  value: {
   dps: 29019.40582
@@ -355,6 +404,13 @@ dps_results: {
  value: {
   dps: 29240.11486
   tps: 29425.39928
+ }
+}
+dps_results: {
+ key: "TestArcane-AllItems-FieryQuintessence-69000"
+ value: {
+  dps: 28841.53962
+  tps: 28982.7993
  }
 }
 dps_results: {
@@ -736,6 +792,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestArcane-AllItems-MatrixRestabilizer-68994"
+ value: {
+  dps: 27722.46924
+  tps: 27857.88575
+ }
+}
+dps_results: {
+ key: "TestArcane-AllItems-MatrixRestabilizer-69150"
+ value: {
+  dps: 27722.46924
+  tps: 27857.88575
+ }
+}
+dps_results: {
  key: "TestArcane-AllItems-MightoftheOcean-55251"
  value: {
   dps: 28009.98281
@@ -764,6 +834,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestArcane-AllItems-MithrilStopwatch-71337"
+ value: {
+  dps: 29145.87601
+  tps: 29272.73255
+ }
+}
+dps_results: {
  key: "TestArcane-AllItems-MoonwellChalice-70142"
  value: {
   dps: 29876.65079
@@ -771,10 +848,38 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestArcane-AllItems-MoonwellPhial-70143"
+ value: {
+  dps: 27722.46924
+  tps: 27857.88575
+ }
+}
+dps_results: {
+ key: "TestArcane-AllItems-NecromanticFocus-68982"
+ value: {
+  dps: 29291.77556
+  tps: 29468.62754
+ }
+}
+dps_results: {
+ key: "TestArcane-AllItems-NecromanticFocus-69139"
+ value: {
+  dps: 29421.39098
+  tps: 29594.78502
+ }
+}
+dps_results: {
  key: "TestArcane-AllItems-Oremantle'sFavor-61448"
  value: {
   dps: 28297.8785
   tps: 28448.71117
+ }
+}
+dps_results: {
+ key: "TestArcane-AllItems-PetrifiedPickledEgg-71336"
+ value: {
+  dps: 29249.46581
+  tps: 29437.17495
  }
 }
 dps_results: {
@@ -855,6 +960,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestArcane-AllItems-Ricket'sMagneticFireball-70144"
+ value: {
+  dps: 28676.76313
+  tps: 28830.39496
+ }
+}
+dps_results: {
  key: "TestArcane-AllItems-RightEyeofRajh-56100"
  value: {
   dps: 28109.58754
@@ -866,6 +978,13 @@ dps_results: {
  value: {
   dps: 28109.58754
   tps: 28245.82881
+ }
+}
+dps_results: {
+ key: "TestArcane-AllItems-RuneofZeth-68998"
+ value: {
+  dps: 29628.85843
+  tps: 29794.59763
  }
 }
 dps_results: {
@@ -1030,6 +1149,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestArcane-AllItems-TheHungerer-68927"
+ value: {
+  dps: 27722.46924
+  tps: 27857.88575
+ }
+}
+dps_results: {
+ key: "TestArcane-AllItems-TheHungerer-69112"
+ value: {
+  dps: 27722.46924
+  tps: 27857.88575
+ }
+}
+dps_results: {
  key: "TestArcane-AllItems-Theralion'sMirror-59519"
  value: {
   dps: 29833.06888
@@ -1111,6 +1244,34 @@ dps_results: {
  value: {
   dps: 28319.26249
   tps: 28469.41689
+ }
+}
+dps_results: {
+ key: "TestArcane-AllItems-VariablePulseLightningCapacitor-68925"
+ value: {
+  dps: 29628.97886
+  tps: 29808.16994
+ }
+}
+dps_results: {
+ key: "TestArcane-AllItems-VariablePulseLightningCapacitor-69110"
+ value: {
+  dps: 30341.09796
+  tps: 30520.46411
+ }
+}
+dps_results: {
+ key: "TestArcane-AllItems-VesselofAcceleration-68995"
+ value: {
+  dps: 27722.46924
+  tps: 27857.88575
+ }
+}
+dps_results: {
+ key: "TestArcane-AllItems-VesselofAcceleration-69167"
+ value: {
+  dps: 27722.46924
+  tps: 27857.88575
  }
 }
 dps_results: {

--- a/sim/mage/fire/TestFire.results
+++ b/sim/mage/fire/TestFire.results
@@ -49,6 +49,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFire-AllItems-AncientPetrifiedSeed-69001"
+ value: {
+  dps: 28922.63679
+  tps: 28341.53985
+ }
+}
+dps_results: {
  key: "TestFire-AllItems-Anhuur'sHymnal-55889"
  value: {
   dps: 29727.40781
@@ -60,6 +67,20 @@ dps_results: {
  value: {
   dps: 29552.67047
   tps: 28943.5734
+ }
+}
+dps_results: {
+ key: "TestFire-AllItems-ApparatusofKhaz'goroth-68972"
+ value: {
+  dps: 28318.98149
+  tps: 27746.20455
+ }
+}
+dps_results: {
+ key: "TestFire-AllItems-ApparatusofKhaz'goroth-69113"
+ value: {
+  dps: 28318.98149
+  tps: 27746.20455
  }
 }
 dps_results: {
@@ -204,6 +225,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFire-AllItems-Brawler'sTrophy-71338"
+ value: {
+  dps: 28318.98149
+  tps: 27746.20455
+ }
+}
+dps_results: {
  key: "TestFire-AllItems-BurningShadowspiritDiamond"
  value: {
   dps: 31228.14363
@@ -215,6 +243,13 @@ dps_results: {
  value: {
   dps: 31119.13536
   tps: 30486.58664
+ }
+}
+dps_results: {
+ key: "TestFire-AllItems-Coren'sChilledChromiumCoaster-71335"
+ value: {
+  dps: 29109.25123
+  tps: 28560.75864
  }
 }
 dps_results: {
@@ -295,6 +330,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFire-AllItems-Dwyer'sCaber-70141"
+ value: {
+  dps: 29081.98381
+  tps: 28500.85128
+ }
+}
+dps_results: {
  key: "TestFire-AllItems-EffulgentShadowspiritDiamond"
  value: {
   dps: 30292.94273
@@ -337,6 +379,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFire-AllItems-EssenceoftheEternalFlame-69002"
+ value: {
+  dps: 28922.63679
+  tps: 28341.53985
+ }
+}
+dps_results: {
  key: "TestFire-AllItems-EternalShadowspiritDiamond"
  value: {
   dps: 30292.94273
@@ -355,6 +404,13 @@ dps_results: {
  value: {
   dps: 29921.59556
   tps: 29283.24358
+ }
+}
+dps_results: {
+ key: "TestFire-AllItems-FieryQuintessence-69000"
+ value: {
+  dps: 30137.88567
+  tps: 29512.24607
  }
 }
 dps_results: {
@@ -736,6 +792,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFire-AllItems-MatrixRestabilizer-68994"
+ value: {
+  dps: 28318.98149
+  tps: 27746.20455
+ }
+}
+dps_results: {
+ key: "TestFire-AllItems-MatrixRestabilizer-69150"
+ value: {
+  dps: 28318.98149
+  tps: 27746.20455
+ }
+}
+dps_results: {
  key: "TestFire-AllItems-MightoftheOcean-55251"
  value: {
   dps: 28717.85104
@@ -764,6 +834,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFire-AllItems-MithrilStopwatch-71337"
+ value: {
+  dps: 30325.70338
+  tps: 29743.53457
+ }
+}
+dps_results: {
  key: "TestFire-AllItems-MoonwellChalice-70142"
  value: {
   dps: 30373.87299
@@ -771,10 +848,38 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFire-AllItems-MoonwellPhial-70143"
+ value: {
+  dps: 28318.98149
+  tps: 27746.20455
+ }
+}
+dps_results: {
+ key: "TestFire-AllItems-NecromanticFocus-68982"
+ value: {
+  dps: 30471.49968
+  tps: 29832.88464
+ }
+}
+dps_results: {
+ key: "TestFire-AllItems-NecromanticFocus-69139"
+ value: {
+  dps: 30767.5842
+  tps: 30126.69773
+ }
+}
+dps_results: {
  key: "TestFire-AllItems-Oremantle'sFavor-61448"
  value: {
   dps: 29049.36575
   tps: 28467.10158
+ }
+}
+dps_results: {
+ key: "TestFire-AllItems-PetrifiedPickledEgg-71336"
+ value: {
+  dps: 29819.22229
+  tps: 29183.70101
  }
 }
 dps_results: {
@@ -855,6 +960,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFire-AllItems-Ricket'sMagneticFireball-70144"
+ value: {
+  dps: 29392.61625
+  tps: 28798.63189
+ }
+}
+dps_results: {
  key: "TestFire-AllItems-RightEyeofRajh-56100"
  value: {
   dps: 28717.85104
@@ -866,6 +978,13 @@ dps_results: {
  value: {
   dps: 28717.85104
   tps: 28148.42576
+ }
+}
+dps_results: {
+ key: "TestFire-AllItems-RuneofZeth-68998"
+ value: {
+  dps: 30772.92704
+  tps: 30166.29457
  }
 }
 dps_results: {
@@ -1030,6 +1149,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFire-AllItems-TheHungerer-68927"
+ value: {
+  dps: 28318.98149
+  tps: 27746.20455
+ }
+}
+dps_results: {
+ key: "TestFire-AllItems-TheHungerer-69112"
+ value: {
+  dps: 28318.98149
+  tps: 27746.20455
+ }
+}
+dps_results: {
  key: "TestFire-AllItems-Theralion'sMirror-59519"
  value: {
   dps: 30300.17667
@@ -1111,6 +1244,34 @@ dps_results: {
  value: {
   dps: 28837.86793
   tps: 28256.77099
+ }
+}
+dps_results: {
+ key: "TestFire-AllItems-VariablePulseLightningCapacitor-68925"
+ value: {
+  dps: 30250.6533
+  tps: 29617.92182
+ }
+}
+dps_results: {
+ key: "TestFire-AllItems-VariablePulseLightningCapacitor-69110"
+ value: {
+  dps: 31173.10637
+  tps: 30534.87596
+ }
+}
+dps_results: {
+ key: "TestFire-AllItems-VesselofAcceleration-68995"
+ value: {
+  dps: 28318.98149
+  tps: 27746.20455
+ }
+}
+dps_results: {
+ key: "TestFire-AllItems-VesselofAcceleration-69167"
+ value: {
+  dps: 28318.98149
+  tps: 27746.20455
  }
 }
 dps_results: {

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -49,6 +49,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestRetribution-AllItems-AncientPetrifiedSeed-69001"
+ value: {
+  dps: 31119.55629
+  tps: 31121.82065
+ }
+}
+dps_results: {
  key: "TestRetribution-AllItems-Anhuur'sHymnal-55889"
  value: {
   dps: 30008.37785
@@ -60,6 +67,20 @@ dps_results: {
  value: {
   dps: 30006.41987
   tps: 30008.68423
+ }
+}
+dps_results: {
+ key: "TestRetribution-AllItems-ApparatusofKhaz'goroth-68972"
+ value: {
+  dps: 31817.20828
+  tps: 31819.47264
+ }
+}
+dps_results: {
+ key: "TestRetribution-AllItems-ApparatusofKhaz'goroth-69113"
+ value: {
+  dps: 32023.25769
+  tps: 32025.52205
  }
 }
 dps_results: {
@@ -218,6 +239,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestRetribution-AllItems-Brawler'sTrophy-71338"
+ value: {
+  dps: 29982.66445
+  tps: 29984.92881
+ }
+}
+dps_results: {
  key: "TestRetribution-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
   dps: 32560.62512
@@ -236,6 +264,13 @@ dps_results: {
  value: {
   dps: 31909.14292
   tps: 31910.60949
+ }
+}
+dps_results: {
+ key: "TestRetribution-AllItems-Coren'sChilledChromiumCoaster-71335"
+ value: {
+  dps: 31021.76043
+  tps: 31018.51438
  }
 }
 dps_results: {
@@ -323,6 +358,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestRetribution-AllItems-Dwyer'sCaber-70141"
+ value: {
+  dps: 31753.83818
+  tps: 31756.10254
+ }
+}
+dps_results: {
  key: "TestRetribution-AllItems-EffulgentShadowspiritDiamond"
  value: {
   dps: 31547.95141
@@ -365,6 +407,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestRetribution-AllItems-EssenceoftheEternalFlame-69002"
+ value: {
+  dps: 31481.63512
+  tps: 31483.89948
+ }
+}
+dps_results: {
  key: "TestRetribution-AllItems-EternalShadowspiritDiamond"
  value: {
   dps: 31547.95141
@@ -383,6 +432,13 @@ dps_results: {
  value: {
   dps: 30097.43092
   tps: 30096.49641
+ }
+}
+dps_results: {
+ key: "TestRetribution-AllItems-FieryQuintessence-69000"
+ value: {
+  dps: 29887.71631
+  tps: 29894.29186
  }
 }
 dps_results: {
@@ -750,6 +806,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestRetribution-AllItems-MatrixRestabilizer-68994"
+ value: {
+  dps: 31385.02579
+  tps: 31380.95409
+ }
+}
+dps_results: {
+ key: "TestRetribution-AllItems-MatrixRestabilizer-69150"
+ value: {
+  dps: 31534.12762
+  tps: 31528.59588
+ }
+}
+dps_results: {
  key: "TestRetribution-AllItems-MightoftheOcean-55251"
  value: {
   dps: 30498.5693
@@ -778,6 +848,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestRetribution-AllItems-MithrilStopwatch-71337"
+ value: {
+  dps: 30630.9867
+  tps: 30627.74064
+ }
+}
+dps_results: {
  key: "TestRetribution-AllItems-MoonwellChalice-70142"
  value: {
   dps: 31124.56859
@@ -785,10 +862,38 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestRetribution-AllItems-MoonwellPhial-70143"
+ value: {
+  dps: 29982.66445
+  tps: 29984.92881
+ }
+}
+dps_results: {
+ key: "TestRetribution-AllItems-NecromanticFocus-68982"
+ value: {
+  dps: 30690.86651
+  tps: 30691.15315
+ }
+}
+dps_results: {
+ key: "TestRetribution-AllItems-NecromanticFocus-69139"
+ value: {
+  dps: 30840.59973
+  tps: 30842.42131
+ }
+}
+dps_results: {
  key: "TestRetribution-AllItems-Oremantle'sFavor-61448"
  value: {
   dps: 31157.64932
   tps: 31159.91368
+ }
+}
+dps_results: {
+ key: "TestRetribution-AllItems-PetrifiedPickledEgg-71336"
+ value: {
+  dps: 30033.30337
+  tps: 30035.62084
  }
 }
 dps_results: {
@@ -883,6 +988,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestRetribution-AllItems-Ricket'sMagneticFireball-70144"
+ value: {
+  dps: 31315.88566
+  tps: 31313.42275
+ }
+}
+dps_results: {
  key: "TestRetribution-AllItems-RightEyeofRajh-56100"
  value: {
   dps: 30757.16378
@@ -894,6 +1006,13 @@ dps_results: {
  value: {
   dps: 30844.38152
   tps: 30846.64588
+ }
+}
+dps_results: {
+ key: "TestRetribution-AllItems-RuneofZeth-68998"
+ value: {
+  dps: 30576.34641
+  tps: 30579.63901
  }
 }
 dps_results: {
@@ -1065,6 +1184,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestRetribution-AllItems-TheHungerer-68927"
+ value: {
+  dps: 30740.83662
+  tps: 30732.39097
+ }
+}
+dps_results: {
+ key: "TestRetribution-AllItems-TheHungerer-69112"
+ value: {
+  dps: 31068.7107
+  tps: 31057.54543
+ }
+}
+dps_results: {
  key: "TestRetribution-AllItems-Theralion'sMirror-59519"
  value: {
   dps: 30329.79435
@@ -1160,6 +1293,34 @@ dps_results: {
  value: {
   dps: 16537.4786
   tps: 16516.37663
+ }
+}
+dps_results: {
+ key: "TestRetribution-AllItems-VariablePulseLightningCapacitor-68925"
+ value: {
+  dps: 30245.3176
+  tps: 30249.14459
+ }
+}
+dps_results: {
+ key: "TestRetribution-AllItems-VariablePulseLightningCapacitor-69110"
+ value: {
+  dps: 30520.94005
+  tps: 30522.50846
+ }
+}
+dps_results: {
+ key: "TestRetribution-AllItems-VesselofAcceleration-68995"
+ value: {
+  dps: 31785.14846
+  tps: 31786.63352
+ }
+}
+dps_results: {
+ key: "TestRetribution-AllItems-VesselofAcceleration-69167"
+ value: {
+  dps: 31982.32108
+  tps: 31983.80614
  }
 }
 dps_results: {

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -49,6 +49,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestShadow-AllItems-AncientPetrifiedSeed-69001"
+ value: {
+  dps: 27610.37596
+  tps: 26093.61587
+ }
+}
+dps_results: {
  key: "TestShadow-AllItems-Anhuur'sHymnal-55889"
  value: {
   dps: 27621.99448
@@ -60,6 +67,20 @@ dps_results: {
  value: {
   dps: 27676.43737
   tps: 26102.36073
+ }
+}
+dps_results: {
+ key: "TestShadow-AllItems-ApparatusofKhaz'goroth-68972"
+ value: {
+  dps: 26987.67162
+  tps: 25471.62427
+ }
+}
+dps_results: {
+ key: "TestShadow-AllItems-ApparatusofKhaz'goroth-69113"
+ value: {
+  dps: 26987.67162
+  tps: 25471.62427
  }
 }
 dps_results: {
@@ -197,6 +218,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestShadow-AllItems-Brawler'sTrophy-71338"
+ value: {
+  dps: 26987.83619
+  tps: 25478.95448
+ }
+}
+dps_results: {
  key: "TestShadow-AllItems-BurningShadowspiritDiamond"
  value: {
   dps: 28994.86459
@@ -208,6 +236,13 @@ dps_results: {
  value: {
   dps: 28886.17312
   tps: 27083.01516
+ }
+}
+dps_results: {
+ key: "TestShadow-AllItems-Coren'sChilledChromiumCoaster-71335"
+ value: {
+  dps: 27430.08234
+  tps: 25839.36984
  }
 }
 dps_results: {
@@ -302,6 +337,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestShadow-AllItems-Dwyer'sCaber-70141"
+ value: {
+  dps: 27501.67342
+  tps: 25941.17211
+ }
+}
+dps_results: {
  key: "TestShadow-AllItems-EffulgentShadowspiritDiamond"
  value: {
   dps: 28401.00523
@@ -344,6 +386,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestShadow-AllItems-EssenceoftheEternalFlame-69002"
+ value: {
+  dps: 27610.37596
+  tps: 26093.61587
+ }
+}
+dps_results: {
  key: "TestShadow-AllItems-EternalShadowspiritDiamond"
  value: {
   dps: 28401.00523
@@ -362,6 +411,13 @@ dps_results: {
  value: {
   dps: 28176.05239
   tps: 26574.1691
+ }
+}
+dps_results: {
+ key: "TestShadow-AllItems-FieryQuintessence-69000"
+ value: {
+  dps: 28411.29317
+  tps: 26803.16147
  }
 }
 dps_results: {
@@ -757,6 +813,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestShadow-AllItems-MatrixRestabilizer-68994"
+ value: {
+  dps: 26987.67162
+  tps: 25471.62427
+ }
+}
+dps_results: {
+ key: "TestShadow-AllItems-MatrixRestabilizer-69150"
+ value: {
+  dps: 26987.67162
+  tps: 25471.62427
+ }
+}
+dps_results: {
  key: "TestShadow-AllItems-MercurialRegalia"
  value: {
   dps: 26111.99694
@@ -792,6 +862,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestShadow-AllItems-MithrilStopwatch-71337"
+ value: {
+  dps: 28806.27453
+  tps: 27073.46403
+ }
+}
+dps_results: {
  key: "TestShadow-AllItems-MoonwellChalice-70142"
  value: {
   dps: 28721.23868
@@ -799,10 +876,38 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestShadow-AllItems-MoonwellPhial-70143"
+ value: {
+  dps: 26987.83619
+  tps: 25478.95448
+ }
+}
+dps_results: {
+ key: "TestShadow-AllItems-NecromanticFocus-68982"
+ value: {
+  dps: 28804.4327
+  tps: 27245.0327
+ }
+}
+dps_results: {
+ key: "TestShadow-AllItems-NecromanticFocus-69139"
+ value: {
+  dps: 29024.89421
+  tps: 27452.52199
+ }
+}
+dps_results: {
  key: "TestShadow-AllItems-Oremantle'sFavor-61448"
  value: {
   dps: 27366.98788
   tps: 25774.66672
+ }
+}
+dps_results: {
+ key: "TestShadow-AllItems-PetrifiedPickledEgg-71336"
+ value: {
+  dps: 28089.24644
+  tps: 26495.46628
  }
 }
 dps_results: {
@@ -883,6 +988,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestShadow-AllItems-Ricket'sMagneticFireball-70144"
+ value: {
+  dps: 27630.79328
+  tps: 25987.75579
+ }
+}
+dps_results: {
  key: "TestShadow-AllItems-RightEyeofRajh-56100"
  value: {
   dps: 26987.67162
@@ -894,6 +1006,13 @@ dps_results: {
  value: {
   dps: 26987.67162
   tps: 25471.62427
+ }
+}
+dps_results: {
+ key: "TestShadow-AllItems-RuneofZeth-68998"
+ value: {
+  dps: 28768.33495
+  tps: 27079.97948
  }
 }
 dps_results: {
@@ -1058,6 +1177,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestShadow-AllItems-TheHungerer-68927"
+ value: {
+  dps: 26987.67162
+  tps: 25471.62427
+ }
+}
+dps_results: {
+ key: "TestShadow-AllItems-TheHungerer-69112"
+ value: {
+  dps: 26987.67162
+  tps: 25471.62427
+ }
+}
+dps_results: {
  key: "TestShadow-AllItems-Theralion'sMirror-59519"
  value: {
   dps: 28660.87966
@@ -1153,6 +1286,34 @@ dps_results: {
  value: {
   dps: 24020.94517
   tps: 22556.47319
+ }
+}
+dps_results: {
+ key: "TestShadow-AllItems-VariablePulseLightningCapacitor-68925"
+ value: {
+  dps: 28493.83394
+  tps: 26902.93907
+ }
+}
+dps_results: {
+ key: "TestShadow-AllItems-VariablePulseLightningCapacitor-69110"
+ value: {
+  dps: 28885.19018
+  tps: 27264.69178
+ }
+}
+dps_results: {
+ key: "TestShadow-AllItems-VesselofAcceleration-68995"
+ value: {
+  dps: 26987.67162
+  tps: 25471.62427
+ }
+}
+dps_results: {
+ key: "TestShadow-AllItems-VesselofAcceleration-69167"
+ value: {
+  dps: 26987.67162
+  tps: 25471.62427
  }
 }
 dps_results: {

--- a/sim/rogue/assassination/TestAssassination.results
+++ b/sim/rogue/assassination/TestAssassination.results
@@ -49,6 +49,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestAssassination-AllItems-AncientPetrifiedSeed-69001"
+ value: {
+  dps: 29763.09362
+  tps: 21131.79647
+ }
+}
+dps_results: {
  key: "TestAssassination-AllItems-Anhuur'sHymnal-55889"
  value: {
   dps: 28772.01044
@@ -60,6 +67,20 @@ dps_results: {
  value: {
   dps: 28787.46026
   tps: 20439.09679
+ }
+}
+dps_results: {
+ key: "TestAssassination-AllItems-ApparatusofKhaz'goroth-68972"
+ value: {
+  dps: 29041.24752
+  tps: 20619.28574
+ }
+}
+dps_results: {
+ key: "TestAssassination-AllItems-ApparatusofKhaz'goroth-69113"
+ value: {
+  dps: 29245.3315
+  tps: 20764.18536
  }
 }
 dps_results: {
@@ -204,6 +225,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestAssassination-AllItems-Brawler'sTrophy-71338"
+ value: {
+  dps: 27915.93642
+  tps: 19820.31486
+ }
+}
+dps_results: {
  key: "TestAssassination-AllItems-BurningShadowspiritDiamond"
  value: {
   dps: 30177.57474
@@ -215,6 +243,13 @@ dps_results: {
  value: {
   dps: 30176.55444
   tps: 21425.35365
+ }
+}
+dps_results: {
+ key: "TestAssassination-AllItems-Coren'sChilledChromiumCoaster-71335"
+ value: {
+  dps: 29426.95177
+  tps: 20893.13576
  }
 }
 dps_results: {
@@ -302,6 +337,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestAssassination-AllItems-Dwyer'sCaber-70141"
+ value: {
+  dps: 28937.14101
+  tps: 20545.37012
+ }
+}
+dps_results: {
  key: "TestAssassination-AllItems-EffulgentShadowspiritDiamond"
  value: {
   dps: 29832.20419
@@ -344,6 +386,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestAssassination-AllItems-EssenceoftheEternalFlame-69002"
+ value: {
+  dps: 29043.88836
+  tps: 20621.16073
+ }
+}
+dps_results: {
  key: "TestAssassination-AllItems-EternalShadowspiritDiamond"
  value: {
   dps: 29832.20419
@@ -359,6 +408,13 @@ dps_results: {
 }
 dps_results: {
  key: "TestAssassination-AllItems-FallofMortality-65124"
+ value: {
+  dps: 27915.93642
+  tps: 19820.31486
+ }
+}
+dps_results: {
+ key: "TestAssassination-AllItems-FieryQuintessence-69000"
  value: {
   dps: 27915.93642
   tps: 19820.31486
@@ -736,6 +792,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestAssassination-AllItems-MatrixRestabilizer-68994"
+ value: {
+  dps: 30130.60123
+  tps: 21392.72688
+ }
+}
+dps_results: {
+ key: "TestAssassination-AllItems-MatrixRestabilizer-69150"
+ value: {
+  dps: 30422.7596
+  tps: 21600.15932
+ }
+}
+dps_results: {
  key: "TestAssassination-AllItems-MightoftheOcean-55251"
  value: {
   dps: 28812.58249
@@ -764,6 +834,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestAssassination-AllItems-MithrilStopwatch-71337"
+ value: {
+  dps: 28331.09717
+  tps: 20115.07899
+ }
+}
+dps_results: {
  key: "TestAssassination-AllItems-MoonwellChalice-70142"
  value: {
   dps: 28580.49555
@@ -771,10 +848,38 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestAssassination-AllItems-MoonwellPhial-70143"
+ value: {
+  dps: 27915.93642
+  tps: 19820.31486
+ }
+}
+dps_results: {
+ key: "TestAssassination-AllItems-NecromanticFocus-68982"
+ value: {
+  dps: 27915.93642
+  tps: 19820.31486
+ }
+}
+dps_results: {
+ key: "TestAssassination-AllItems-NecromanticFocus-69139"
+ value: {
+  dps: 27915.93642
+  tps: 19820.31486
+ }
+}
+dps_results: {
  key: "TestAssassination-AllItems-Oremantle'sFavor-61448"
  value: {
   dps: 28426.51509
   tps: 20182.82571
+ }
+}
+dps_results: {
+ key: "TestAssassination-AllItems-PetrifiedPickledEgg-71336"
+ value: {
+  dps: 27915.93642
+  tps: 19820.31486
  }
 }
 dps_results: {
@@ -848,6 +953,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestAssassination-AllItems-Ricket'sMagneticFireball-70144"
+ value: {
+  dps: 29651.91018
+  tps: 21052.85623
+ }
+}
+dps_results: {
  key: "TestAssassination-AllItems-RightEyeofRajh-56100"
  value: {
   dps: 29266.51019
@@ -859,6 +971,13 @@ dps_results: {
  value: {
   dps: 29354.09075
   tps: 20841.40443
+ }
+}
+dps_results: {
+ key: "TestAssassination-AllItems-RuneofZeth-68998"
+ value: {
+  dps: 28408.18225
+  tps: 20169.8094
  }
 }
 dps_results: {
@@ -1023,6 +1142,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestAssassination-AllItems-TheHungerer-68927"
+ value: {
+  dps: 30038.27464
+  tps: 21327.17499
+ }
+}
+dps_results: {
+ key: "TestAssassination-AllItems-TheHungerer-69112"
+ value: {
+  dps: 30222.3487
+  tps: 21457.86757
+ }
+}
+dps_results: {
  key: "TestAssassination-AllItems-Theralion'sMirror-59519"
  value: {
   dps: 28462.35708
@@ -1111,6 +1244,34 @@ dps_results: {
  value: {
   dps: 29881.87185
   tps: 21216.12901
+ }
+}
+dps_results: {
+ key: "TestAssassination-AllItems-VariablePulseLightningCapacitor-68925"
+ value: {
+  dps: 27950.1948
+  tps: 19844.63831
+ }
+}
+dps_results: {
+ key: "TestAssassination-AllItems-VariablePulseLightningCapacitor-69110"
+ value: {
+  dps: 28032.00416
+  tps: 19902.72296
+ }
+}
+dps_results: {
+ key: "TestAssassination-AllItems-VesselofAcceleration-68995"
+ value: {
+  dps: 29061.96343
+  tps: 20633.99404
+ }
+}
+dps_results: {
+ key: "TestAssassination-AllItems-VesselofAcceleration-69167"
+ value: {
+  dps: 29160.48944
+  tps: 20703.9475
  }
 }
 dps_results: {

--- a/sim/rogue/combat/TestCombat.results
+++ b/sim/rogue/combat/TestCombat.results
@@ -56,6 +56,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestCombat-AllItems-AncientPetrifiedSeed-69001"
+ value: {
+  dps: 29096.86
+  tps: 20658.7706
+ }
+}
+dps_results: {
  key: "TestCombat-AllItems-Anhuur'sHymnal-55889"
  value: {
   dps: 27544.10292
@@ -67,6 +74,20 @@ dps_results: {
  value: {
   dps: 27644.62352
   tps: 19627.6827
+ }
+}
+dps_results: {
+ key: "TestCombat-AllItems-ApparatusofKhaz'goroth-68972"
+ value: {
+  dps: 28292.44384
+  tps: 20087.63513
+ }
+}
+dps_results: {
+ key: "TestCombat-AllItems-ApparatusofKhaz'goroth-69113"
+ value: {
+  dps: 28439.07144
+  tps: 20191.74072
  }
 }
 dps_results: {
@@ -218,6 +239,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestCombat-AllItems-Brawler'sTrophy-71338"
+ value: {
+  dps: 27161.78422
+  tps: 19284.8668
+ }
+}
+dps_results: {
  key: "TestCombat-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
   dps: 29148.4763
@@ -236,6 +264,13 @@ dps_results: {
  value: {
   dps: 29001.78176
   tps: 20591.26505
+ }
+}
+dps_results: {
+ key: "TestCombat-AllItems-Coren'sChilledChromiumCoaster-71335"
+ value: {
+  dps: 28618.0762
+  tps: 20318.8341
  }
 }
 dps_results: {
@@ -323,6 +358,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestCombat-AllItems-Dwyer'sCaber-70141"
+ value: {
+  dps: 28168.63767
+  tps: 19999.73274
+ }
+}
+dps_results: {
  key: "TestCombat-AllItems-EffulgentShadowspiritDiamond"
  value: {
   dps: 28595.61713
@@ -365,6 +407,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestCombat-AllItems-EssenceoftheEternalFlame-69002"
+ value: {
+  dps: 28303.20795
+  tps: 20095.27764
+ }
+}
+dps_results: {
  key: "TestCombat-AllItems-EternalShadowspiritDiamond"
  value: {
   dps: 28595.61713
@@ -380,6 +429,13 @@ dps_results: {
 }
 dps_results: {
  key: "TestCombat-AllItems-FallofMortality-65124"
+ value: {
+  dps: 27161.78422
+  tps: 19284.8668
+ }
+}
+dps_results: {
+ key: "TestCombat-AllItems-FieryQuintessence-69000"
  value: {
   dps: 27161.78422
   tps: 19284.8668
@@ -764,6 +820,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestCombat-AllItems-MatrixRestabilizer-68994"
+ value: {
+  dps: 29345.81139
+  tps: 20835.52609
+ }
+}
+dps_results: {
+ key: "TestCombat-AllItems-MatrixRestabilizer-69150"
+ value: {
+  dps: 29649.55812
+  tps: 21051.18626
+ }
+}
+dps_results: {
  key: "TestCombat-AllItems-MightoftheOcean-55251"
  value: {
   dps: 27733.18371
@@ -792,6 +862,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestCombat-AllItems-MithrilStopwatch-71337"
+ value: {
+  dps: 27530.06929
+  tps: 19546.3492
+ }
+}
+dps_results: {
  key: "TestCombat-AllItems-MoonwellChalice-70142"
  value: {
   dps: 27577.47139
@@ -799,10 +876,38 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestCombat-AllItems-MoonwellPhial-70143"
+ value: {
+  dps: 27161.78422
+  tps: 19284.8668
+ }
+}
+dps_results: {
+ key: "TestCombat-AllItems-NecromanticFocus-68982"
+ value: {
+  dps: 27161.78422
+  tps: 19284.8668
+ }
+}
+dps_results: {
+ key: "TestCombat-AllItems-NecromanticFocus-69139"
+ value: {
+  dps: 27161.78422
+  tps: 19284.8668
+ }
+}
+dps_results: {
  key: "TestCombat-AllItems-Oremantle'sFavor-61448"
  value: {
   dps: 27686.5064
   tps: 19657.41954
+ }
+}
+dps_results: {
+ key: "TestCombat-AllItems-PetrifiedPickledEgg-71336"
+ value: {
+  dps: 27161.78422
+  tps: 19284.8668
  }
 }
 dps_results: {
@@ -876,6 +981,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestCombat-AllItems-Ricket'sMagneticFireball-70144"
+ value: {
+  dps: 28887.54347
+  tps: 20510.15586
+ }
+}
+dps_results: {
  key: "TestCombat-AllItems-RightEyeofRajh-56100"
  value: {
   dps: 28023.96634
@@ -887,6 +999,13 @@ dps_results: {
  value: {
   dps: 28207.96154
   tps: 20027.65269
+ }
+}
+dps_results: {
+ key: "TestCombat-AllItems-RuneofZeth-68998"
+ value: {
+  dps: 27568.89212
+  tps: 19573.91341
  }
 }
 dps_results: {
@@ -1058,6 +1177,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestCombat-AllItems-TheHungerer-68927"
+ value: {
+  dps: 29158.47347
+  tps: 20702.51616
+ }
+}
+dps_results: {
+ key: "TestCombat-AllItems-TheHungerer-69112"
+ value: {
+  dps: 29507.57906
+  tps: 20950.38113
+ }
+}
+dps_results: {
  key: "TestCombat-AllItems-Theralion'sMirror-59519"
  value: {
   dps: 27161.78422
@@ -1153,6 +1286,34 @@ dps_results: {
  value: {
   dps: 25678.83044
   tps: 18231.96961
+ }
+}
+dps_results: {
+ key: "TestCombat-AllItems-VariablePulseLightningCapacitor-68925"
+ value: {
+  dps: 27161.78422
+  tps: 19284.8668
+ }
+}
+dps_results: {
+ key: "TestCombat-AllItems-VariablePulseLightningCapacitor-69110"
+ value: {
+  dps: 27161.78422
+  tps: 19284.8668
+ }
+}
+dps_results: {
+ key: "TestCombat-AllItems-VesselofAcceleration-68995"
+ value: {
+  dps: 28209.13683
+  tps: 20028.48715
+ }
+}
+dps_results: {
+ key: "TestCombat-AllItems-VesselofAcceleration-69167"
+ value: {
+  dps: 28350.94155
+  tps: 20129.1685
  }
 }
 dps_results: {

--- a/sim/rogue/subtlety/TestSubtlety.results
+++ b/sim/rogue/subtlety/TestSubtlety.results
@@ -50,6 +50,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestSubtlety-AllItems-AncientPetrifiedSeed-69001"
+ value: {
+  dps: 23746.09243
+  tps: 16859.72562
+ }
+}
+dps_results: {
  key: "TestSubtlety-AllItems-Anhuur'sHymnal-55889"
  value: {
   dps: 22364.69885
@@ -61,6 +68,20 @@ dps_results: {
  value: {
   dps: 22435.44405
   tps: 15929.16528
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-ApparatusofKhaz'goroth-68972"
+ value: {
+  dps: 23175.16269
+  tps: 16454.36551
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-ApparatusofKhaz'goroth-69113"
+ value: {
+  dps: 23396.77387
+  tps: 16611.70945
  }
 }
 dps_results: {
@@ -205,6 +226,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestSubtlety-AllItems-Brawler'sTrophy-71338"
+ value: {
+  dps: 22110.32104
+  tps: 15698.32794
+ }
+}
+dps_results: {
  key: "TestSubtlety-AllItems-BurningShadowspiritDiamond"
  value: {
   dps: 23594.96839
@@ -216,6 +244,13 @@ dps_results: {
  value: {
   dps: 23733.49014
   tps: 16850.778
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-Coren'sChilledChromiumCoaster-71335"
+ value: {
+  dps: 23139.08075
+  tps: 16428.74733
  }
 }
 dps_results: {
@@ -303,6 +338,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestSubtlety-AllItems-Dwyer'sCaber-70141"
+ value: {
+  dps: 22923.92496
+  tps: 16275.98672
+ }
+}
+dps_results: {
  key: "TestSubtlety-AllItems-EffulgentShadowspiritDiamond"
  value: {
   dps: 23219.22721
@@ -345,6 +387,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestSubtlety-AllItems-EssenceoftheEternalFlame-69002"
+ value: {
+  dps: 22655.7569
+  tps: 16085.5874
+ }
+}
+dps_results: {
  key: "TestSubtlety-AllItems-EternalShadowspiritDiamond"
  value: {
   dps: 23219.22721
@@ -360,6 +409,13 @@ dps_results: {
 }
 dps_results: {
  key: "TestSubtlety-AllItems-FallofMortality-65124"
+ value: {
+  dps: 22110.32104
+  tps: 15698.32794
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-FieryQuintessence-69000"
  value: {
   dps: 22110.32104
   tps: 15698.32794
@@ -738,6 +794,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestSubtlety-AllItems-MatrixRestabilizer-68994"
+ value: {
+  dps: 24210.24528
+  tps: 17189.27415
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-MatrixRestabilizer-69150"
+ value: {
+  dps: 24507.40977
+  tps: 17400.26094
+ }
+}
+dps_results: {
  key: "TestSubtlety-AllItems-MightoftheOcean-55251"
  value: {
   dps: 22507.79551
@@ -766,6 +836,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestSubtlety-AllItems-MithrilStopwatch-71337"
+ value: {
+  dps: 22415.72148
+  tps: 15915.16225
+ }
+}
+dps_results: {
  key: "TestSubtlety-AllItems-MoonwellChalice-70142"
  value: {
   dps: 21855.289
@@ -773,10 +850,38 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestSubtlety-AllItems-MoonwellPhial-70143"
+ value: {
+  dps: 22110.32104
+  tps: 15698.32794
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-NecromanticFocus-68982"
+ value: {
+  dps: 22110.32104
+  tps: 15698.32794
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-NecromanticFocus-69139"
+ value: {
+  dps: 22110.32104
+  tps: 15698.32794
+ }
+}
+dps_results: {
  key: "TestSubtlety-AllItems-Oremantle'sFavor-61448"
  value: {
   dps: 22542.57442
   tps: 16005.22784
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-PetrifiedPickledEgg-71336"
+ value: {
+  dps: 22110.32104
+  tps: 15698.32794
  }
 }
 dps_results: {
@@ -850,6 +955,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestSubtlety-AllItems-Ricket'sMagneticFireball-70144"
+ value: {
+  dps: 23767.47108
+  tps: 16874.90447
+ }
+}
+dps_results: {
  key: "TestSubtlety-AllItems-RightEyeofRajh-56100"
  value: {
   dps: 22714.12267
@@ -861,6 +973,13 @@ dps_results: {
  value: {
   dps: 22841.52898
   tps: 16217.48557
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-RuneofZeth-68998"
+ value: {
+  dps: 22469.0339
+  tps: 15953.01407
  }
 }
 dps_results: {
@@ -1025,6 +1144,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestSubtlety-AllItems-TheHungerer-68927"
+ value: {
+  dps: 23897.41534
+  tps: 16967.16489
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-TheHungerer-69112"
+ value: {
+  dps: 24024.56404
+  tps: 17057.44047
+ }
+}
+dps_results: {
  key: "TestSubtlety-AllItems-Theralion'sMirror-59519"
  value: {
   dps: 22110.32104
@@ -1113,6 +1246,34 @@ dps_results: {
  value: {
   dps: 23715.14008
   tps: 16837.74946
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-VariablePulseLightningCapacitor-68925"
+ value: {
+  dps: 22110.32104
+  tps: 15698.32794
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-VariablePulseLightningCapacitor-69110"
+ value: {
+  dps: 22110.32104
+  tps: 15698.32794
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-VesselofAcceleration-68995"
+ value: {
+  dps: 22897.92192
+  tps: 16257.52457
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-VesselofAcceleration-69167"
+ value: {
+  dps: 22985.03928
+  tps: 16319.37789
  }
 }
 dps_results: {

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -56,6 +56,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestElemental-AllItems-AncientPetrifiedSeed-69001"
+ value: {
+  dps: 30549.37918
+  tps: 571.93314
+ }
+}
+dps_results: {
  key: "TestElemental-AllItems-Anhuur'sHymnal-55889"
  value: {
   dps: 30884.49709
@@ -67,6 +74,20 @@ dps_results: {
  value: {
   dps: 31069.70015
   tps: 564.61006
+ }
+}
+dps_results: {
+ key: "TestElemental-AllItems-ApparatusofKhaz'goroth-68972"
+ value: {
+  dps: 30116.35064
+  tps: 563.84893
+ }
+}
+dps_results: {
+ key: "TestElemental-AllItems-ApparatusofKhaz'goroth-69113"
+ value: {
+  dps: 30116.35064
+  tps: 563.84893
  }
 }
 dps_results: {
@@ -218,6 +239,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestElemental-AllItems-Brawler'sTrophy-71338"
+ value: {
+  dps: 30116.35064
+  tps: 563.84893
+ }
+}
+dps_results: {
  key: "TestElemental-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
   dps: 32356.04284
@@ -236,6 +264,13 @@ dps_results: {
  value: {
   dps: 32207.03547
   tps: 566.72554
+ }
+}
+dps_results: {
+ key: "TestElemental-AllItems-Coren'sChilledChromiumCoaster-71335"
+ value: {
+  dps: 30505.80786
+  tps: 562.89071
  }
 }
 dps_results: {
@@ -316,6 +351,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestElemental-AllItems-Dwyer'sCaber-70141"
+ value: {
+  dps: 30559.7613
+  tps: 563.77784
+ }
+}
+dps_results: {
  key: "TestElemental-AllItems-EffulgentShadowspiritDiamond"
  value: {
   dps: 31442.00068
@@ -358,6 +400,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestElemental-AllItems-EssenceoftheEternalFlame-69002"
+ value: {
+  dps: 30549.37918
+  tps: 571.93314
+ }
+}
+dps_results: {
  key: "TestElemental-AllItems-EternalShadowspiritDiamond"
  value: {
   dps: 31442.00068
@@ -376,6 +425,13 @@ dps_results: {
  value: {
   dps: 31462.77231
   tps: 580.73006
+ }
+}
+dps_results: {
+ key: "TestElemental-AllItems-FieryQuintessence-69000"
+ value: {
+  dps: 31751.68674
+  tps: 595.51279
  }
 }
 dps_results: {
@@ -757,6 +813,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestElemental-AllItems-MatrixRestabilizer-68994"
+ value: {
+  dps: 30116.35064
+  tps: 563.84893
+ }
+}
+dps_results: {
+ key: "TestElemental-AllItems-MatrixRestabilizer-69150"
+ value: {
+  dps: 30116.35064
+  tps: 563.84893
+ }
+}
+dps_results: {
  key: "TestElemental-AllItems-MightoftheOcean-55251"
  value: {
   dps: 30112.85443
@@ -785,6 +855,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestElemental-AllItems-MithrilStopwatch-71337"
+ value: {
+  dps: 32022.92686
+  tps: 563.46168
+ }
+}
+dps_results: {
  key: "TestElemental-AllItems-MoonwellChalice-70142"
  value: {
   dps: 31795.15385
@@ -792,10 +869,38 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestElemental-AllItems-MoonwellPhial-70143"
+ value: {
+  dps: 30116.35064
+  tps: 563.84893
+ }
+}
+dps_results: {
+ key: "TestElemental-AllItems-NecromanticFocus-68982"
+ value: {
+  dps: 31987.72582
+  tps: 592.16728
+ }
+}
+dps_results: {
+ key: "TestElemental-AllItems-NecromanticFocus-69139"
+ value: {
+  dps: 32264.67066
+  tps: 595.5098
+ }
+}
+dps_results: {
  key: "TestElemental-AllItems-Oremantle'sFavor-61448"
  value: {
   dps: 30341.24419
   tps: 563.22287
+ }
+}
+dps_results: {
+ key: "TestElemental-AllItems-PetrifiedPickledEgg-71336"
+ value: {
+  dps: 31373.4065
+  tps: 579.82941
  }
 }
 dps_results: {
@@ -883,6 +988,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestElemental-AllItems-Ricket'sMagneticFireball-70144"
+ value: {
+  dps: 30505.66578
+  tps: 562.86955
+ }
+}
+dps_results: {
  key: "TestElemental-AllItems-RightEyeofRajh-56100"
  value: {
   dps: 30112.85443
@@ -894,6 +1006,13 @@ dps_results: {
  value: {
   dps: 30112.85443
   tps: 563.84893
+ }
+}
+dps_results: {
+ key: "TestElemental-AllItems-RuneofZeth-68998"
+ value: {
+  dps: 32138.20648
+  tps: 590.67218
  }
 }
 dps_results: {
@@ -1072,6 +1191,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestElemental-AllItems-TheHungerer-68927"
+ value: {
+  dps: 30116.35064
+  tps: 563.84893
+ }
+}
+dps_results: {
+ key: "TestElemental-AllItems-TheHungerer-69112"
+ value: {
+  dps: 30116.35064
+  tps: 563.84893
+ }
+}
+dps_results: {
  key: "TestElemental-AllItems-Theralion'sMirror-59519"
  value: {
   dps: 31752.20189
@@ -1174,6 +1307,34 @@ dps_results: {
  value: {
   dps: 26691.38771
   tps: 543.81014
+ }
+}
+dps_results: {
+ key: "TestElemental-AllItems-VariablePulseLightningCapacitor-68925"
+ value: {
+  dps: 31745.73492
+  tps: 912.07053
+ }
+}
+dps_results: {
+ key: "TestElemental-AllItems-VariablePulseLightningCapacitor-69110"
+ value: {
+  dps: 32831.85801
+  tps: 1584.53953
+ }
+}
+dps_results: {
+ key: "TestElemental-AllItems-VesselofAcceleration-68995"
+ value: {
+  dps: 30116.35064
+  tps: 563.84893
+ }
+}
+dps_results: {
+ key: "TestElemental-AllItems-VesselofAcceleration-69167"
+ value: {
+  dps: 30116.35064
+  tps: 563.84893
  }
 }
 dps_results: {

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -56,6 +56,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestEnhancement-AllItems-AncientPetrifiedSeed-69001"
+ value: {
+  dps: 29759.0902
+  tps: 19710.18838
+ }
+}
+dps_results: {
  key: "TestEnhancement-AllItems-Anhuur'sHymnal-55889"
  value: {
   dps: 28162.98577
@@ -67,6 +74,20 @@ dps_results: {
  value: {
   dps: 28173.06167
   tps: 18790.24372
+ }
+}
+dps_results: {
+ key: "TestEnhancement-AllItems-ApparatusofKhaz'goroth-68972"
+ value: {
+  dps: 28833.13108
+  tps: 19238.0926
+ }
+}
+dps_results: {
+ key: "TestEnhancement-AllItems-ApparatusofKhaz'goroth-69113"
+ value: {
+  dps: 28955.75735
+  tps: 19318.38238
  }
 }
 dps_results: {
@@ -225,6 +246,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestEnhancement-AllItems-Brawler'sTrophy-71338"
+ value: {
+  dps: 27819.52287
+  tps: 18558.31239
+ }
+}
+dps_results: {
  key: "TestEnhancement-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
   dps: 29663.69334
@@ -243,6 +271,13 @@ dps_results: {
  value: {
   dps: 29663.69334
   tps: 19752.40364
+ }
+}
+dps_results: {
+ key: "TestEnhancement-AllItems-Coren'sChilledChromiumCoaster-71335"
+ value: {
+  dps: 29156.15294
+  tps: 19422.87773
  }
 }
 dps_results: {
@@ -330,6 +365,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestEnhancement-AllItems-Dwyer'sCaber-70141"
+ value: {
+  dps: 28809.76282
+  tps: 19230.74077
+ }
+}
+dps_results: {
  key: "TestEnhancement-AllItems-EffulgentShadowspiritDiamond"
  value: {
   dps: 29169.85795
@@ -365,6 +407,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestEnhancement-AllItems-EssenceoftheEternalFlame-69002"
+ value: {
+  dps: 28971.96858
+  tps: 19186.27065
+ }
+}
+dps_results: {
  key: "TestEnhancement-AllItems-EternalShadowspiritDiamond"
  value: {
   dps: 29169.85795
@@ -383,6 +432,13 @@ dps_results: {
  value: {
   dps: 27862.28031
   tps: 18577.54023
+ }
+}
+dps_results: {
+ key: "TestEnhancement-AllItems-FieryQuintessence-69000"
+ value: {
+  dps: 27920.56113
+  tps: 18619.56239
  }
 }
 dps_results: {
@@ -757,6 +813,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestEnhancement-AllItems-MatrixRestabilizer-68994"
+ value: {
+  dps: 29803.94172
+  tps: 19918.3715
+ }
+}
+dps_results: {
+ key: "TestEnhancement-AllItems-MatrixRestabilizer-69150"
+ value: {
+  dps: 30020.66115
+  tps: 20067.00329
+ }
+}
+dps_results: {
  key: "TestEnhancement-AllItems-MightoftheOcean-55251"
  value: {
   dps: 28339.94283
@@ -785,6 +855,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestEnhancement-AllItems-MithrilStopwatch-71337"
+ value: {
+  dps: 28132.78488
+  tps: 18780.32735
+ }
+}
+dps_results: {
  key: "TestEnhancement-AllItems-MoonwellChalice-70142"
  value: {
   dps: 28445.36371
@@ -792,10 +869,38 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestEnhancement-AllItems-MoonwellPhial-70143"
+ value: {
+  dps: 27819.52287
+  tps: 18558.31239
+ }
+}
+dps_results: {
+ key: "TestEnhancement-AllItems-NecromanticFocus-68982"
+ value: {
+  dps: 28449.26592
+  tps: 18862.93251
+ }
+}
+dps_results: {
+ key: "TestEnhancement-AllItems-NecromanticFocus-69139"
+ value: {
+  dps: 28530.4028
+  tps: 18900.576
+ }
+}
+dps_results: {
  key: "TestEnhancement-AllItems-Oremantle'sFavor-61448"
  value: {
   dps: 28368.6543
   tps: 18941.56545
+ }
+}
+dps_results: {
+ key: "TestEnhancement-AllItems-PetrifiedPickledEgg-71336"
+ value: {
+  dps: 27860.57495
+  tps: 18577.42543
  }
 }
 dps_results: {
@@ -883,6 +988,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestEnhancement-AllItems-Ricket'sMagneticFireball-70144"
+ value: {
+  dps: 29454.81576
+  tps: 19695.12566
+ }
+}
+dps_results: {
  key: "TestEnhancement-AllItems-RightEyeofRajh-56100"
  value: {
   dps: 28646.31481
@@ -894,6 +1006,13 @@ dps_results: {
  value: {
   dps: 28708.16633
   tps: 19126.92256
+ }
+}
+dps_results: {
+ key: "TestEnhancement-AllItems-RuneofZeth-68998"
+ value: {
+  dps: 28228.54076
+  tps: 18936.52148
  }
 }
 dps_results: {
@@ -1072,6 +1191,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestEnhancement-AllItems-TheHungerer-68927"
+ value: {
+  dps: 29536.42313
+  tps: 19737.16294
+ }
+}
+dps_results: {
+ key: "TestEnhancement-AllItems-TheHungerer-69112"
+ value: {
+  dps: 29759.87911
+  tps: 19811.36847
+ }
+}
+dps_results: {
  key: "TestEnhancement-AllItems-Theralion'sMirror-59519"
  value: {
   dps: 28431.99201
@@ -1174,6 +1307,34 @@ dps_results: {
  value: {
   dps: 25046.37085
   tps: 16478.97378
+ }
+}
+dps_results: {
+ key: "TestEnhancement-AllItems-VariablePulseLightningCapacitor-68925"
+ value: {
+  dps: 28039.91222
+  tps: 18758.68597
+ }
+}
+dps_results: {
+ key: "TestEnhancement-AllItems-VariablePulseLightningCapacitor-69110"
+ value: {
+  dps: 28564.38801
+  tps: 19299.68867
+ }
+}
+dps_results: {
+ key: "TestEnhancement-AllItems-VesselofAcceleration-68995"
+ value: {
+  dps: 28822.82667
+  tps: 19223.04599
+ }
+}
+dps_results: {
+ key: "TestEnhancement-AllItems-VesselofAcceleration-69167"
+ value: {
+  dps: 28939.29812
+  tps: 19291.28369
  }
 }
 dps_results: {

--- a/sim/warlock/affliction/TestAffliction.results
+++ b/sim/warlock/affliction/TestAffliction.results
@@ -49,6 +49,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestAffliction-AllItems-AncientPetrifiedSeed-69001"
+ value: {
+  dps: 26266.93346
+  tps: 19717.13543
+ }
+}
+dps_results: {
  key: "TestAffliction-AllItems-Anhuur'sHymnal-55889"
  value: {
   dps: 26786.50922
@@ -60,6 +67,20 @@ dps_results: {
  value: {
   dps: 26822.48779
   tps: 20036.48456
+ }
+}
+dps_results: {
+ key: "TestAffliction-AllItems-ApparatusofKhaz'goroth-68972"
+ value: {
+  dps: 26121.91929
+  tps: 19530.90397
+ }
+}
+dps_results: {
+ key: "TestAffliction-AllItems-ApparatusofKhaz'goroth-69113"
+ value: {
+  dps: 26121.91929
+  tps: 19530.90397
  }
 }
 dps_results: {
@@ -197,6 +218,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestAffliction-AllItems-Brawler'sTrophy-71338"
+ value: {
+  dps: 26121.91929
+  tps: 19530.90397
+ }
+}
+dps_results: {
  key: "TestAffliction-AllItems-BurningShadowspiritDiamond"
  value: {
   dps: 28007.36481
@@ -208,6 +236,13 @@ dps_results: {
  value: {
   dps: 27867.48234
   tps: 20868.31865
+ }
+}
+dps_results: {
+ key: "TestAffliction-AllItems-Coren'sChilledChromiumCoaster-71335"
+ value: {
+  dps: 26464.50033
+  tps: 19758.50256
  }
 }
 dps_results: {
@@ -288,6 +323,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestAffliction-AllItems-Dwyer'sCaber-70141"
+ value: {
+  dps: 26462.93555
+  tps: 19772.96504
+ }
+}
+dps_results: {
  key: "TestAffliction-AllItems-EffulgentShadowspiritDiamond"
  value: {
   dps: 27518.86202
@@ -330,6 +372,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestAffliction-AllItems-EssenceoftheEternalFlame-69002"
+ value: {
+  dps: 26266.93346
+  tps: 19717.13543
+ }
+}
+dps_results: {
  key: "TestAffliction-AllItems-EternalShadowspiritDiamond"
  value: {
   dps: 27518.86202
@@ -348,6 +397,13 @@ dps_results: {
  value: {
   dps: 27090.93299
   tps: 20136.51744
+ }
+}
+dps_results: {
+ key: "TestAffliction-AllItems-FieryQuintessence-69000"
+ value: {
+  dps: 27023.82143
+  tps: 20102.9316
  }
 }
 dps_results: {
@@ -722,6 +778,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestAffliction-AllItems-MatrixRestabilizer-68994"
+ value: {
+  dps: 26121.91929
+  tps: 19530.90397
+ }
+}
+dps_results: {
+ key: "TestAffliction-AllItems-MatrixRestabilizer-69150"
+ value: {
+  dps: 26121.91929
+  tps: 19530.90397
+ }
+}
+dps_results: {
  key: "TestAffliction-AllItems-MightoftheOcean-55251"
  value: {
   dps: 26125.04534
@@ -750,6 +820,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestAffliction-AllItems-MithrilStopwatch-71337"
+ value: {
+  dps: 27552.78422
+  tps: 20546.03205
+ }
+}
+dps_results: {
  key: "TestAffliction-AllItems-MoonwellChalice-70142"
  value: {
   dps: 27523.27511
@@ -757,10 +834,38 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestAffliction-AllItems-MoonwellPhial-70143"
+ value: {
+  dps: 26108.12556
+  tps: 19510.45331
+ }
+}
+dps_results: {
+ key: "TestAffliction-AllItems-NecromanticFocus-68982"
+ value: {
+  dps: 27463.94559
+  tps: 20546.88133
+ }
+}
+dps_results: {
+ key: "TestAffliction-AllItems-NecromanticFocus-69139"
+ value: {
+  dps: 27744.64792
+  tps: 20763.5489
+ }
+}
+dps_results: {
  key: "TestAffliction-AllItems-Oremantle'sFavor-61448"
  value: {
   dps: 26242.77227
   tps: 19582.56793
+ }
+}
+dps_results: {
+ key: "TestAffliction-AllItems-PetrifiedPickledEgg-71336"
+ value: {
+  dps: 27040.70763
+  tps: 20134.76447
  }
 }
 dps_results: {
@@ -841,6 +946,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestAffliction-AllItems-Ricket'sMagneticFireball-70144"
+ value: {
+  dps: 26469.18084
+  tps: 19718.28617
+ }
+}
+dps_results: {
  key: "TestAffliction-AllItems-RightEyeofRajh-56100"
  value: {
   dps: 26235.83107
@@ -852,6 +964,13 @@ dps_results: {
  value: {
   dps: 26235.83107
   tps: 19628.73041
+ }
+}
+dps_results: {
+ key: "TestAffliction-AllItems-RuneofZeth-68998"
+ value: {
+  dps: 27484.02263
+  tps: 20470.69505
  }
 }
 dps_results: {
@@ -1023,6 +1142,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestAffliction-AllItems-TheHungerer-68927"
+ value: {
+  dps: 26121.91929
+  tps: 19530.90397
+ }
+}
+dps_results: {
+ key: "TestAffliction-AllItems-TheHungerer-69112"
+ value: {
+  dps: 26121.91929
+  tps: 19530.90397
+ }
+}
+dps_results: {
  key: "TestAffliction-AllItems-Theralion'sMirror-59519"
  value: {
   dps: 27308.28625
@@ -1111,6 +1244,34 @@ dps_results: {
  value: {
   dps: 26267.16765
   tps: 19698.08873
+ }
+}
+dps_results: {
+ key: "TestAffliction-AllItems-VariablePulseLightningCapacitor-68925"
+ value: {
+  dps: 27482.66176
+  tps: 20553.36119
+ }
+}
+dps_results: {
+ key: "TestAffliction-AllItems-VariablePulseLightningCapacitor-69110"
+ value: {
+  dps: 27727.00389
+  tps: 20846.67086
+ }
+}
+dps_results: {
+ key: "TestAffliction-AllItems-VesselofAcceleration-68995"
+ value: {
+  dps: 26121.91929
+  tps: 19530.90397
+ }
+}
+dps_results: {
+ key: "TestAffliction-AllItems-VesselofAcceleration-69167"
+ value: {
+  dps: 26121.91929
+  tps: 19530.90397
  }
 }
 dps_results: {

--- a/sim/warlock/demonology/TestDemonology.results
+++ b/sim/warlock/demonology/TestDemonology.results
@@ -49,6 +49,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestDemonology-AllItems-AncientPetrifiedSeed-69001"
+ value: {
+  dps: 25719.8573
+  tps: 14521.41857
+ }
+}
+dps_results: {
  key: "TestDemonology-AllItems-Anhuur'sHymnal-55889"
  value: {
   dps: 27786.54655
@@ -60,6 +67,20 @@ dps_results: {
  value: {
   dps: 27871.79291
   tps: 14735.41707
+ }
+}
+dps_results: {
+ key: "TestDemonology-AllItems-ApparatusofKhaz'goroth-68972"
+ value: {
+  dps: 26808.03933
+  tps: 14222.36009
+ }
+}
+dps_results: {
+ key: "TestDemonology-AllItems-ApparatusofKhaz'goroth-69113"
+ value: {
+  dps: 26808.03933
+  tps: 14222.36009
  }
 }
 dps_results: {
@@ -197,6 +218,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestDemonology-AllItems-Brawler'sTrophy-71338"
+ value: {
+  dps: 26808.03933
+  tps: 14222.36009
+ }
+}
+dps_results: {
  key: "TestDemonology-AllItems-BurningShadowspiritDiamond"
  value: {
   dps: 29362.83212
@@ -208,6 +236,13 @@ dps_results: {
  value: {
   dps: 29258.04565
   tps: 15385.77503
+ }
+}
+dps_results: {
+ key: "TestDemonology-AllItems-Coren'sChilledChromiumCoaster-71335"
+ value: {
+  dps: 27286.07992
+  tps: 14495.35112
  }
 }
 dps_results: {
@@ -288,6 +323,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestDemonology-AllItems-Dwyer'sCaber-70141"
+ value: {
+  dps: 27284.24269
+  tps: 14438.20405
+ }
+}
+dps_results: {
  key: "TestDemonology-AllItems-EffulgentShadowspiritDiamond"
  value: {
   dps: 28988.36242
@@ -330,6 +372,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestDemonology-AllItems-EssenceoftheEternalFlame-69002"
+ value: {
+  dps: 25719.8573
+  tps: 14521.41857
+ }
+}
+dps_results: {
  key: "TestDemonology-AllItems-EternalShadowspiritDiamond"
  value: {
   dps: 28988.36242
@@ -348,6 +397,13 @@ dps_results: {
  value: {
   dps: 27916.06272
   tps: 14793.79865
+ }
+}
+dps_results: {
+ key: "TestDemonology-AllItems-FieryQuintessence-69000"
+ value: {
+  dps: 26153.32534
+  tps: 14831.38675
  }
 }
 dps_results: {
@@ -722,6 +778,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestDemonology-AllItems-MatrixRestabilizer-68994"
+ value: {
+  dps: 26808.03933
+  tps: 14222.36009
+ }
+}
+dps_results: {
+ key: "TestDemonology-AllItems-MatrixRestabilizer-69150"
+ value: {
+  dps: 26808.03933
+  tps: 14222.36009
+ }
+}
+dps_results: {
  key: "TestDemonology-AllItems-MightoftheOcean-55251"
  value: {
   dps: 25476.02569
@@ -750,6 +820,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestDemonology-AllItems-MithrilStopwatch-71337"
+ value: {
+  dps: 28377.71231
+  tps: 15026.44425
+ }
+}
+dps_results: {
  key: "TestDemonology-AllItems-MoonwellChalice-70142"
  value: {
   dps: 26412.96058
@@ -757,10 +834,38 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestDemonology-AllItems-MoonwellPhial-70143"
+ value: {
+  dps: 26801.75355
+  tps: 14223.44165
+ }
+}
+dps_results: {
+ key: "TestDemonology-AllItems-NecromanticFocus-68982"
+ value: {
+  dps: 28461.639
+  tps: 14978.01233
+ }
+}
+dps_results: {
+ key: "TestDemonology-AllItems-NecromanticFocus-69139"
+ value: {
+  dps: 28713.68755
+  tps: 15094.1997
+ }
+}
+dps_results: {
  key: "TestDemonology-AllItems-Oremantle'sFavor-61448"
  value: {
   dps: 25418.79184
   tps: 14397.63567
+ }
+}
+dps_results: {
+ key: "TestDemonology-AllItems-PetrifiedPickledEgg-71336"
+ value: {
+  dps: 27844.33389
+  tps: 14755.42793
  }
 }
 dps_results: {
@@ -841,6 +946,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestDemonology-AllItems-Ricket'sMagneticFireball-70144"
+ value: {
+  dps: 25675.78022
+  tps: 14554.02587
+ }
+}
+dps_results: {
  key: "TestDemonology-AllItems-RightEyeofRajh-56100"
  value: {
   dps: 27158.78199
@@ -852,6 +964,13 @@ dps_results: {
  value: {
   dps: 27158.78199
   tps: 14393.75564
+ }
+}
+dps_results: {
+ key: "TestDemonology-AllItems-RuneofZeth-68998"
+ value: {
+  dps: 26502.8117
+  tps: 15045.19861
  }
 }
 dps_results: {
@@ -1023,6 +1142,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestDemonology-AllItems-TheHungerer-68927"
+ value: {
+  dps: 26808.03933
+  tps: 14222.36009
+ }
+}
+dps_results: {
+ key: "TestDemonology-AllItems-TheHungerer-69112"
+ value: {
+  dps: 26808.03933
+  tps: 14222.36009
+ }
+}
+dps_results: {
  key: "TestDemonology-AllItems-Theralion'sMirror-59519"
  value: {
   dps: 28356.94983
@@ -1111,6 +1244,34 @@ dps_results: {
  value: {
   dps: 25617.45667
   tps: 14451.82728
+ }
+}
+dps_results: {
+ key: "TestDemonology-AllItems-VariablePulseLightningCapacitor-68925"
+ value: {
+  dps: 28266.68433
+  tps: 15019.8704
+ }
+}
+dps_results: {
+ key: "TestDemonology-AllItems-VariablePulseLightningCapacitor-69110"
+ value: {
+  dps: 28740.51269
+  tps: 15402.28336
+ }
+}
+dps_results: {
+ key: "TestDemonology-AllItems-VesselofAcceleration-68995"
+ value: {
+  dps: 26808.03933
+  tps: 14222.36009
+ }
+}
+dps_results: {
+ key: "TestDemonology-AllItems-VesselofAcceleration-69167"
+ value: {
+  dps: 26808.03933
+  tps: 14222.36009
  }
 }
 dps_results: {

--- a/sim/warlock/destruction/TestDestruction.results
+++ b/sim/warlock/destruction/TestDestruction.results
@@ -49,6 +49,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestDestruction-AllItems-AncientPetrifiedSeed-69001"
+ value: {
+  dps: 26671.49592
+  tps: 17751.73522
+ }
+}
+dps_results: {
  key: "TestDestruction-AllItems-Anhuur'sHymnal-55889"
  value: {
   dps: 27389.39952
@@ -60,6 +67,20 @@ dps_results: {
  value: {
   dps: 27437.02786
   tps: 18233.85928
+ }
+}
+dps_results: {
+ key: "TestDestruction-AllItems-ApparatusofKhaz'goroth-68972"
+ value: {
+  dps: 26307.65527
+  tps: 17452.81348
+ }
+}
+dps_results: {
+ key: "TestDestruction-AllItems-ApparatusofKhaz'goroth-69113"
+ value: {
+  dps: 26307.65527
+  tps: 17452.81348
  }
 }
 dps_results: {
@@ -197,6 +218,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestDestruction-AllItems-Brawler'sTrophy-71338"
+ value: {
+  dps: 26307.65527
+  tps: 17452.81348
+ }
+}
+dps_results: {
  key: "TestDestruction-AllItems-BurningShadowspiritDiamond"
  value: {
   dps: 28486.32655
@@ -208,6 +236,13 @@ dps_results: {
  value: {
   dps: 28396.33997
   tps: 18877.88877
+ }
+}
+dps_results: {
+ key: "TestDestruction-AllItems-Coren'sChilledChromiumCoaster-71335"
+ value: {
+  dps: 26699.71246
+  tps: 17705.08476
  }
 }
 dps_results: {
@@ -288,6 +323,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestDestruction-AllItems-Dwyer'sCaber-70141"
+ value: {
+  dps: 26749.38772
+  tps: 17740.43369
+ }
+}
+dps_results: {
  key: "TestDestruction-AllItems-EffulgentShadowspiritDiamond"
  value: {
   dps: 28042.44628
@@ -330,6 +372,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestDestruction-AllItems-EssenceoftheEternalFlame-69002"
+ value: {
+  dps: 26671.49592
+  tps: 17751.73522
+ }
+}
+dps_results: {
  key: "TestDestruction-AllItems-EternalShadowspiritDiamond"
  value: {
   dps: 28042.44628
@@ -348,6 +397,13 @@ dps_results: {
  value: {
   dps: 27381.73416
   tps: 18154.25404
+ }
+}
+dps_results: {
+ key: "TestDestruction-AllItems-FieryQuintessence-69000"
+ value: {
+  dps: 27337.90415
+  tps: 18125.65585
  }
 }
 dps_results: {
@@ -722,6 +778,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestDestruction-AllItems-MatrixRestabilizer-68994"
+ value: {
+  dps: 26307.65527
+  tps: 17452.81348
+ }
+}
+dps_results: {
+ key: "TestDestruction-AllItems-MatrixRestabilizer-69150"
+ value: {
+  dps: 26307.65527
+  tps: 17452.81348
+ }
+}
+dps_results: {
  key: "TestDestruction-AllItems-MightoftheOcean-55251"
  value: {
   dps: 26730.97818
@@ -750,6 +820,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestDestruction-AllItems-MithrilStopwatch-71337"
+ value: {
+  dps: 27814.60952
+  tps: 18397.73017
+ }
+}
+dps_results: {
  key: "TestDestruction-AllItems-MoonwellChalice-70142"
  value: {
   dps: 27787.38517
@@ -757,10 +834,38 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestDestruction-AllItems-MoonwellPhial-70143"
+ value: {
+  dps: 26307.65527
+  tps: 17453.37576
+ }
+}
+dps_results: {
+ key: "TestDestruction-AllItems-NecromanticFocus-68982"
+ value: {
+  dps: 27849.92203
+  tps: 18499.34581
+ }
+}
+dps_results: {
+ key: "TestDestruction-AllItems-NecromanticFocus-69139"
+ value: {
+  dps: 28053.66881
+  tps: 18641.42083
+ }
+}
+dps_results: {
  key: "TestDestruction-AllItems-Oremantle'sFavor-61448"
  value: {
   dps: 26560.55462
   tps: 17642.91722
+ }
+}
+dps_results: {
+ key: "TestDestruction-AllItems-PetrifiedPickledEgg-71336"
+ value: {
+  dps: 27315.26671
+  tps: 18109.4519
  }
 }
 dps_results: {
@@ -841,6 +946,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestDestruction-AllItems-Ricket'sMagneticFireball-70144"
+ value: {
+  dps: 26748.52694
+  tps: 17741.78848
+ }
+}
+dps_results: {
  key: "TestDestruction-AllItems-RightEyeofRajh-56100"
  value: {
   dps: 26761.6533
@@ -852,6 +964,13 @@ dps_results: {
  value: {
   dps: 26761.6533
   tps: 17809.87593
+ }
+}
+dps_results: {
+ key: "TestDestruction-AllItems-RuneofZeth-68998"
+ value: {
+  dps: 27738.55465
+  tps: 18381.37847
  }
 }
 dps_results: {
@@ -1023,6 +1142,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestDestruction-AllItems-TheHungerer-68927"
+ value: {
+  dps: 26307.65527
+  tps: 17452.81348
+ }
+}
+dps_results: {
+ key: "TestDestruction-AllItems-TheHungerer-69112"
+ value: {
+  dps: 26307.65527
+  tps: 17452.81348
+ }
+}
+dps_results: {
  key: "TestDestruction-AllItems-Theralion'sMirror-59519"
  value: {
   dps: 27735.46119
@@ -1111,6 +1244,34 @@ dps_results: {
  value: {
   dps: 26600.25768
   tps: 17708.77032
+ }
+}
+dps_results: {
+ key: "TestDestruction-AllItems-VariablePulseLightningCapacitor-68925"
+ value: {
+  dps: 27744.06747
+  tps: 18502.56048
+ }
+}
+dps_results: {
+ key: "TestDestruction-AllItems-VariablePulseLightningCapacitor-69110"
+ value: {
+  dps: 28265.14852
+  tps: 18941.11404
+ }
+}
+dps_results: {
+ key: "TestDestruction-AllItems-VesselofAcceleration-68995"
+ value: {
+  dps: 26307.65527
+  tps: 17452.81348
+ }
+}
+dps_results: {
+ key: "TestDestruction-AllItems-VesselofAcceleration-69167"
+ value: {
+  dps: 26307.65527
+  tps: 17452.81348
  }
 }
 dps_results: {

--- a/sim/warrior/arms/TestArms.results
+++ b/sim/warrior/arms/TestArms.results
@@ -49,6 +49,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestArms-AllItems-AncientPetrifiedSeed-69001"
+ value: {
+  dps: 32397.74227
+  tps: 21734.4085
+ }
+}
+dps_results: {
  key: "TestArms-AllItems-Anhuur'sHymnal-55889"
  value: {
   dps: 31386.13327
@@ -60,6 +67,20 @@ dps_results: {
  value: {
   dps: 31386.13327
   tps: 20968.02437
+ }
+}
+dps_results: {
+ key: "TestArms-AllItems-ApparatusofKhaz'goroth-68972"
+ value: {
+  dps: 33540.40867
+  tps: 22377.76158
+ }
+}
+dps_results: {
+ key: "TestArms-AllItems-ApparatusofKhaz'goroth-69113"
+ value: {
+  dps: 33911.38994
+  tps: 22611.00215
  }
 }
 dps_results: {
@@ -204,6 +225,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestArms-AllItems-Brawler'sTrophy-71338"
+ value: {
+  dps: 31386.13327
+  tps: 20968.02437
+ }
+}
+dps_results: {
  key: "TestArms-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
   dps: 33933.98498
@@ -236,6 +264,13 @@ dps_results: {
  value: {
   dps: 30635.41828
   tps: 20595.84715
+ }
+}
+dps_results: {
+ key: "TestArms-AllItems-Coren'sChilledChromiumCoaster-71335"
+ value: {
+  dps: 32853.73367
+  tps: 21973.05704
  }
 }
 dps_results: {
@@ -323,6 +358,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestArms-AllItems-Dwyer'sCaber-70141"
+ value: {
+  dps: 33184.60796
+  tps: 22168.47819
+ }
+}
+dps_results: {
  key: "TestArms-AllItems-EarthenBattleplate"
  value: {
   dps: 27277.85548
@@ -379,6 +421,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestArms-AllItems-EssenceoftheEternalFlame-69002"
+ value: {
+  dps: 32971.70441
+  tps: 22105.11114
+ }
+}
+dps_results: {
  key: "TestArms-AllItems-EternalShadowspiritDiamond"
  value: {
   dps: 32726.2384
@@ -397,6 +446,13 @@ dps_results: {
  value: {
   dps: 31386.13327
   tps: 20968.02437
+ }
+}
+dps_results: {
+ key: "TestArms-AllItems-FieryQuintessence-69000"
+ value: {
+  dps: 31389.01351
+  tps: 20972.54062
  }
 }
 dps_results: {
@@ -764,6 +820,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestArms-AllItems-MatrixRestabilizer-68994"
+ value: {
+  dps: 33017.16905
+  tps: 22086.43729
+ }
+}
+dps_results: {
+ key: "TestArms-AllItems-MatrixRestabilizer-69150"
+ value: {
+  dps: 33233.54761
+  tps: 22225.58405
+ }
+}
+dps_results: {
  key: "TestArms-AllItems-MightoftheOcean-55251"
  value: {
   dps: 31918.79002
@@ -792,6 +862,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestArms-AllItems-MithrilStopwatch-71337"
+ value: {
+  dps: 32001.64988
+  tps: 21400.60184
+ }
+}
+dps_results: {
  key: "TestArms-AllItems-MoltenGiantBattleplate"
  value: {
   dps: 28059.123
@@ -813,10 +890,38 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestArms-AllItems-MoonwellPhial-70143"
+ value: {
+  dps: 31386.13327
+  tps: 20968.02437
+ }
+}
+dps_results: {
+ key: "TestArms-AllItems-NecromanticFocus-68982"
+ value: {
+  dps: 31386.13327
+  tps: 20968.02437
+ }
+}
+dps_results: {
+ key: "TestArms-AllItems-NecromanticFocus-69139"
+ value: {
+  dps: 31386.13327
+  tps: 20968.02437
+ }
+}
+dps_results: {
  key: "TestArms-AllItems-Oremantle'sFavor-61448"
  value: {
   dps: 32594.14346
   tps: 21748.2608
+ }
+}
+dps_results: {
+ key: "TestArms-AllItems-PetrifiedPickledEgg-71336"
+ value: {
+  dps: 31386.13327
+  tps: 20968.02437
  }
 }
 dps_results: {
@@ -897,6 +1002,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestArms-AllItems-Ricket'sMagneticFireball-70144"
+ value: {
+  dps: 32675.53666
+  tps: 21854.18088
+ }
+}
+dps_results: {
  key: "TestArms-AllItems-RightEyeofRajh-56100"
  value: {
   dps: 32284.97107
@@ -908,6 +1020,13 @@ dps_results: {
  value: {
   dps: 32405.95566
   tps: 21648.40676
+ }
+}
+dps_results: {
+ key: "TestArms-AllItems-RuneofZeth-68998"
+ value: {
+  dps: 32140.26823
+  tps: 21504.73519
  }
 }
 dps_results: {
@@ -1079,6 +1198,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestArms-AllItems-TheHungerer-68927"
+ value: {
+  dps: 32195.04313
+  tps: 21500.86752
+ }
+}
+dps_results: {
+ key: "TestArms-AllItems-TheHungerer-69112"
+ value: {
+  dps: 32503.57279
+  tps: 21748.76515
+ }
+}
+dps_results: {
  key: "TestArms-AllItems-Theralion'sMirror-59519"
  value: {
   dps: 31386.13327
@@ -1174,6 +1307,34 @@ dps_results: {
  value: {
   dps: 18685.84774
   tps: 11849.48905
+ }
+}
+dps_results: {
+ key: "TestArms-AllItems-VariablePulseLightningCapacitor-68925"
+ value: {
+  dps: 31386.13327
+  tps: 20968.02437
+ }
+}
+dps_results: {
+ key: "TestArms-AllItems-VariablePulseLightningCapacitor-69110"
+ value: {
+  dps: 31386.13327
+  tps: 20968.02437
+ }
+}
+dps_results: {
+ key: "TestArms-AllItems-VesselofAcceleration-68995"
+ value: {
+  dps: 33368.37433
+  tps: 22339.02919
+ }
+}
+dps_results: {
+ key: "TestArms-AllItems-VesselofAcceleration-69167"
+ value: {
+  dps: 33656.16728
+  tps: 22545.92983
  }
 }
 dps_results: {

--- a/sim/warrior/fury/TestFury.results
+++ b/sim/warrior/fury/TestFury.results
@@ -56,6 +56,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFury-AllItems-AncientPetrifiedSeed-69001"
+ value: {
+  dps: 28461.30399
+  tps: 22994.31906
+ }
+}
+dps_results: {
  key: "TestFury-AllItems-Anhuur'sHymnal-55889"
  value: {
   dps: 27745.21112
@@ -67,6 +74,20 @@ dps_results: {
  value: {
   dps: 27868.34399
   tps: 22716.57956
+ }
+}
+dps_results: {
+ key: "TestFury-AllItems-ApparatusofKhaz'goroth-68972"
+ value: {
+  dps: 29568.56857
+  tps: 24137.47296
+ }
+}
+dps_results: {
+ key: "TestFury-AllItems-ApparatusofKhaz'goroth-69113"
+ value: {
+  dps: 29770.58437
+  tps: 24340.02575
  }
 }
 dps_results: {
@@ -218,6 +239,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFury-AllItems-Brawler'sTrophy-71338"
+ value: {
+  dps: 27274.16648
+  tps: 22138.57419
+ }
+}
+dps_results: {
  key: "TestFury-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
   dps: 29274.17835
@@ -250,6 +278,13 @@ dps_results: {
  value: {
   dps: 27184.05739
   tps: 21944.78914
+ }
+}
+dps_results: {
+ key: "TestFury-AllItems-Coren'sChilledChromiumCoaster-71335"
+ value: {
+  dps: 29040.69332
+  tps: 23695.16721
  }
 }
 dps_results: {
@@ -337,6 +372,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFury-AllItems-Dwyer'sCaber-70141"
+ value: {
+  dps: 29390.86185
+  tps: 23980.23471
+ }
+}
+dps_results: {
  key: "TestFury-AllItems-EarthenBattleplate"
  value: {
   dps: 23723.84408
@@ -393,6 +435,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFury-AllItems-EssenceoftheEternalFlame-69002"
+ value: {
+  dps: 29011.73442
+  tps: 23492.78609
+ }
+}
+dps_results: {
  key: "TestFury-AllItems-EternalShadowspiritDiamond"
  value: {
   dps: 28759.57941
@@ -411,6 +460,13 @@ dps_results: {
  value: {
   dps: 27274.16648
   tps: 22138.57419
+ }
+}
+dps_results: {
+ key: "TestFury-AllItems-FieryQuintessence-69000"
+ value: {
+  dps: 27117.84134
+  tps: 22110.24103
  }
 }
 dps_results: {
@@ -785,6 +841,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFury-AllItems-MatrixRestabilizer-68994"
+ value: {
+  dps: 29200.87001
+  tps: 23916.73369
+ }
+}
+dps_results: {
+ key: "TestFury-AllItems-MatrixRestabilizer-69150"
+ value: {
+  dps: 29370.36287
+  tps: 24046.16799
+ }
+}
+dps_results: {
  key: "TestFury-AllItems-MightoftheOcean-55251"
  value: {
   dps: 28136.73299
@@ -813,6 +883,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFury-AllItems-MithrilStopwatch-71337"
+ value: {
+  dps: 28150.78359
+  tps: 22956.83674
+ }
+}
+dps_results: {
  key: "TestFury-AllItems-MoltenGiantBattleplate"
  value: {
   dps: 24950.59446
@@ -834,10 +911,38 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFury-AllItems-MoonwellPhial-70143"
+ value: {
+  dps: 27274.16648
+  tps: 22138.57419
+ }
+}
+dps_results: {
+ key: "TestFury-AllItems-NecromanticFocus-68982"
+ value: {
+  dps: 27274.16648
+  tps: 22138.57419
+ }
+}
+dps_results: {
+ key: "TestFury-AllItems-NecromanticFocus-69139"
+ value: {
+  dps: 27274.16648
+  tps: 22138.57419
+ }
+}
+dps_results: {
  key: "TestFury-AllItems-Oremantle'sFavor-61448"
  value: {
   dps: 28408.05138
   tps: 23116.80781
+ }
+}
+dps_results: {
+ key: "TestFury-AllItems-PetrifiedPickledEgg-71336"
+ value: {
+  dps: 27274.16648
+  tps: 22138.57419
  }
 }
 dps_results: {
@@ -918,6 +1023,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFury-AllItems-Ricket'sMagneticFireball-70144"
+ value: {
+  dps: 28780.63038
+  tps: 23554.12354
+ }
+}
+dps_results: {
  key: "TestFury-AllItems-RightEyeofRajh-56100"
  value: {
   dps: 28808.30443
@@ -929,6 +1041,13 @@ dps_results: {
  value: {
   dps: 29050.46585
   tps: 23705.93052
+ }
+}
+dps_results: {
+ key: "TestFury-AllItems-RuneofZeth-68998"
+ value: {
+  dps: 28111.5777
+  tps: 22894.33992
  }
 }
 dps_results: {
@@ -1100,6 +1219,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFury-AllItems-TheHungerer-68927"
+ value: {
+  dps: 28567.74515
+  tps: 23346.4212
+ }
+}
+dps_results: {
+ key: "TestFury-AllItems-TheHungerer-69112"
+ value: {
+  dps: 28624.39474
+  tps: 23361.66736
+ }
+}
+dps_results: {
  key: "TestFury-AllItems-Theralion'sMirror-59519"
  value: {
   dps: 27274.16648
@@ -1195,6 +1328,34 @@ dps_results: {
  value: {
   dps: 25948.20221
   tps: 21217.11378
+ }
+}
+dps_results: {
+ key: "TestFury-AllItems-VariablePulseLightningCapacitor-68925"
+ value: {
+  dps: 27274.16648
+  tps: 22138.57419
+ }
+}
+dps_results: {
+ key: "TestFury-AllItems-VariablePulseLightningCapacitor-69110"
+ value: {
+  dps: 27274.16648
+  tps: 22138.57419
+ }
+}
+dps_results: {
+ key: "TestFury-AllItems-VesselofAcceleration-68995"
+ value: {
+  dps: 29846.17656
+  tps: 24347.06541
+ }
+}
+dps_results: {
+ key: "TestFury-AllItems-VesselofAcceleration-69167"
+ value: {
+  dps: 29979.62327
+  tps: 24463.62743
  }
 }
 dps_results: {

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -56,6 +56,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestProtectionWarrior-AllItems-AncientPetrifiedSeed-69001"
+ value: {
+  dps: 4581.43274
+  tps: 27923.08852
+ }
+}
+dps_results: {
  key: "TestProtectionWarrior-AllItems-Anhuur'sHymnal-55889"
  value: {
   dps: 4676.52016
@@ -67,6 +74,20 @@ dps_results: {
  value: {
   dps: 4687.16876
   tps: 28511.06202
+ }
+}
+dps_results: {
+ key: "TestProtectionWarrior-AllItems-ApparatusofKhaz'goroth-68972"
+ value: {
+  dps: 4861.84067
+  tps: 29643.07015
+ }
+}
+dps_results: {
+ key: "TestProtectionWarrior-AllItems-ApparatusofKhaz'goroth-69113"
+ value: {
+  dps: 4898.44745
+  tps: 29867.61083
  }
 }
 dps_results: {
@@ -217,6 +238,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestProtectionWarrior-AllItems-Brawler'sTrophy-71338"
+ value: {
+  dps: 4581.43274
+  tps: 27923.08852
+ }
+}
+dps_results: {
  key: "TestProtectionWarrior-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
   dps: 4581.43274
@@ -249,6 +277,13 @@ dps_results: {
  value: {
   dps: 5433.99246
   tps: 32957.0694
+ }
+}
+dps_results: {
+ key: "TestProtectionWarrior-AllItems-Coren'sChilledChromiumCoaster-71335"
+ value: {
+  dps: 4799.60021
+  tps: 29165.5383
  }
 }
 dps_results: {
@@ -336,6 +371,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestProtectionWarrior-AllItems-Dwyer'sCaber-70141"
+ value: {
+  dps: 4994.10651
+  tps: 30366.97783
+ }
+}
+dps_results: {
  key: "TestProtectionWarrior-AllItems-EarthenBattleplate"
  value: {
   dps: 4656.40002
@@ -392,6 +434,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestProtectionWarrior-AllItems-EssenceoftheEternalFlame-69002"
+ value: {
+  dps: 4581.43274
+  tps: 27923.08852
+ }
+}
+dps_results: {
  key: "TestProtectionWarrior-AllItems-EternalShadowspiritDiamond"
  value: {
   dps: 4581.43274
@@ -407,6 +456,13 @@ dps_results: {
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FallofMortality-65124"
+ value: {
+  dps: 4581.43274
+  tps: 27923.08852
+ }
+}
+dps_results: {
+ key: "TestProtectionWarrior-AllItems-FieryQuintessence-69000"
  value: {
   dps: 4581.43274
   tps: 27923.08852
@@ -798,6 +854,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestProtectionWarrior-AllItems-MatrixRestabilizer-68994"
+ value: {
+  dps: 4699.66221
+  tps: 28564.195
+ }
+}
+dps_results: {
+ key: "TestProtectionWarrior-AllItems-MatrixRestabilizer-69150"
+ value: {
+  dps: 4720.98383
+  tps: 28684.83052
+ }
+}
+dps_results: {
  key: "TestProtectionWarrior-AllItems-MightoftheOcean-55251"
  value: {
   dps: 4687.50748
@@ -826,6 +896,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestProtectionWarrior-AllItems-MithrilStopwatch-71337"
+ value: {
+  dps: 4713.46071
+  tps: 28640.61174
+ }
+}
+dps_results: {
  key: "TestProtectionWarrior-AllItems-MoltenGiantBattleplate"
  value: {
   dps: 4968.14958
@@ -847,10 +924,38 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestProtectionWarrior-AllItems-MoonwellPhial-70143"
+ value: {
+  dps: 4581.43274
+  tps: 27923.08852
+ }
+}
+dps_results: {
+ key: "TestProtectionWarrior-AllItems-NecromanticFocus-68982"
+ value: {
+  dps: 4581.43274
+  tps: 27923.08852
+ }
+}
+dps_results: {
+ key: "TestProtectionWarrior-AllItems-NecromanticFocus-69139"
+ value: {
+  dps: 4581.43274
+  tps: 27923.08852
+ }
+}
+dps_results: {
  key: "TestProtectionWarrior-AllItems-Oremantle'sFavor-61448"
  value: {
   dps: 4723.46704
   tps: 28794.30637
+ }
+}
+dps_results: {
+ key: "TestProtectionWarrior-AllItems-PetrifiedPickledEgg-71336"
+ value: {
+  dps: 4581.43274
+  tps: 27923.08852
  }
 }
 dps_results: {
@@ -931,6 +1036,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestProtectionWarrior-AllItems-Ricket'sMagneticFireball-70144"
+ value: {
+  dps: 4673.58797
+  tps: 28419.25694
+ }
+}
+dps_results: {
  key: "TestProtectionWarrior-AllItems-RightEyeofRajh-56100"
  value: {
   dps: 4849.24183
@@ -942,6 +1054,13 @@ dps_results: {
  value: {
   dps: 4872.84286
   tps: 29620.49882
+ }
+}
+dps_results: {
+ key: "TestProtectionWarrior-AllItems-RuneofZeth-68998"
+ value: {
+  dps: 4728.23017
+  tps: 28726.49971
  }
 }
 dps_results: {
@@ -1106,6 +1225,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestProtectionWarrior-AllItems-TheHungerer-68927"
+ value: {
+  dps: 4772.51137
+  tps: 28923.31826
+ }
+}
+dps_results: {
+ key: "TestProtectionWarrior-AllItems-TheHungerer-69112"
+ value: {
+  dps: 4725.43821
+  tps: 28606.45242
+ }
+}
+dps_results: {
  key: "TestProtectionWarrior-AllItems-Theralion'sMirror-59519"
  value: {
   dps: 4581.43274
@@ -1201,6 +1334,34 @@ dps_results: {
  value: {
   dps: 3706.25109
   tps: 23520.55176
+ }
+}
+dps_results: {
+ key: "TestProtectionWarrior-AllItems-VariablePulseLightningCapacitor-68925"
+ value: {
+  dps: 4581.43274
+  tps: 27923.08852
+ }
+}
+dps_results: {
+ key: "TestProtectionWarrior-AllItems-VariablePulseLightningCapacitor-69110"
+ value: {
+  dps: 4581.43274
+  tps: 27923.08852
+ }
+}
+dps_results: {
+ key: "TestProtectionWarrior-AllItems-VesselofAcceleration-68995"
+ value: {
+  dps: 4972.18278
+  tps: 30246.69105
+ }
+}
+dps_results: {
+ key: "TestProtectionWarrior-AllItems-VesselofAcceleration-69167"
+ value: {
+  dps: 5024.80998
+  tps: 30557.43975
  }
 }
 dps_results: {


### PR DESCRIPTION
## **1. Raid items**

- [x] [Vessel of Acceleration](https://www.wowhead.com/cata/item=68995/vessel-of-acceleration)

- [x] [Vessel of Acceleration Heroic](https://www.wowhead.com/cata/item=69167/vessel-of-acceleration)

- [x] [Matrix Restabilizer](https://www.wowhead.com/cata/item=68994/matrix-restabilizer)

- [x] [Matrix Restabilizer Heroic](https://www.wowhead.com/cata/item=69150/matrix-restabilizer)

- [x] [Variable Pulse Lightning Capacitor](https://www.wowhead.com/cata/item=68925/variable-pulse-lightning-capacitor)

- [x] [Variable Pulse Lightning Capacitor Heroic](https://www.wowhead.com/cata/item=69110/variable-pulse-lightning-capacitor)

- [ ] [Jaws of Defeat](https://www.wowhead.com/cata/item=68926/jaws-of-defeat)

- [ ] [Jaws of Defeat Heroic](https://www.wowhead.com/cata/item=69111/jaws-of-defeat)

- [x] [The Hungerer](https://www.wowhead.com/cata/item=68927/the-hungerer)

- [x] [The Hungerer Heroic](https://www.wowhead.com/cata/item=69112/the-hungerer)

- [ ] [Spidersilk Spindle](https://www.wowhead.com/cata/item=68981/spidersilk-spindle)

- [ ] [Spidersilk Spindle Heroic](https://www.wowhead.com/cata/item=69138/spidersilk-spindle)

- [x] [Necromatic Focus](https://www.wowhead.com/cata/item=68982/necromantic-focus)

- [x] [Necromatic Focus Heroic](https://www.wowhead.com/cata/item=69139/necromantic-focus)

- [ ] [Eye of Blazing Power](https://www.wowhead.com/cata/item=68983/eye-of-blazing-power)

- [ ] [Eye of Blazing Power Heroic](https://www.wowhead.com/cata/item=69149/eye-of-blazing-power)

- [x] [Apparatus of Khaz'goroth](https://www.wowhead.com/cata/item=68972/apparatus-of-khazgoroth)

- [x] [Apparatus of Khaz'goroth Heroic](https://www.wowhead.com/cata/item=69113/apparatus-of-khazgoroth)

- [ ] [Scales of Life](https://www.wowhead.com/cata/item=68915/scales-of-life)

- [ ] [Scales of Life Heroic](https://www.wowhead.com/cata/item=69109/scales-of-life) 

## **2. Avengers of Hyjal and Quest Rewards**
 There seems to be heroic versions of the avengers of hyjal items in the database, but those were not available back in the day, just like the heroic trash loot from tier 11 raids.
- [ ] [Stay of Execution](https://www.wowhead.com/cata/item=68996/stay-of-execution)

- [x] [Rune of Zeth](https://www.wowhead.com/cata/item=68998/rune-of-zeth)

- [x] [Fiery Quintessence](https://www.wowhead.com/cata/item=69000/fiery-quintessence)

- [x] [Ancient Petrified Seed](https://www.wowhead.com/cata/item=69001/ancient-petrified-seed)

- [x] [Essence of the Eternal Flame](https://www.wowhead.com/cata/item=69002/essence-of-the-eternal-flame) 

- [x] [Dwyer's Caber](https://www.wowhead.com/cata/item=70141/dwyers-caber)

- [x] [Moonwell Chalice](https://www.wowhead.com/cata/item=70142/moonwell-chalice)

- [x] [Moonwell Phial](https://www.wowhead.com/cata/item=70143/moonwell-phial)

- [x] [Ricket's Magnetic Fireball](https://www.wowhead.com/cata/item=70144/rickets-magnetic-fireball)

## Brewfest
 Do we even bother implementing the tank's brewmaiden on use? [bubblier](https://www.wowhead.com/cata/item=71334/bubblier-brightbrew-charm) and [bitterer](https://www.wowhead.com/cata/item=71333/bitterer-balebrew-charm)
- [x] [Brawler's Trophy](https://www.wowhead.com/cata/item=71338/brawlers-trophy)

- [x] [Coren's Chilled Chromium Coaster](https://www.wowhead.com/cata/item=71335/corens-chilled-chromium-coaster)

- [x] [Mithril Stopwatch](https://www.wowhead.com/cata/item=71337/mithril-stopwatch)

- [x] [Petrified Pickled Egg](https://www.wowhead.com/cata/item=71336/petrified-pickled-egg)


## TBD
The legendary staff will require more thought than any of the other items to implement. There needs to be a discussion if we even bother implementing it following simc and old data for now, or we wait for more information.
- [ ] [Dragonwrath, Tarecgosa's Rest](https://www.wowhead.com/cata/item=71086/dragonwrath-tarecgosas-rest)