### PR TITLE
[UI] Remove rating from reforge interface

### DIFF
--- a/ui/core/components/suggest_reforges_action.tsx
+++ b/ui/core/components/suggest_reforges_action.tsx
@@ -9,7 +9,7 @@ import { Player } from '../player';
 import { Class, ItemSlot, PseudoStat, Spec, Stat } from '../proto/common';
 import { StatCapType } from '../proto/ui';
 import { Gear } from '../proto_utils/gear';
-import { shortSecondaryStatNames, slotNames, statCapTypeNames } from '../proto_utils/names';
+import { slotNames, statCapTypeNames } from '../proto_utils/names';
 import { pseudoStatIsCapped, StatCap, Stats, UnitStat } from '../proto_utils/stats';
 import { SpecTalents } from '../proto_utils/utils';
 import { Sim } from '../sim';
@@ -41,16 +41,12 @@ type StatTooltipContent = { [key in Stat]?: () => Element | string };
 const STAT_TOOLTIPS: StatTooltipContent = {
 	[Stat.StatMasteryRating]: () => (
 		<>
-			Rating: <strong>excluding</strong> your base mastery
-			<br />
-			%: <strong>including</strong> your base mastery
+			<strong>Including</strong> your base mastery
 		</>
 	),
 	[Stat.StatHasteRating]: () => (
 		<>
-			Rating: final rating <strong>including</strong> all buffs/gear.
-			<br />
-			%: final percentage value <strong>including</strong> all buffs/gear.
+			Final percentage value <strong>including</strong> all buffs/gear.
 		</>
 	),
 };
@@ -263,40 +259,44 @@ export class ReforgeOptimizer {
 						{this.softCapsConfig?.map(({ unitStat, breakpoints, capType, postCapEPs }, index) => (
 							<>
 								<tr>
-									<th colSpan={2}>{unitStat.getShortName(this.player.getClass())}</th>
+									<th className="text-nowrap" colSpan={2}>
+										{unitStat.getShortName(this.player.getClass())}
+									</th>
 									<td className="text-end">{statCapTypeNames.get(capType)}</td>
 								</tr>
 								{this.additionalSoftCapTooltipInformation[unitStat.getRootStat()] && (
-									<tr>
-										<td colSpan={3}>{this.additionalSoftCapTooltipInformation[unitStat.getRootStat()]?.()}</td>
-									</tr>
+									<>
+										<tr>
+											<td colSpan={3}>{this.additionalSoftCapTooltipInformation[unitStat.getRootStat()]?.()}</td>
+										</tr>
+										<tr>
+											<td colSpan={3} className="pb-2"></td>
+										</tr>
+									</>
 								)}
 								<tr>
-									<th>
-										<em>Rating</em>
-									</th>
 									<th className="text-end">
 										<em>%</em>
 									</th>
-									<th className="text-end">
+									<th colSpan={2} className="text-nowrap text-end">
 										<em>Post cap EP</em>
 									</th>
 								</tr>
 								{breakpoints.map((breakpoint, breakpointIndex) => (
 									<tr>
-										<td>
-											{Math.ceil(
-												unitStat.equalsStat(Stat.StatMasteryRating)
-													? breakpoint - this.player.getBaseMastery() * Mechanics.MASTERY_RATING_PER_MASTERY_POINT
-													: unitStat.convertDefaultUnitsToRating(breakpoint)!,
-											)}
-										</td>
 										<td className="text-end">
 											{unitStat.equalsStat(Stat.StatMasteryRating)
-												? (breakpoint / Mechanics.MASTERY_RATING_PER_MASTERY_POINT * this.player.getMasteryPerPointModifier()).toFixed(2)
+												? (
+														(breakpoint / Mechanics.MASTERY_RATING_PER_MASTERY_POINT) *
+														this.player.getMasteryPerPointModifier()
+												  ).toFixed(2)
 												: unitStat.convertDefaultUnitsToPercent(breakpoint)!.toFixed(2)}
 										</td>
-										<td className="text-end">{unitStat.convertEpToRatingScale(capType === StatCapType.TypeThreshold ? postCapEPs[0] : postCapEPs[breakpointIndex]).toFixed(2)}</td>
+										<td colSpan={2} className="text-end">
+											{unitStat
+												.convertEpToRatingScale(capType === StatCapType.TypeThreshold ? postCapEPs[0] : postCapEPs[breakpointIndex])
+												.toFixed(2)}
+										</td>
 									</tr>
 								))}
 								{index !== this.softCapsConfig.length - 1 && (
@@ -469,7 +469,6 @@ export class ReforgeOptimizer {
 					</tr>
 					<tr>
 						<th>Stat</th>
-						<th className="text-end">Rating</th>
 						<th className="text-end">%</th>
 					</tr>
 				</thead>
@@ -481,22 +480,7 @@ export class ReforgeOptimizer {
 
 						const listElementRef = ref<HTMLTableRowElement>();
 						const statName = unitStat.getShortName(this.player.getClass());
-						const ratingPicker = new NumberPicker(null, this.player, {
-							...numberPickerSharedConfig,
-							id: `reforge-optimizer-${statName}-rating`,
-							enableWhen: () => this.isAllowedToOverrideStatCaps || !this.softCapsConfig.some(config => config.unitStat.equals(unitStat)),
-							getValue: () => {
-								let ratingValue = unitStat.convertDefaultUnitsToRating(this.statCaps.getUnitStat(unitStat))!;
-								if (unitStat.equalsStat(Stat.StatMasteryRating)) ratingValue = this.toVisualBaseMasteryRating(ratingValue);
 
-								return ratingValue;
-							},
-							setValue: (_eventID, _player, newValue) => {
-								const statValue = unitStat.equalsStat(Stat.StatMasteryRating) ? (newValue + this.baseMastery) : unitStat.convertRatingToDefaultUnits(newValue)!;
-
-								this.setStatCap(unitStat, statValue);
-							},
-						});
 						const percentagePicker = new NumberPicker(null, this.player, {
 							...numberPickerSharedConfig,
 							id: `reforge-optimizer-${statName}-percentage`,
@@ -527,7 +511,9 @@ export class ReforgeOptimizer {
 										...[...statPresets.keys()].map(key => {
 											const ratingValue = statPresets.get(key)!;
 											const percentOrPointsValue = unitStat.convertRatingToPercent(ratingValue)!;
-											const percentValue = unitStat.equalsStat(Stat.StatMasteryRating) ? (percentOrPointsValue * this.player.getMasteryPerPointModifier()) : percentOrPointsValue;
+											const percentValue = unitStat.equalsStat(Stat.StatMasteryRating)
+												? percentOrPointsValue * this.player.getMasteryPerPointModifier()
+												: percentOrPointsValue;
 											return {
 												name: `${key} - ${percentValue.toFixed(2)}%`,
 												value: ratingValue,
@@ -542,7 +528,9 @@ export class ReforgeOptimizer {
 										return ratingValue;
 									},
 									setValue: (_eventID, _player, newValue) => {
-										const statValue = unitStat.equalsStat(Stat.StatMasteryRating) ? (newValue + this.baseMastery) : unitStat.convertRatingToDefaultUnits(newValue)!;
+										const statValue = unitStat.equalsStat(Stat.StatMasteryRating)
+											? newValue + this.baseMastery
+											: unitStat.convertRatingToDefaultUnits(newValue)!;
 										this.setStatCap(unitStat, statValue);
 									},
 									...sharedInputConfig,
@@ -565,13 +553,12 @@ export class ReforgeOptimizer {
 											)}
 										</div>
 									</td>
-									<td>{ratingPicker.rootElem}</td>
 									<td>{percentagePicker.rootElem}</td>
 								</tr>
 								{presets && (
 									<tr>
 										<td></td>
-										<td colSpan={2}>{presets.rootElem}</td>
+										<td>{presets.rootElem}</td>
 									</tr>
 								)}
 							</>
@@ -712,29 +699,27 @@ export class ReforgeOptimizer {
 		const reforgeSoftCaps: StatCap[] = [];
 
 		if (!this.isAllowedToOverrideStatCaps) {
-			this.softCapsConfig
-				.slice()
-				.forEach(config => {
-					let weights = config.postCapEPs.slice();
-					const relativeBreakpoints = [];
+			this.softCapsConfig.slice().forEach(config => {
+				let weights = config.postCapEPs.slice();
+				const relativeBreakpoints = [];
 
-					for (const breakpoint of config.breakpoints) {
-						relativeBreakpoints.push(baseStats.computeGapToCap(config.unitStat, breakpoint));
-					}
+				for (const breakpoint of config.breakpoints) {
+					relativeBreakpoints.push(baseStats.computeGapToCap(config.unitStat, breakpoint));
+				}
 
-					// For stats that are configured as thresholds rather than soft caps,
-					// reverse the order of evaluation of the breakpoints so that the
-					// largest relevant threshold is always targeted. Likewise, use a
-					// single value for the post-cap EP for these stats, which should be
-					// interpreted (and computed) as the residual stat value just after
-					// passing a threshold discontinuity.
-					if (config.capType == StatCapType.TypeThreshold) {
-						relativeBreakpoints.reverse();
-						weights = Array(relativeBreakpoints.length).fill(weights[0]);
-					}
+				// For stats that are configured as thresholds rather than soft caps,
+				// reverse the order of evaluation of the breakpoints so that the
+				// largest relevant threshold is always targeted. Likewise, use a
+				// single value for the post-cap EP for these stats, which should be
+				// interpreted (and computed) as the residual stat value just after
+				// passing a threshold discontinuity.
+				if (config.capType == StatCapType.TypeThreshold) {
+					relativeBreakpoints.reverse();
+					weights = Array(relativeBreakpoints.length).fill(weights[0]);
+				}
 
-					reforgeSoftCaps.push(new StatCap(config.unitStat, relativeBreakpoints, config.capType, weights));
-				});
+				reforgeSoftCaps.push(new StatCap(config.unitStat, relativeBreakpoints, config.capType, weights));
+			});
 		}
 
 		return reforgeSoftCaps;
@@ -772,7 +757,7 @@ export class ReforgeOptimizer {
 	applyReforgeStat(coefficients: YalpsCoefficients, stat: Stat, amount: number, preCapEPs: Stats) {
 		// Handle Spirit to Spell Hit conversion for hybrid casters separately from standard dependencies
 		if (stat == Stat.StatSpirit && this.isHybridCaster) {
-			let appliedAmount = amount / Mechanics.SPELL_HIT_RATING_PER_HIT_PERCENT
+			let appliedAmount = amount / Mechanics.SPELL_HIT_RATING_PER_HIT_PERCENT;
 
 			switch (this.player.getSpec()) {
 				case Spec.SpecBalanceDruid:
@@ -820,14 +805,7 @@ export class ReforgeOptimizer {
 		return constraints;
 	}
 
-	async solveModel(
-		gear: Gear,
-		weights: Stats,
-		reforgeCaps: Stats,
-		reforgeSoftCaps: StatCap[],
-		variables: YalpsVariables,
-		constraints: YalpsConstraints,
-	) {
+	async solveModel(gear: Gear, weights: Stats, reforgeCaps: Stats, reforgeSoftCaps: StatCap[], variables: YalpsVariables, constraints: YalpsConstraints) {
 		// Calculate EP scores for each Reforge option
 		if (isDevMode()) {
 			console.log('Stat weights for this iteration:');

--- a/ui/scss/core/components/_suggest_reforges_action.scss
+++ b/ui/scss/core/components/_suggest_reforges_action.scss
@@ -8,6 +8,17 @@
 .tippy-box[data-theme='suggest-reforges-softcaps'] {
 	max-height: 40vh;
 	overflow: auto;
+
+	table {
+		width: 100%;
+		table-layout: auto;
+
+		tr {
+			> *:first-child {
+				width: 0;
+			}
+		}
+	}
 }
 
 .suggest-reforges-settings-group {
@@ -25,6 +36,7 @@
 	border-collapse: collapse;
 	border-spacing: 0;
 	padding: 0;
+	width: 100%;
 
 	tr {
 		td,


### PR DESCRIPTION
With the stat refactor the "rating" value became even more confusing as it now only points to gear rating.
To remove some of the confusion I've removed the Rating fields (as they resemble total rating which is just a derivative of %)

![image](https://github.com/user-attachments/assets/34a54eb0-8f71-4545-87a4-10d11687964b)
![image](https://github.com/user-attachments/assets/a05cfa48-23fc-4a38-9dd4-80d563ba6349)
