### PR TITLE
[WARLOCK] Add random cast delay to Doomguard

### DIFF
--- a/sim/warlock/affliction/TestAffliction.results
+++ b/sim/warlock/affliction/TestAffliction.results
@@ -37,1555 +37,1555 @@ character_stats_results: {
 dps_results: {
  key: "TestAffliction-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 27537.50151
-  tps: 20611.75521
+  dps: 27533.91574
+  tps: 20598.26752
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 26604.2901
-  tps: 19828.05555
+  dps: 26580.60833
+  tps: 19840.86847
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 26197.53495
-  tps: 19640.36748
+  dps: 26155.32721
+  tps: 19660.46892
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 26665.24837
-  tps: 19908.20861
+  dps: 26653.01769
+  tps: 19933.49247
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 26706.91413
-  tps: 19938.20272
+  dps: 26697.44126
+  tps: 19963.80868
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 27321.75199
-  tps: 20374.13049
+  dps: 27332.04503
+  tps: 20377.68714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 26020.63823
-  tps: 19448.42674
-  hps: 101.36566
+  dps: 25995.19559
+  tps: 19459.92779
+  hps: 101.40915
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 27359.02784
-  tps: 20333.06184
+  dps: 27332.39539
+  tps: 20359.12603
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BindingPromise-67037"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 26155.85048
-  tps: 19589.34675
+  dps: 26113.84256
+  tps: 19617.4578
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 26135.43285
-  tps: 19546.69677
+  dps: 26105.36673
+  tps: 19562.21053
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 26135.43285
-  tps: 19546.69677
+  dps: 26105.36673
+  tps: 19562.21053
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 25937.6502
-  tps: 19367.37983
+  dps: 25889.79496
+  tps: 19373.34679
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 26835.65399
-  tps: 20035.38217
+  dps: 26792.06458
+  tps: 20046.35417
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 25953.93522
-  tps: 19398.79109
+  dps: 25912.86233
+  tps: 19408.25369
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 26315.95659
-  tps: 19621.55863
+  dps: 26271.88062
+  tps: 19631.93895
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 25989.12862
-  tps: 19391.94431
+  dps: 25947.74479
+  tps: 19401.11673
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 25989.12862
-  tps: 19391.94431
+  dps: 25947.74479
+  tps: 19401.11673
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 26718.35284
-  tps: 19916.52279
+  dps: 26685.53324
+  tps: 19931.63055
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BottledLightning-66879"
  value: {
-  dps: 26711.12274
-  tps: 19927.23251
+  dps: 26704.17512
+  tps: 19947.12829
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 27530.71217
-  tps: 20146.30826
+  dps: 27544.95808
+  tps: 20145.71501
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Brawler'sTrophy-71338"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 27825.54287
-  tps: 20836.9893
+  dps: 27839.61727
+  tps: 20836.21243
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 27631.46976
-  tps: 20683.05655
+  dps: 27627.59465
+  tps: 20669.58972
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Coren'sChilledChromiumCoaster-71335"
  value: {
-  dps: 26286.24416
-  tps: 19587.52127
+  dps: 26275.33452
+  tps: 19622.68247
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 27023.32882
-  tps: 20171.23053
+  dps: 26955.34671
+  tps: 20120.54277
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CrushingWeight-59506"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CrushingWeight-65118"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 25989.12862
-  tps: 19391.98427
+  dps: 25947.74479
+  tps: 19401.15669
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 27019.35797
-  tps: 20114.43535
+  dps: 27044.92649
+  tps: 20171.64225
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 26128.00585
-  tps: 19485.11824
+  dps: 26083.9119
+  tps: 19498.47939
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 27340.00489
-  tps: 20400.57256
+  dps: 27336.94748
+  tps: 20387.92343
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 26673.02504
-  tps: 19986.22447
+  dps: 26689.87019
+  tps: 20021.45339
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 26281.55564
-  tps: 19591.72242
+  dps: 26257.65687
+  tps: 19614.37164
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 27321.75199
-  tps: 20374.13049
+  dps: 27332.04503
+  tps: 20377.68714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 26393.4839
-  tps: 19693.65006
+  dps: 26359.70645
+  tps: 19690.18468
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 27679.0582
-  tps: 20619.95833
+  dps: 27697.72403
+  tps: 20629.12829
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 27340.00489
-  tps: 20400.57256
+  dps: 27336.94748
+  tps: 20387.92343
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 26197.53495
-  tps: 19640.36748
+  dps: 26155.32721
+  tps: 19660.46892
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 27321.75199
-  tps: 20374.13049
+  dps: 27332.04503
+  tps: 20377.68714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FallofMortality-59500"
  value: {
-  dps: 27019.35797
-  tps: 20114.43535
+  dps: 27044.92649
+  tps: 20171.64225
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FallofMortality-65124"
  value: {
-  dps: 27094.83834
-  tps: 20174.58375
+  dps: 27091.85823
+  tps: 20206.24432
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 27034.477
-  tps: 20155.34082
+  dps: 27002.34876
+  tps: 20143.07301
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 26076.7674
-  tps: 19466.30363
+  dps: 26068.42641
+  tps: 19493.94672
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 26901.76024
-  tps: 20107.55976
+  dps: 26849.72906
+  tps: 20098.0421
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 26026.38249
-  tps: 19423.80727
+  dps: 26036.62604
+  tps: 19447.75709
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 27738.24609
-  tps: 20711.70602
+  dps: 27686.04673
+  tps: 20703.61806
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 26150.4818
-  tps: 19595.33767
+  dps: 26109.30646
+  tps: 19604.69782
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 27351.79587
-  tps: 20434.91887
+  dps: 27349.02899
+  tps: 20422.25006
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FluidDeath-58181"
  value: {
-  dps: 26121.53867
-  tps: 19531.37975
+  dps: 26110.47229
+  tps: 19555.08807
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 27530.71217
-  tps: 20551.07888
+  dps: 27544.95808
+  tps: 20550.47352
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 26273.44878
-  tps: 19583.41079
+  dps: 26250.29285
+  tps: 19606.32569
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GaleofShadows-56138"
  value: {
-  dps: 27097.44
-  tps: 20345.57612
+  dps: 27086.39832
+  tps: 20356.92041
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GaleofShadows-56462"
  value: {
-  dps: 27122.51089
-  tps: 20323.57935
+  dps: 27120.57387
+  tps: 20329.04749
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GearDetector-61462"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 22946.61867
-  tps: 17098.79236
+  dps: 22936.72322
+  tps: 17090.95398
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 26674.13242
-  tps: 19886.83335
+  dps: 26652.03663
+  tps: 19905.9461
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HarmlightToken-63839"
  value: {
-  dps: 27140.52529
-  tps: 20165.04491
+  dps: 27096.64534
+  tps: 20162.54244
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 27213.77106
-  tps: 20508.57979
+  dps: 27187.7975
+  tps: 20544.18313
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 27295.77534
-  tps: 20625.16161
+  dps: 27285.89373
+  tps: 20649.58118
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofRage-59224"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofRage-65072"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofSolace-55868"
  value: {
-  dps: 26419.53275
-  tps: 19829.70647
+  dps: 26408.89482
+  tps: 19840.83393
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofSolace-56393"
  value: {
-  dps: 26355.20449
-  tps: 19740.9188
+  dps: 26353.31264
+  tps: 19746.27911
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofThunder-55845"
  value: {
-  dps: 25942.68929
-  tps: 19367.99924
+  dps: 25896.97233
+  tps: 19365.84782
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofThunder-56370"
  value: {
-  dps: 25965.26203
-  tps: 19370.23529
+  dps: 25919.0741
+  tps: 19369.84509
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 27340.00489
-  tps: 20400.57256
+  dps: 27336.94748
+  tps: 20387.92343
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 26248.75509
-  tps: 19693.61096
+  dps: 26207.52853
+  tps: 19702.91988
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 26248.75509
-  tps: 19693.61096
+  dps: 26207.52853
+  tps: 19702.91988
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 26130.68987
-  tps: 19545.52321
+  dps: 26099.79382
+  tps: 19560.20704
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 26130.68987
-  tps: 19545.52321
+  dps: 26099.79382
+  tps: 19560.20704
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 25925.29942
-  tps: 19353.17921
+  dps: 25890.96432
+  tps: 19360.83901
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 26581.72359
-  tps: 19863.61421
+  dps: 26537.83352
+  tps: 19893.2213
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 26086.66485
-  tps: 19494.29041
+  dps: 26089.38469
+  tps: 19521.34376
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 26061.86459
-  tps: 19486.99247
+  dps: 26053.60099
+  tps: 19515.88454
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 26155.85048
-  tps: 19589.34675
+  dps: 26113.84256
+  tps: 19617.4578
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 26121.53867
-  tps: 19531.37975
+  dps: 26110.47229
+  tps: 19555.08807
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 26121.53867
-  tps: 19531.37975
+  dps: 26110.47229
+  tps: 19555.08807
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 26169.3781
-  tps: 19630.71589
+  dps: 26172.39127
+  tps: 19635.9431
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 26169.3781
-  tps: 19630.71589
+  dps: 26172.39127
+  tps: 19635.9431
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 26188.41557
-  tps: 19609.88401
+  dps: 26176.74483
+  tps: 19601.0183
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LeadenDespair-55816"
  value: {
-  dps: 26017.50253
-  tps: 19439.53014
+  dps: 26035.02967
+  tps: 19470.84552
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LeadenDespair-56347"
  value: {
-  dps: 26026.38249
-  tps: 19423.80727
+  dps: 26036.62604
+  tps: 19447.75709
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 26121.53867
-  tps: 19531.37975
+  dps: 26110.47229
+  tps: 19555.08807
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 25959.62709
-  tps: 19393.12336
+  dps: 25917.65614
+  tps: 19421.27138
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 25959.62709
-  tps: 19393.12336
+  dps: 25917.65614
+  tps: 19421.27138
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 26197.12273
-  tps: 19630.619
+  dps: 26155.01086
+  tps: 19658.6261
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 26240.30376
-  tps: 19673.80003
+  dps: 26198.16626
+  tps: 19701.78151
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 26076.86647
-  tps: 19491.64532
+  dps: 26070.24188
+  tps: 19515.42725
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 26076.86647
-  tps: 19491.64532
+  dps: 26070.24188
+  tps: 19515.42725
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 26228.47422
-  tps: 19643.30756
+  dps: 26197.50095
+  tps: 19657.91417
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 26228.47422
-  tps: 19643.30756
+  dps: 26197.50095
+  tps: 19657.91417
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MithrilStopwatch-71337"
  value: {
-  dps: 27381.59576
-  tps: 20388.07932
+  dps: 27369.48857
+  tps: 20422.38115
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 27416.43968
-  tps: 20592.02567
+  dps: 27421.68165
+  tps: 20615.33307
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 26013.04576
-  tps: 19441.18561
+  dps: 26021.47335
+  tps: 19453.97257
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 27472.88441
-  tps: 20526.94906
+  dps: 27472.30264
+  tps: 20563.10376
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 27800.38276
-  tps: 20845.28224
+  dps: 27765.00186
+  tps: 20832.28644
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 26221.68448
-  tps: 19572.82965
+  dps: 26190.83191
+  tps: 19584.62215
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PetrifiedPickledEgg-71336"
  value: {
-  dps: 27045.50651
-  tps: 20139.66554
+  dps: 27066.87961
+  tps: 20181.11479
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 26769.05524
-  tps: 19943.17167
+  dps: 26724.55843
+  tps: 19958.17979
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 27321.75199
-  tps: 20374.13049
+  dps: 27332.04503
+  tps: 20377.68714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Rainsong-55854"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Rainsong-56377"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 27537.50151
-  tps: 20611.75521
+  dps: 27533.91574
+  tps: 20598.26752
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 27537.50151
-  tps: 20611.75521
+  dps: 27533.91574
+  tps: 20598.26752
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 26455.0368
-  tps: 19715.68083
+  dps: 26418.65197
+  tps: 19722.22176
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 26121.53867
-  tps: 19531.37975
+  dps: 26110.47229
+  tps: 19555.08807
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 26121.53867
-  tps: 19531.37975
+  dps: 26110.47229
+  tps: 19555.08807
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuneofZeth-68998"
  value: {
-  dps: 27415.01592
-  tps: 20375.86851
+  dps: 27392.1932
+  tps: 20392.10191
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SeaStar-55256"
  value: {
-  dps: 26397.69499
-  tps: 19719.18068
+  dps: 26355.35557
+  tps: 19729.40295
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SeaStar-56290"
  value: {
-  dps: 26780.54656
-  tps: 19995.59523
+  dps: 26737.11444
+  tps: 20006.47289
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ShadowflameRegalia"
  value: {
-  dps: 25370.90896
-  tps: 18943.57341
+  dps: 25320.76777
+  tps: 18937.21966
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ShardofWoe-60233"
  value: {
-  dps: 26611.34635
-  tps: 19946.22957
+  dps: 26468.05128
+  tps: 19837.8397
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 25962.17924
-  tps: 19379.45297
+  dps: 25990.32565
+  tps: 19445.81601
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 26222.80779
-  tps: 19667.66367
+  dps: 26181.86266
+  tps: 19677.25401
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 26271.69372
-  tps: 19716.54959
+  dps: 26230.77181
+  tps: 19726.16316
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Sorrowsong-55879"
  value: {
-  dps: 26752.18983
-  tps: 20015.8501
+  dps: 26725.00172
+  tps: 20034.03081
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Sorrowsong-56400"
  value: {
-  dps: 26832.95563
-  tps: 20077.28684
+  dps: 26806.1444
+  tps: 20095.8168
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 26076.86647
-  tps: 19491.64532
+  dps: 26070.24188
+  tps: 19515.42725
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SoulCasket-58183"
  value: {
-  dps: 27378.72785
-  tps: 20512.98114
+  dps: 27334.30227
+  tps: 20524.19232
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 26920.2357
-  tps: 20071.86955
+  dps: 26893.90106
+  tps: 20066.24829
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StumpofTime-62465"
  value: {
-  dps: 27156.68991
-  tps: 20306.97055
+  dps: 27144.96186
+  tps: 20330.35708
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StumpofTime-62470"
  value: {
-  dps: 27163.72926
-  tps: 20277.03842
+  dps: 27151.00321
+  tps: 20302.02157
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 26008.97459
-  tps: 19457.60061
+  dps: 26016.47175
+  tps: 19476.23167
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 26023.6314
-  tps: 19406.53996
+  dps: 26010.93854
+  tps: 19420.80755
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 27020.18193
-  tps: 20195.57018
+  dps: 26963.91469
+  tps: 20177.58367
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TearofBlood-55819"
  value: {
-  dps: 26751.86076
-  tps: 19942.13197
+  dps: 26707.80543
+  tps: 19936.88911
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TearofBlood-56351"
  value: {
-  dps: 26938.05656
-  tps: 20074.8241
+  dps: 26915.01291
+  tps: 20108.99246
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 26635.83481
-  tps: 19898.17311
+  dps: 26606.55584
+  tps: 19914.64841
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 26786.34961
-  tps: 20003.14199
+  dps: 26755.82213
+  tps: 20019.11576
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TheHungerer-68927"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TheHungerer-69112"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 27340.47613
-  tps: 20435.55351
+  dps: 27365.44325
+  tps: 20492.159
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 27444.57781
-  tps: 20524.32321
+  dps: 27446.31319
+  tps: 20560.69928
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 26135.43285
-  tps: 19546.69677
+  dps: 26105.36673
+  tps: 19562.21053
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 26135.43285
-  tps: 19546.69677
+  dps: 26105.36673
+  tps: 19562.21053
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 26035.93448
-  tps: 19426.86521
+  dps: 25998.16885
+  tps: 19436.09845
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 26705.11519
-  tps: 20007.20802
+  dps: 26750.13967
+  tps: 19991.25175
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnheededWarning-59520"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 25953.93522
-  tps: 19398.79109
+  dps: 25912.86233
+  tps: 19408.25369
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 26248.75509
-  tps: 19693.61096
+  dps: 26207.52853
+  tps: 19702.91988
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 26248.75509
-  tps: 19693.61096
+  dps: 26207.52853
+  tps: 19702.91988
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 26248.75509
-  tps: 19693.61096
+  dps: 26207.52853
+  tps: 19702.91988
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 27347.94689
-  tps: 20471.25429
+  dps: 27314.37259
+  tps: 20448.73708
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 27738.77776
-  tps: 20841.4632
+  dps: 27715.13504
+  tps: 20850.7498
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 26008.97459
-  tps: 19457.60061
+  dps: 26016.47175
+  tps: 19476.23167
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 26023.6314
-  tps: 19406.53996
+  dps: 26010.93854
+  tps: 19420.80755
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 25953.93522
-  tps: 19398.79109
+  dps: 25912.86233
+  tps: 19408.25369
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 26884.96063
-  tps: 20070.98101
+  dps: 26841.23049
+  tps: 20082.03742
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 25953.93522
-  tps: 19398.79109
+  dps: 25912.86233
+  tps: 19408.25369
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 26155.80427
-  tps: 19542.12151
+  dps: 26137.44365
+  tps: 19557.35056
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 26515.18325
-  tps: 19862.30708
+  dps: 26511.18865
+  tps: 19864.20424
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 26388.27955
-  tps: 19686.28645
+  dps: 26349.47006
+  tps: 19697.73847
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 26020.66263
-  tps: 19429.14233
+  dps: 25980.51492
+  tps: 19435.35608
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 26316.01526
-  tps: 19724.49496
+  dps: 26275.5282
+  tps: 19730.36935
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 26020.66263
-  tps: 19429.14233
+  dps: 25980.51492
+  tps: 19435.35608
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 26678.31616
-  tps: 19874.03127
+  dps: 26645.81389
+  tps: 19890.49714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 25939.86646
-  tps: 19351.13037
+  dps: 25909.94116
+  tps: 19366.78496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 26657.38368
-  tps: 19918.76282
+  dps: 26632.50401
+  tps: 19902.61306
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 27205.8785
-  tps: 20418.16294
+  dps: 27207.82376
+  tps: 20424.39329
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 26150.4818
-  tps: 19595.33767
+  dps: 26109.30646
+  tps: 19604.69782
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 26216.6303
-  tps: 19674.01501
+  dps: 26144.71066
+  tps: 19660.28807
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 26216.6303
-  tps: 19674.01501
+  dps: 26144.71066
+  tps: 19660.28807
  }
 }
 dps_results: {
  key: "TestAffliction-Average-Default"
  value: {
-  dps: 28195.95493
-  tps: 21102.44186
+  dps: 28170.80239
+  tps: 21107.09022
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 28413.75821
-  tps: 27897.38595
+  dps: 28377.00081
+  tps: 27889.9457
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 27384.42131
-  tps: 20703.50208
+  dps: 27391.21367
+  tps: 20681.48324
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p1-Affliction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 35428.00272
-  tps: 24052.54803
+  dps: 35366.31533
+  tps: 24021.16869
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p1-Affliction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 18265.76865
-  tps: 21405.89403
+  dps: 18238.29842
+  tps: 21425.57542
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p1-Affliction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 18265.76865
-  tps: 13609.98898
+  dps: 18238.29842
+  tps: 13629.67037
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p1-Affliction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 20986.63241
-  tps: 13106.14407
+  dps: 20890.85064
+  tps: 13091.70371
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 28243.72053
-  tps: 27513.07459
+  dps: 28220.26776
+  tps: 27508.84473
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 27253.83393
-  tps: 20643.51176
+  dps: 27267.89479
+  tps: 20643.25928
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p1-Affliction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 35589.91566
-  tps: 24289.06752
+  dps: 35512.66533
+  tps: 24273.98329
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p1-Affliction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 18099.24378
-  tps: 21258.22219
+  dps: 18061.03724
+  tps: 21257.48303
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p1-Affliction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 18099.24378
-  tps: 13462.31714
+  dps: 18061.03724
+  tps: 13461.57799
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p1-Affliction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 20842.85835
-  tps: 12978.36381
+  dps: 20788.29275
+  tps: 12973.61424
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 28819.70659
-  tps: 27706.74512
+  dps: 28795.61845
+  tps: 27702.27915
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 27825.54287
-  tps: 20836.9893
+  dps: 27839.61727
+  tps: 20836.21243
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p1-Affliction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 35086.9557
-  tps: 24334.31681
+  dps: 35005.25513
+  tps: 24295.65662
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p1-Affliction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 18505.10162
-  tps: 21379.84018
+  dps: 18465.04074
+  tps: 21378.72221
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p1-Affliction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 18505.10162
-  tps: 13583.04457
+  dps: 18465.04074
+  tps: 13581.9266
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p1-Affliction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 20486.77998
-  tps: 13195.01413
+  dps: 20541.26388
+  tps: 13181.82292
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 28645.90243
-  tps: 27989.21286
+  dps: 28607.04272
+  tps: 27963.31527
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 27667.56429
-  tps: 20948.16412
+  dps: 27652.93899
+  tps: 20937.42863
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p1-Affliction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 36125.6169
-  tps: 24654.5028
+  dps: 36047.08504
+  tps: 24689.1798
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p1-Affliction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 18315.69035
-  tps: 21513.43041
+  dps: 18319.62419
+  tps: 21513.59137
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p1-Affliction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 18315.69035
-  tps: 13675.61189
+  dps: 18319.62419
+  tps: 13675.77285
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p1-Affliction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 21522.75949
-  tps: 13719.63878
+  dps: 21466.70679
+  tps: 13686.48677
  }
 }
 dps_results: {
  key: "TestAffliction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 27711.20295
-  tps: 20836.9893
+  dps: 27725.24947
+  tps: 20836.21243
  }
 }

--- a/sim/warlock/demonology/TestDemonology.results
+++ b/sim/warlock/demonology/TestDemonology.results
@@ -37,15 +37,15 @@ character_stats_results: {
 dps_results: {
  key: "TestDemonology-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 29186.21295
-  tps: 15366.55097
+  dps: 29211.59992
+  tps: 15346.32315
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 27349.26787
-  tps: 14483.65623
+  dps: 27345.13014
+  tps: 14472.156
  }
 }
 dps_results: {
@@ -58,65 +58,65 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 27773.21167
-  tps: 14694.38162
+  dps: 27716.27089
+  tps: 14687.54279
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 27860.0101
-  tps: 14728.23936
+  dps: 27793.64724
+  tps: 14719.38081
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 28985.68128
-  tps: 15213.07196
+  dps: 29012.49469
+  tps: 15194.21489
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 26825.56124
-  tps: 14227.09501
-  hps: 98.44733
+  dps: 26820.59493
+  tps: 14230.18719
+  hps: 97.61977
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 28500.83163
-  tps: 15110.98612
+  dps: 28451.54122
+  tps: 15087.90111
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BindingPromise-67037"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
@@ -129,15 +129,15 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 27222.75896
-  tps: 14393.47705
+  dps: 27202.24512
+  tps: 14379.7816
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 27353.92962
-  tps: 14444.97885
+  dps: 27333.38552
+  tps: 14431.27848
  }
 }
 dps_results: {
@@ -164,43 +164,43 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 27238.53526
-  tps: 14482.24506
+  dps: 27192.51982
+  tps: 14464.73972
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 26817.85989
-  tps: 14229.26246
+  dps: 26808.80196
+  tps: 14224.88169
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 26829.22505
-  tps: 14238.94971
+  dps: 26808.80196
+  tps: 14225.269
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 26829.22505
-  tps: 14238.94971
+  dps: 26808.80196
+  tps: 14225.269
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 27702.14687
-  tps: 14695.68815
+  dps: 27685.62834
+  tps: 14684.99193
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 26829.22505
-  tps: 14238.94971
+  dps: 26808.80196
+  tps: 14225.269
  }
 }
 dps_results: {
@@ -213,36 +213,36 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 29158.53895
-  tps: 15026.18732
+  dps: 29185.58608
+  tps: 15007.80777
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Brawler'sTrophy-71338"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 29361.72881
-  tps: 15478.25068
+  dps: 29387.34064
+  tps: 15457.71566
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 29254.79535
-  tps: 15397.72205
+  dps: 29279.92325
+  tps: 15378.49087
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Coren'sChilledChromiumCoaster-71335"
  value: {
-  dps: 27305.74737
-  tps: 14513.91986
+  dps: 27256.68069
+  tps: 14494.20787
  }
 }
 dps_results: {
@@ -255,85 +255,85 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CrushingWeight-59506"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CrushingWeight-65118"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 26829.22505
-  tps: 14238.94971
+  dps: 26808.80196
+  tps: 14225.269
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 27796.04327
-  tps: 14741.59931
+  dps: 27736.04274
+  tps: 14703.02656
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 27040.35687
-  tps: 14344.60721
+  dps: 27007.22632
+  tps: 14330.73645
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 29051.65291
-  tps: 15242.63111
+  dps: 29078.22989
+  tps: 15224.81294
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 27660.68296
-  tps: 14714.57807
+  dps: 27713.53392
+  tps: 14737.54897
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 27293.56396
-  tps: 14448.08081
+  dps: 27262.79489
+  tps: 14452.11915
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 28985.68128
-  tps: 15213.07196
+  dps: 29012.49469
+  tps: 15194.21489
  }
 }
 dps_results: {
@@ -346,29 +346,29 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 29150.61932
-  tps: 15297.52974
+  dps: 29178.28673
+  tps: 15281.39802
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 29051.65291
-  tps: 15242.63111
+  dps: 29078.22989
+  tps: 15224.81294
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
@@ -381,22 +381,22 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 28985.68128
-  tps: 15213.07196
+  dps: 29012.49469
+  tps: 15194.21489
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FallofMortality-59500"
  value: {
-  dps: 27796.04327
-  tps: 14741.59931
+  dps: 27736.04274
+  tps: 14703.02656
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FallofMortality-65124"
  value: {
-  dps: 27909.74516
-  tps: 14809.01069
+  dps: 27853.03639
+  tps: 14771.52587
  }
 }
 dps_results: {
@@ -423,8 +423,8 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 26829.247
-  tps: 14239.38594
+  dps: 26808.82391
+  tps: 14225.91236
  }
 }
 dps_results: {
@@ -444,162 +444,162 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 28985.68128
-  tps: 15213.03267
+  dps: 29012.49469
+  tps: 15194.19524
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FluidDeath-58181"
  value: {
-  dps: 27145.25603
-  tps: 14386.26887
+  dps: 27087.86285
+  tps: 14381.22223
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 29158.53895
-  tps: 15322.09938
+  dps: 29185.58608
+  tps: 15302.96342
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 27281.09392
-  tps: 14506.7779
+  dps: 27234.38659
+  tps: 14487.33537
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GaleofShadows-56138"
  value: {
-  dps: 27910.56234
-  tps: 14793.25789
+  dps: 27920.82591
+  tps: 14822.43481
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GaleofShadows-56462"
  value: {
-  dps: 27999.6039
-  tps: 14879.89331
+  dps: 27996.10564
+  tps: 14926.28009
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GearDetector-61462"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 23698.48053
-  tps: 12377.63027
+  dps: 23660.76357
+  tps: 12343.11824
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 27380.91962
-  tps: 14500.05398
+  dps: 27376.75937
+  tps: 14488.48233
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HarmlightToken-63839"
  value: {
-  dps: 27902.25883
-  tps: 14752.28463
+  dps: 27879.86341
+  tps: 14744.09487
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 28004.90485
-  tps: 14899.56541
+  dps: 27962.34104
+  tps: 14853.85262
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 28127.02736
-  tps: 14954.14395
+  dps: 28122.93582
+  tps: 14953.17102
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofRage-59224"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofRage-65072"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofSolace-55868"
  value: {
-  dps: 27276.56416
-  tps: 14455.42031
+  dps: 27284.81395
+  tps: 14483.88419
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofSolace-56393"
  value: {
-  dps: 27281.89178
-  tps: 14495.35521
+  dps: 27276.31041
+  tps: 14540.35581
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofThunder-55845"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofThunder-56370"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 29051.65291
-  tps: 15242.63111
+  dps: 29078.22989
+  tps: 15224.81294
  }
 }
 dps_results: {
@@ -619,22 +619,22 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 27222.75896
-  tps: 14393.47705
+  dps: 27202.24512
+  tps: 14379.7816
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 27353.92962
-  tps: 14444.97885
+  dps: 27333.38552
+  tps: 14431.27848
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
@@ -647,15 +647,15 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 26816.61894
-  tps: 14241.26686
+  dps: 26805.32025
+  tps: 14226.11263
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 26815.07016
-  tps: 14239.12499
+  dps: 26785.05295
+  tps: 14218.93912
  }
 }
 dps_results: {
@@ -668,29 +668,29 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 27145.25603
-  tps: 14386.26887
+  dps: 27087.86285
+  tps: 14381.22223
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 27145.25603
-  tps: 14386.26887
+  dps: 27087.86285
+  tps: 14381.22223
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 27246.44277
-  tps: 14463.60575
+  dps: 27239.40258
+  tps: 14476.36574
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 27246.44277
-  tps: 14463.60575
+  dps: 27239.40258
+  tps: 14476.36574
  }
 }
 dps_results: {
@@ -703,36 +703,36 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-LeadenDespair-55816"
  value: {
-  dps: 26829.247
-  tps: 14239.28504
+  dps: 26808.82391
+  tps: 14225.76101
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-LeadenDespair-56347"
  value: {
-  dps: 26829.247
-  tps: 14239.38594
+  dps: 26808.82391
+  tps: 14225.91236
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 27145.25603
-  tps: 14386.26887
+  dps: 27087.86285
+  tps: 14381.22223
  }
 }
 dps_results: {
@@ -752,15 +752,15 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 26817.88184
-  tps: 14229.25619
+  dps: 26808.82391
+  tps: 14224.8779
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 26817.88184
-  tps: 14229.25619
+  dps: 26808.82391
+  tps: 14224.8779
  }
 }
 dps_results: {
@@ -780,15 +780,15 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
@@ -808,22 +808,22 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 27353.92962
-  tps: 14444.97885
+  dps: 27333.38552
+  tps: 14431.27848
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 27353.92962
-  tps: 14444.97885
+  dps: 27333.38552
+  tps: 14431.27848
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MithrilStopwatch-71337"
  value: {
-  dps: 28396.90639
-  tps: 15052.79127
+  dps: 28342.46359
+  tps: 15030.82176
  }
 }
 dps_results: {
@@ -836,22 +836,22 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 26822.96122
-  tps: 14240.03738
+  dps: 26802.53813
+  tps: 14226.60407
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 28454.81378
-  tps: 14993.67325
+  dps: 28397.94212
+  tps: 14956.58705
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 28706.56759
-  tps: 15109.3839
+  dps: 28654.11335
+  tps: 15084.22478
  }
 }
 dps_results: {
@@ -864,85 +864,85 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-PetrifiedPickledEgg-71336"
  value: {
-  dps: 27838.05881
-  tps: 14770.51929
+  dps: 27783.60321
+  tps: 14735.29197
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 27742.68296
-  tps: 14705.94299
+  dps: 27711.84523
+  tps: 14690.63802
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 28985.68128
-  tps: 15213.07196
+  dps: 29012.49469
+  tps: 15194.21489
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Rainsong-55854"
  value: {
-  dps: 26817.60804
-  tps: 14229.32863
+  dps: 26808.82391
+  tps: 14225.0143
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Rainsong-56377"
  value: {
-  dps: 26817.80966
-  tps: 14224.2308
+  dps: 26808.82391
+  tps: 14224.92423
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 29186.21295
-  tps: 15366.55097
+  dps: 29211.59992
+  tps: 15346.32315
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 29186.21295
-  tps: 15366.4618
+  dps: 29211.59992
+  tps: 15346.2206
  }
 }
 dps_results: {
@@ -955,15 +955,15 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 27145.25603
-  tps: 14386.26887
+  dps: 27087.86285
+  tps: 14381.22223
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 27145.25603
-  tps: 14386.26887
+  dps: 27087.86285
+  tps: 14381.22223
  }
 }
 dps_results: {
@@ -976,8 +976,8 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
@@ -997,29 +997,29 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-ShadowflameRegalia"
  value: {
-  dps: 26667.99434
-  tps: 13972.63709
+  dps: 26690.72919
+  tps: 13974.47463
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ShardofWoe-60233"
  value: {
-  dps: 27524.78205
-  tps: 14610.9358
+  dps: 27608.45214
+  tps: 14633.01768
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 26829.247
-  tps: 14239.22197
+  dps: 26808.82391
+  tps: 14225.66642
  }
 }
 dps_results: {
@@ -1039,15 +1039,15 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-Sorrowsong-55879"
  value: {
-  dps: 27793.35421
-  tps: 14699.13217
+  dps: 27780.45801
+  tps: 14686.89956
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Sorrowsong-56400"
  value: {
-  dps: 28002.23562
-  tps: 14791.87912
+  dps: 27990.3637
+  tps: 14779.83541
  }
 }
 dps_results: {
@@ -1067,141 +1067,141 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 27768.16983
-  tps: 14704.85501
+  dps: 27762.09338
+  tps: 14698.29008
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-StumpofTime-62465"
  value: {
-  dps: 28213.55564
-  tps: 14959.27528
+  dps: 28151.07727
+  tps: 14956.51649
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-StumpofTime-62470"
  value: {
-  dps: 28271.8652
-  tps: 14954.79232
+  dps: 28208.28756
+  tps: 14947.0452
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 26823.30593
-  tps: 14239.76729
+  dps: 26802.88285
+  tps: 14226.3204
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 26822.96122
-  tps: 14240.08686
+  dps: 26802.53813
+  tps: 14226.67004
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 27974.63226
-  tps: 14772.28028
+  dps: 27979.35434
+  tps: 14768.99472
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TearofBlood-55819"
  value: {
-  dps: 27477.31882
-  tps: 14557.08625
+  dps: 27469.20559
+  tps: 14548.31725
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TearofBlood-56351"
  value: {
-  dps: 27675.56498
-  tps: 14687.01652
+  dps: 27632.45791
+  tps: 14654.38421
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 27810.34174
-  tps: 14691.76107
+  dps: 27788.17072
+  tps: 14676.21821
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 28181.71094
-  tps: 14851.09801
+  dps: 28160.35639
+  tps: 14835.72015
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TheHungerer-68927"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TheHungerer-69112"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 28359.84443
-  tps: 14893.64981
+  dps: 28298.08395
+  tps: 14856.59865
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 28562.8996
-  tps: 14997.53107
+  dps: 28502.81686
+  tps: 14959.38361
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 27222.75896
-  tps: 14393.47705
+  dps: 27202.24512
+  tps: 14379.7816
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 27353.92962
-  tps: 14444.97885
+  dps: 27333.38552
+  tps: 14431.27848
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 27094.14153
-  tps: 14295.24968
+  dps: 27039.10052
+  tps: 14295.78048
  }
 }
 dps_results: {
@@ -1214,8 +1214,8 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-UnheededWarning-59520"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
@@ -1249,43 +1249,43 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 28162.41882
-  tps: 14950.60008
+  dps: 28234.46891
+  tps: 14989.37301
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 28562.14957
-  tps: 15344.51596
+  dps: 28554.12887
+  tps: 15324.53163
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 26823.30593
-  tps: 14239.76729
+  dps: 26802.88285
+  tps: 14226.3204
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 26822.96122
-  tps: 14240.08686
+  dps: 26802.53813
+  tps: 14226.67004
  }
 }
 dps_results: {
@@ -1312,78 +1312,78 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 27145.23408
-  tps: 14386.24692
+  dps: 27087.8409
+  tps: 14381.20028
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 27428.64106
-  tps: 14648.9874
+  dps: 27413.05065
+  tps: 14611.02423
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 27305.72541
-  tps: 14513.89791
+  dps: 27256.65874
+  tps: 14494.18592
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 26829.22505
-  tps: 14238.94971
+  dps: 26808.80196
+  tps: 14225.269
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 27353.90711
-  tps: 14444.95634
+  dps: 27333.36301
+  tps: 14431.25597
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 26829.22505
-  tps: 14238.94971
+  dps: 26808.80196
+  tps: 14225.269
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 27728.60855
-  tps: 14691.23761
+  dps: 27706.15991
+  tps: 14678.77026
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 26829.247
-  tps: 14238.97166
+  dps: 26808.82391
+  tps: 14225.29095
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 27826.17973
-  tps: 14722.60006
+  dps: 27829.66348
+  tps: 14783.0282
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 28368.25773
-  tps: 15094.13587
+  dps: 28357.97819
+  tps: 15115.30241
  }
 }
 dps_results: {
@@ -1410,182 +1410,182 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Average-Default"
  value: {
-  dps: 29563.64745
-  tps: 15620.18632
+  dps: 29539.28284
+  tps: 15613.28374
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p1-Demonology Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 44330.54295
-  tps: 41179.98947
+  dps: 44220.64417
+  tps: 40990.12256
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p1-Demonology Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28759.22584
-  tps: 15438.73739
+  dps: 28639.2689
+  tps: 15358.18416
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p1-Demonology Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 46328.1591
-  tps: 23030.2692
+  dps: 46267.01668
+  tps: 22970.60247
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p1-Demonology Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 29668.98117
-  tps: 30197.18172
+  dps: 29652.83385
+  tps: 30141.16574
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p1-Demonology Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20332.40209
-  tps: 10774.52704
+  dps: 20304.67485
+  tps: 10764.83592
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p1-Demonology Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 28215.81722
-  tps: 12879.09706
+  dps: 28205.22551
+  tps: 12930.18362
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p1-Demonology Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 43716.03749
-  tps: 40273.90092
+  dps: 43629.99808
+  tps: 39855.09687
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p1-Demonology Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28487.89396
-  tps: 15269.21838
+  dps: 28502.96934
+  tps: 15249.20851
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p1-Demonology Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 45678.34338
-  tps: 22758.42901
+  dps: 45737.12589
+  tps: 22746.44865
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p1-Demonology Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 29465.8376
-  tps: 29771.17826
+  dps: 29368.01522
+  tps: 29850.05979
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p1-Demonology Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20153.43142
-  tps: 10651.04335
+  dps: 20111.1571
+  tps: 10648.90116
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p1-Demonology Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27932.10056
-  tps: 12673.66558
+  dps: 27865.80549
+  tps: 12660.61796
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p1-Demonology Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 45067.81138
-  tps: 40875.95774
+  dps: 44981.72278
+  tps: 40611.68596
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p1-Demonology Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29361.72881
-  tps: 15478.25068
+  dps: 29387.34064
+  tps: 15457.71566
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p1-Demonology Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 47377.06723
-  tps: 23096.21656
+  dps: 47439.66002
+  tps: 23084.44001
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p1-Demonology Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 30490.85414
-  tps: 30386.65624
+  dps: 30379.48243
+  tps: 30382.05979
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p1-Demonology Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20809.00828
-  tps: 10791.64753
+  dps: 20759.05088
+  tps: 10776.65572
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p1-Demonology Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 29148.07964
-  tps: 12884.41684
+  dps: 29074.75989
+  tps: 12869.31819
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p1-Demonology Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 45593.39743
-  tps: 41898.81209
+  dps: 45642.40663
+  tps: 42206.59388
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p1-Demonology Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28961.89682
-  tps: 15659.91448
+  dps: 28893.71137
+  tps: 15605.38942
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p1-Demonology Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 47439.23684
-  tps: 24016.47693
+  dps: 47363.901
+  tps: 23911.38595
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p1-Demonology Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 30655.77434
-  tps: 31077.83196
+  dps: 30624.80252
+  tps: 30934.30605
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p1-Demonology Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20497.47006
-  tps: 10862.32443
+  dps: 20485.67344
+  tps: 10870.62546
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p1-Demonology Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 29574.31388
-  tps: 13853.94517
+  dps: 29500.347
+  tps: 13784.16527
  }
 }
 dps_results: {
  key: "TestDemonology-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 29213.62916
-  tps: 15478.25068
+  dps: 29239.48128
+  tps: 15457.71566
  }
 }

--- a/sim/warlock/destruction/TestDestruction.results
+++ b/sim/warlock/destruction/TestDestruction.results
@@ -37,1555 +37,1555 @@ character_stats_results: {
 dps_results: {
  key: "TestDestruction-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 28518.72949
-  tps: 19050.5406
+  dps: 28530.86959
+  tps: 19051.30696
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 27099.10202
-  tps: 18110.81439
+  dps: 27092.72482
+  tps: 18134.53422
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 26928.27191
-  tps: 18041.23362
+  dps: 26965.38207
+  tps: 18096.31824
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 27525.62007
-  tps: 18392.68411
+  dps: 27531.32544
+  tps: 18423.03342
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 27591.41498
-  tps: 18441.09898
+  dps: 27593.49757
+  tps: 18466.11758
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 28246.96737
-  tps: 18838.84897
+  dps: 28258.79155
+  tps: 18839.30652
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 26598.94638
-  tps: 17764.23393
-  hps: 98.81702
+  dps: 26632.76647
+  tps: 17824.85106
+  hps: 98.90295
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 28022.75454
-  tps: 18677.85141
+  dps: 28024.69702
+  tps: 18705.82111
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BindingPromise-67037"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 26761.2995
-  tps: 17920.52616
+  dps: 26790.98157
+  tps: 17966.88619
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 26835.4147
-  tps: 17951.44387
+  dps: 26858.41882
+  tps: 17995.45999
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 26870.54173
-  tps: 17977.55528
+  dps: 26893.6573
+  tps: 18021.67445
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 26528.51146
-  tps: 17751.66166
+  dps: 26552.87197
+  tps: 17798.3725
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 27421.07224
-  tps: 18281.69451
+  dps: 27446.77496
+  tps: 18331.19797
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 26528.23164
-  tps: 17752.12744
+  dps: 26551.34536
+  tps: 17796.56464
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 26910.5846
-  tps: 17991.78695
+  dps: 26915.35261
+  tps: 18017.88089
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 26567.17198
-  tps: 17751.98506
+  dps: 26589.32496
+  tps: 17795.44403
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.50656
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 27398.10426
-  tps: 18269.28284
+  dps: 27423.98343
+  tps: 18318.12052
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BottledLightning-66879"
  value: {
-  dps: 27222.29353
-  tps: 18216.71224
+  dps: 27228.41235
+  tps: 18251.65098
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 28411.10108
-  tps: 18583.91023
+  dps: 28430.20343
+  tps: 18597.92163
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Brawler'sTrophy-71338"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 28684.89956
-  tps: 19160.82121
+  dps: 28704.93312
+  tps: 19176.33865
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 28575.95798
-  tps: 19091.2612
+  dps: 28584.43777
+  tps: 19089.18178
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Coren'sChilledChromiumCoaster-71335"
  value: {
-  dps: 26975.492
-  tps: 18042.10236
+  dps: 26976.62608
+  tps: 18061.61401
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 27494.04088
-  tps: 18397.17914
+  dps: 27507.22344
+  tps: 18435.19895
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CrushingWeight-59506"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CrushingWeight-65118"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.50934
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 27521.60482
-  tps: 18392.05654
+  dps: 27546.27355
+  tps: 18440.79349
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 26762.74232
-  tps: 17887.58522
+  dps: 26775.98893
+  tps: 17917.5096
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 28301.48654
-  tps: 18877.37627
+  dps: 28309.79529
+  tps: 18875.13291
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 27444.7943
-  tps: 18421.3137
+  dps: 27440.6394
+  tps: 18446.52323
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 27046.6943
-  tps: 18076.90591
+  dps: 27034.75551
+  tps: 18097.97122
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 28246.96737
-  tps: 18838.84897
+  dps: 28258.79155
+  tps: 18839.30652
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 26930.21309
-  tps: 17987.64635
+  dps: 26969.05032
+  tps: 18052.36938
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 28411.68234
-  tps: 18964.574
+  dps: 28430.72619
+  tps: 18973.91697
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 28301.48654
-  tps: 18877.37627
+  dps: 28309.79529
+  tps: 18875.13291
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 26928.27191
-  tps: 18041.23362
+  dps: 26965.38207
+  tps: 18096.31824
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 28246.96737
-  tps: 18838.84897
+  dps: 28258.79155
+  tps: 18839.30652
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FallofMortality-59500"
  value: {
-  dps: 27521.60482
-  tps: 18392.05654
+  dps: 27546.27355
+  tps: 18440.79349
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FallofMortality-65124"
  value: {
-  dps: 27655.66886
-  tps: 18485.98809
+  dps: 27672.99878
+  tps: 18526.70551
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 27656.44874
-  tps: 18484.12615
+  dps: 27660.98901
+  tps: 18510.75751
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 26865.90823
-  tps: 18005.24844
+  dps: 26871.47337
+  tps: 18036.214
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 27398.32226
-  tps: 18334.9021
+  dps: 27404.9537
+  tps: 18368.48823
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 26566.70433
-  tps: 17752.30781
+  dps: 26589.32496
+  tps: 17795.65345
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 28238.05072
-  tps: 18832.91679
+  dps: 28244.38103
+  tps: 18868.76063
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 26831.49353
-  tps: 17977.61883
+  dps: 26855.46639
+  tps: 18022.92234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 28307.47182
-  tps: 18883.94876
+  dps: 28319.32294
+  tps: 18884.43203
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FluidDeath-58181"
  value: {
-  dps: 26906.21001
-  tps: 18005.69961
+  dps: 26910.08676
+  tps: 18032.05814
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 28411.10108
-  tps: 18947.60843
+  dps: 28430.20343
+  tps: 18962.04607
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 26944.10425
-  tps: 18020.32533
+  dps: 26947.65118
+  tps: 18044.96803
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GaleofShadows-56138"
  value: {
-  dps: 27755.37189
-  tps: 18602.38009
+  dps: 27720.45146
+  tps: 18584.83995
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GaleofShadows-56462"
  value: {
-  dps: 27827.99716
-  tps: 18674.26359
+  dps: 27807.28259
+  tps: 18661.65902
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GearDetector-61462"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 21436.1167
-  tps: 13490.96339
+  dps: 21439.26119
+  tps: 13509.95828
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 27135.17512
-  tps: 18132.39327
+  dps: 27128.80925
+  tps: 18156.14205
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HarmlightToken-63839"
  value: {
-  dps: 27348.44452
-  tps: 18313.26247
+  dps: 27356.70764
+  tps: 18348.99908
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 27889.63756
-  tps: 18677.37381
+  dps: 27853.6134
+  tps: 18653.81614
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 28016.68168
-  tps: 18781.73534
+  dps: 28016.18203
+  tps: 18772.44543
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofRage-59224"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofRage-65072"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofSolace-55868"
  value: {
-  dps: 27071.52507
-  tps: 18153.13318
+  dps: 27036.98382
+  tps: 18136.01529
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofSolace-56393"
  value: {
-  dps: 27054.36394
-  tps: 18165.32182
+  dps: 27033.71391
+  tps: 18153.26193
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofThunder-55845"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofThunder-56370"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 28301.48654
-  tps: 18877.37627
+  dps: 28309.79529
+  tps: 18875.13291
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 26869.80029
-  tps: 18006.10195
+  dps: 26893.88168
+  tps: 18051.51489
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 26869.80029
-  tps: 18006.10195
+  dps: 26893.88168
+  tps: 18051.51489
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 26835.4147
-  tps: 17951.44387
+  dps: 26858.41882
+  tps: 17995.45999
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 26870.54173
-  tps: 17977.55528
+  dps: 26893.6573
+  tps: 18021.67445
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 27248.88186
-  tps: 18205.46559
+  dps: 27278.41569
+  tps: 18253.81064
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 26581.51252
-  tps: 17780.4567
+  dps: 26579.1277
+  tps: 17810.88698
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 26581.51252
-  tps: 17784.1667
+  dps: 26581.16776
+  tps: 17816.38176
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 26761.2995
-  tps: 17920.52616
+  dps: 26790.98157
+  tps: 17966.88619
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 26906.21001
-  tps: 18005.69961
+  dps: 26910.08676
+  tps: 18032.05814
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 26906.21001
-  tps: 18005.69961
+  dps: 26910.08676
+  tps: 18032.05814
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 26803.99997
-  tps: 18017.73366
+  dps: 26801.00867
+  tps: 18035.52379
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 26803.99997
-  tps: 18017.73366
+  dps: 26801.00867
+  tps: 18035.52379
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 26776.03961
-  tps: 17930.5104
+  dps: 26764.62568
+  tps: 17941.24438
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LeadenDespair-55816"
  value: {
-  dps: 26567.17198
-  tps: 17752.26125
+  dps: 26589.32496
+  tps: 17795.56172
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LeadenDespair-56347"
  value: {
-  dps: 26566.70433
-  tps: 17752.30781
+  dps: 26589.32496
+  tps: 17795.65345
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 26906.21001
-  tps: 18005.69961
+  dps: 26910.08676
+  tps: 18032.05814
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 26528.32967
-  tps: 17747.37647
+  dps: 26557.27766
+  tps: 17793.04691
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 26528.32967
-  tps: 17747.37647
+  dps: 26557.27766
+  tps: 17793.04691
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 26567.17198
-  tps: 17751.9809
+  dps: 26589.32496
+  tps: 17795.21015
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 26567.17198
-  tps: 17751.9809
+  dps: 26589.32496
+  tps: 17795.21015
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 26824.66082
-  tps: 17970.07006
+  dps: 26856.08054
+  tps: 18018.15905
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 26863.46609
-  tps: 17999.23231
+  dps: 26895.20949
+  tps: 18047.63802
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 26891.33583
-  tps: 18019.52832
+  dps: 26880.17988
+  tps: 18032.94778
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 26891.33583
-  tps: 18019.52832
+  dps: 26880.17988
+  tps: 18032.94778
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 26908.86212
-  tps: 18006.04047
+  dps: 26932.09928
+  tps: 18050.27205
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 26908.86212
-  tps: 18006.04047
+  dps: 26932.09928
+  tps: 18050.27205
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MithrilStopwatch-71337"
  value: {
-  dps: 28100.88787
-  tps: 18748.68083
+  dps: 28100.13507
+  tps: 18766.95842
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 28061.2651
-  tps: 18812.66035
+  dps: 28080.18522
+  tps: 18854.07824
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 26569.13442
-  tps: 17755.23887
+  dps: 26589.32496
+  tps: 17795.72666
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 28135.00414
-  tps: 18840.95279
+  dps: 28147.55346
+  tps: 18876.64984
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 28343.60382
-  tps: 18985.22399
+  dps: 28356.28428
+  tps: 19018.6872
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 26800.66645
-  tps: 17923.63573
+  dps: 26838.08767
+  tps: 17975.61897
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PetrifiedPickledEgg-71336"
  value: {
-  dps: 27581.24831
-  tps: 18434.18335
+  dps: 27603.86957
+  tps: 18479.14341
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 27427.472
-  tps: 18296.88394
+  dps: 27441.44749
+  tps: 18329.10857
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 28246.96737
-  tps: 18838.84897
+  dps: 28258.79155
+  tps: 18839.30652
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Rainsong-55854"
  value: {
-  dps: 26567.17198
-  tps: 17752.00292
+  dps: 26589.32496
+  tps: 17795.23217
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Rainsong-56377"
  value: {
-  dps: 26567.17198
-  tps: 17751.98838
+  dps: 26589.32496
+  tps: 17795.21763
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 28518.72949
-  tps: 19050.5406
+  dps: 28530.86959
+  tps: 19051.30696
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 28518.72949
-  tps: 19050.52944
+  dps: 28523.65353
+  tps: 19043.15182
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 27014.89881
-  tps: 18036.2724
+  dps: 27014.05966
+  tps: 18073.00256
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 26906.21001
-  tps: 18005.69961
+  dps: 26910.08676
+  tps: 18032.05814
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 26906.21001
-  tps: 18005.69961
+  dps: 26910.08676
+  tps: 18032.05814
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RuneofZeth-68998"
  value: {
-  dps: 28078.03038
-  tps: 18771.45642
+  dps: 28066.17762
+  tps: 18786.88765
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SeaStar-55256"
  value: {
-  dps: 26977.58891
-  tps: 18018.61142
+  dps: 27002.00565
+  tps: 18065.59842
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SeaStar-56290"
  value: {
-  dps: 27365.2697
-  tps: 18248.53736
+  dps: 27390.81061
+  tps: 18297.72418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ShadowflameRegalia"
  value: {
-  dps: 26064.87247
-  tps: 17404.99205
+  dps: 26000.18025
+  tps: 17379.12245
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ShardofWoe-60233"
  value: {
-  dps: 27203.65316
-  tps: 18215.85882
+  dps: 27250.94814
+  tps: 18278.35641
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 26567.17198
-  tps: 17752.21826
+  dps: 26589.32496
+  tps: 17795.50439
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 26895.66965
-  tps: 18022.19095
+  dps: 26921.98695
+  tps: 18069.27046
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 26943.78653
-  tps: 18057.55641
+  dps: 26970.52335
+  tps: 18104.98194
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Sorrowsong-55879"
  value: {
-  dps: 27433.69134
-  tps: 18345.04245
+  dps: 27458.33766
+  tps: 18389.2229
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Sorrowsong-56400"
  value: {
-  dps: 27548.09548
-  tps: 18423.41105
+  dps: 27573.0699
+  tps: 18467.71511
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 26891.33583
-  tps: 18019.52832
+  dps: 26880.17988
+  tps: 18032.94778
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SoulCasket-58183"
  value: {
-  dps: 28015.37982
-  tps: 18687.55044
+  dps: 28042.89362
+  tps: 18739.50228
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 27475.2175
-  tps: 18368.38562
+  dps: 27459.73685
+  tps: 18381.55337
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-StumpofTime-62465"
  value: {
-  dps: 27898.21988
-  tps: 18637.71623
+  dps: 27898.9589
+  tps: 18659.41997
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-StumpofTime-62470"
  value: {
-  dps: 27933.83299
-  tps: 18647.14004
+  dps: 27936.93879
+  tps: 18674.20142
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 26569.13442
-  tps: 17755.22035
+  dps: 26589.32496
+  tps: 17795.70196
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 26569.13442
-  tps: 17755.26136
+  dps: 26589.32496
+  tps: 17795.75664
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 27526.14595
-  tps: 18416.30741
+  dps: 27527.82082
+  tps: 18445.35345
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TearofBlood-55819"
  value: {
-  dps: 27219.35282
-  tps: 18188.5413
+  dps: 27223.61333
+  tps: 18220.36534
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TearofBlood-56351"
  value: {
-  dps: 27426.522
-  tps: 18328.62406
+  dps: 27435.53616
+  tps: 18364.13074
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 27392.85613
-  tps: 18301.82995
+  dps: 27414.83521
+  tps: 18345.54382
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 27671.03863
-  tps: 18479.67491
+  dps: 27699.83171
+  tps: 18527.80844
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TheHungerer-68927"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TheHungerer-69112"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 28013.01825
-  tps: 18758.18279
+  dps: 28037.38525
+  tps: 18809.6895
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 28199.55134
-  tps: 18887.71676
+  dps: 28216.67028
+  tps: 18930.15524
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 26835.4147
-  tps: 17951.44387
+  dps: 26858.41882
+  tps: 17995.45999
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 26870.54173
-  tps: 17977.55528
+  dps: 26893.6573
+  tps: 18021.67445
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 26751.16001
-  tps: 17888.43201
+  dps: 26790.99841
+  tps: 17962.04995
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 27442.20667
-  tps: 18444.26623
+  dps: 27404.67093
+  tps: 18402.8114
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-UnheededWarning-59520"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 26528.23164
-  tps: 17752.09171
+  dps: 26551.34536
+  tps: 17796.52891
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 26869.80029
-  tps: 18006.10195
+  dps: 26893.88168
+  tps: 18051.51489
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 26869.80029
-  tps: 18006.10195
+  dps: 26893.88168
+  tps: 18051.51489
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 26869.80029
-  tps: 18006.10195
+  dps: 26893.88168
+  tps: 18051.51489
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 27927.79324
-  tps: 18706.81686
+  dps: 27972.04718
+  tps: 18771.79622
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 28409.75109
-  tps: 19121.95671
+  dps: 28409.07942
+  tps: 19169.95025
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 26569.13442
-  tps: 17755.22035
+  dps: 26589.32496
+  tps: 17795.70196
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 26569.13442
-  tps: 17755.26136
+  dps: 26589.32496
+  tps: 17795.75664
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 26528.23164
-  tps: 17752.12744
+  dps: 26551.34536
+  tps: 17796.56464
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 27471.00082
-  tps: 18311.30846
+  dps: 27496.84833
+  tps: 18361.09522
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 26528.23164
-  tps: 17752.12744
+  dps: 26551.34536
+  tps: 17796.56464
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 26906.21001
-  tps: 18005.94255
+  dps: 26910.08676
+  tps: 18032.05814
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 27033.46627
-  tps: 18080.98495
+  dps: 27056.28822
+  tps: 18113.88807
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 26975.492
-  tps: 18042.10236
+  dps: 26976.62608
+  tps: 18061.85695
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.51978
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 26929.08677
-  tps: 18021.07431
+  dps: 26952.38811
+  tps: 18065.60816
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.51978
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 27390.47045
-  tps: 18259.80811
+  dps: 27414.11302
+  tps: 18305.14009
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 26567.17198
-  tps: 17752.04759
+  dps: 26589.32496
+  tps: 17795.27684
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 27585.95515
-  tps: 18519.70716
+  dps: 27582.93574
+  tps: 18560.8482
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 27902.9277
-  tps: 18695.27878
+  dps: 27909.51016
+  tps: 18722.42871
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 26761.26446
-  tps: 17925.39977
+  dps: 26785.03836
+  tps: 17970.50266
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 26785.85555
-  tps: 17941.12543
+  dps: 26816.95159
+  tps: 17988.82517
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 26785.85555
-  tps: 17941.12543
+  dps: 26816.95159
+  tps: 17988.82517
  }
 }
 dps_results: {
  key: "TestDestruction-Average-Default"
  value: {
-  dps: 29087.64678
-  tps: 19516.82175
+  dps: 29068.03793
+  tps: 19508.95477
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Goblin-p1-Destruction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 30042.88244
-  tps: 35375.57523
+  dps: 30037.8331
+  tps: 35343.69806
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Goblin-p1-Destruction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28352.03666
-  tps: 19134.85613
+  dps: 28352.79267
+  tps: 19132.84289
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Goblin-p1-Destruction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 38392.34101
-  tps: 23803.29716
+  dps: 38402.81045
+  tps: 23800.44565
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Goblin-p1-Destruction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 18555.55287
-  tps: 25987.96966
+  dps: 18520.50234
+  tps: 26036.97506
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Goblin-p1-Destruction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 18555.55287
-  tps: 12484.03481
+  dps: 18520.50234
+  tps: 12420.96598
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Goblin-p1-Destruction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 21648.69458
-  tps: 13145.13219
+  dps: 21632.38928
+  tps: 13074.88139
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p1-Destruction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 29875.08126
-  tps: 35129.76923
+  dps: 29882.63465
+  tps: 35170.48949
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p1-Destruction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28158.64784
-  tps: 19012.16165
+  dps: 28177.5929
+  tps: 19027.33538
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p1-Destruction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 38463.89505
-  tps: 23859.36733
+  dps: 38426.43631
+  tps: 23775.7274
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p1-Destruction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 18429.01766
-  tps: 25696.52056
+  dps: 18450.22393
+  tps: 25780.03512
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p1-Destruction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 18429.01766
-  tps: 12422.39775
+  dps: 18450.22393
+  tps: 12460.94316
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p1-Destruction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 21532.0504
-  tps: 13029.33979
+  dps: 21509.67199
+  tps: 13042.18542
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p1-Destruction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 30407.77075
-  tps: 35280.34822
+  dps: 30415.13203
+  tps: 35320.89493
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p1-Destruction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28684.89956
-  tps: 19160.82121
+  dps: 28704.93312
+  tps: 19176.33865
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p1-Destruction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 39541.28664
-  tps: 24161.32949
+  dps: 39506.64537
+  tps: 24075.92936
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p1-Destruction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 18817.82104
-  tps: 25756.93958
+  dps: 18822.22754
+  tps: 25805.21255
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p1-Destruction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 18817.82104
-  tps: 12537.7184
+  dps: 18822.22754
+  tps: 12555.08071
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p1-Destruction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 22241.39094
-  tps: 13204.19624
+  dps: 22215.62711
+  tps: 13217.04066
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p1-Destruction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 30241.40725
-  tps: 35594.395
+  dps: 30214.4442
+  tps: 35460.48794
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p1-Destruction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28545.67739
-  tps: 19298.76106
+  dps: 28518.03346
+  tps: 19273.04953
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p1-Destruction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 39323.01385
-  tps: 24402.60746
+  dps: 39123.56804
+  tps: 24188.47395
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p1-Destruction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 18680.20692
-  tps: 26185.7633
+  dps: 18668.29946
+  tps: 26189.91953
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p1-Destruction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 18680.20692
-  tps: 12620.00573
+  dps: 18668.29946
+  tps: 12573.96271
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p1-Destruction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 22421.33782
-  tps: 13763.9086
+  dps: 22364.30512
+  tps: 13651.97964
  }
 }
 dps_results: {
  key: "TestDestruction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 28677.74069
-  tps: 19160.82121
+  dps: 28697.77425
+  tps: 19176.33865
  }
 }

--- a/sim/warlock/doomguard.go
+++ b/sim/warlock/doomguard.go
@@ -81,8 +81,13 @@ func (pet *DoomguardPet) Reset(_ *core.Simulation) {}
 func (pet *DoomguardPet) ExecuteCustomRotation(sim *core.Simulation) {
 	if pet.DoomBolt.CanCast(sim, pet.CurrentTarget) {
 		pet.DoomBolt.Cast(sim, pet.CurrentTarget)
-		// ~400ms ish delay between casts
-		pet.WaitUntil(sim, pet.NextGCDAt()+400*time.Millisecond)
+		minDelay := 150.0
+		maxDelay := 750.0
+		delayRange := maxDelay - minDelay
+		// ~150-750ms delay between casts
+		// Research: https://docs.google.com/spreadsheets/d/e/2PACX-1vSaFavGbmrd0l3r7XsPWivap9wMjeaRB6Sl5ieg_GpJ8AfdWkzdG3o2czJ60WHFIZwK0QK5yWF22p8D/pubchart?oid=586881278&format=interactive
+		randomDelay := time.Duration(minDelay+delayRange*sim.RandomFloat("Doomguard Cast Delay")) * time.Millisecond
+		pet.WaitUntil(sim, pet.NextGCDAt()+randomDelay)
 		return
 	}
 }


### PR DESCRIPTION
When plotting breakpoints and stat scaling I found out that Doomguard has massive peaks at certain fixed haste breakpoints. After some digging together with Ketesh, TheNameLess and Malvanis in the Warlock Discord we found that it is related to Doomguard gaining a extra cast.

The fixed 400ms cast delay is however not "game like" and should be changed. I've analysed 1700+ Doomguard casts in logs and created the following Histogram highlighting a more accurate interpretation:
![Doomguard cast delay](https://github.com/user-attachments/assets/43299a98-16ad-48ed-934a-d9235f605a24)

We came to the consensus to set the cast delay to a random number between 150 and 750ms.

**Results**

**Stat scaling**
Before: https://docs.google.com/spreadsheets/d/e/2PACX-1vSOhHz6EmXS4SOdfz8MCdXkx9jzOP0_7yhGreE_HeUIjSjxdXv3rMXLYacYfwEWudM3cA00O1ndgc4Z/pubchart?oid=1571781985&format=interactive

After: https://docs.google.com/spreadsheets/d/e/2PACX-1vSOhHz6EmXS4SOdfz8MCdXkx9jzOP0_7yhGreE_HeUIjSjxdXv3rMXLYacYfwEWudM3cA00O1ndgc4Z/pubchart?oid=840962925&format=interactive

**Breakpoints**
Before: https://docs.google.com/spreadsheets/d/e/2PACX-1vSOhHz6EmXS4SOdfz8MCdXkx9jzOP0_7yhGreE_HeUIjSjxdXv3rMXLYacYfwEWudM3cA00O1ndgc4Z/pubchart?oid=303894196&format=interactive

After: https://docs.google.com/spreadsheets/d/e/2PACX-1vSOhHz6EmXS4SOdfz8MCdXkx9jzOP0_7yhGreE_HeUIjSjxdXv3rMXLYacYfwEWudM3cA00O1ndgc4Z/pubchart?oid=1405742270&format=interactive