### PR TITLE
[Priest] Fixes for Mastery and Sear refactor

### DIFF
--- a/sim/death_knight/frost/TestFrost.results
+++ b/sim/death_knight/frost/TestFrost.results
@@ -320,7 +320,7 @@ dps_results: {
  value: {
   dps: 21998.53427
   tps: 19961.6477
-  hps: 245.25882
+  hps: 245.25883
  }
 }
 dps_results: {
@@ -336,7 +336,7 @@ dps_results: {
  value: {
   dps: 21944.09428
   tps: 20055.84482
-  hps: 245.25882
+  hps: 245.25883
  }
 }
 dps_results: {
@@ -344,7 +344,7 @@ dps_results: {
  value: {
   dps: 21351.64308
   tps: 19499.4618
-  hps: 245.25882
+  hps: 245.25883
  }
 }
 dps_results: {
@@ -368,7 +368,7 @@ dps_results: {
  value: {
   dps: 21150.92099
   tps: 19199.08409
-  hps: 245.25882
+  hps: 245.25883
  }
 }
 dps_results: {
@@ -1024,7 +1024,7 @@ dps_results: {
  value: {
   dps: 20899.85176
   tps: 19038.60319
-  hps: 245.25882
+  hps: 245.25883
  }
 }
 dps_results: {

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -38,1562 +38,1562 @@ character_stats_results: {
 dps_results: {
  key: "TestShadow-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 29737.4977
-  tps: 27564.69095
+  dps: 29580.54306
+  tps: 27407.7363
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 28483.35765
-  tps: 26499.18319
+  dps: 28332.8225
+  tps: 26348.64804
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 28446.16649
-  tps: 26507.07045
+  dps: 28439.89878
+  tps: 26500.80274
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 28500.00667
-  tps: 26488.91478
+  dps: 28349.73723
+  tps: 26338.64534
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 28577.28377
-  tps: 26551.15882
+  dps: 28426.67596
+  tps: 26400.55102
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 29262.79769
-  tps: 27100.09156
+  dps: 29108.56212
+  tps: 26945.85599
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 27821.1887
-  tps: 25877.27006
+  dps: 27674.39881
+  tps: 25730.48016
   hps: 97.44006
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 29595.75208
-  tps: 27409.44006
+  dps: 29439.56728
+  tps: 27253.25526
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BindingPromise-67037"
  value: {
-  dps: 27813.63533
-  tps: 25878.9984
+  dps: 27666.83157
+  tps: 25732.19464
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 28140.83979
-  tps: 26219.52067
+  dps: 28036.84273
+  tps: 26115.52362
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 28216.54413
-  tps: 26278.07115
+  dps: 28062.60592
+  tps: 26124.13294
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 28266.36726
-  tps: 26327.89428
+  dps: 28221.41959
+  tps: 26282.94661
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 27802.84076
-  tps: 25887.8203
+  dps: 27655.86616
+  tps: 25740.8457
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 28737.9477
-  tps: 26686.8931
+  dps: 28586.09095
+  tps: 26535.03635
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 27791.71569
-  tps: 25864.17964
+  dps: 27644.49197
+  tps: 25716.95592
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 28360.54001
-  tps: 26324.05883
+  dps: 28210.91408
+  tps: 26174.4329
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 27805.78107
-  tps: 25878.9984
+  dps: 27658.97731
+  tps: 25732.19464
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 27805.78107
-  tps: 25878.9984
+  dps: 27658.97731
+  tps: 25732.19464
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 27827.52301
-  tps: 25897.60366
+  dps: 27680.70677
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 28777.90596
-  tps: 26736.97544
+  dps: 28626.22607
+  tps: 26585.29555
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 27825.9253
-  tps: 25897.60366
+  dps: 27679.10906
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BottledLightning-66879"
  value: {
-  dps: 28668.90079
-  tps: 26607.25605
+  dps: 28517.39435
+  tps: 26455.74961
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 29496.30378
-  tps: 26781.01207
+  dps: 29341.04131
+  tps: 26628.85484
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Brawler'sTrophy-71338"
  value: {
-  dps: 27813.63533
-  tps: 25878.9984
+  dps: 27666.83157
+  tps: 25732.19464
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 29979.47494
-  tps: 27785.89775
+  dps: 29821.45061
+  tps: 27627.87342
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 29833.18741
-  tps: 27646.34694
+  dps: 29676.31453
+  tps: 27489.47406
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Coren'sChilledChromiumCoaster-71335"
  value: {
-  dps: 28392.4139
-  tps: 26361.56078
+  dps: 28242.75253
+  tps: 26211.89941
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 29013.71144
-  tps: 26967.87057
+  dps: 28860.27214
+  tps: 26814.43127
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CrimsonAcolyte'sRaiment"
  value: {
-  dps: 21924.50884
-  tps: 20665.20526
+  dps: 21872.46657
+  tps: 20613.16299
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CrimsonAcolyte'sRegalia"
  value: {
-  dps: 23676.4106
-  tps: 22370.38182
+  dps: 23621.1793
+  tps: 22315.15053
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CrushingWeight-59506"
  value: {
-  dps: 28022.29326
-  tps: 26077.82104
+  dps: 27874.83893
+  tps: 25930.36671
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CrushingWeight-65118"
  value: {
-  dps: 28035.49615
-  tps: 26090.05234
+  dps: 27887.55934
+  tps: 25942.11553
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 27805.78107
-  tps: 25878.9984
+  dps: 27658.97731
+  tps: 25732.19464
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 28991.73382
-  tps: 26922.52563
+  dps: 28838.50928
+  tps: 26769.3011
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 28118.70338
-  tps: 26085.59357
+  dps: 27970.60884
+  tps: 25937.49903
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 29351.37326
-  tps: 27174.89329
+  dps: 29197.23912
+  tps: 27020.75916
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 28756.91233
-  tps: 26792.67406
+  dps: 28604.52035
+  tps: 26640.28207
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 28428.75494
-  tps: 26319.97813
+  dps: 28278.75972
+  tps: 26169.98291
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 29262.79769
-  tps: 27100.09156
+  dps: 29108.56212
+  tps: 26945.85599
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 28270.37028
-  tps: 26298.57431
+  dps: 28120.79973
+  tps: 26149.00376
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 29496.30378
-  tps: 27322.05995
+  dps: 29341.04131
+  tps: 27166.79748
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 29351.37326
-  tps: 27174.89329
+  dps: 29197.23912
+  tps: 27020.75916
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 28446.16649
-  tps: 26507.07045
+  dps: 28439.89878
+  tps: 26500.80274
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 29262.79769
-  tps: 27100.09156
+  dps: 29108.56212
+  tps: 26945.85599
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FallofMortality-59500"
  value: {
-  dps: 28991.73382
-  tps: 26922.52563
+  dps: 28838.50928
+  tps: 26769.3011
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FallofMortality-65124"
  value: {
-  dps: 29131.4279
-  tps: 27048.19529
+  dps: 28977.66116
+  tps: 26894.42855
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 29123.87289
-  tps: 27104.51565
+  dps: 28970.30558
+  tps: 26950.94834
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 27791.71569
-  tps: 25864.17964
+  dps: 27644.49197
+  tps: 25716.95592
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 28905.70462
-  tps: 26863.90743
+  dps: 28752.93939
+  tps: 26711.1422
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 27813.63533
-  tps: 25878.9984
+  dps: 27666.83157
+  tps: 25732.19464
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 29804.60344
-  tps: 27639.07531
+  dps: 29647.47151
+  tps: 27481.94338
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 28223.12744
-  tps: 26295.59139
+  dps: 28178.06266
+  tps: 26250.52661
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 29348.85457
-  tps: 27186.14844
+  dps: 29285.18243
+  tps: 27122.4763
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FluidDeath-58181"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 29496.30378
-  tps: 27312.8723
+  dps: 29341.04131
+  tps: 27157.60982
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 28382.21975
-  tps: 26336.69276
+  dps: 28232.35588
+  tps: 26186.82889
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GaleofShadows-56138"
  value: {
-  dps: 29135.20934
-  tps: 27174.93616
+  dps: 28980.47045
+  tps: 27020.19728
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GaleofShadows-56462"
  value: {
-  dps: 29224.96566
-  tps: 27236.85358
+  dps: 29069.97548
+  tps: 27081.86339
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GearDetector-61462"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Gladiator'sInvestiture"
  value: {
-  dps: 23740.53032
-  tps: 22303.5473
+  dps: 23655.57424
+  tps: 22218.59122
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Gladiator'sRaiment"
  value: {
-  dps: 27245.31913
-  tps: 25505.52523
+  dps: 27118.76706
+  tps: 25378.97317
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 28518.10909
-  tps: 26498.8942
+  dps: 28367.25863
+  tps: 26348.04374
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-HarmlightToken-63839"
  value: {
-  dps: 28576.18859
-  tps: 26573.76327
+  dps: 28426.10297
+  tps: 26423.67765
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 29309.86836
-  tps: 27303.31865
+  dps: 29154.26596
+  tps: 27147.71625
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 29601.70753
-  tps: 27530.00929
+  dps: 29445.12675
+  tps: 27373.42852
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-HeartofRage-59224"
  value: {
-  dps: 27835.26084
-  tps: 25897.60366
+  dps: 27688.4446
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-HeartofRage-65072"
  value: {
-  dps: 27834.65897
-  tps: 25897.60366
+  dps: 27687.84273
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-HeartofSolace-55868"
  value: {
-  dps: 28400.08994
-  tps: 26462.72981
+  dps: 28249.55807
+  tps: 26312.19794
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-HeartofSolace-56393"
  value: {
-  dps: 28385.54507
-  tps: 26431.87348
+  dps: 28235.30697
+  tps: 26281.63538
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-HeartofThunder-55845"
  value: {
-  dps: 27821.74526
-  tps: 25897.60366
+  dps: 27674.92902
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-HeartofThunder-56370"
  value: {
-  dps: 27821.74526
-  tps: 25897.60366
+  dps: 27674.92902
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Heartpierce-50641"
  value: {
-  dps: 29979.47494
-  tps: 27785.89775
+  dps: 29821.45061
+  tps: 27627.87342
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 29351.37326
-  tps: 27174.89329
+  dps: 29197.23912
+  tps: 27020.75916
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 28277.62155
-  tps: 26350.0855
+  dps: 28197.09087
+  tps: 26269.55482
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 28277.62155
-  tps: 26350.0855
+  dps: 28197.09087
+  tps: 26269.55482
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 28202.56431
-  tps: 26278.07115
+  dps: 28048.6261
+  tps: 26124.13294
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 28252.38744
-  tps: 26327.89428
+  dps: 28207.43977
+  tps: 26282.94661
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 27821.74526
-  tps: 25897.60366
+  dps: 27674.92902
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 28738.1153
-  tps: 26740.04821
+  dps: 28661.52265
+  tps: 26663.45557
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 27822.78563
-  tps: 25891.57876
+  dps: 27675.98187
+  tps: 25744.775
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 27822.78563
-  tps: 25892.91521
+  dps: 27675.98187
+  tps: 25746.11145
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 28140.83979
-  tps: 26219.52067
+  dps: 28036.84273
+  tps: 26115.52362
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 28246.42101
-  tps: 26324.981
+  dps: 28096.04895
+  tps: 26174.60894
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 28246.42101
-  tps: 26324.981
+  dps: 28096.04895
+  tps: 26174.60894
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 28216.33069
-  tps: 26249.9426
+  dps: 28067.4369
+  tps: 26101.04881
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-LastWord-50708"
  value: {
-  dps: 29979.47494
-  tps: 27785.89775
+  dps: 29821.45061
+  tps: 27627.87342
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-LeadenDespair-55816"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-LeadenDespair-56347"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 27820.62115
-  tps: 25897.60366
+  dps: 27673.8049
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 27807.81594
-  tps: 25886.49683
+  dps: 27660.81044
+  tps: 25739.49132
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 27807.81594
-  tps: 25886.49683
+  dps: 27660.81044
+  tps: 25739.49132
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 28286.31207
-  tps: 26364.99296
+  dps: 28171.06634
+  tps: 26249.74723
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 28348.97228
-  tps: 26427.65317
+  dps: 28219.73308
+  tps: 26298.41397
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MercurialRegalia"
  value: {
-  dps: 26809.59343
-  tps: 24926.95108
+  dps: 26685.0059
+  tps: 24802.36355
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 27807.81594
-  tps: 25886.49683
+  dps: 27660.81044
+  tps: 25739.49132
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 27807.81594
-  tps: 25886.49683
+  dps: 27660.81044
+  tps: 25739.49132
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 28306.73994
-  tps: 26382.24678
+  dps: 28226.34315
+  tps: 26301.84999
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 28306.73994
-  tps: 26382.24678
+  dps: 28226.34315
+  tps: 26301.84999
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MithrilStopwatch-71337"
  value: {
-  dps: 29757.42612
-  tps: 27565.35715
+  dps: 29600.70591
+  tps: 27408.63694
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 29750.9204
-  tps: 27695.14357
+  dps: 29608.65889
+  tps: 27552.88207
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 27813.63533
-  tps: 25878.9984
+  dps: 27666.83157
+  tps: 25732.19464
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 29751.55854
-  tps: 27710.87452
+  dps: 29731.1752
+  tps: 27690.49117
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 29996.12212
-  tps: 27938.86008
+  dps: 29907.2383
+  tps: 27849.97625
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 28199.12093
-  tps: 26182.62486
+  dps: 28050.41244
+  tps: 26033.91637
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PetrifiedPickledEgg-71336"
  value: {
-  dps: 29055.59911
-  tps: 26980.96528
+  dps: 28902.20012
+  tps: 26827.56629
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 28884.62831
-  tps: 26766.35173
+  dps: 28732.616
+  tps: 26614.33941
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 29262.79769
-  tps: 27100.09156
+  dps: 29108.56212
+  tps: 26945.85599
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Rainsong-55854"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Rainsong-56377"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RegaliaoftheCleansingFlame"
  value: {
-  dps: 29379.49454
-  tps: 26953.80652
+  dps: 29242.81427
+  tps: 26817.12625
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 29737.4977
-  tps: 27564.69095
+  dps: 29580.54306
+  tps: 27407.7363
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 29737.4977
-  tps: 27564.69095
+  dps: 29580.54306
+  tps: 27407.7363
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 28455.53687
-  tps: 26360.75829
+  dps: 28305.59605
+  tps: 26210.81747
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RuneofZeth-68998"
  value: {
-  dps: 29747.27938
-  tps: 27540.44043
+  dps: 29590.78472
+  tps: 27383.94578
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SeaStar-55256"
  value: {
-  dps: 28267.9443
-  tps: 26278.24266
+  dps: 28118.38883
+  tps: 26128.68719
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SeaStar-56290"
  value: {
-  dps: 28678.8082
-  tps: 26635.47351
+  dps: 28527.24102
+  tps: 26483.90632
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ShardofWoe-60233"
  value: {
-  dps: 28361.24848
-  tps: 26409.23818
+  dps: 28210.51168
+  tps: 26258.50138
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 27822.09682
-  tps: 25897.60366
+  dps: 27675.28058
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 28246.66764
-  tps: 26319.13159
+  dps: 28128.92213
+  tps: 26201.38608
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 28306.24468
-  tps: 26378.70863
+  dps: 28175.82937
+  tps: 26248.29332
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Sorrowsong-55879"
  value: {
-  dps: 28947.33513
-  tps: 26950.1259
+  dps: 28789.52401
+  tps: 26792.31478
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Sorrowsong-56400"
  value: {
-  dps: 29094.84941
-  tps: 27089.30586
+  dps: 29048.68415
+  tps: 27043.1406
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 27807.81594
-  tps: 25886.49683
+  dps: 27660.81044
+  tps: 25739.49132
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SoulCasket-58183"
  value: {
-  dps: 29496.07944
-  tps: 27412.03239
+  dps: 29412.31149
+  tps: 27328.26443
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 28829.44882
-  tps: 26776.94218
+  dps: 28677.34503
+  tps: 26624.83839
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-StumpofTime-62465"
  value: {
-  dps: 28913.83254
-  tps: 26864.3775
+  dps: 28761.36555
+  tps: 26711.91052
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-StumpofTime-62470"
  value: {
-  dps: 28960.39167
-  tps: 26902.76537
+  dps: 28807.71096
+  tps: 26750.08465
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 29034.96012
-  tps: 27004.39561
+  dps: 28904.4311
+  tps: 26873.86658
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TearofBlood-55819"
  value: {
-  dps: 28635.8303
-  tps: 26616.30448
+  dps: 28484.39593
+  tps: 26464.87011
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TearofBlood-56351"
  value: {
-  dps: 28901.33419
-  tps: 26845.70535
+  dps: 28748.78375
+  tps: 26693.15491
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 28782.25213
-  tps: 26784.35286
+  dps: 28682.00753
+  tps: 26684.10826
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 29163.28668
-  tps: 27137.39024
+  dps: 29116.92174
+  tps: 27091.0253
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TheHungerer-68927"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TheHungerer-69112"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 29621.4186
-  tps: 27556.905
+  dps: 29483.62025
+  tps: 27419.10665
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 29806.3402
-  tps: 27727.38348
+  dps: 29665.62421
+  tps: 27586.66748
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 28216.54413
-  tps: 26278.07115
+  dps: 28062.60592
+  tps: 26124.13294
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 28266.36726
-  tps: 26327.89428
+  dps: 28221.41959
+  tps: 26282.94661
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 28667.65916
-  tps: 26628.3675
+  dps: 28516.32854
+  tps: 26477.03688
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-UnheededWarning-59520"
  value: {
-  dps: 27836.07664
-  tps: 25897.60366
+  dps: 27689.2604
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 27791.71569
-  tps: 25864.17964
+  dps: 27644.49197
+  tps: 25716.95592
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 28277.62155
-  tps: 26350.0855
+  dps: 28197.09087
+  tps: 26269.55482
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 28277.62155
-  tps: 26350.0855
+  dps: 28197.09087
+  tps: 26269.55482
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 28277.62155
-  tps: 26350.0855
+  dps: 28197.09087
+  tps: 26269.55482
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 24737.87661
-  tps: 22999.90934
+  dps: 24678.963
+  tps: 22940.99573
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 29528.77522
-  tps: 27441.08171
+  dps: 29374.08565
+  tps: 27286.39214
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 30247.03918
-  tps: 28137.66007
+  dps: 30091.65924
+  tps: 27982.28013
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 27865.90669
-  tps: 25926.79508
+  dps: 27718.84604
+  tps: 25779.73443
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 27866.78278
-  tps: 25924.37837
+  dps: 27719.72366
+  tps: 25777.31925
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 27813.63533
-  tps: 25878.9984
+  dps: 27666.83157
+  tps: 25732.19464
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 27813.63533
-  tps: 25878.9984
+  dps: 27666.83157
+  tps: 25732.19464
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 27791.71569
-  tps: 25864.17964
+  dps: 27644.49197
+  tps: 25716.95592
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 28790.86199
-  tps: 26732.9001
+  dps: 28638.74616
+  tps: 26580.78427
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 27791.71569
-  tps: 25864.17964
+  dps: 27644.49197
+  tps: 25716.95592
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 27805.78107
-  tps: 25878.9984
+  dps: 27658.97731
+  tps: 25732.19464
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 28586.96255
-  tps: 26599.1354
+  dps: 28435.52256
+  tps: 26447.69541
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 28375.10581
-  tps: 26361.56078
+  dps: 28225.44444
+  tps: 26211.89941
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 27805.78107
-  tps: 25878.9984
+  dps: 27658.97731
+  tps: 25732.19464
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 28319.18581
-  tps: 26392.40313
+  dps: 28219.07805
+  tps: 26292.29538
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 27805.78107
-  tps: 25878.9984
+  dps: 27658.97731
+  tps: 25732.19464
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 27828.32987
-  tps: 25897.60366
+  dps: 27681.51363
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 28748.66621
-  tps: 26700.51848
+  dps: 28597.13267
+  tps: 26548.98494
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 27828.90638
-  tps: 25897.60366
+  dps: 27682.09013
+  tps: 25750.78742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 29059.59793
-  tps: 27011.64637
+  dps: 28905.98604
+  tps: 26858.03449
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 29327.72433
-  tps: 27274.40315
+  dps: 29172.51193
+  tps: 27119.19074
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 28131.78559
-  tps: 26195.68551
+  dps: 28027.37428
+  tps: 26091.2742
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 28223.65187
-  tps: 26302.33275
+  dps: 28083.39569
+  tps: 26162.07657
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 28223.65187
-  tps: 26302.33275
+  dps: 28083.39569
+  tps: 26162.07657
  }
 }
 dps_results: {
  key: "TestShadow-Average-Default"
  value: {
-  dps: 29951.22993
-  tps: 27827.34548
+  dps: 29793.6543
+  tps: 27669.76984
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 29422.74173
-  tps: 40595.24072
+  dps: 29267.89652
+  tps: 40440.39551
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 29422.74173
-  tps: 27195.83647
+  dps: 29267.89652
+  tps: 27040.99126
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 37501.56129
-  tps: 33998.71445
+  dps: 37319.26072
+  tps: 33816.41389
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17220.61174
-  tps: 27576.1246
+  dps: 17129.25536
+  tps: 27484.76822
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 17220.61174
-  tps: 16396.67485
+  dps: 17129.25536
+  tps: 16305.31848
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 18511.40671
-  tps: 17087.70044
+  dps: 18420.23866
+  tps: 16996.5324
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 29422.74173
-  tps: 40595.24072
+  dps: 29267.89652
+  tps: 40440.39551
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 29422.74173
-  tps: 27195.83647
+  dps: 29267.89652
+  tps: 27040.99126
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 37501.56129
-  tps: 33998.71445
+  dps: 37319.26072
+  tps: 33816.41389
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17220.61174
-  tps: 27576.1246
+  dps: 17129.25536
+  tps: 27484.76822
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 17220.61174
-  tps: 16396.67485
+  dps: 17129.25536
+  tps: 16305.31848
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 18511.40671
-  tps: 17087.70044
+  dps: 18420.23866
+  tps: 16996.5324
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Troll-p1-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 29979.47494
-  tps: 41463.24865
+  dps: 29821.45061
+  tps: 41305.22432
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Troll-p1-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 29979.47494
-  tps: 27785.89775
+  dps: 29821.45061
+  tps: 27627.87342
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Troll-p1-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 39427.1891
-  tps: 35707.38624
+  dps: 39234.88318
+  tps: 35515.08032
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Troll-p1-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17573.36148
-  tps: 28219.52608
+  dps: 17479.85545
+  tps: 28126.02004
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Troll-p1-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 17573.36148
-  tps: 16770.73367
+  dps: 17479.85545
+  tps: 16677.22764
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Troll-p1-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 19561.22858
-  tps: 18312.50304
+  dps: 19462.7962
+  tps: 18214.07067
  }
 }
 dps_results: {
  key: "TestShadow-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 29944.50615
-  tps: 27785.89775
+  dps: 29786.48182
+  tps: 27627.87342
  }
 }

--- a/sim/priest/shadow/shadow.go
+++ b/sim/priest/shadow/shadow.go
@@ -1,6 +1,7 @@
 package shadow
 
 import (
+	"math"
 	"time"
 
 	"github.com/wowsims/cata/sim/core"
@@ -92,6 +93,10 @@ func (spriest *ShadowPriest) ApplyTalents() {
 		},
 	)
 
+	var floorPercent = func(val float64) float64 {
+		return math.Floor(val*100) / 100
+	}
+
 	// Shadow Power
 	spriest.AddStaticMod(core.SpellModConfig{
 		Kind:       core.SpellMod_CritMultiplier_Pct,
@@ -102,7 +107,7 @@ func (spriest *ShadowPriest) ApplyTalents() {
 
 	shadowOrbMod := spriest.AddDynamicMod(core.SpellModConfig{
 		ClassMask:  int64(priest.PriestSpellMindBlast) | int64(priest.PriestSpellMindSpike),
-		FloatValue: 0.216 + spriest.GetMasteryPoints()*0.0145,
+		FloatValue: floorPercent(0.216 + spriest.GetMasteryPoints()*0.0145),
 		Kind:       core.SpellMod_DamageDone_Pct,
 	})
 
@@ -113,7 +118,7 @@ func (spriest *ShadowPriest) ApplyTalents() {
 		Duration:  time.Minute,
 		MaxStacks: 3,
 		OnStacksChange: func(_ *core.Aura, _ *core.Simulation, oldStacks int32, newStacks int32) {
-			shadowOrbMod.UpdateFloatValue((0.216 + spriest.GetMasteryPoints()*0.0145) * float64(newStacks))
+			shadowOrbMod.UpdateFloatValue(floorPercent((0.216 + spriest.GetMasteryPoints()*0.0145) * float64(newStacks)))
 			shadowOrbMod.Activate()
 		},
 
@@ -133,13 +138,13 @@ func (spriest *ShadowPriest) ApplyTalents() {
 	})
 
 	spriest.AddOnMasteryStatChanged(func(sim *core.Simulation, oldMastery, newMastery float64) {
-		shadowOrbMod.UpdateFloatValue((0.216 + core.MasteryRatingToMasteryPoints(newMastery)*0.0145) * float64(spriest.shadowOrbsAura.GetStacks()))
+		shadowOrbMod.UpdateFloatValue(floorPercent((0.216 + core.MasteryRatingToMasteryPoints(newMastery)*0.0145) * float64(spriest.shadowOrbsAura.GetStacks())))
 	})
 
 	empoweredShadowMod := spriest.AddDynamicMod(core.SpellModConfig{
 		ClassMask:  priest.PriestSpellDoT | priest.PriestSpellMindSear,
 		Kind:       core.SpellMod_DamageDone_Flat,
-		FloatValue: 0.216 + spriest.GetMasteryPoints()*0.0145,
+		FloatValue: floorPercent(0.216 + spriest.GetMasteryPoints()*0.0145),
 	})
 
 	spriest.empoweredShadowAura = spriest.RegisterAura(core.Aura{
@@ -147,7 +152,7 @@ func (spriest *ShadowPriest) ApplyTalents() {
 		ActionID: core.ActionID{SpellID: 95799},
 		Duration: time.Second * 15,
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
-			empoweredShadowMod.UpdateFloatValue(0.216 + aura.Unit.GetMasteryPoints()*0.0145)
+			empoweredShadowMod.UpdateFloatValue(floorPercent(0.216 + aura.Unit.GetMasteryPoints()*0.0145))
 			empoweredShadowMod.Activate()
 		},
 


### PR DESCRIPTION
* Implements proper mastery flooring for `Empowered Shadows`
* Implements proper mastery flooring for `Shadow Orb`
* Refactor for Mind sear to deal AoE damage for each channel cast instead of creating a cast for each target per channel tick