### PR TITLE
Update API version in build-and-deploy workflow

### DIFF
--- a/.deployedprotoversion
+++ b/.deployedprotoversion
@@ -1,0 +1,1 @@
+saved_version_number: -1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,20 @@ jobs:
               run: |
                   make dist/cata/.dirstamp
 
+            - name: Update proto version file
+              run: |
+                  cp sim/core/TestProtoVersioning.results .deployedprotoversion
+
+            - name: Commit updated version file
+              run: |
+                  git config --local user.name actions-user
+                  git config --local user.email "actions@github.com"
+                  if git diff --exit-code; then
+                      git add .deployedprotoversion
+                      git commit -m "Updating .deployedprotoversion file due to API version increase"
+                      git push origin master
+                  fi
+
             - name: Test
               run: |
                   make test

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,7 @@ jobs:
               run: |
                   git config --local user.name actions-user
                   git config --local user.email "actions@github.com"
-                  if git diff --exit-code; then
+                  if ! git diff --exit-code; then
                       git add .deployedprotoversion
                       git commit -m "Updating .deployedprotoversion file due to API version increase"
                       git push origin master

--- a/sim/core/TestProtoVersioning.results
+++ b/sim/core/TestProtoVersioning.results
@@ -1,0 +1,1 @@
+saved_version_number: 0


### PR DESCRIPTION
This PR updates our `build-and-deploy` GitHub Actions workflow to copy the `TestProtoVersioning.results` file into a `.deployedprotoversion` reference file before running tests, and to automatically push this file to `master` if the version number was incremented in the merge commit that triggered the workflow. These two files are not currently used for anything, but are required for the proto versioning unit test that was added to #866 . I am PRing the workflow change separately from #866 in order to test that the workflow is functioning properly before finalizing the new unit test in #866 .