### PR TITLE
[Warlock] Fix errors when no warlock pet selected in settings

### DIFF
--- a/sim/warlock/demonology/demonology.go
+++ b/sim/warlock/demonology/demonology.go
@@ -74,6 +74,8 @@ func (demonology *DemonologyWarlock) Reset(sim *core.Simulation) {
 }
 
 func (demonology *DemonologyWarlock) registerSummonFelguard() {
+	stunActionID := core.ActionID{SpellID: 32752}
+
 	demonology.Felguard.RegisterAura(demonology.GetSummonStunAura())
 	demonology.RegisterSpell(core.SpellConfig{
 		ActionID:       core.ActionID{SpellID: 30146},
@@ -89,7 +91,7 @@ func (demonology *DemonologyWarlock) registerSummonFelguard() {
 				CastTime: 6 * time.Second,
 			},
 			ModifyCast: func(sim *core.Simulation, spell *core.Spell, cast *core.Cast) {
-				demonology.ActivePet.GetAuraByID(core.ActionID{SpellID: 32752}).Activate(sim)
+				demonology.ActivatePetSummonStun(sim, stunActionID)
 			},
 		},
 

--- a/sim/warlock/summon_demon.go
+++ b/sim/warlock/summon_demon.go
@@ -7,7 +7,9 @@ import (
 )
 
 func (warlock *Warlock) ChangeActivePet(sim *core.Simulation, newPet *WarlockPet) {
-	warlock.ActivePet.Disable(sim)
+	if warlock.ActivePet != nil {
+		warlock.ActivePet.Disable(sim)
+	}
 	newPet.Enable(sim, newPet)
 	warlock.ActivePet = newPet
 }
@@ -43,7 +45,7 @@ func (warlock *Warlock) registerSummonDemon() {
 				CastTime: 6 * time.Second,
 			},
 			ModifyCast: func(sim *core.Simulation, spell *core.Spell, cast *core.Cast) {
-				warlock.ActivePet.GetAuraByID(stunActionID).Activate(sim)
+				warlock.ActivatePetSummonStun(sim, stunActionID)
 			},
 		},
 
@@ -69,7 +71,7 @@ func (warlock *Warlock) registerSummonDemon() {
 				CastTime: 6 * time.Second,
 			},
 			ModifyCast: func(sim *core.Simulation, spell *core.Spell, cast *core.Cast) {
-				warlock.ActivePet.GetAuraByID(stunActionID).Activate(sim)
+				warlock.ActivatePetSummonStun(sim, stunActionID)
 			},
 		},
 
@@ -94,7 +96,7 @@ func (warlock *Warlock) registerSummonDemon() {
 				CastTime: 6 * time.Second,
 			},
 			ModifyCast: func(sim *core.Simulation, spell *core.Spell, cast *core.Cast) {
-				warlock.ActivePet.GetAuraByID(stunActionID).Activate(sim)
+				warlock.ActivatePetSummonStun(sim, stunActionID)
 			},
 		},
 
@@ -103,4 +105,10 @@ func (warlock *Warlock) registerSummonDemon() {
 			warlock.ChangeActivePet(sim, warlock.Succubus)
 		},
 	})
+}
+
+func (warlock *Warlock) ActivatePetSummonStun(sim *core.Simulation, stunActionID core.ActionID) {
+	if warlock.ActivePet != nil {
+		warlock.ActivePet.GetAuraByID(stunActionID).Activate(sim)
+	}
 }

--- a/sim/warlock/talents_demonology.go
+++ b/sim/warlock/talents_demonology.go
@@ -113,6 +113,10 @@ func (warlock *Warlock) registerImpendingDoom() {
 
 	impendingDoomProcChance := 0.05 * float64(warlock.Talents.ImpendingDoom)
 
+	if !warlock.Talents.Metamorphosis {
+		return
+	}
+
 	core.MakePermanent(
 		warlock.RegisterAura(core.Aura{
 			Label:    "Impending Doom",

--- a/ui/warlock/destruction/apls/default.apl.json
+++ b/ui/warlock/destruction/apls/default.apl.json
@@ -134,7 +134,14 @@
 		},
 		{
 			"action": {
-				"condition": { "cmp": { "op": "OpGe", "lhs": { "auraNumStacks": { "auraId": { "spellId": 89937 } } }, "rhs": { "const": { "val": "1" } } } },
+				"condition": {
+					"and": {
+						"vals": [
+							{ "auraIsKnown": { "auraId": { "spellId": 89937 } } },
+							{ "cmp": { "op": "OpGe", "lhs": { "auraNumStacks": { "auraId": { "spellId": 89937 } } }, "rhs": { "const": { "val": "1" } } } }
+						]
+					}
+				},
 				"castSpell": { "spellId": { "spellId": 77799 } }
 			}
 		},


### PR DESCRIPTION
- Resolves https://github.com/wowsims/cata/issues/927
  - Add a guard to prevent errors when the warlock doesn't have a pet selected in settings
- Resolves https://github.com/wowsims/cata/issues/917
  - Impending doom CD reduction should only be initialized if also using the Metamorphosis talent
- Update Destro APL to handle not using T11 4pc "Fel Spark"