### PR TITLE
Don't generate variables for reforges of zero EP stats

### DIFF
--- a/ui/core/components/suggest_reforges_action.tsx
+++ b/ui/core/components/suggest_reforges_action.tsx
@@ -715,6 +715,8 @@ export class ReforgeOptimizer {
 	buildYalpsVariables(gear: Gear): YalpsVariables {
 		const variables = new Map<string, YalpsCoefficients>();
 
+		const epStats = this.simUI.individualConfig.epStats;
+
 		for (const slot of gear.getItemSlots()) {
 			const item = gear.getEquippedItem(slot);
 
@@ -731,11 +733,17 @@ export class ReforgeOptimizer {
 					this.applyReforgeStat(coefficients, fromStat, reforgeData.fromAmount);
 				}
 
+				let containsEpStat = false
 				for (const toStat of reforgeData.toStat) {
+					if (epStats.includes(toStat)) {
+						containsEpStat = true
+					}
 					this.applyReforgeStat(coefficients, toStat, reforgeData.toAmount);
 				}
 
-				variables.set(variableKey, coefficients);
+				if (containsEpStat) {
+					variables.set(variableKey, coefficients);
+				}
 			}
 		}
 

--- a/ui/core/components/suggest_reforges_action.tsx
+++ b/ui/core/components/suggest_reforges_action.tsx
@@ -733,10 +733,10 @@ export class ReforgeOptimizer {
 					this.applyReforgeStat(coefficients, fromStat, reforgeData.fromAmount);
 				}
 
-				let containsEpStat = false
+				let containsEpStat = false;
 				for (const toStat of reforgeData.toStat) {
 					if (epStats.includes(toStat)) {
-						containsEpStat = true
+						containsEpStat = true;
 					}
 					this.applyReforgeStat(coefficients, toStat, reforgeData.toAmount);
 				}


### PR DESCRIPTION
Prunes reforges whose destination stats aren't in the spec's EP stats.

Improves Suggest Reforge runtime on Combat Rogue sim from 54 seconds to 26 seconds in Edge.