### PR TITLE
Swap build and test order in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,13 +43,13 @@ jobs:
               with:
                   ref: ${{ github.event.inputs.ref }}
 
-            - name: Test
-              run: |
-                  make test
-
             - name: Build 🔧
               run: |
                   make clean && VERSION=${{ github.event.inputs.tag }} make release
+
+            - name: Test
+              run: |
+                  make test
 
             - name: Release
               uses: ncipollo/release-action@v1


### PR DESCRIPTION
This should ensure that `npm install` is run before `make tests`, since `npx buf` is called in one of the unit tests after the proto versioning update. 

On branch versioning_workflow
 Changes to be committed:
	modified:   .github/workflows/release.yml