### PR TITLE
[WARLOCK][DEMO] Fix Mastery flooring breakpoints

### DIFF
--- a/ui/core/components/character_stats.tsx
+++ b/ui/core/components/character_stats.tsx
@@ -340,7 +340,6 @@ export class CharacterStats extends Component {
 			displayStr += ` (${statAsPercentageOrPoint.toFixed(2)}%)`;
 		} else if (stat == Stat.StatMastery) {
 			displayStr += ` (${(statAsPercentageOrPoint + (includeBase ? this.player.getBaseMastery() : 0)).toFixed(2)} Points)`;
-			console.log(statAsPercentageOrPoint, displayStr);
 		}
 
 		return displayStr;

--- a/ui/core/components/character_stats.tsx
+++ b/ui/core/components/character_stats.tsx
@@ -340,6 +340,7 @@ export class CharacterStats extends Component {
 			displayStr += ` (${statAsPercentageOrPoint.toFixed(2)}%)`;
 		} else if (stat == Stat.StatMastery) {
 			displayStr += ` (${(statAsPercentageOrPoint + (includeBase ? this.player.getBaseMastery() : 0)).toFixed(2)} Points)`;
+			console.log(statAsPercentageOrPoint, displayStr);
 		}
 
 		return displayStr;

--- a/ui/core/components/suggest_reforges_action.tsx
+++ b/ui/core/components/suggest_reforges_action.tsx
@@ -256,17 +256,24 @@ export class ReforgeOptimizer {
 								{breakpoints.map((breakpoint, breakpointIndex) => (
 									<tr>
 										<td>{Math.round(breakpoint)}</td>
-										<td className="text-end">{statToPercentageOrPoints(stat, breakpoint, new Stats()).toFixed(2)}</td>
+										<td className="text-end">
+											{stat === Stat.StatMastery
+												? (
+														(statToPercentageOrPoints(stat, breakpoint, new Stats()) + this.player.getBaseMastery()) *
+														this.player.getMasteryPerPointModifier()
+												  ).toFixed(2)
+												: statToPercentageOrPoints(stat, breakpoint, new Stats()).toFixed(2)}
+										</td>
 										<td className="text-end">{capType === StatCapType.TypeThreshold ? postCapEPs[0] : postCapEPs[breakpointIndex]}</td>
 									</tr>
 								))}
 								{index !== this.softCapsConfig.length - 1 && (
 									<>
 										<tr>
-											<td colSpan={2} className="border-bottom pb-2"></td>
+											<td colSpan={3} className="border-bottom pb-2"></td>
 										</tr>
 										<tr>
-											<td colSpan={2} className="pb-2"></td>
+											<td colSpan={3} className="pb-2"></td>
 										</tr>
 									</>
 								)}

--- a/ui/core/components/suggest_reforges_action.tsx
+++ b/ui/core/components/suggest_reforges_action.tsx
@@ -667,7 +667,6 @@ export class ReforgeOptimizer {
 		this.player.setGear(TypedEvent.nextEventID(), gear);
 		await this.sim.updateCharacterStats(TypedEvent.nextEventID());
 		let baseStats = Stats.fromProto(this.player.getCurrentStats().finalStats);
-		baseStats = baseStats.addStat(Stat.StatMastery, this.player.getBaseMastery() * Mechanics.MASTERY_RATING_PER_MASTERY_POINT);
 		if (this.updateGearStatsModifier) baseStats = this.updateGearStatsModifier(baseStats);
 		return baseStats.withHasteMultipliers(this.playerClass);
 	}

--- a/ui/warlock/affliction/sim.ts
+++ b/ui/warlock/affliction/sim.ts
@@ -55,7 +55,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecAfflictionWarlock, {
 			const masteryRatingBreakpoints = [];
 			const masteryPercentPerPoint = Mechanics.masteryPercentPerPoint.get(Spec.SpecAfflictionWarlock)!;
 
-			for (let masteryPercent = 14; masteryPercent <= 200; masteryPercent++) {
+			for (let masteryPercent = 1; masteryPercent <= 200; masteryPercent++) {
 				masteryRatingBreakpoints.push((masteryPercent / masteryPercentPerPoint) * Mechanics.MASTERY_RATING_PER_MASTERY_POINT);
 			}
 

--- a/ui/warlock/affliction/sim.ts
+++ b/ui/warlock/affliction/sim.ts
@@ -53,11 +53,10 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecAfflictionWarlock, {
 			// These should be removed once the bugfix to make Mastery
 			// continuous goes live!
 			const masteryRatingBreakpoints = [];
+			const masteryPercentPerPoint = Mechanics.masteryPercentPerPoint.get(Spec.SpecAfflictionWarlock)!;
 
 			for (let masteryPercent = 14; masteryPercent <= 200; masteryPercent++) {
-				masteryRatingBreakpoints.push(
-					(masteryPercent / Mechanics.masteryPercentPerPoint.get(Spec.SpecAfflictionWarlock)!) * Mechanics.MASTERY_RATING_PER_MASTERY_POINT,
-				);
+				masteryRatingBreakpoints.push((masteryPercent / masteryPercentPerPoint) * Mechanics.MASTERY_RATING_PER_MASTERY_POINT);
 			}
 
 			const masterySoftCapConfig = {

--- a/ui/warlock/demonology/sim.ts
+++ b/ui/warlock/demonology/sim.ts
@@ -54,7 +54,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecDemonologyWarlock, {
 			const masteryRatingBreakpoints = [];
 			const masteryPercentPerPoint = Mechanics.masteryPercentPerPoint.get(Spec.SpecDemonologyWarlock)!;
 			const initialMasteryOffset = Math.round((Mechanics.MASTERY_RATING_PER_MASTERY_POINT / masteryPercentPerPoint) * 0.6);
-			for (let masteryPercent = 19; masteryPercent <= 200; masteryPercent++) {
+			for (let masteryPercent = 0; masteryPercent <= 200; masteryPercent++) {
 				masteryRatingBreakpoints.push(
 					Math.round(initialMasteryOffset + masteryPercent * (Mechanics.MASTERY_RATING_PER_MASTERY_POINT / masteryPercentPerPoint)),
 				);

--- a/ui/warlock/demonology/sim.ts
+++ b/ui/warlock/demonology/sim.ts
@@ -52,10 +52,11 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecDemonologyWarlock, {
 			// These should be removed once the bugfix to make Mastery
 			// continuous goes live!
 			const masteryRatingBreakpoints = [];
-
+			const masteryPercentPerPoint = Mechanics.masteryPercentPerPoint.get(Spec.SpecDemonologyWarlock)!;
+			const initialMasteryOffset = Math.round((Mechanics.MASTERY_RATING_PER_MASTERY_POINT / masteryPercentPerPoint) * 0.6);
 			for (let masteryPercent = 19; masteryPercent <= 200; masteryPercent++) {
 				masteryRatingBreakpoints.push(
-					(masteryPercent / Mechanics.masteryPercentPerPoint.get(Spec.SpecDemonologyWarlock)!) * Mechanics.MASTERY_RATING_PER_MASTERY_POINT,
+					Math.round(initialMasteryOffset + masteryPercent * (Mechanics.MASTERY_RATING_PER_MASTERY_POINT / masteryPercentPerPoint)),
 				);
 			}
 


### PR DESCRIPTION
- Added initial Mastery rounding offset of 0.60% to Demo breakpoints table
- Changed breakpoints overview table to include Mastery skill % instead of points

**Current**
![image](https://github.com/user-attachments/assets/d53819dd-225c-4d23-b0b6-23dc5c5491d7)

**Fixed**
![image](https://github.com/user-attachments/assets/aeace0f6-f569-4e8c-9196-34b8fa022623)

Matches table from Discord:
![image](https://github.com/user-attachments/assets/2c9cff9f-c609-45b9-bef7-63b08040c088)

