### PR TITLE
[WARLOCK] Visual Mastery breakpoints

### DIFF
--- a/ui/core/components/suggest_reforges_action.tsx
+++ b/ui/core/components/suggest_reforges_action.tsx
@@ -255,13 +255,18 @@ export class ReforgeOptimizer {
 								</tr>
 								{breakpoints.map((breakpoint, breakpointIndex) => (
 									<tr>
-										<td>{Math.round(breakpoint)}</td>
+										<td>
+											{Math.ceil(
+												stat === Stat.StatMastery
+													? breakpoint - this.player.getBaseMastery() * Mechanics.MASTERY_RATING_PER_MASTERY_POINT
+													: breakpoint,
+											)}
+										</td>
 										<td className="text-end">
 											{stat === Stat.StatMastery
-												? (
-														(statToPercentageOrPoints(stat, breakpoint, new Stats()) + this.player.getBaseMastery()) *
-														this.player.getMasteryPerPointModifier()
-												  ).toFixed(2)
+												? (statToPercentageOrPoints(stat, breakpoint, new Stats()) * this.player.getMasteryPerPointModifier()).toFixed(
+														2,
+												  )
 												: statToPercentageOrPoints(stat, breakpoint, new Stats()).toFixed(2)}
 										</td>
 										<td className="text-end">{capType === StatCapType.TypeThreshold ? postCapEPs[0] : postCapEPs[breakpointIndex]}</td>
@@ -667,6 +672,7 @@ export class ReforgeOptimizer {
 		this.player.setGear(TypedEvent.nextEventID(), gear);
 		await this.sim.updateCharacterStats(TypedEvent.nextEventID());
 		let baseStats = Stats.fromProto(this.player.getCurrentStats().finalStats);
+		baseStats = baseStats.addStat(Stat.StatMastery, this.player.getBaseMastery() * Mechanics.MASTERY_RATING_PER_MASTERY_POINT);
 		if (this.updateGearStatsModifier) baseStats = this.updateGearStatsModifier(baseStats);
 		return baseStats.withHasteMultipliers(this.playerClass);
 	}

--- a/ui/warlock/affliction/sim.ts
+++ b/ui/warlock/affliction/sim.ts
@@ -55,7 +55,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecAfflictionWarlock, {
 			const masteryRatingBreakpoints = [];
 			const masteryPercentPerPoint = Mechanics.masteryPercentPerPoint.get(Spec.SpecAfflictionWarlock)!;
 
-			for (let masteryPercent = 1; masteryPercent <= 200; masteryPercent++) {
+			for (let masteryPercent = 14; masteryPercent <= 200; masteryPercent++) {
 				masteryRatingBreakpoints.push((masteryPercent / masteryPercentPerPoint) * Mechanics.MASTERY_RATING_PER_MASTERY_POINT);
 			}
 

--- a/ui/warlock/demonology/sim.ts
+++ b/ui/warlock/demonology/sim.ts
@@ -53,11 +53,8 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecDemonologyWarlock, {
 			// continuous goes live!
 			const masteryRatingBreakpoints = [];
 			const masteryPercentPerPoint = Mechanics.masteryPercentPerPoint.get(Spec.SpecDemonologyWarlock)!;
-			const initialMasteryOffset = Math.round((Mechanics.MASTERY_RATING_PER_MASTERY_POINT / masteryPercentPerPoint) * 0.6);
-			for (let masteryPercent = 0; masteryPercent <= 200; masteryPercent++) {
-				masteryRatingBreakpoints.push(
-					Math.ceil(initialMasteryOffset + masteryPercent * (Mechanics.MASTERY_RATING_PER_MASTERY_POINT / masteryPercentPerPoint)),
-				);
+			for (let masteryPercent = 19; masteryPercent <= 200; masteryPercent++) {
+				masteryRatingBreakpoints.push((masteryPercent / masteryPercentPerPoint) * Mechanics.MASTERY_RATING_PER_MASTERY_POINT);
 			}
 
 			const masterySoftCapConfig = {

--- a/ui/warlock/demonology/sim.ts
+++ b/ui/warlock/demonology/sim.ts
@@ -56,7 +56,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecDemonologyWarlock, {
 			const initialMasteryOffset = Math.round((Mechanics.MASTERY_RATING_PER_MASTERY_POINT / masteryPercentPerPoint) * 0.6);
 			for (let masteryPercent = 0; masteryPercent <= 200; masteryPercent++) {
 				masteryRatingBreakpoints.push(
-					Math.round(initialMasteryOffset + masteryPercent * (Mechanics.MASTERY_RATING_PER_MASTERY_POINT / masteryPercentPerPoint)),
+					Math.ceil(initialMasteryOffset + masteryPercent * (Mechanics.MASTERY_RATING_PER_MASTERY_POINT / masteryPercentPerPoint)),
 				);
 			}
 


### PR DESCRIPTION
- Fix visual representation of Mastery breakpoints
- Undo "fix" (skill issue)

![image](https://github.com/user-attachments/assets/d960300d-4625-45f2-9fe9-71357c9c13cf)
