### PR TITLE
[UI] Add DPET column

### DIFF
--- a/ui/core/components/detailed_results/melee_metrics.ts
+++ b/ui/core/components/detailed_results/melee_metrics.ts
@@ -22,6 +22,19 @@ export class MeleeMetricsTable extends MetricsTable<ActionMetrics> {
 				getDisplayString: (metric: ActionMetrics) => metric.dps.toFixed(1),
 			},
 			{
+				name: 'DPET',
+				tooltip: 'Damage / Effective (Cast) Time',
+				sort: ColumnSortType.Descending,
+				getValue: (metric: ActionMetrics) => {
+					if (!metric.avgCastTimeMs || (metric.unit?.isPet && !metric.actionId.spellId)) return 0;
+					return metric.avgCast / (metric.avgCastTimeMs / 1000);
+				},
+				getDisplayString: (metric: ActionMetrics) => {
+					if (!metric.avgCastTimeMs || (metric.unit?.isPet && !metric.actionId.spellId)) return '';
+					return (metric.avgCast / (metric.avgCastTimeMs / 1000)).toFixed(1);
+				},
+			},
+			{
 				name: 'Avg Cast',
 				tooltip: 'Damage / Casts',
 				getValue: (metric: ActionMetrics) => metric.avgCast,

--- a/ui/core/components/detailed_results/spell_metrics.ts
+++ b/ui/core/components/detailed_results/spell_metrics.ts
@@ -22,6 +22,19 @@ export class SpellMetricsTable extends MetricsTable<ActionMetrics> {
 				getDisplayString: (metric: ActionMetrics) => metric.dps.toFixed(1),
 			},
 			{
+				name: 'DPET',
+				tooltip: 'Damage / Effective (Cast) Time',
+				sort: ColumnSortType.Descending,
+				getValue: (metric: ActionMetrics) => {
+					if (!metric.avgCastTimeMs || (metric.unit?.isPet && !metric.actionId.spellId)) return 0;
+					return metric.avgCast / (metric.avgCastTimeMs / 1000);
+				},
+				getDisplayString: (metric: ActionMetrics) => {
+					if (!metric.avgCastTimeMs || (metric.unit?.isPet && !metric.actionId.spellId)) return '';
+					return (metric.avgCast / (metric.avgCastTimeMs / 1000)).toFixed(1);
+				},
+			},
+			{
 				name: 'Avg Cast',
 				tooltip: 'Damage / Casts',
 				getValue: (metric: ActionMetrics) => metric.avgCast,


### PR DESCRIPTION
- Added DPET (Damage Per Effective (Cast) Time) column to Melee/Spell metric
- Nice to have to have Pet DPET however the cast time (summon time) is not available in the ActionMetrics, thus I wasn't able to easily display this.

![image](https://github.com/user-attachments/assets/94cf752a-9e42-437c-9132-cc556ba90f31)
![image](https://github.com/user-attachments/assets/155293d0-479a-49e9-8bb5-a0e15bf8c34b)
![image](https://github.com/user-attachments/assets/37211c40-4dd9-4a27-ac08-2dd8b27f9719)
![image](https://github.com/user-attachments/assets/ee769ba5-31ca-4ba1-8141-f52a674fe836)
