### PR TITLE
Add "pull-requests: write" permission to build-and-deploy workflow.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,7 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             contents: write
+            pull-requests: write
         steps:
             - name: Install Go
               uses: actions/setup-go@v2


### PR DESCRIPTION
#872 did not deploy since the PR could not be created, even though it deployed just fine with default permissions. This is an attempted fix by explicitly adding the "pull-requests: write" permission to the config.