### PR TITLE
[Ret] Fix Guardian of Ancient Kings hit, exp and crit stats

### DIFF
--- a/sim/paladin/ancient_guardian_pet.go
+++ b/sim/paladin/ancient_guardian_pet.go
@@ -15,18 +15,25 @@ type AncientGuardianPet struct {
 func (guardian *AncientGuardianPet) Initialize() {
 }
 
-const PetExpertiseScale = 3.25
+const PetExpertiseScale = 3.25 * core.ExpertisePerQuarterPercentReduction / core.MeleeHitRatingPerHitChance // 0.8125
 
 func (paladin *Paladin) NewAncientGuardian() *AncientGuardianPet {
 	ancientGuardian := &AncientGuardianPet{
 		Pet: core.NewPet("Ancient Guardian", &paladin.Character, stats.Stats{
 			stats.Stamina: 100,
 		}, func(ownerStats stats.Stats) stats.Stats {
-			return stats.Stats{
-				stats.MeleeHit:  ownerStats[stats.MeleeHit],
-				stats.Expertise: ownerStats[stats.MeleeHit] * PetExpertiseScale,
+			// Draenei Heroic Presence is not included
+			hit := ownerStats[stats.MeleeHit]
+			if paladin.Race == proto.Race_RaceDraenei {
+				hit -= 1 * core.MeleeHitRatingPerHitChance
+			}
 
-				stats.MeleeCrit: ownerStats[stats.MeleeCrit],
+			return stats.Stats{
+				stats.MeleeHit:  hit,
+				stats.Expertise: hit * PetExpertiseScale,
+
+				// Taken from combined logs with > 1600 hits, seems to be around 2%
+				stats.MeleeCrit: (5 + 1.8) * core.CritRatingPerCritChance,
 			}
 		}, false, true),
 		paladinOwner: paladin,

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -37,56 +37,56 @@ character_stats_results: {
 dps_results: {
  key: "TestRetribution-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 31953.88224
+  dps: 31928.76923
   tps: 31942.29543
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 29981.83572
+  dps: 29958.18276
   tps: 29968.06995
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 30009.93637
+  dps: 29986.28341
   tps: 29999.80961
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 30006.88966
+  dps: 29983.23669
   tps: 29996.76289
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 31558.42545
+  dps: 31534.77249
   tps: 31548.29869
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BattleplateofImmolation"
  value: {
-  dps: 30704.72299
+  dps: 30679.53926
   tps: 30669.79068
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BattleplateofRadiantGlory"
  value: {
-  dps: 31528.29977
+  dps: 31503.20239
   tps: 31515.00584
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 29985.2476
+  dps: 29961.59463
   tps: 29975.12083
   hps: 125.74785
  }
@@ -94,1358 +94,1358 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 29983.97483
+  dps: 29960.32187
   tps: 29973.84806
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 30587.04134
+  dps: 30557.4963
   tps: 30571.0225
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 30663.58586
+  dps: 30634.04082
   tps: 30647.56701
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BindingPromise-67037"
  value: {
-  dps: 29983.97483
+  dps: 29960.32187
   tps: 29973.84806
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 30715.9171
+  dps: 30692.26413
   tps: 30705.79033
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 30395.49863
+  dps: 30371.84566
   tps: 30385.37186
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 30449.38865
+  dps: 30425.73569
   tps: 30439.26188
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 30594.3901
+  dps: 30570.73713
   tps: 30584.26333
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 30038.19896
+  dps: 30014.54599
   tps: 30028.07219
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 31400.26201
+  dps: 31376.60904
   tps: 31390.13524
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 30471.77446
+  dps: 30443.70958
   tps: 30457.23578
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 29983.97483
+  dps: 29960.32187
   tps: 29973.84806
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 29983.97483
+  dps: 29960.32187
   tps: 29973.84806
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 30418.99543
+  dps: 30395.34247
   tps: 30408.86866
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 30046.89222
+  dps: 30023.23925
   tps: 30036.76545
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 30949.46622
+  dps: 30925.81325
   tps: 30939.33945
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BottledLightning-66879"
  value: {
-  dps: 30281.56179
+  dps: 30257.90882
   tps: 30267.79601
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 31535.78161
+  dps: 31511.40141
   tps: 30898.79777
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 32599.12846
+  dps: 32575.47549
   tps: 32589.00169
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 31847.56113
+  dps: 31823.18093
   tps: 31836.1567
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 31961.66089
+  dps: 31936.54789
   tps: 31950.07409
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 30137.16396
+  dps: 30113.51099
   tps: 30123.83269
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 29983.97483
+  dps: 29960.32187
   tps: 29973.84806
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CrushingWeight-59506"
  value: {
-  dps: 31286.28124
+  dps: 31260.03396
   tps: 31270.18177
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CrushingWeight-65118"
  value: {
-  dps: 31309.13754
+  dps: 31276.10108
   tps: 31282.7402
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 29983.97483
+  dps: 29960.32187
   tps: 29973.84806
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 31682.90439
+  dps: 31660.6666
   tps: 31666.5862
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 31164.65125
+  dps: 31138.69553
   tps: 31144.61513
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 30005.46376
+  dps: 29981.8108
   tps: 29993.17655
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 30543.69989
+  dps: 30520.04692
   tps: 30536.5371
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 30675.34962
+  dps: 30650.16778
   tps: 30660.62218
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 31644.48657
+  dps: 31619.37356
   tps: 31632.89976
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 30250.27722
+  dps: 30226.62425
   tps: 30237.01575
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 31558.42545
+  dps: 31534.77249
   tps: 31548.29869
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 30062.50211
+  dps: 30037.371
   tps: 30050.40418
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 31526.93519
+  dps: 31503.28222
   tps: 31516.41139
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 31644.48657
+  dps: 31619.37356
   tps: 31632.89976
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 30856.24325
+  dps: 30828.17837
   tps: 30841.70457
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 31019.92552
+  dps: 30990.38048
   tps: 31003.90668
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 31558.42545
+  dps: 31534.77249
   tps: 31548.29869
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FallofMortality-59500"
  value: {
-  dps: 30005.46376
+  dps: 29981.8108
   tps: 29993.17655
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FallofMortality-65124"
  value: {
-  dps: 30078.34533
+  dps: 30054.69236
   tps: 30065.79882
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 30549.39157
+  dps: 30525.7386
   tps: 30539.2648
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 30020.33321
+  dps: 29996.68025
   tps: 30007.45157
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 29983.97483
+  dps: 29960.32187
   tps: 29973.84806
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 30088.21052
+  dps: 30064.55755
   tps: 30076.16941
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 31801.85737
+  dps: 31778.2044
   tps: 31791.7306
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 31650.32294
+  dps: 31626.66997
   tps: 31640.19617
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FluidDeath-58181"
  value: {
-  dps: 30512.09451
+  dps: 30488.44155
   tps: 30501.96775
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 31535.78161
+  dps: 31511.40141
   tps: 31524.37718
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 31883.50408
+  dps: 31853.95904
   tps: 31867.48524
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GaleofShadows-56138"
  value: {
-  dps: 30436.55492
+  dps: 30412.78747
   tps: 30421.76397
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GaleofShadows-56462"
  value: {
-  dps: 30216.38324
+  dps: 30192.61578
   tps: 30200.69243
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GearDetector-61462"
  value: {
-  dps: 30307.56854
+  dps: 30284.77118
   tps: 30297.86202
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Gladiator'sVindication"
  value: {
-  dps: 25848.9308
-  tps: 25847.76606
+  dps: 25827.44005
+  tps: 25845.7319
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 29983.37337
+  dps: 29959.7204
   tps: 29967.17269
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 30407.16276
+  dps: 30382.04975
   tps: 30395.57595
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 30619.68321
+  dps: 30593.10226
   tps: 30606.62845
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HarmlightToken-63839"
  value: {
-  dps: 30062.90523
+  dps: 30039.25226
   tps: 30051.01677
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 31060.93819
+  dps: 31037.28522
   tps: 31050.81142
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 30251.4557
+  dps: 30226.95363
   tps: 30235.93666
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 30236.73176
+  dps: 30213.07879
   tps: 30223.27792
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HeartofRage-59224"
  value: {
-  dps: 31177.07546
+  dps: 31153.4225
   tps: 31166.94869
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HeartofSolace-55868"
  value: {
-  dps: 30373.94175
+  dps: 30350.17429
   tps: 30359.15079
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HeartofSolace-56393"
  value: {
-  dps: 31189.99241
+  dps: 31166.22495
   tps: 31174.3016
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HeartofThunder-55845"
  value: {
-  dps: 29983.97483
+  dps: 29960.32187
   tps: 29973.84806
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HeartofThunder-56370"
  value: {
-  dps: 29983.97483
+  dps: 29960.32187
   tps: 29973.84806
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 30446.65079
+  dps: 30420.83302
   tps: 30434.35922
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 31644.48657
+  dps: 31619.37356
   tps: 31632.89976
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 32034.99867
+  dps: 32011.3457
   tps: 32024.8719
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 30395.49863
+  dps: 30371.84566
   tps: 30385.37186
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 30449.38865
+  dps: 30425.73569
   tps: 30439.26188
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 29983.97483
+  dps: 29960.32187
   tps: 29973.84806
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 30321.33815
+  dps: 30297.68518
   tps: 30311.21138
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 29925.24303
+  dps: 29901.59007
   tps: 29933.7574
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 29961.11719
+  dps: 29937.46423
   tps: 29974.20156
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 30715.9171
+  dps: 30692.26413
   tps: 30705.79033
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 30331.95144
+  dps: 30308.29847
   tps: 30321.82467
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 30426.32932
+  dps: 30402.67635
   tps: 30416.20255
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 30550.5925
+  dps: 30526.93954
   tps: 30537.51158
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 30550.5925
+  dps: 30526.93954
   tps: 30537.51158
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 30297.42551
+  dps: 30272.18696
   tps: 30281.27308
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LastWord-50708"
  value: {
-  dps: 32385.08437
+  dps: 32361.4314
   tps: 32374.9576
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LeadenDespair-55816"
  value: {
-  dps: 29983.97483
+  dps: 29960.32187
   tps: 29973.84806
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LeadenDespair-56347"
  value: {
-  dps: 29983.97483
+  dps: 29960.32187
   tps: 29973.84806
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 30319.11603
+  dps: 30295.46307
   tps: 30308.98926
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 30361.27605
+  dps: 30337.62308
   tps: 30351.14928
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 31118.80776
+  dps: 31095.15479
   tps: 31108.68099
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 30717.17367
+  dps: 30693.52071
   tps: 30707.0469
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 30955.88957
+  dps: 30932.23661
   tps: 30945.76281
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 29983.97483
+  dps: 29960.32187
   tps: 29973.84806
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 29983.97483
+  dps: 29960.32187
   tps: 29973.84806
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 31400.21596
+  dps: 31376.56299
   tps: 31390.08919
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 31587.77052
+  dps: 31564.11755
   tps: 31577.64375
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 30505.73959
+  dps: 30482.08662
   tps: 30495.61282
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 30955.88957
+  dps: 30932.23661
   tps: 30945.76281
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 30508.17777
+  dps: 30484.5248
   tps: 30498.051
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 30508.17777
+  dps: 30484.5248
   tps: 30498.051
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 31234.06644
+  dps: 31210.41347
   tps: 31220.20532
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 31047.34535
+  dps: 31023.69238
   tps: 31037.21858
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 29983.97483
+  dps: 29960.32187
   tps: 29973.84806
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 30348.76848
+  dps: 30323.65548
   tps: 30337.18167
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 30360.0655
+  dps: 30336.41253
   tps: 30349.93873
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 30693.09193
+  dps: 30669.43896
   tps: 30682.96516
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 31558.42545
+  dps: 31534.77249
   tps: 31548.29869
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 30688.04823
+  dps: 30659.2035
   tps: 30666.68094
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 30874.11296
+  dps: 30847.39837
   tps: 30850.71528
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Rainsong-55854"
  value: {
-  dps: 29983.97483
+  dps: 29960.32187
   tps: 29973.84806
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Rainsong-56377"
  value: {
-  dps: 29983.97483
+  dps: 29960.32187
   tps: 29973.84806
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ReinforcedSapphiriumBattlearmor"
  value: {
-  dps: 27088.89874
+  dps: 27063.79374
   tps: 26949.8833
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ReinforcedSapphiriumBattleplate"
  value: {
-  dps: 29102.88306
+  dps: 29083.87457
   tps: 29095.6512
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 32034.99867
+  dps: 32011.3457
   tps: 32024.8719
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 31870.33376
+  dps: 31846.68079
   tps: 31860.20699
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 30756.73318
+  dps: 30733.08021
   tps: 30746.60641
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 30831.47638
+  dps: 30807.82342
   tps: 30821.34961
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 30709.15732
+  dps: 30683.33955
   tps: 30696.86575
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SeaStar-55256"
  value: {
-  dps: 30011.26527
+  dps: 29987.6123
   tps: 30001.1385
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SeaStar-56290"
  value: {
-  dps: 30034.80995
+  dps: 30011.15698
   tps: 30024.68318
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Shadowmourne-49623"
  value: {
-  dps: 33990.34483
+  dps: 33965.23182
   tps: 33976.35623
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ShardofWoe-60233"
  value: {
-  dps: 30281.31834
+  dps: 30258.48507
   tps: 30253.99846
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 30896.72836
+  dps: 30871.15403
   tps: 30884.04631
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 29983.97483
+  dps: 29960.32187
   tps: 29973.84806
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 31234.63639
+  dps: 31208.81863
   tps: 31222.34482
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 31389.03593
+  dps: 31362.45497
   tps: 31375.98117
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Sorrowsong-55879"
  value: {
-  dps: 30447.54151
+  dps: 30423.88854
   tps: 30437.41474
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Sorrowsong-56400"
  value: {
-  dps: 30508.24667
+  dps: 30484.5937
   tps: 30498.1199
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 30505.73959
+  dps: 30482.08662
   tps: 30495.61282
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SoulCasket-58183"
  value: {
-  dps: 30576.88544
+  dps: 30553.23247
   tps: 30566.75867
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 30229.68096
+  dps: 30206.02799
   tps: 30214.37458
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-StumpofTime-62465"
  value: {
-  dps: 30062.38148
+  dps: 30038.72851
   tps: 30052.25471
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-StumpofTime-62470"
  value: {
-  dps: 30060.07542
+  dps: 30036.42245
   tps: 30049.94865
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 29983.97483
+  dps: 29960.32187
   tps: 29973.84806
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 29983.97483
+  dps: 29960.32187
   tps: 29973.84806
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 30299.42212
+  dps: 30275.76915
   tps: 30288.19022
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 30917.91621
+  dps: 30894.07709
   tps: 30905.08544
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TearofBlood-55819"
  value: {
-  dps: 29985.9808
+  dps: 29962.32783
   tps: 29972.31171
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TearofBlood-56351"
  value: {
-  dps: 30036.63098
+  dps: 30012.97802
   tps: 30024.58988
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 30357.99567
+  dps: 30334.34271
   tps: 30347.8689
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 30483.58017
+  dps: 30459.9272
   tps: 30473.4534
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 30279.86056
+  dps: 30256.20759
   tps: 30267.57334
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 30411.68617
+  dps: 30388.0332
   tps: 30399.13966
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 29983.97483
+  dps: 29960.32187
   tps: 29973.84806
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 29983.97483
+  dps: 29960.32187
   tps: 29973.84806
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 30844.10576
+  dps: 30820.45279
   tps: 30833.97899
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 30944.16682
+  dps: 30920.51386
   tps: 30934.04006
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 30942.20549
+  dps: 30921.94188
   tps: 30934.58187
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 30167.88561
+  dps: 30144.23264
   tps: 30171.04106
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-UnheededWarning-59520"
  value: {
-  dps: 30913.94228
+  dps: 30885.8774
   tps: 30899.40359
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 30013.37765
+  dps: 29989.72468
   tps: 30001.67815
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 31147.79905
+  dps: 31124.14608
   tps: 31137.67228
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 31147.79905
+  dps: 31124.14608
   tps: 31137.67228
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 31147.79905
+  dps: 31124.14608
   tps: 31137.67228
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 16861.50702
-  tps: 16825.29717
+  dps: 16838.28639
+  tps: 16825.09214
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 29983.97483
+  dps: 29960.32187
   tps: 29973.84806
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 29983.97483
+  dps: 29960.32187
   tps: 29973.84806
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 30611.23105
+  dps: 30587.57808
   tps: 30601.10428
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 30041.23123
+  dps: 30017.57826
   tps: 30031.10446
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 31479.46228
+  dps: 31455.80931
   tps: 31469.33551
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 29983.97483
+  dps: 29960.32187
   tps: 29973.84806
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 30289.05922
+  dps: 30264.46334
   tps: 30276.35269
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 30555.04575
+  dps: 30525.50071
   tps: 30539.02691
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 29983.97483
+  dps: 29960.32187
   tps: 29973.84806
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 30539.20535
+  dps: 30515.55239
   tps: 30529.07859
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 29983.97483
+  dps: 29960.32187
   tps: 29973.84806
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 30471.06986
+  dps: 30447.41689
   tps: 30460.94309
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 30025.6174
+  dps: 30001.96443
   tps: 30015.49063
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 30991.24776
+  dps: 30967.59479
   tps: 30981.12099
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 30078.91666
+  dps: 30054.37604
   tps: 30068.61298
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 30225.17255
+  dps: 30201.51958
   tps: 30216.55282
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 30341.60861
+  dps: 30317.95564
   tps: 30331.48184
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 30545.24693
+  dps: 30521.59396
   tps: 30535.12016
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 30545.24693
+  dps: 30521.59396
   tps: 30535.12016
  }
 }
 dps_results: {
  key: "TestRetribution-Average-Default"
  value: {
-  dps: 32040.9136
+  dps: 32015.84265
   tps: 32018.28982
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 31425.5773
+  dps: 31410.71968
   tps: 35767.3146
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26758.72486
+  dps: 26744.10912
   tps: 26754.89126
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 35573.99541
+  dps: 35500.91673
   tps: 34562.4864
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17430.39265
+  dps: 17431.0928
   tps: 20950.80025
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 15808.98064
+  dps: 15810.57358
   tps: 15787.97375
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 19751.93171
+  dps: 19759.89642
   tps: 18868.38421
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Seal of Insight-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 25423.72646
+  dps: 25405.43449
   tps: 31953.41367
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Seal of Insight-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 20472.42229
+  dps: 20454.04777
   tps: 20580.18961
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Seal of Insight-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 27827.71269
+  dps: 27735.84007
   tps: 26950.86669
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Seal of Insight-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 14860.42884
+  dps: 14863.25367
   tps: 20885.44848
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Seal of Insight-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 12300.67797
+  dps: 12304.3187
   tps: 12419.41899
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Seal of Insight-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 15637.95908
+  dps: 15656.16274
   tps: 14904.44182
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Seal of Justice-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 26227.18061
+  dps: 26212.41429
   tps: 30564.37042
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Seal of Justice-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 21619.96968
+  dps: 21602.67075
   tps: 21614.52937
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Seal of Justice-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 29680.09209
+  dps: 29593.59745
   tps: 28659.0858
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Seal of Justice-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 14644.97726
+  dps: 14647.16718
   tps: 18166.26033
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Seal of Justice-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 13078.47619
+  dps: 13079.8014
   tps: 13058.27992
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Seal of Justice-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 16866.75531
+  dps: 16873.38138
   tps: 15993.55766
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Seal of Righteousness-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 80251.99712
+  dps: 80228.46011
   tps: 84582.89997
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Seal of Righteousness-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 23076.52244
+  dps: 23059.22351
   tps: 23071.08213
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Seal of Righteousness-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 31651.06662
+  dps: 31564.57198
   tps: 30630.06033
  }
 }
@@ -1459,1673 +1459,1673 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Seal of Righteousness-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 13793.46365
+  dps: 13794.78887
   tps: 13773.26739
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Seal of Righteousness-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 17728.26369
+  dps: 17734.88977
   tps: 16855.06604
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Snapshot Guardian-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 31489.4883
+  dps: 31463.24026
   tps: 35686.68081
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Snapshot Guardian-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26963.99252
+  dps: 26939.70129
   tps: 26826.25747
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Snapshot Guardian-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 36784.25811
+  dps: 36662.80193
   tps: 35113.47572
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Snapshot Guardian-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17613.71392
+  dps: 17615.10314
   tps: 21023.13763
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Snapshot Guardian-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 15964.91385
+  dps: 15967.84749
   tps: 15831.33499
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Snapshot Guardian-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 20652.02673
+  dps: 20666.69492
   tps: 19203.58055
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 37176.90949
+  dps: 37153.17751
   tps: 41516.86182
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 32034.99867
+  dps: 32011.3457
   tps: 32024.8719
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 41947.66515
+  dps: 41829.40031
   tps: 40899.69727
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 20550.82671
+  dps: 20547.84824
   tps: 24164.69257
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 19125.44047
+  dps: 19119.59362
   tps: 19093.97177
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 23775.59689
+  dps: 23746.36268
   tps: 22863.60244
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Seal of Insight-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 30021.33403
+  dps: 29995.18583
   tps: 36581.59445
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Seal of Insight-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 24693.58814
+  dps: 24666.89266
   tps: 24796.32352
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Seal of Insight-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 33461.53591
+  dps: 33336.4568
   tps: 32563.915
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Seal of Insight-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17446.59906
+  dps: 17444.28711
   tps: 23545.63464
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Seal of Insight-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 15159.16299
+  dps: 15156.9799
   tps: 15281.97371
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Seal of Insight-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 19011.32176
+  dps: 19000.40628
   tps: 18269.13247
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Seal of Justice-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 30900.04795
+  dps: 30873.99538
   tps: 35231.05448
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Seal of Justice-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26168.62766
+  dps: 26145.88442
   tps: 26157.85744
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Seal of Justice-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 35173.5981
+  dps: 35063.76081
   tps: 34125.58535
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Seal of Justice-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17301.83639
+  dps: 17300.39447
   tps: 20915.08666
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Seal of Justice-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 15962.30628
+  dps: 15958.08184
   tps: 15937.33734
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Seal of Justice-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 20060.18442
+  dps: 20039.06219
   tps: 19169.28907
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Seal of Righteousness-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 92878.14743
+  dps: 92851.61135
   tps: 97210.85836
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Seal of Righteousness-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 27830.72484
+  dps: 27807.98159
   tps: 27819.95461
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Seal of Righteousness-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 37430.83464
+  dps: 37320.99734
   tps: 36382.82189
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Seal of Righteousness-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 50753.90067
+  dps: 50749.99325
   tps: 54367.1661
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Seal of Righteousness-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 16799.67028
+  dps: 16795.44584
   tps: 16774.70134
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Seal of Righteousness-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 21072.32297
+  dps: 21051.20075
   tps: 20181.42762
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Snapshot Guardian-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 37447.95288
+  dps: 37409.93087
   tps: 41606.92666
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Snapshot Guardian-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 32288.39168
+  dps: 32253.41005
   tps: 32145.31629
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Snapshot Guardian-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 43417.62455
+  dps: 43242.7164
   tps: 41704.52834
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Snapshot Guardian-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 20775.8564
+  dps: 20768.68787
   tps: 24274.37907
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Snapshot Guardian-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 19295.45793
+  dps: 19284.46511
   tps: 19145.96483
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Snapshot Guardian-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 24786.19513
+  dps: 24734.61681
   tps: 23286.05216
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 31243.94728
+  dps: 31229.08966
   tps: 35486.46315
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26928.82152
+  dps: 26914.20578
   tps: 26917.32392
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 35585.86868
+  dps: 35512.79
   tps: 34564.95089
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17168.21602
+  dps: 17168.91618
   tps: 20424.9684
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 15413.14185
+  dps: 15414.7348
   tps: 15381.49941
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 19740.84599
+  dps: 19748.8107
   tps: 18845.09195
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Seal of Insight-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 25433.41871
+  dps: 25415.12673
   tps: 31943.15369
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Seal of Insight-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 20480.18001
+  dps: 20461.80549
   tps: 20587.03724
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Seal of Insight-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 27837.24426
+  dps: 27745.37164
   tps: 26958.63264
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Seal of Insight-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 14861.60728
+  dps: 14864.43211
   tps: 20864.95198
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Seal of Insight-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 12303.57346
+  dps: 12307.21419
   tps: 12421.51361
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Seal of Insight-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 15643.50703
+  dps: 15661.71069
   tps: 14907.77332
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Seal of Justice-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 26012.97694
+  dps: 25998.21062
   tps: 30250.6259
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Seal of Justice-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 21632.01608
+  dps: 21613.83742
   tps: 21617.65567
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Seal of Justice-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 29688.28673
+  dps: 29601.7921
   tps: 28657.87167
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Seal of Justice-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 14360.31815
+  dps: 14362.50808
   tps: 17617.42458
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Seal of Justice-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 12736.69582
+  dps: 12738.02103
   tps: 12707.32092
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Seal of Justice-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 16872.70351
+  dps: 16879.32959
   tps: 15987.29933
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Seal of Righteousness-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 80010.05413
+  dps: 79988.12133
   tps: 84244.631
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Seal of Righteousness-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 23088.99729
+  dps: 23070.81862
   tps: 23074.63688
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Seal of Righteousness-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 31659.80061
+  dps: 31573.30597
   tps: 30629.38555
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Seal of Righteousness-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 42993.02984
+  dps: 42993.67842
   tps: 46248.48465
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Seal of Righteousness-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 13443.05316
+  dps: 13444.37837
   tps: 13413.67826
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Seal of Righteousness-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 17734.5282
+  dps: 17741.15427
   tps: 16849.12401
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Snapshot Guardian-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 31402.14915
+  dps: 31375.90111
   tps: 35506.33666
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Snapshot Guardian-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 27069.17236
+  dps: 27044.88112
   tps: 26923.26077
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Snapshot Guardian-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 36796.65992
+  dps: 36675.20375
   tps: 35116.46892
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Snapshot Guardian-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17333.15663
+  dps: 17334.54584
   tps: 20479.12768
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Snapshot Guardian-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 15586.14851
+  dps: 15589.08215
   tps: 15441.47739
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Snapshot Guardian-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 20646.78317
+  dps: 20661.45136
   tps: 19185.77496
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 37038.8216
+  dps: 37015.08962
   tps: 41293.82979
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 32349.50804
+  dps: 32325.85507
   tps: 32327.5883
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 41933.66434
+  dps: 41815.3995
   tps: 40878.14871
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 20226.62741
+  dps: 20223.64894
   tps: 23611.01832
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 19149.37657
+  dps: 19142.87752
   tps: 19113.09579
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 23762.43405
+  dps: 23733.19984
   tps: 22837.10632
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Seal of Insight-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 30031.99563
+  dps: 30005.84743
   tps: 36576.35582
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Seal of Insight-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 24702.19043
+  dps: 24675.49496
   tps: 24804.04914
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Seal of Insight-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 33472.09924
+  dps: 33347.02014
   tps: 32573.81728
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Seal of Insight-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17451.98599
+  dps: 17449.67404
   tps: 23540.61591
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Seal of Insight-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 15161.48015
+  dps: 15159.29705
   tps: 15283.64318
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Seal of Insight-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 19017.53953
+  dps: 19006.62405
   tps: 18274.09932
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Seal of Justice-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 30704.38853
+  dps: 30677.51802
   tps: 34949.68704
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Seal of Justice-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26240.93462
+  dps: 26217.50117
   tps: 26217.91547
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Seal of Justice-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 35192.62533
+  dps: 35082.78804
   tps: 34137.06483
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Seal of Justice-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 16933.53127
+  dps: 16932.08934
   tps: 20316.65555
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Seal of Justice-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 15970.73867
+  dps: 15966.50787
   tps: 15939.98229
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Seal of Justice-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 20041.9548
+  dps: 20024.03473
   tps: 19140.92834
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Seal of Righteousness-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 92675.85612
+  dps: 92649.32004
   tps: 96923.58417
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Seal of Righteousness-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 27907.52319
+  dps: 27884.08974
   tps: 27884.50404
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Seal of Righteousness-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 37449.21705
+  dps: 37339.37975
   tps: 36393.65655
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Seal of Righteousness-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 50221.21081
+  dps: 50217.30338
   tps: 53605.61037
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Seal of Righteousness-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 16805.62897
+  dps: 16801.39817
   tps: 16774.87259
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Seal of Righteousness-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 21054.95429
+  dps: 21037.03422
   tps: 20153.92783
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Snapshot Guardian-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 37523.50539
+  dps: 37485.48338
   tps: 41550.30347
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Snapshot Guardian-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 32507.99919
+  dps: 32473.01756
   tps: 32350.40791
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Snapshot Guardian-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 43408.3234
+  dps: 43233.41524
   tps: 41687.67943
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Snapshot Guardian-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 20470.92311
+  dps: 20463.75459
   tps: 23741.06403
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Snapshot Guardian-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 19350.00276
+  dps: 19339.00994
   tps: 19196.28299
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Snapshot Guardian-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 24782.06668
+  dps: 24730.48836
   tps: 23268.72628
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 31273.11878
+  dps: 31258.26116
   tps: 35517.72525
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26938.71124
+  dps: 26924.0955
   tps: 26927.21399
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 35598.96318
+  dps: 35525.88449
   tps: 34578.04757
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17196.4154
+  dps: 17197.11555
   tps: 20484.61261
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 15401.25115
+  dps: 15402.8441
   tps: 15365.00139
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 19748.54828
+  dps: 19756.513
   tps: 18852.79425
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Seal of Insight-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 25443.03248
+  dps: 25425.55482
   tps: 31953.67166
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Seal of Insight-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 20487.36092
+  dps: 20469.80071
   tps: 20595.03756
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Seal of Insight-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 27842.95785
+  dps: 27755.15682
   tps: 26968.4215
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Seal of Insight-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 14867.89975
+  dps: 14870.72459
   tps: 20871.24446
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Seal of Insight-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 12308.51809
+  dps: 12312.15882
   tps: 12426.45823
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Seal of Insight-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 15649.25969
+  dps: 15667.46335
   tps: 14913.52597
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Seal of Justice-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 26056.40955
+  dps: 26041.64322
   tps: 30296.03217
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Seal of Justice-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 21640.18861
+  dps: 21622.00995
   tps: 21625.82856
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Seal of Justice-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 29698.91322
+  dps: 29612.41858
   tps: 28668.50034
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Seal of Justice-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 14384.14812
+  dps: 14386.33804
   tps: 17672.78257
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Seal of Justice-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 12732.56529
+  dps: 12733.89051
   tps: 12698.69185
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Seal of Justice-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 16879.04934
+  dps: 16885.67541
   tps: 15993.64515
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Seal of Righteousness-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 80038.59824
+  dps: 80016.66544
   tps: 84275.24225
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Seal of Righteousness-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 23096.93911
+  dps: 23078.76044
   tps: 23082.57905
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Seal of Righteousness-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 31671.29497
+  dps: 31584.80033
   tps: 30640.88209
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Seal of Righteousness-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 43049.47863
+  dps: 43050.12721
   tps: 46336.34028
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Seal of Righteousness-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 13438.89555
+  dps: 13440.22076
   tps: 13405.0221
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Seal of Righteousness-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 17741.33861
+  dps: 17747.96469
   tps: 16855.93443
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Snapshot Guardian-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 31432.4109
+  dps: 31406.16286
   tps: 35538.64985
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Snapshot Guardian-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 27079.36723
+  dps: 27055.076
   tps: 26933.45601
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Snapshot Guardian-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 36810.2647
+  dps: 36688.80853
   tps: 35130.07593
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Snapshot Guardian-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17360.08174
+  dps: 17361.47095
   tps: 20537.49776
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Snapshot Guardian-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 15578.36824
+  dps: 15581.30188
   tps: 15429.34754
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Snapshot Guardian-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 20654.81702
+  dps: 20669.48521
   tps: 19193.80881
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 37030.21791
+  dps: 37006.48593
   tps: 41285.28258
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 32361.59205
+  dps: 32337.93908
   tps: 32339.67362
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 41947.81857
+  dps: 41829.55374
   tps: 40892.30618
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 20272.97903
+  dps: 20270.00056
   tps: 23656.55058
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 19156.47487
+  dps: 19149.97582
   tps: 19120.19409
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 23770.89788
+  dps: 23741.66367
   tps: 22845.57016
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Seal of Insight-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 30043.44584
+  dps: 30017.29764
   tps: 36587.89297
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Seal of Insight-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 24711.03952
+  dps: 24684.34404
   tps: 24812.90404
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Seal of Insight-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 33482.92402
+  dps: 33357.84491
   tps: 32584.64683
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Seal of Insight-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17458.61539
+  dps: 17456.30345
   tps: 23547.24531
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Seal of Insight-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 15167.02992
+  dps: 15164.84682
   tps: 15289.19295
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Seal of Insight-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 19023.96524
+  dps: 19013.04976
   tps: 18280.52503
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Seal of Justice-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 30704.47118
+  dps: 30677.60067
   tps: 34949.82618
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Seal of Justice-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26250.45588
+  dps: 26227.02242
   tps: 26227.43804
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Seal of Justice-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 35204.18972
+  dps: 35094.35242
   tps: 34148.63245
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Seal of Justice-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 16951.31735
+  dps: 16949.87543
   tps: 20333.86881
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Seal of Justice-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 15976.54706
+  dps: 15972.31625
   tps: 15945.79067
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Seal of Justice-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 20048.8689
+  dps: 20030.94883
   tps: 19147.84244
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Seal of Righteousness-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 92711.3976
+  dps: 92684.86152
   tps: 96959.18214
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Seal of Righteousness-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 27917.79885
+  dps: 27894.3654
   tps: 27894.78101
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Seal of Righteousness-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 37461.69353
+  dps: 37351.85624
   tps: 36406.13626
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Seal of Righteousness-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 50230.53211
+  dps: 50226.62469
   tps: 53614.28584
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Seal of Righteousness-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 16811.87495
+  dps: 16807.64415
   tps: 16781.11857
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Seal of Righteousness-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 21062.362
+  dps: 21044.44192
   tps: 20161.33553
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Snapshot Guardian-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 37404.10585
+  dps: 37366.08385
   tps: 41429.69289
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Snapshot Guardian-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 32520.16028
+  dps: 32485.17865
   tps: 32362.57031
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Snapshot Guardian-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 43423.11124
+  dps: 43248.20308
   tps: 41702.4705
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Snapshot Guardian-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 20515.17277
+  dps: 20508.00424
   tps: 23784.8079
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Snapshot Guardian-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 19357.18324
+  dps: 19346.19042
   tps: 19203.46347
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Snapshot Guardian-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 24790.89562
+  dps: 24739.3173
   tps: 23277.55522
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 31241.4236
+  dps: 31226.56597
   tps: 35483.93947
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26926.84522
+  dps: 26912.22948
   tps: 26915.34761
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 35582.53956
+  dps: 35509.46087
   tps: 34561.62177
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17168.56821
+  dps: 17169.26837
   tps: 20425.32059
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 15411.46514
+  dps: 15413.05808
   tps: 15379.82269
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 19738.87866
+  dps: 19746.84338
   tps: 18843.12463
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Seal of Insight-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 25430.7419
+  dps: 25412.44992
   tps: 31940.47688
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Seal of Insight-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 20478.15152
+  dps: 20459.777
   tps: 20585.00874
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Seal of Insight-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 27834.76626
+  dps: 27742.89364
   tps: 26956.15464
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Seal of Insight-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 14864.76959
+  dps: 14867.59442
   tps: 20868.11429
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Seal of Insight-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 12304.20746
+  dps: 12307.8482
   tps: 12422.14761
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Seal of Insight-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 15642.04328
+  dps: 15660.24694
   tps: 14906.30957
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Seal of Justice-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 26010.2437
+  dps: 25995.47738
   tps: 30247.89266
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Seal of Justice-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 21629.84617
+  dps: 21611.66751
   tps: 21615.48576
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Seal of Justice-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 29685.59668
+  dps: 29599.10204
   tps: 28655.18162
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Seal of Justice-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 14362.73945
+  dps: 14364.92937
   tps: 17619.84587
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Seal of Justice-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 12735.38101
+  dps: 12736.70622
   tps: 12706.00611
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Seal of Justice-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 16871.0898
+  dps: 16877.71587
   tps: 15985.68561
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Seal of Righteousness-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 80012.51463
+  dps: 79989.80045
   tps: 84246.31012
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Seal of Righteousness-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 23086.61327
+  dps: 23068.43461
   tps: 23072.25287
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Seal of Righteousness-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 31656.85253
+  dps: 31570.35789
   tps: 30626.43747
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Seal of Righteousness-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 42991.92922
+  dps: 42992.5778
   tps: 46247.38403
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Seal of Righteousness-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 13441.6124
+  dps: 13442.93761
   tps: 13412.2375
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Seal of Righteousness-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 17732.77235
+  dps: 17739.39843
   tps: 16847.36817
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Snapshot Guardian-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 31399.75527
+  dps: 31373.50723
   tps: 35503.94278
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Snapshot Guardian-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 27067.17868
+  dps: 27042.88744
   tps: 26921.26709
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Snapshot Guardian-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 36793.20551
+  dps: 36671.74934
   tps: 35113.01451
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Snapshot Guardian-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17333.75192
+  dps: 17335.14114
   tps: 20479.72298
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Snapshot Guardian-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 15585.29837
+  dps: 15588.23201
   tps: 15440.62725
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Snapshot Guardian-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 20644.73422
+  dps: 20659.40241
   tps: 19183.72602
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 37046.90804
+  dps: 37023.17606
   tps: 41301.91622
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 32347.69919
+  dps: 32324.04622
   tps: 32325.77945
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 41930.0683
+  dps: 41811.80346
   tps: 40874.55268
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 20225.41773
+  dps: 20222.43926
   tps: 23609.80864
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 19147.48906
+  dps: 19140.99002
   tps: 19111.20828
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 23760.27561
+  dps: 23731.0414
   tps: 22834.94789
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Seal of Insight-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 30029.09471
+  dps: 30002.94651
   tps: 36573.4549
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Seal of Insight-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 24699.94731
+  dps: 24673.25184
   tps: 24801.80602
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Seal of Insight-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 33469.36037
+  dps: 33344.28127
   tps: 32571.07841
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Seal of Insight-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17450.26711
+  dps: 17447.95517
   tps: 23538.89703
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Seal of Insight-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 15160.07258
+  dps: 15157.88949
   tps: 15282.23562
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Seal of Insight-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 19015.90711
+  dps: 19004.99163
   tps: 18272.4669
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Seal of Justice-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 30708.91027
+  dps: 30682.03976
   tps: 34954.20878
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Seal of Justice-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26245.5089
+  dps: 26222.07545
   tps: 26222.48975
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Seal of Justice-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 35189.70027
+  dps: 35079.86298
   tps: 34134.13977
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Seal of Justice-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 16931.9596
+  dps: 16930.51767
   tps: 20315.08388
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Seal of Justice-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 15969.29151
+  dps: 15965.06071
   tps: 15938.53513
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Seal of Justice-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 20040.19828
+  dps: 20022.2782
   tps: 19139.17181
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Seal of Righteousness-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 92679.42337
+  dps: 92652.88729
   tps: 96927.15142
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Seal of Righteousness-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 27912.1271
+  dps: 27888.69365
   tps: 27889.10795
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Seal of Righteousness-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 37446.02063
+  dps: 37336.18334
   tps: 36390.46013
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Seal of Righteousness-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 50223.81133
+  dps: 50219.90391
   tps: 53608.21089
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Seal of Righteousness-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 16804.17704
+  dps: 16799.94623
   tps: 16773.42065
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Seal of Righteousness-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 21053.04684
+  dps: 21035.12677
   tps: 20152.02038
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Snapshot Guardian-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 37521.03883
+  dps: 37483.01682
   tps: 41547.8369
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Snapshot Guardian-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 32506.18283
+  dps: 32471.2012
   tps: 32348.59155
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Snapshot Guardian-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 43404.57145
+  dps: 43229.6633
   tps: 41683.92748
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Snapshot Guardian-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 20469.71501
+  dps: 20462.54648
   tps: 23739.85593
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Snapshot Guardian-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 19348.09825
+  dps: 19337.10543
   tps: 19194.37847
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Snapshot Guardian-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 24779.81815
+  dps: 24728.23983
   tps: 23266.47775
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 31278.428
+  dps: 31263.57038
   tps: 35486.49714
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26938.05582
+  dps: 26923.44008
   tps: 26926.55963
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 35598.29715
+  dps: 35525.21847
   tps: 34577.38808
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17168.35014
+  dps: 17169.0503
   tps: 20444.79841
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 15289.84006
+  dps: 15291.43301
   tps: 15251.05914
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 19748.04726
+  dps: 19756.01198
   tps: 18852.29323
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Seal of Insight-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 25442.10449
+  dps: 25424.62683
   tps: 31953.0133
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Seal of Insight-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 20487.00466
+  dps: 20469.44446
   tps: 20594.6966
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Seal of Insight-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 27842.57742
+  dps: 27754.77639
   tps: 26968.0521
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Seal of Insight-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 14867.34233
+  dps: 14870.16716
   tps: 20870.68703
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Seal of Insight-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 12308.27857
+  dps: 12311.9193
   tps: 12426.21872
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Seal of Insight-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 15648.95263
+  dps: 15667.1563
   tps: 14913.21892
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Seal of Justice-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 26068.22445
+  dps: 26053.45812
   tps: 30271.57248
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Seal of Justice-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 21639.82633
+  dps: 21621.64767
   tps: 21625.46734
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Seal of Justice-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 29698.51207
+  dps: 29612.01743
   tps: 28668.10572
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Seal of Justice-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 14340.80994
+  dps: 14342.99986
   tps: 17617.86972
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Seal of Justice-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 12637.08413
+  dps: 12638.40934
   tps: 12600.30586
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Seal of Justice-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 16878.72225
+  dps: 16885.34832
   tps: 15993.31807
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Seal of Righteousness-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 80073.42388
+  dps: 80051.49108
   tps: 84272.34961
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Seal of Righteousness-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 23096.14712
+  dps: 23077.96846
   tps: 23081.78812
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Seal of Righteousness-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 31670.40103
+  dps: 31583.9064
   tps: 30639.99469
  }
 }
@@ -3139,273 +3139,273 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Seal of Righteousness-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 13337.7303
+  dps: 13339.05551
   tps: 13300.95203
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Seal of Righteousness-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 17740.69972
+  dps: 17747.3258
   tps: 16855.29554
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Snapshot Guardian-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 31462.56739
+  dps: 31436.31935
   tps: 35542.06601
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Snapshot Guardian-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 27078.71919
+  dps: 27054.42795
   tps: 26932.80905
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Snapshot Guardian-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 36809.62608
+  dps: 36688.16991
   tps: 35129.444
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Snapshot Guardian-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17333.77202
+  dps: 17335.16123
   tps: 20499.57887
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Snapshot Guardian-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 15475.20203
+  dps: 15478.13567
   tps: 15323.42689
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Snapshot Guardian-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 20654.33122
+  dps: 20668.99941
   tps: 19193.32301
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 36985.1794
+  dps: 36961.44742
   tps: 41261.97154
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 32377.03594
+  dps: 32353.38297
   tps: 32353.28713
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 41947.12886
+  dps: 41828.86402
   tps: 40891.62615
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 20376.18115
+  dps: 20373.20268
   tps: 23765.95873
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 19002.0488
+  dps: 18995.54975
   tps: 18960.75513
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 23770.3882
+  dps: 23741.15399
   tps: 22845.06048
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Seal of Insight-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 30042.38676
+  dps: 30016.23856
   tps: 36587.09471
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Seal of Insight-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 24708.1626
+  dps: 24681.46713
   tps: 24810.04457
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Seal of Insight-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 33482.53187
+  dps: 33357.45276
   tps: 32584.26902
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Seal of Insight-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17458.03759
+  dps: 17455.72564
   tps: 23546.66751
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Seal of Insight-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 15166.78843
+  dps: 15164.60533
   tps: 15288.95146
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Seal of Insight-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 19023.65333
+  dps: 19012.73785
   tps: 18280.21312
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Seal of Justice-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 30701.45295
+  dps: 30674.58244
   tps: 34968.47113
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Seal of Justice-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26236.75402
+  dps: 26213.32057
   tps: 26211.8939
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Seal of Justice-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 35203.78214
+  dps: 35093.94485
   tps: 34148.23456
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Seal of Justice-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17048.66088
+  dps: 17047.21896
   tps: 20437.48001
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Seal of Justice-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 15810.32193
+  dps: 15806.09112
   tps: 15774.7723
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Seal of Justice-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 20048.53293
+  dps: 20030.61286
   tps: 19147.50647
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Seal of Righteousness-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 92638.785
+  dps: 92612.24891
   tps: 96908.1564
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Seal of Righteousness-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 27905.14146
+  dps: 27881.70801
   tps: 27880.28134
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Seal of Righteousness-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 37460.76598
+  dps: 37350.92869
   tps: 36405.2184
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Seal of Righteousness-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 50337.93399
+  dps: 50334.02656
   tps: 53727.77638
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Seal of Righteousness-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 16638.75396
+  dps: 16634.52315
   tps: 16603.20433
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Seal of Righteousness-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 21061.69572
+  dps: 21043.77564
   tps: 20160.66926
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Snapshot Guardian-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 37354.48636
+  dps: 37316.46436
   tps: 41402.55197
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Snapshot Guardian-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 32523.20676
+  dps: 32488.22513
   tps: 32363.8231
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Snapshot Guardian-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 43422.45141
+  dps: 43247.54325
   tps: 41701.82036
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Snapshot Guardian-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 20602.10668
+  dps: 20594.93815
   tps: 23877.90487
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Snapshot Guardian-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 19189.25647
+  dps: 19178.26365
   tps: 19031.08042
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Snapshot Guardian-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 24790.40003
+  dps: 24738.82171
   tps: 23277.05963
  }
 }
 dps_results: {
  key: "TestRetribution-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 29392.78801
-  tps: 29382.90998
+  dps: 29347.10648
+  tps: 29375.35281
  }
 }


### PR DESCRIPTION
* Hit from owner should not include Draenei Heroic Presence.
* Expertise conversion was way off.
* Crit should not be inherited and seems to be about 2% after suppression.