### PR TITLE
Small style tweaks on results refactor

### DIFF
--- a/ui/core/components/raid_sim_action.tsx
+++ b/ui/core/components/raid_sim_action.tsx
@@ -600,7 +600,7 @@ export class RaidSimResultsManager {
 					<thead className="metrics-table-header">
 						<tr className="metrics-table-header-row">
 							{data.map(({ name, classes }) => {
-								const cell = <th className={clsx('metrics-table-header-cell text-center', classes)}>{name}</th>;
+								const cell = <th className={clsx('metrics-table-header-cell', classes)}>{name}</th>;
 
 								tippy(cell, {
 									content: TOOLTIP_METRIC_LABELS[name],

--- a/ui/scss/core/components/_detailed_results.scss
+++ b/ui/scss/core/components/_detailed_results.scss
@@ -39,10 +39,6 @@
 	display: none;
 }
 
-.dr-row {
-	padding-right: 10px;
-}
-
 .dr-root {
 	display: flex;
 	flex-direction: column;
@@ -196,6 +192,7 @@
 .metrics-table-header-cell {
 	padding: var(--spacer-1) var(--spacer-2);
 	cursor: pointer;
+	text-align: center;
 }
 
 .metrics-table-body tr {
@@ -217,12 +214,10 @@
 	}
 }
 
-.metrics-table-header-cell:first-child,
 .metrics-table-body td:first-child,
 .metrics-table-footer td:first-child {
 	text-align: left;
 }
-.metrics-table-header-cell:not(:first-child),
 .metrics-table-body td:not(:first-child),
 .metrics-table-footer td:not(:first-child) {
 	text-align: right;

--- a/ui/scss/core/components/detailed_results/_topline_results.scss
+++ b/ui/scss/core/components/detailed_results/_topline_results.scss
@@ -9,11 +9,15 @@
 		width: max-content;
 		max-width: 100%;
 		width: 100%;
+		table-layout: fixed;
 	}
-
 	.metrics-table-body {
-		tr:hover {
-			background-color: transparent;
+		tr {
+			border-bottom: 0;
+
+			&:hover {
+				background-color: transparent;
+			}
 		}
 	}
 }


### PR DESCRIPTION
- Make topline results equally-sized
- Removed bottom border from topline results
- Center all results header `th`s (matches how WCL does it as well)
- Removed an extra `padding-right: 10px` that was causing the topline results to be misaligned on the right side of the screen

<img width="1728" alt="image" src="https://github.com/user-attachments/assets/714dabf6-65bd-4c56-a5cb-db42c475fb76">
