### PR TITLE
[UI] Add spell school colors

### DIFF
--- a/sim/core/flags.go
+++ b/sim/core/flags.go
@@ -250,6 +250,28 @@ func (ss SpellSchool) ResistanceStat() stats.Stat {
 	}
 }
 
+// Returns the proto value for this spell school.
+func (ss SpellSchool) ToProto() proto.SpellSchool {
+	switch ss {
+	case SpellSchoolPhysical:
+		return proto.SpellSchool_SpellSchoolPhysical
+	case SpellSchoolArcane:
+		return proto.SpellSchool_SpellSchoolArcane
+	case SpellSchoolFire:
+		return proto.SpellSchool_SpellSchoolFire
+	case SpellSchoolFrost:
+		return proto.SpellSchool_SpellSchoolFrost
+	case SpellSchoolHoly:
+		return proto.SpellSchool_SpellSchoolHoly
+	case SpellSchoolNature:
+		return proto.SpellSchool_SpellSchoolNature
+	case SpellSchoolShadow:
+		return proto.SpellSchool_SpellSchoolShadow
+	default:
+		return proto.SpellSchool_SpellSchoolPhysical
+	}
+}
+
 func SpellSchoolFromProto(p proto.SpellSchool) SpellSchool {
 	switch p {
 	case proto.SpellSchool_SpellSchoolPhysical:

--- a/sim/core/spell_result.go
+++ b/sim/core/spell_result.go
@@ -288,12 +288,11 @@ func (spell *Spell) dealDamageInternal(sim *Simulation, isPeriodic bool, result 
 	if result.Target.Type == EnemyUnit {
 		sim.Encounter.DamageTaken += result.Damage
 	}
-
 	if sim.Log != nil {
 		if isPeriodic {
-			spell.Unit.Log(sim, "%s %s tick %s. (Threat: %0.3f)", result.Target.LogLabel(), spell.ActionID, result.DamageString(), result.Threat)
+			spell.Unit.Log(sim, "%s %s tick %s (SpellSchool: %d). (Threat: %0.3f)", result.Target.LogLabel(), spell.ActionID, result.DamageString(), spell.SpellSchool.ToProto(), result.Threat)
 		} else {
-			spell.Unit.Log(sim, "%s %s %s. (Threat: %0.3f)", result.Target.LogLabel(), spell.ActionID, result.DamageString(), result.Threat)
+			spell.Unit.Log(sim, "%s %s %s (SpellSchool: %d). (Threat: %0.3f)", result.Target.LogLabel(), spell.ActionID, result.DamageString(), spell.SpellSchool.ToProto(), result.Threat)
 		}
 	}
 

--- a/ui/core/proto_utils/names.ts
+++ b/ui/core/proto_utils/names.ts
@@ -1,5 +1,5 @@
 import { ResourceType } from '../proto/api.js';
-import { ArmorType, Class, ItemSlot, Profession, PseudoStat, Race, RangedWeaponType, Spec, Stat, WeaponType } from '../proto/common.js';
+import { ArmorType, Class, ItemSlot, Profession, PseudoStat, Race, RangedWeaponType, Spec, SpellSchool, Stat, WeaponType } from '../proto/common.js';
 import { DungeonDifficulty, RaidFilterOption, RepFaction, RepLevel, SourceFilterOption, StatCapType } from '../proto/ui.js';
 
 export const armorTypeNames: Map<ArmorType, string> = new Map([
@@ -211,6 +211,16 @@ export function getClassStatName(stat: Stat, playerClass: Class): string {
 		return statName;
 	}
 }
+
+export const spellSchoolNames: Map<SpellSchool, string> = new Map([
+	[SpellSchool.SpellSchoolPhysical, 'Physical'],
+	[SpellSchool.SpellSchoolArcane, 'Arcane'],
+	[SpellSchool.SpellSchoolFire, 'Fire'],
+	[SpellSchool.SpellSchoolFrost, 'Frost'],
+	[SpellSchool.SpellSchoolHoly, 'Holy'],
+	[SpellSchool.SpellSchoolNature, 'Nature'],
+	[SpellSchool.SpellSchoolShadow, 'Shadow'],
+]);
 
 export const slotNames: Map<ItemSlot, string> = new Map([
 	[ItemSlot.ItemSlotHead, 'Head'],

--- a/ui/scss/shared/_global.scss
+++ b/ui/scss/shared/_global.scss
@@ -181,7 +181,6 @@ kbd {
 		color: var(--bs-#{$label}) !important;
 	}
 }
-
 @each $label, $value in $resource-colors {
 	.resource-#{$label} {
 		color: var(--bs-#{$label}) !important;
@@ -194,6 +193,11 @@ kbd {
 }
 @each $label, $value in $faction-colors {
 	.faction-#{$label} {
+		color: var(--bs-#{$label}) !important;
+	}
+}
+@each $label, $value in $spell-school-colors {
+	.spell-school-#{$label} {
 		color: var(--bs-#{$label}) !important;
 	}
 }

--- a/ui/scss/shared/_variables.scss
+++ b/ui/scss/shared/_variables.scss
@@ -39,6 +39,17 @@ $class-colors: (
 );
 $theme-colors: map-merge($theme-colors, $class-colors);
 
+$spell-school-colors:(
+	physical: #e5cc80,
+	arcane: #8ff2ff,
+	fire: #eb4561,
+	frost: #4a80ff,
+	holy: #ffff8f,
+	nature: #d1fa99,
+	shadow: #b8a8f0,
+);
+$theme-colors: map-merge($theme-colors, $spell-school-colors);
+
 $custom-colors: (
 	expansion: $expansion,
 	brand: $brand,


### PR DESCRIPTION
In preparation of the Results refactor I've added spell schools to be able to visually distinguish between different schools. Should also add more clarity when browsing through the logs.

- Added spell school to the Log output
- Added `SpellSchool.ToProto()` function
- Added spell school colors to the UI
- Added spell school colors to the damage done portion of the log

![image](https://github.com/user-attachments/assets/3ebfa371-ca5d-4f22-8a8e-d227e6d424b4)
![image](https://github.com/user-attachments/assets/f37710a9-5447-4ff1-b6e4-ab24fa2480de)
![image](https://github.com/user-attachments/assets/00ae7fed-1456-403c-8c92-1fc135f5800b)
