### PR TITLE
Tank Fixes

### DIFF
--- a/sim/core/consumes.go
+++ b/sim/core/consumes.go
@@ -15,6 +15,7 @@ func applyConsumeEffects(agent Agent) {
 		return
 	}
 	alchemyFlaskBonus := TernaryFloat64(character.HasProfession(proto.Profession_Alchemy), 80, 0)
+	alchemyBattleElixirBonus := TernaryFloat64(character.HasProfession(proto.Profession_Alchemy), 40, 0)
 	if consumes.Flask != proto.Flask_FlaskUnknown {
 		switch consumes.Flask {
 		case proto.Flask_FlaskOfTitanicStrength:
@@ -106,27 +107,27 @@ func applyConsumeEffects(agent Agent) {
 		switch consumes.BattleElixir {
 		case proto.BattleElixir_ElixirOfTheMaster:
 			character.AddStats(stats.Stats{
-				stats.MasteryRating: 225,
+				stats.MasteryRating: 225 + alchemyBattleElixirBonus,
 			})
 		case proto.BattleElixir_ElixirOfMightySpeed:
 			character.AddStats(stats.Stats{
-				stats.HasteRating: 225,
+				stats.HasteRating: 225 + alchemyBattleElixirBonus,
 			})
 		case proto.BattleElixir_ElixirOfImpossibleAccuracy:
 			character.AddStats(stats.Stats{
-				stats.HitRating: 225,
+				stats.HitRating: 225 + alchemyBattleElixirBonus,
 			})
 		case proto.BattleElixir_ElixirOfTheCobra:
 			character.AddStats(stats.Stats{
-				stats.CritRating: 225,
+				stats.CritRating: 225 + alchemyBattleElixirBonus,
 			})
 		case proto.BattleElixir_ElixirOfTheNaga:
 			character.AddStats(stats.Stats{
-				stats.ExpertiseRating: 225,
+				stats.ExpertiseRating: 225 + alchemyBattleElixirBonus,
 			})
 		case proto.BattleElixir_GhostElixir:
 			character.AddStats(stats.Stats{
-				stats.Spirit: 225,
+				stats.Spirit: 225 + alchemyBattleElixirBonus,
 			})
 		case proto.BattleElixir_ElixirOfAccuracy:
 			character.AddStats(stats.Stats{

--- a/sim/core/consumes.go
+++ b/sim/core/consumes.go
@@ -27,7 +27,7 @@ func applyConsumeEffects(agent Agent) {
 			})
 		case proto.Flask_FlaskOfSteelskin:
 			character.AddStats(stats.Stats{
-				stats.Stamina: 450,
+				stats.Stamina: 450 + alchemyFlaskBonus * 1.5,
 			})
 		case proto.Flask_FlaskOfFlowingWater:
 			character.AddStats(stats.Stats{

--- a/sim/encounters/bwd/magmaw_ai.go
+++ b/sim/encounters/bwd/magmaw_ai.go
@@ -287,26 +287,28 @@ func (ai *MagmawAI) registerSpells() {
 			} else if isIndividualSim {
 				// Individual sim fake tank swaps
 				if tankUnit.Metrics.IsTanking() {
-					if ai.Target.Env.GetNumTargets() > 1 {
-						if !ai.individualTankSwap {
-							// Remove boss target
-							ai.individualTankSwap = true
-							ai.Target.CurrentTarget = nil
+					if !ai.individualTankSwap {
+						// Remove boss target
+						ai.individualTankSwap = true
+						ai.Target.CurrentTarget = nil
 
-							// Set add target
+						// Set add target
+						if ai.Target.Env.GetNumTargets() > 1 {
 							addTarget := ai.Target.Env.NextTargetUnit(&ai.Target.Unit)
 							tankUnit.CurrentTarget = addTarget
 
 							addTarget.CurrentTarget = tankUnit
 							addTarget.AutoAttacks.EnableAutoSwing(sim)
-						} else {
-							ai.individualTankSwap = false
+						}
+					} else {
+						ai.individualTankSwap = false
 
-							// Set boss target
-							ai.Target.CurrentTarget = tankUnit
-							tankUnit.CurrentTarget = &ai.Target.Unit
+						// Set boss target
+						ai.Target.CurrentTarget = tankUnit
+						tankUnit.CurrentTarget = &ai.Target.Unit
 
-							// Remove add target
+						// Remove add target
+						if ai.Target.Env.GetNumTargets() > 1 {
 							addTarget := ai.Target.Env.NextTargetUnit(&ai.Target.Unit)
 							addTarget.AutoAttacks.CancelAutoSwing(sim)
 							addTarget.CurrentTarget = nil

--- a/sim/encounters/bwd/magmaw_ai.go
+++ b/sim/encounters/bwd/magmaw_ai.go
@@ -223,6 +223,7 @@ func (ai *MagmawAI) ExecuteCustomRotation(sim *core.Simulation) {
 	if target == nil {
 		// For individual non tank sims we still want abilities to work
 		target = &ai.Target.Env.Raid.Parties[0].Players[0].GetCharacter().Unit
+		ai.individualTankSwap = true
 	}
 
 	// Mangle


### PR DESCRIPTION
- Fixed a bug where Tank 2 was taking the first Mangle rather than the second on Magmaw Heroic presets, leading to unrealistic damage intake on fast kills.
- Added simulated tank swaps to Normal mode Magmaw presets in order to match Heroic behavior. This fixes an unintuitive result where survival rates were lower on Normal than Heroic, since the Normal mode agent was tanking Magmaw the entire time even with the Sweltering Armor debuff.
- Implemented missing Alchemy bonus for Stamina flasks and Battle Elixirs.