### PR TITLE
Display Spirit as Hit Rating for hybrid casters

### DIFF
--- a/ui/druid/balance/sim.ts
+++ b/ui/druid/balance/sim.ts
@@ -41,10 +41,15 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecBalanceDruid, {
 	),
 
 	modifyDisplayStats: (player: Player<Spec.SpecBalanceDruid>) => {
-		let stats = new Stats().withPseudoStat(PseudoStat.PseudoStatSpellCritPercent, player.getTalents().naturesMajesty * 2);
+		const playerStats = player.getCurrentStats();
+		const gearStats = Stats.fromProto(playerStats.gearStats);
+		const talentsStats = Stats.fromProto(playerStats.talentsStats);
+		const talentsDelta = talentsStats.subtract(gearStats);
+		let talentsMod = new Stats().withPseudoStat(PseudoStat.PseudoStatSpellCritPercent, player.getTalents().naturesMajesty * 2);
+		talentsMod = talentsMod.addStat(Stat.StatHitRating, talentsDelta.getPseudoStat(PseudoStat.PseudoStatSpellHitPercent) * Mechanics.SPELL_HIT_RATING_PER_HIT_PERCENT);
 
 		return {
-			talents: stats,
+			talents: talentsMod,
 		};
 	},
 

--- a/ui/priest/shadow/sim.ts
+++ b/ui/priest/shadow/sim.ts
@@ -39,6 +39,16 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecShadowPriest, {
 			PseudoStat.PseudoStatSpellHastePercent,
 		],
 	),
+	modifyDisplayStats: (player: Player<Spec.SpecShadowPriest>) => {
+		const playerStats = player.getCurrentStats();
+		const gearStats = Stats.fromProto(playerStats.gearStats);
+		const talentsStats = Stats.fromProto(playerStats.talentsStats);
+		const talentsDelta = talentsStats.subtract(gearStats);
+
+		return {
+			talents: new Stats().withStat(Stat.StatHitRating, talentsDelta.getPseudoStat(PseudoStat.PseudoStatSpellHitPercent) * Mechanics.SPELL_HIT_RATING_PER_HIT_PERCENT),
+		};
+	},
 
 	defaults: {
 		// Default equipped gear.

--- a/ui/shaman/elemental/sim.ts
+++ b/ui/shaman/elemental/sim.ts
@@ -58,13 +58,16 @@ const totems = simUI.player.getSpecOptions().classOptions?.totems;
 			PseudoStat.PseudoStatSpellHastePercent,
 		],
 	),
-	// modifyDisplayStats: (player: Player<Spec.SpecElementalShaman>) => {
-	// 	let stats = new Stats();
-	// 	stats = stats.addStat(Stat.StatSpellCrit, player.getTalents().tidalMastery * 1 * Mechanics.SPELL_CRIT_RATING_PER_CRIT_CHANCE);
-	// 	return {
-	// 		talents: stats,
-	// 	};
-	// },
+	modifyDisplayStats: (player: Player<Spec.SpecElementalShaman>) => {
+		const playerStats = player.getCurrentStats();
+		const gearStats = Stats.fromProto(playerStats.gearStats);
+		const talentsStats = Stats.fromProto(playerStats.talentsStats);
+		const talentsDelta = talentsStats.subtract(gearStats);
+
+		return {
+			talents: new Stats().withStat(Stat.StatHitRating, talentsDelta.getPseudoStat(PseudoStat.PseudoStatSpellHitPercent) * Mechanics.SPELL_HIT_RATING_PER_HIT_PERCENT),
+		};
+	},
 
 	defaults: {
 		// Default equipped gear.


### PR DESCRIPTION
 On branch stats_refactor
 Changes to be committed:
	modified:   ui/druid/balance/sim.ts
	modified:   ui/priest/shadow/sim.ts
	modified:   ui/shaman/elemental/sim.ts