### PR TITLE
fix dot mage crit metrics

### DIFF
--- a/sim/mage/combustion.go
+++ b/sim/mage/combustion.go
@@ -33,6 +33,7 @@ func (mage *Mage) registerCombustionSpell() {
 			baseDamage := 0.429 * mage.ClassSpellScaling
 			result := spell.CalcDamage(sim, target, baseDamage, spell.OutcomeMagicHitAndCrit)
 			if result.Landed() {
+				spell.SpellMetrics[target.UnitIndex].Hits--
 				spell.DealDamage(sim, result)
 				spell.RelatedDotSpell.Cast(sim, target)
 			}

--- a/sim/mage/living_bomb.go
+++ b/sim/mage/living_bomb.go
@@ -73,7 +73,7 @@ func (mage *Mage) registerLivingBombSpell() {
 				OnExpire: func(aura *core.Aura, sim *core.Simulation) {
 					if bombExplode {
 						livingBombExplosionSpell.Cast(sim, aura.Unit)
-						mage.WaitUntil(sim, sim.CurrentTime + mage.ReactionTime)
+						mage.WaitUntil(sim, sim.CurrentTime+mage.ReactionTime)
 						if len(activeLivingBombs) != 0 {
 							activeLivingBombs = activeLivingBombs[1:]
 						}
@@ -96,6 +96,7 @@ func (mage *Mage) registerLivingBombSpell() {
 			result := spell.CalcOutcome(sim, target, spell.OutcomeMagicHit)
 
 			if result.Landed() {
+				spell.SpellMetrics[target.UnitIndex].Hits--
 				activeLbs := len(activeLivingBombs)
 				if activeLbs >= maxLivingBombs {
 					bombExplode = false


### PR DESCRIPTION
resolves the issue where dot crit chance is a lot lower than the explosion:
![image](https://github.com/user-attachments/assets/77bd1344-e6ac-43bd-8609-d749934c355a)
 
caused by hit count to be incremented when the dot is applied