### PR TITLE
Frozen slots support for auto-Reforge

### DIFF
--- a/ui/core/proto_utils/gear.ts
+++ b/ui/core/proto_utils/gear.ts
@@ -306,13 +306,13 @@ export class Gear extends BaseGear {
 		return curGear;
 	}
 
-	withoutReforges(canDualWield2H: boolean): Gear {
+	withoutReforges(canDualWield2H: boolean, ignoreSlots?: Map<ItemSlot, boolean>): Gear {
 		let curGear: Gear = this;
 
 		for (const slot of this.getItemSlots()) {
 			const item = this.getEquippedItem(slot);
 
-			if (item) {
+			if (item && !ignoreSlots?.get(slot)) {
 				curGear = curGear.withEquippedItem(slot, item.withItem(item.item).withRandomSuffix(item._randomSuffix), canDualWield2H);
 			}
 		}


### PR DESCRIPTION
Added support for blacklisting item slots in auto-Reforge configuration so that they are not changed by the optimizer.

 On branch auto_reforge
 Changes to be committed:
	modified:   ui/core/components/suggest_reforges_action.tsx
	modified:   ui/core/proto_utils/gear.ts