### PR TITLE
Remove version before adding to equipmentspec proto

### DIFF
--- a/ui/core/components/importers.tsx
+++ b/ui/core/components/importers.tsx
@@ -608,6 +608,8 @@ export class IndividualAddonImporter<SpecType extends Spec> extends Importer {
 
 		const gearJson = importJson['gear'];
 		gearJson.items = (gearJson.items as Array<any>).filter(item => item != null);
+		delete gearJson.version;
+
 		(gearJson.items as Array<any>).forEach(item => {
 			if (item.gems) {
 				item.gems = (item.gems as Array<any>).map(gem => gem || 0);


### PR DESCRIPTION
Since the exporter adds the version to the equipment the importer would break since the proto would try to parse the version tag