### PR TITLE
[FIX] Remove CDR from Power Infusion

### DIFF
--- a/sim/core/buffs.go
+++ b/sim/core/buffs.go
@@ -1265,7 +1265,7 @@ func registerPowerInfusionCD(agent Agent, numPowerInfusions int32) {
 			AuraTag:          PowerInfusionAuraTag,
 			CooldownPriority: CooldownPriorityDefault,
 			AuraDuration:     PowerInfusionDuration,
-			AuraCD:           time.Duration(float64(PowerInfusionCD) * 0.8), // All disc priests take Ascension talent.
+			AuraCD:           PowerInfusionCD,
 			Type:             CooldownTypeDPS,
 
 			ShouldActivate: func(sim *Simulation, character *Character) bool {


### PR DESCRIPTION
The code was referencing a `Ascension` (probably meant to be Aspiration) talent, which I cannot find anywhere.
Power Infusion CD in cata is 2 minutes and I'm not aware of any talent/glyph that reduces this.