### PR TITLE
Add filler breakpoints to allow crit prio

### DIFF
--- a/ui/mage/fire/sim.ts
+++ b/ui/mage/fire/sim.ts
@@ -63,9 +63,14 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFireMage, {
 			// https://docs.google.com/spreadsheets/d/1WLOZ1YevGPw_WZs0JhGzVVy906W5y0i9UqHa3ejyBkE/htmlview?gid=19
 			const breakpoints = [
 				1602, // 12.51% - 5-tick LvB + Pyro
+				1800, // Filler
 				1922, // 15.01% - 12-tick Combust
+				2620, // Filler - Minor breakpoint
+				2850, // Filler
 				3212, // 25.08% - 13-tick Combust
+				3850, // Filler
 				4488, // 35.04% - 14-tick Combust
+				4600, // Filler
 				4805, // 37.52% - 6-tick LvB + Pyro
 				5767, // 45.03% - 15-tick Combust
 				7033, // 54.92% - 16-tick Combust
@@ -93,7 +98,20 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFireMage, {
 				stat: Stat.StatSpellHaste,
 				breakpoints,
 				capType: StatCapType.TypeSoftCap,
-				postCapEPs: [0.86, 0.77, 0.77, 1.17, 0.76, 0.65, 0.64],
+				postCapEPs: [
+					0.59, // 12.51% - 5-tick LvB + Pyro
+					0.66, // Filler
+					0.59, // 15.01% - 12-tick Combust
+					0.61, // Filler - Minor breakpoint
+					0.77, // Filler
+					0.61, // 25.08% - 13-tick Combust
+					0.77, // Filler
+					0.61, // 35.04% - 14-tick Combust
+					1.17, // Filler
+					0.76, // 37.52% - 6-tick LvB + Pyro
+					0.65, // 45.03% - 15-tick Combust
+					0.64, // 54.92% - 16-tick Combust
+				],
 			};
 
 			return [hasteSoftCapConfig];

--- a/ui/mage/fire/sim.ts
+++ b/ui/mage/fire/sim.ts
@@ -63,15 +63,12 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFireMage, {
 			// https://docs.google.com/spreadsheets/d/1WLOZ1YevGPw_WZs0JhGzVVy906W5y0i9UqHa3ejyBkE/htmlview?gid=19
 			const breakpoints = [
 				1602, // 12.51% - 5-tick LvB + Pyro
-				1800, // Filler
 				1922, // 15.01% - 12-tick Combust
-				2620, // Filler - Minor breakpoint
-				2850, // Filler
+				2453, // Filler
 				3212, // 25.08% - 13-tick Combust
-				3850, // Filler
 				4488, // 35.04% - 14-tick Combust
-				4600, // Filler
 				4805, // 37.52% - 6-tick LvB + Pyro
+				5118, // Filler
 				5767, // 45.03% - 15-tick Combust
 				7033, // 54.92% - 16-tick Combust
 				// 8000, // 62.47% - 7-tick LvB + Pyro
@@ -97,21 +94,8 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFireMage, {
 			const hasteSoftCapConfig = {
 				stat: Stat.StatSpellHaste,
 				breakpoints,
-				capType: StatCapType.TypeSoftCap,
-				postCapEPs: [
-					0.59, // 12.51% - 5-tick LvB + Pyro
-					0.66, // Filler
-					0.59, // 15.01% - 12-tick Combust
-					0.61, // Filler - Minor breakpoint
-					0.77, // Filler
-					0.61, // 25.08% - 13-tick Combust
-					0.77, // Filler
-					0.61, // 35.04% - 14-tick Combust
-					1.17, // Filler
-					0.76, // 37.52% - 6-tick LvB + Pyro
-					0.65, // 45.03% - 15-tick Combust
-					0.64, // 54.92% - 16-tick Combust
-				],
+				capType: StatCapType.TypeThreshold,
+				postCapEPs: Array(breakpoints.length).fill(0),
 			};
 
 			return [hasteSoftCapConfig];

--- a/ui/warlock/affliction/sim.ts
+++ b/ui/warlock/affliction/sim.ts
@@ -54,7 +54,9 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecAfflictionWarlock, {
 			const masteryRatingBreakpoints = [];
 
 			for (let masteryPercent = 14; masteryPercent <= 200; masteryPercent++) {
-				masteryRatingBreakpoints.push((masteryPercent / 1.63) * Mechanics.MASTERY_RATING_PER_MASTERY_POINT);
+				masteryRatingBreakpoints.push(
+					(masteryPercent / Mechanics.masteryPercentPerPoint.get(Spec.SpecAfflictionWarlock)!) * Mechanics.MASTERY_RATING_PER_MASTERY_POINT,
+				);
 			}
 
 			const masterySoftCapConfig = {

--- a/ui/warlock/demonology/sim.ts
+++ b/ui/warlock/demonology/sim.ts
@@ -51,10 +51,12 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecDemonologyWarlock, {
 			// Set up Mastery breakpoints for integer % damage increments.
 			// These should be removed once the bugfix to make Mastery
 			// continuous goes live!
-			const masteryRatingBreakpoints = [];
+			const masteryRatingBreakpoints: number[] = [];
 
 			for (let masteryPercent = 19; masteryPercent <= 200; masteryPercent++) {
-				masteryRatingBreakpoints.push((masteryPercent / 2.3) * Mechanics.MASTERY_RATING_PER_MASTERY_POINT);
+				masteryRatingBreakpoints.push(
+					(masteryPercent / Mechanics.masteryPercentPerPoint.get(Spec.SpecDemonologyWarlock)!) * Mechanics.MASTERY_RATING_PER_MASTERY_POINT,
+				);
 			}
 
 			const masterySoftCapConfig = {


### PR DESCRIPTION
- Added filler breakpoints to improve Haste x Crit variation
  - Doesn't deadlock 
- Changed to Threshold capping due to how Crit always > Haste when no breakpoint is met. (until you are in the 10000+ crit rating levels)

Red = Breakpoint
Black = Filler

![image](https://github.com/wowsims/cata/assets/1216787/41148dbb-3864-44bf-99fa-54c188982f0e)
