### PR TITLE
[Priest] Add shadow T12 set

### DIFF
--- a/sim/priest/items.go
+++ b/sim/priest/items.go
@@ -308,5 +308,119 @@ var ItemSetMercurialRegalia = core.NewItemSet(core.ItemSet{
 	},
 })
 
+// T12 - Shadow
+var ItemSetRegaliaOfTheCleansingFlame = core.NewItemSet(core.ItemSet{
+	Name: "Regalia of the Cleansing Flame",
+	Bonuses: map[int32]core.ApplyEffect{
+		2: func(agent core.Agent) {
+
+			// Fiend deals 20% extra damage as fire damage and cooldown reduced by 75 seconds
+			character := agent.GetCharacter()
+
+			character.AddStaticMod(core.SpellModConfig{
+				Kind:      core.SpellMod_Cooldown_Flat,
+				TimeValue: time.Second * 75,
+				ClassMask: PriestSpellShadowFiend,
+			})
+
+			priest := agent.(PriestAgent).GetPriest()
+			shadowFlameProc := priest.ShadowfiendPet.RegisterSpell(core.SpellConfig{
+				ActionID:         core.ActionID{SpellID: 99156},
+				SpellSchool:      core.SpellSchoolFire,
+				ProcMask:         core.ProcMaskEmpty,
+				Flags:            core.SpellFlagIgnoreModifiers | core.SpellFlagNoSpellMods,
+				BaseCost:         0,
+				CritMultiplier:   1.0,
+				DamageMultiplier: 1.0,
+				ThreatMultiplier: 1.0,
+				ManaCost: core.ManaCostOptions{
+					BaseCost:   0.0,
+					Multiplier: 1,
+				},
+
+				Cast: core.CastConfig{
+					DefaultCast: core.Cast{
+						GCD:      0,
+						CastTime: 0,
+					},
+				},
+
+				ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
+					spell.CalcAndDealDamage(sim, target, spell.BonusSpellPower, spell.OutcomeAlwaysHit)
+				},
+			})
+
+			core.MakePermanent(
+				core.MakeProcTriggerAura(&priest.ShadowfiendPet.Unit, core.ProcTrigger{
+					ActionID:   core.ActionID{SpellID: 99155},
+					Name:       "Shadowflame (T12-2P)",
+					Callback:   core.CallbackOnSpellHitDealt,
+					ProcMask:   core.ProcMaskMelee,
+					Outcome:    core.OutcomeLanded,
+					ProcChance: 1.0,
+					Handler: func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+
+						// deal 20% of melee damage on hit
+						shadowFlameProc.BonusSpellPower = result.Damage * 0.2
+						shadowFlameProc.Cast(sim, result.Target)
+					},
+				}))
+		},
+		4: func(agent core.Agent) {
+			character := agent.GetCharacter()
+			mbMod := character.AddDynamicMod(core.SpellModConfig{
+				Kind:       core.SpellMod_DamageDone_Flat,
+				FloatValue: 0.15,
+				ClassMask:  PriestSpellMindBlast,
+			})
+
+			mbAura := character.RegisterAura(core.Aura{
+				ActionID: core.ActionID{SpellID: 99158},
+				Label:    "Dark Flames",
+				Duration: core.NeverExpires,
+				OnGain: func(aura *core.Aura, sim *core.Simulation) {
+					mbMod.Activate()
+				},
+				OnExpire: func(aura *core.Aura, sim *core.Simulation) {
+					mbMod.Deactivate()
+				},
+			})
+
+			priest := agent.(PriestAgent).GetPriest()
+			dotTracker := make([]int, len(priest.Env.AllUnits))
+			setHandler := func(aura *core.Aura, sim *core.Simulation) {
+				if aura.IsActive() {
+					dotTracker[aura.Unit.UnitIndex]++
+				} else {
+					dotTracker[aura.Unit.UnitIndex]--
+				}
+
+				// check if we have 3 dots anywhere
+				for _, count := range dotTracker {
+					if count == 3 {
+						mbAura.Activate(sim)
+						return
+					}
+				}
+
+				mbAura.Deactivate(sim)
+			}
+
+			priest.OnSpellRegistered(func(spell *core.Spell) {
+				if spell.ClassSpellMask&(PriestSpellShadowWordPain|PriestSpellVampiricTouch|PriestSpellDevouringPlague) == 0 {
+					return
+				}
+
+				for _, target := range priest.Env.AllUnits {
+					if target.Type == core.EnemyUnit {
+						spell.Dot(target).ApplyOnGain(setHandler)
+						spell.Dot(target).ApplyOnExpire(setHandler)
+					}
+				}
+			})
+		},
+	},
+})
+
 func init() {
 }

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -974,6 +974,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestShadow-AllItems-RegaliaoftheCleansingFlame"
+ value: {
+  dps: 27743.35937
+  tps: 26472.05159
+ }
+}
+dps_results: {
  key: "TestShadow-AllItems-ReverberatingShadowspiritDiamond"
  value: {
   dps: 28814.12516


### PR DESCRIPTION
Adds set effects for the T12 set for shadow priests.

**2P**: `While you are in Shadowform, your Shadowfiend deals 20% additional damage as Fire damage and its cooldown is reduced by 75 sec.`

**4P**: `While you have Shadow Word: Pain, Devouring Plague, and Vampiric Touch active on the same target you gain Dark Flames, which increases the damage done by Mind Blast by 15%.`