### PR TITLE
Replenishment fix

### DIFF
--- a/sim/core/buffs.go
+++ b/sim/core/buffs.go
@@ -1326,7 +1326,7 @@ func registerTricksOfTheTradeCD(agent Agent, tristateConfig proto.TristateEffect
 
 	// Add a small offset to the tooltip CD to account for input delays
 	// between the Rogue pressing Tricks and hitting a target.
-	effectiveCD := time.Second * 30 + unit.ReactionTime
+	effectiveCD := time.Second*30 + unit.ReactionTime
 
 	registerExternalConsecutiveCDApproximation(
 		agent,
@@ -1788,7 +1788,7 @@ func replenishmentAura(unit *Unit, _ ActionID) *Aura {
 		return unit.ReplenishmentAura
 	}
 
-	replenishmentDep := unit.NewDynamicStatDependency(stats.Mana, stats.MP5, 0.01)
+	replenishmentDep := unit.NewDynamicStatDependency(stats.Mana, stats.MP5, 0.005)
 
 	unit.ReplenishmentAura = unit.RegisterAura(Aura{
 		Label:    "Replenishment",

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -39,63 +39,63 @@ dps_results: {
  key: "TestFeral-AllItems-AgileShadowspiritDiamond"
  value: {
   dps: 27119.18803
-  tps: 37597.03605
+  tps: 37598.07184
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50366"
  value: {
   dps: 25450.96886
-  tps: 35194.61363
+  tps: 35195.78233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AncientPetrifiedSeed-69001"
  value: {
   dps: 27405.61133
-  tps: 37614.18697
+  tps: 37615.19573
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-55889"
  value: {
   dps: 25447.50762
-  tps: 35202.95786
+  tps: 35203.99365
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-56407"
  value: {
   dps: 25448.47792
-  tps: 35207.84934
+  tps: 35208.88513
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
   dps: 26321.87262
-  tps: 36705.34792
+  tps: 36706.35668
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
   dps: 26439.80151
-  tps: 36904.41642
+  tps: 36905.42068
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereShadowspiritDiamond"
  value: {
   dps: 26463.57539
-  tps: 36624.35097
+  tps: 36625.40027
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50726"
  value: {
   dps: 25450.96886
-  tps: 35194.87946
+  tps: 35195.91525
   hps: 88.86807
  }
 }
@@ -103,1372 +103,1372 @@ dps_results: {
  key: "TestFeral-AllItems-BedrockTalisman-58182"
  value: {
   dps: 25450.96886
-  tps: 35194.87946
+  tps: 35195.91525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-59326"
  value: {
   dps: 25784.30641
-  tps: 35974.48921
+  tps: 35975.45294
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-65053"
  value: {
   dps: 25819.49827
-  tps: 35994.13538
+  tps: 35995.13514
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BindingPromise-67037"
  value: {
   dps: 25450.96886
-  tps: 35194.87946
+  tps: 35195.91525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Blood-SoakedAleMug-63843"
  value: {
   dps: 26756.15
-  tps: 36475.65854
+  tps: 36476.6673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-55995"
  value: {
   dps: 25736.92385
-  tps: 35643.77716
+  tps: 35644.81294
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-56414"
  value: {
   dps: 25774.37034
-  tps: 35702.56138
+  tps: 35703.59716
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
   dps: 27220.33829
-  tps: 36956.03762
+  tps: 36957.08241
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
   dps: 25450.96886
-  tps: 35194.87946
+  tps: 35195.91525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
   dps: 25962.03263
-  tps: 35833.92959
+  tps: 35834.96538
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
   dps: 25758.53711
-  tps: 35844.82511
+  tps: 35845.80235
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
   dps: 25450.96886
-  tps: 35194.87946
+  tps: 35195.91525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
   dps: 25450.96886
-  tps: 35194.87946
+  tps: 35195.91525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
   dps: 26759.208
-  tps: 37214.20304
+  tps: 37215.25684
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
   dps: 25450.96886
-  tps: 35194.87946
+  tps: 35195.91525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
   dps: 25923.94782
-  tps: 35782.66117
+  tps: 35783.69696
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledLightning-66879"
  value: {
   dps: 25521.19094
-  tps: 35300.76874
+  tps: 35301.8968
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingShadowspiritDiamond"
  value: {
   dps: 26463.57539
-  tps: 35892.0232
+  tps: 35893.11477
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Brawler'sTrophy-71338"
  value: {
   dps: 25450.96886
-  tps: 35194.87946
+  tps: 35195.91525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BurningShadowspiritDiamond"
  value: {
   dps: 26893.27743
-  tps: 37195.97962
+  tps: 37197.07119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticShadowspiritDiamond"
  value: {
   dps: 27012.04684
-  tps: 37150.85863
+  tps: 37151.96647
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Coren'sChilledChromiumCoaster-71335"
  value: {
   dps: 26711.85909
-  tps: 37101.9523
+  tps: 37102.95206
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CoreofRipeness-58184"
  value: {
   dps: 25450.96886
-  tps: 35194.38334
+  tps: 35195.66719
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50349"
  value: {
   dps: 25450.96886
-  tps: 35194.87946
+  tps: 35195.91525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-59506"
  value: {
   dps: 26254.66296
-  tps: 35767.43329
+  tps: 35768.49639
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-65118"
  value: {
   dps: 26309.9802
-  tps: 35349.25678
+  tps: 35350.28357
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
   dps: 25450.96886
-  tps: 35194.87946
+  tps: 35195.91525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
   dps: 26079.56154
-  tps: 35988.85263
+  tps: 35989.94697
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
   dps: 26744.40406
-  tps: 36671.02378
+  tps: 36672.09109
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
   dps: 25450.96886
-  tps: 35194.38334
+  tps: 35195.66719
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Volcano-62047"
  value: {
   dps: 25809.76634
-  tps: 35735.4196
+  tps: 35736.39234
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50363"
  value: {
   dps: 26124.46097
-  tps: 36119.47517
+  tps: 36120.55599
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveShadowspiritDiamond"
  value: {
   dps: 26575.64051
-  tps: 36573.87778
+  tps: 36574.98562
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50348"
  value: {
   dps: 25393.51118
-  tps: 34826.48699
+  tps: 34827.43299
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dwyer'sCaber-70141"
  value: {
   dps: 26348.37573
-  tps: 36464.36448
+  tps: 36465.40026
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EffulgentShadowspiritDiamond"
  value: {
   dps: 26463.57539
-  tps: 36624.35097
+  tps: 36625.40027
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ElectrosparkHeartstarter-67118"
  value: {
   dps: 25450.96886
-  tps: 35227.24695
+  tps: 35230.16733
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberShadowspiritDiamond"
  value: {
   dps: 26463.57539
-  tps: 36624.22276
+  tps: 36625.33616
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticShadowspiritDiamond"
  value: {
   dps: 26575.64051
-  tps: 36573.87778
+  tps: 36574.98562
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-59473"
  value: {
   dps: 27097.97312
-  tps: 37400.37677
+  tps: 37401.37653
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-65140"
  value: {
   dps: 27286.85911
-  tps: 38288.85365
+  tps: 38289.88494
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheEternalFlame-69002"
  value: {
   dps: 26474.34544
-  tps: 36614.25168
+  tps: 36615.28297
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalShadowspiritDiamond"
  value: {
   dps: 26463.57539
-  tps: 36624.35097
+  tps: 36625.40027
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-59500"
  value: {
   dps: 25450.96886
-  tps: 35194.38334
+  tps: 35195.66719
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-65124"
  value: {
   dps: 25450.96886
-  tps: 35194.31843
+  tps: 35195.63473
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FieryQuintessence-69000"
  value: {
   dps: 25433.75778
-  tps: 35210.36283
+  tps: 35212.47544
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DemonPanther-52199"
  value: {
   dps: 26686.57744
-  tps: 36810.77796
+  tps: 36811.78222
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DreamOwl-52354"
  value: {
   dps: 25450.96886
-  tps: 35194.43898
+  tps: 35195.69501
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-EarthenGuardian-52352"
  value: {
   dps: 25450.96886
-  tps: 35194.87946
+  tps: 35195.91525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-JeweledSerpent-52353"
  value: {
   dps: 25450.96886
-  tps: 35194.43898
+  tps: 35195.69501
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-KingofBoars-52351"
  value: {
   dps: 26259.79955
-  tps: 36311.12587
+  tps: 36312.16166
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FleetShadowspiritDiamond"
  value: {
   dps: 26526.88212
-  tps: 36724.6135
+  tps: 36725.66279
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornShadowspiritDiamond"
  value: {
   dps: 26463.57539
-  tps: 36624.26642
+  tps: 36625.358
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryofAngerforge-59461"
  value: {
   dps: 26402.2129
-  tps: 36773.68184
+  tps: 36774.64558
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56138"
  value: {
   dps: 25595.83346
-  tps: 34958.07096
+  tps: 34959.12476
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56462"
  value: {
   dps: 25609.48632
-  tps: 34714.4965
+  tps: 34715.49204
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GearDetector-61462"
  value: {
   dps: 26244.26961
-  tps: 35986.28117
+  tps: 35987.36649
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Gladiator'sSanctuary"
  value: {
   dps: 23097.47364
-  tps: 30827.03078
+  tps: 30827.90083
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54589"
  value: {
   dps: 25450.96886
-  tps: 35194.59508
+  tps: 35195.77306
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-55266"
  value: {
   dps: 26283.4406
-  tps: 36472.64746
+  tps: 36473.66523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-56295"
  value: {
   dps: 26713.16179
-  tps: 36939.26689
+  tps: 36940.3432
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HarmlightToken-63839"
  value: {
   dps: 25460.41251
-  tps: 35186.25035
+  tps: 35187.45537
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
   dps: 26018.64462
-  tps: 35983.58642
+  tps: 35984.62221
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-59514"
  value: {
   dps: 25450.96886
-  tps: 35194.87946
+  tps: 35195.91525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-65110"
  value: {
   dps: 25450.96886
-  tps: 35194.87946
+  tps: 35195.91525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-59224"
  value: {
   dps: 26384.95469
-  tps: 36336.1768
+  tps: 36337.32067
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-65072"
  value: {
   dps: 26381.62091
-  tps: 36289.37524
+  tps: 36290.47858
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-55868"
  value: {
   dps: 25595.83346
-  tps: 34958.07096
+  tps: 34959.12476
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-56393"
  value: {
   dps: 26160.92507
-  tps: 35383.25662
+  tps: 35384.25216
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-55845"
  value: {
   dps: 25450.96886
-  tps: 35194.87946
+  tps: 35195.91525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-56370"
  value: {
   dps: 25450.96886
-  tps: 35194.87946
+  tps: 35195.91525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartoftheVile-66969"
  value: {
   dps: 26458.75129
-  tps: 36861.62934
+  tps: 36862.66963
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-50641"
  value: {
   dps: 27489.82907
-  tps: 37660.98405
+  tps: 37661.75893
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveShadowspiritDiamond"
  value: {
   dps: 26575.64051
-  tps: 36573.87778
+  tps: 36574.98562
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62464"
  value: {
   dps: 26362.86493
-  tps: 36453.4706
+  tps: 36454.50638
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62469"
  value: {
   dps: 26362.86493
-  tps: 36453.4706
+  tps: 36454.50638
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-55881"
  value: {
   dps: 25741.86338
-  tps: 35688.0479
+  tps: 35689.07919
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-56406"
  value: {
   dps: 25779.32586
-  tps: 35746.84717
+  tps: 35747.87846
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaofDiplomacy-61433"
  value: {
   dps: 25450.96886
-  tps: 35194.87946
+  tps: 35195.91525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
   dps: 25671.10881
-  tps: 35540.45943
+  tps: 35541.49522
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-59354"
  value: {
   dps: 25450.96886
-  tps: 35195.27801
+  tps: 35196.34982
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-65029"
  value: {
   dps: 25450.96886
-  tps: 35195.27801
+  tps: 35196.34982
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JujuofNimbleness-63840"
  value: {
   dps: 26756.15
-  tps: 36475.65854
+  tps: 36476.6673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-55795"
  value: {
   dps: 26549.42498
-  tps: 36575.94465
+  tps: 36576.95792
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-56328"
  value: {
   dps: 26861.1895
-  tps: 37079.94613
+  tps: 37080.94589
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59685"
  value: {
   dps: 25710.99229
-  tps: 35323.12209
+  tps: 35324.14465
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59689"
  value: {
   dps: 25710.99229
-  tps: 35323.12209
+  tps: 35324.14465
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
   dps: 25531.49946
-  tps: 34831.85841
+  tps: 34832.8987
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50708"
  value: {
   dps: 27289.91791
-  tps: 37834.48449
+  tps: 37835.52028
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-55816"
  value: {
   dps: 25450.96886
-  tps: 35194.87946
+  tps: 35195.91525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-56347"
  value: {
   dps: 25450.96886
-  tps: 35194.87946
+  tps: 35195.91525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56102"
  value: {
   dps: 26718.61107
-  tps: 36886.901
+  tps: 36887.93257
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LicensetoSlay-58180"
  value: {
   dps: 25999.21934
-  tps: 35975.71486
+  tps: 35976.75065
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-55814"
  value: {
   dps: 25884.75618
-  tps: 35750.95835
+  tps: 35752.02566
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-56345"
  value: {
   dps: 26136.3476
-  tps: 35965.13834
+  tps: 35966.23746
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62467"
  value: {
   dps: 25450.96886
-  tps: 35194.87946
+  tps: 35195.91525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62472"
  value: {
   dps: 25450.96886
-  tps: 35194.87946
+  tps: 35195.91525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56132"
  value: {
   dps: 26188.71098
-  tps: 36187.10445
+  tps: 36188.14024
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56458"
  value: {
   dps: 26286.16499
-  tps: 36318.16379
+  tps: 36319.19958
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MatrixRestabilizer-68994"
  value: {
   dps: 27586.12484
-  tps: 38514.29753
+  tps: 38515.33782
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MatrixRestabilizer-69150"
  value: {
   dps: 27895.60056
-  tps: 38862.22631
+  tps: 38863.20356
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-55251"
  value: {
   dps: 25724.78041
-  tps: 35523.74031
+  tps: 35524.7761
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-56285"
  value: {
   dps: 25964.96645
-  tps: 35805.38527
+  tps: 35806.42106
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62466"
  value: {
   dps: 25820.19402
-  tps: 35810.99183
+  tps: 35812.02311
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62471"
  value: {
   dps: 25820.19402
-  tps: 35810.99183
+  tps: 35812.02311
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MithrilStopwatch-71337"
  value: {
   dps: 25792.69905
-  tps: 35972.83516
+  tps: 35973.83492
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellChalice-70142"
  value: {
   dps: 25880.65029
-  tps: 35823.50477
+  tps: 35824.8033
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellPhial-70143"
  value: {
   dps: 25450.96886
-  tps: 35194.87946
+  tps: 35195.91525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NecromanticFocus-68982"
  value: {
   dps: 25450.96886
-  tps: 35194.28752
+  tps: 35195.61928
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NecromanticFocus-69139"
  value: {
   dps: 25450.96886
-  tps: 35194.21024
+  tps: 35195.58064
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ObsidianArborweaveRegalia"
  value: {
   dps: 19316.40579
-  tps: 25835.53156
+  tps: 25837.61672
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Oremantle'sFavor-61448"
  value: {
   dps: 25933.548
-  tps: 35794.68038
+  tps: 35795.69365
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedPickledEgg-71336"
  value: {
   dps: 25450.96886
-  tps: 35194.35398
+  tps: 35195.65251
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54591"
  value: {
   dps: 25450.96886
-  tps: 35194.87946
+  tps: 35195.91525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
   dps: 25626.72362
-  tps: 35619.24764
+  tps: 35620.2474
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-55237"
  value: {
   dps: 25667.17977
-  tps: 35497.3158
+  tps: 35498.35159
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-56280"
  value: {
   dps: 25835.92323
-  tps: 35748.59348
+  tps: 35749.62926
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulShadowspiritDiamond"
  value: {
   dps: 26463.57539
-  tps: 36624.35097
+  tps: 36625.40027
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
   dps: 26953.84001
-  tps: 35418.50889
+  tps: 35419.54947
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
   dps: 27211.94805
-  tps: 36182.65118
+  tps: 36183.70048
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-55854"
  value: {
   dps: 25450.96886
-  tps: 35194.87946
+  tps: 35195.91525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-56377"
  value: {
   dps: 25450.96886
-  tps: 35194.87946
+  tps: 35195.91525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReverberatingShadowspiritDiamond"
  value: {
   dps: 26974.03201
-  tps: 37307.63129
+  tps: 37308.68059
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingShadowspiritDiamond"
  value: {
   dps: 26893.27743
-  tps: 37196.06417
+  tps: 37197.11347
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ricket'sMagneticFireball-70144"
  value: {
   dps: 27127.97856
-  tps: 37849.52835
+  tps: 37850.57765
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56100"
  value: {
   dps: 25900.26005
-  tps: 35808.68534
+  tps: 35809.72113
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56431"
  value: {
   dps: 25958.25269
-  tps: 35861.99296
+  tps: 35863.02874
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuneofZeth-68998"
  value: {
   dps: 25864.30876
-  tps: 36154.84914
+  tps: 36155.55617
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
   dps: 26547.26864
-  tps: 37059.63866
+  tps: 37060.63392
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-55256"
  value: {
   dps: 25450.96886
-  tps: 35194.87946
+  tps: 35195.91525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-56290"
  value: {
   dps: 25450.96886
-  tps: 35194.87946
+  tps: 35195.91525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShardofWoe-60233"
  value: {
   dps: 25628.70153
-  tps: 34984.61383
+  tps: 34985.02806
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Shrine-CleansingPurifier-63838"
  value: {
   dps: 25931.29524
-  tps: 35140.33078
+  tps: 35141.37586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
   dps: 25455.78629
-  tps: 35239.0353
+  tps: 35240.06659
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56115"
  value: {
   dps: 26706.14639
-  tps: 37309.26856
+  tps: 37310.26832
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56440"
  value: {
   dps: 26875.20232
-  tps: 37357.12969
+  tps: 37358.12945
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-55879"
  value: {
   dps: 25736.92385
-  tps: 35643.77716
+  tps: 35644.81294
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-56400"
  value: {
   dps: 25774.37034
-  tps: 35702.56138
+  tps: 35703.59716
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Soul'sAnguish-66994"
  value: {
   dps: 25724.78041
-  tps: 35523.74031
+  tps: 35524.7761
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulCasket-58183"
  value: {
   dps: 25815.22105
-  tps: 35766.68962
+  tps: 35767.72541
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stonemother'sKiss-61411"
  value: {
   dps: 25506.0095
-  tps: 35158.26671
+  tps: 35159.41117
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stormrider'sBattlegarb"
  value: {
   dps: 25021.6888
-  tps: 34733.63773
+  tps: 34734.69355
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stormrider'sRegalia"
  value: {
   dps: 19232.97277
-  tps: 25642.82893
+  tps: 25644.99657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62465"
  value: {
   dps: 25449.44821
-  tps: 35212.74082
+  tps: 35213.7766
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62470"
  value: {
   dps: 25449.44821
-  tps: 35212.74082
+  tps: 35213.7766
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-59332"
  value: {
   dps: 25450.96886
-  tps: 35194.87946
+  tps: 35195.91525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-65048"
  value: {
   dps: 25450.96886
-  tps: 35194.87946
+  tps: 35195.91525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofSinisterOrder-65804"
  value: {
   dps: 25471.41004
-  tps: 35224.48755
+  tps: 35225.70416
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tank-CommanderInsignia-63841"
  value: {
   dps: 25950.00867
-  tps: 35065.24222
+  tps: 35066.31404
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-55819"
  value: {
   dps: 25450.96886
-  tps: 35194.54717
+  tps: 35195.7491
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-56351"
  value: {
   dps: 25450.96886
-  tps: 35194.43898
+  tps: 35195.69501
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-55810"
  value: {
   dps: 25694.9384
-  tps: 35577.86757
+  tps: 35578.90336
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-56339"
  value: {
   dps: 25774.37034
-  tps: 35702.56138
+  tps: 35703.59716
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheHungerer-68927"
  value: {
   dps: 27192.43854
-  tps: 36469.44425
+  tps: 36470.43951
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheHungerer-69112"
  value: {
   dps: 27546.74333
-  tps: 37751.87203
+  tps: 37752.93033
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-59519"
  value: {
   dps: 25474.56238
-  tps: 35231.17884
+  tps: 35232.46268
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-65105"
  value: {
   dps: 25498.55369
-  tps: 35264.48762
+  tps: 35265.80392
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56121"
  value: {
   dps: 25450.96886
-  tps: 35194.87946
+  tps: 35195.91525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56449"
  value: {
   dps: 25450.96886
-  tps: 35194.87946
+  tps: 35195.91525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-55874"
  value: {
   dps: 26852.29399
-  tps: 37359.95829
+  tps: 37360.95805
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-56394"
  value: {
   dps: 27010.58543
-  tps: 37735.94481
+  tps: 37736.9806
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
   dps: 25502.10602
-  tps: 34917.64607
+  tps: 34918.59629
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
   dps: 25513.77907
-  tps: 35320.52083
+  tps: 35321.90515
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnheededWarning-59520"
  value: {
   dps: 27197.13331
-  tps: 37753.90585
+  tps: 37754.90561
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnquenchableFlame-67101"
  value: {
   dps: 25450.96886
-  tps: 35194.87946
+  tps: 35195.91525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62463"
  value: {
   dps: 27202.2596
-  tps: 37433.65067
+  tps: 37434.66394
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62468"
  value: {
   dps: 27202.2596
-  tps: 37433.65067
+  tps: 37434.66394
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-68709"
  value: {
   dps: 27202.2596
-  tps: 37433.65067
+  tps: 37434.66394
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
   dps: 22507.88233
-  tps: 31895.04839
+  tps: 31896.11599
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
   dps: 25452.14308
-  tps: 35200.16305
+  tps: 35201.51258
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
   dps: 25454.61475
-  tps: 35212.44103
+  tps: 35213.83075
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VesselofAcceleration-68995"
  value: {
   dps: 26475.46253
-  tps: 36867.25873
+  tps: 36868.26299
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VesselofAcceleration-69167"
  value: {
   dps: 26603.66709
-  tps: 37062.35201
+  tps: 37063.33826
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-59515"
  value: {
   dps: 25450.96886
-  tps: 35194.87946
+  tps: 35195.91525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-65109"
  value: {
   dps: 25450.96886
-  tps: 35194.87946
+  tps: 35195.91525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
   dps: 26818.9786
-  tps: 36835.41536
+  tps: 36836.42863
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
   dps: 25450.96886
-  tps: 35194.87946
+  tps: 35195.91525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
   dps: 25990.61186
-  tps: 35869.66595
+  tps: 35870.70174
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
   dps: 25449.44821
-  tps: 35212.74082
+  tps: 35213.7766
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
   dps: 25732.05494
-  tps: 35047.17545
+  tps: 35048.13947
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
   dps: 25792.69905
-  tps: 35972.83516
+  tps: 35973.83492
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
   dps: 25760.43272
-  tps: 35530.21565
+  tps: 35531.37753
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
   dps: 25836.78115
-  tps: 35800.53508
+  tps: 35801.57087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
   dps: 25450.96886
-  tps: 35194.87946
+  tps: 35195.91525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
   dps: 26823.90132
-  tps: 37125.81959
+  tps: 37126.83736
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
   dps: 25450.96886
-  tps: 35194.87946
+  tps: 35195.91525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
   dps: 25968.56915
-  tps: 35831.55376
+  tps: 35832.58955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-55787"
  value: {
   dps: 25495.02925
-  tps: 35275.7282
+  tps: 35276.88749
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-56320"
  value: {
   dps: 25488.62338
-  tps: 35183.58708
+  tps: 35184.83218
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-World-QuellerFocus-63842"
  value: {
   dps: 25699.47737
-  tps: 35584.99293
+  tps: 35586.02872
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
   dps: 25765.71244
-  tps: 35607.55724
+  tps: 35608.59302
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
   dps: 25765.71244
-  tps: 35607.55724
+  tps: 35608.59302
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
   dps: 27288.79276
-  tps: 37252.58942
+  tps: 37253.61722
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
   dps: 72482.79527
-  tps: 102408.66836
+  tps: 102452.5317
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
   dps: 17314.8806
-  tps: 30602.09794
+  tps: 30603.86836
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
   dps: 20168.86034
-  tps: 27208.92922
+  tps: 27210.30277
  }
 }
 dps_results: {
@@ -1496,21 +1496,21 @@ dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
   dps: 33620.98087
-  tps: 50247.40795
+  tps: 50269.47472
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
   dps: 30620.78709
-  tps: 41995.72179
+  tps: 41996.72155
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
   dps: 37320.58526
-  tps: 36113.32372
+  tps: 36114.06678
  }
 }
 dps_results: {
@@ -1580,21 +1580,21 @@ dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
   dps: 72438.94596
-  tps: 101996.41926
+  tps: 102036.95006
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
   dps: 17176.04684
-  tps: 30275.40375
+  tps: 30277.02948
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
   dps: 19996.9155
-  tps: 26248.74761
+  tps: 26249.58074
  }
 }
 dps_results: {
@@ -1622,21 +1622,21 @@ dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
   dps: 33545.9488
-  tps: 51326.90219
+  tps: 51346.62718
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
   dps: 29716.04571
-  tps: 39829.45718
+  tps: 39830.4119
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
   dps: 36513.58928
-  tps: 34392.52364
+  tps: 34393.04153
  }
 }
 dps_results: {
@@ -1706,21 +1706,21 @@ dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
   dps: 64291.34925
-  tps: 90364.66688
+  tps: 90404.297
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
   dps: 15235.6643
-  tps: 27461.41642
+  tps: 27463.07961
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
   dps: 17430.69181
-  tps: 24755.56682
+  tps: 24756.67016
  }
 }
 dps_results: {
@@ -1748,21 +1748,21 @@ dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
   dps: 30350.22019
-  tps: 45806.87135
+  tps: 45826.32614
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
   dps: 27119.18803
-  tps: 37597.03605
+  tps: 37598.07184
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
   dps: 32961.51429
-  tps: 30317.26923
+  tps: 30317.90067
  }
 }
 dps_results: {
@@ -1832,21 +1832,21 @@ dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
   dps: 63809.88282
-  tps: 90766.63391
+  tps: 90803.83218
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
   dps: 15041.44365
-  tps: 26892.19854
+  tps: 26893.82878
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
   dps: 17294.61122
-  tps: 24414.23764
+  tps: 24415.40853
  }
 }
 dps_results: {
@@ -1874,21 +1874,21 @@ dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
   dps: 29975.67308
-  tps: 45824.81578
+  tps: 45843.91029
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
   dps: 26367.77664
-  tps: 35350.10057
+  tps: 35350.88867
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
   dps: 32446.80145
-  tps: 29914.47617
+  tps: 29914.81393
  }
 }
 dps_results: {
@@ -1958,6 +1958,6 @@ dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
   dps: 23779.06358
-  tps: 33370.52903
+  tps: 33371.44773
  }
 }

--- a/sim/druid/guardian/TestGuardian.results
+++ b/sim/druid/guardian/TestGuardian.results
@@ -348,7 +348,7 @@ dps_results: {
  key: "TestGuardian-AllItems-ElectrosparkHeartstarter-67118"
  value: {
   dps: 7812.79531
-  tps: 39154.28703
+  tps: 39155.22445
  }
 }
 dps_results: {
@@ -411,7 +411,7 @@ dps_results: {
  key: "TestGuardian-AllItems-FieryQuintessence-69000"
  value: {
   dps: 7790.92127
-  tps: 39092.23054
+  tps: 39093.13976
  }
 }
 dps_results: {

--- a/sim/mage/arcane/TestArcane.results
+++ b/sim/mage/arcane/TestArcane.results
@@ -38,1416 +38,1416 @@ character_stats_results: {
 dps_results: {
  key: "TestArcane-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 29475.90264
-  tps: 29574.58415
+  dps: 29341.93538
+  tps: 29420.93685
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 28417.21438
-  tps: 28591.11871
+  dps: 28137.20439
+  tps: 28312.73716
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 28179.79867
-  tps: 28358.79085
+  dps: 28063.63971
+  tps: 28212.75448
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 28826.81043
-  tps: 28971.99082
+  dps: 28527.04923
+  tps: 28658.74416
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 28912.63591
-  tps: 29054.64867
+  dps: 28594.8258
+  tps: 28721.65271
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 29065.09561
-  tps: 29169.14032
+  dps: 28923.74084
+  tps: 29008.2236
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 27737.9288
-  tps: 27896.57552
+  dps: 27594.12743
+  tps: 27748.06659
   hps: 99.81156
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 29152.72807
-  tps: 29277.58313
+  dps: 29183.26482
+  tps: 29287.63501
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BindingPromise-67037"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 28039.54426
-  tps: 28210.46579
+  dps: 27931.53727
+  tps: 28097.92572
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 28069.14957
-  tps: 28222.77427
+  dps: 27916.12434
+  tps: 28050.83848
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 28114.02992
-  tps: 28267.65463
+  dps: 27959.60556
+  tps: 28094.3197
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 27569.96819
-  tps: 27715.40767
+  dps: 27427.20252
+  tps: 27540.44884
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 28799.08439
-  tps: 28923.06894
+  dps: 28560.64746
+  tps: 28651.97365
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 27622.97252
-  tps: 27781.11708
+  dps: 27381.61965
+  tps: 27507.52299
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 27981.4012
-  tps: 28138.58824
+  dps: 27999.47499
+  tps: 28133.54997
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 27673.53737
-  tps: 27839.42712
+  dps: 27617.85201
+  tps: 27756.45179
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 27726.42683
-  tps: 27880.25425
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.02724
+  tps: 27718.74138
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 28524.20875
-  tps: 28657.87935
+  dps: 28377.20052
+  tps: 28489.46874
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.02724
+  tps: 27718.74138
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BottledLightning-66879"
  value: {
-  dps: 28542.60345
-  tps: 28721.30033
+  dps: 28357.96143
+  tps: 28524.38241
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 29312.81005
-  tps: 28869.17659
+  dps: 29050.43195
+  tps: 28579.14642
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Brawler'sTrophy-71338"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 29728.82997
-  tps: 29852.26575
+  dps: 29466.66446
+  tps: 29555.98679
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 29545.68413
-  tps: 29646.20339
+  dps: 29418.28549
+  tps: 29496.05854
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Coren'sChilledChromiumCoaster-71335"
  value: {
-  dps: 27991.36792
-  tps: 28147.15675
+  dps: 28023.05787
+  tps: 28155.69386
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 29050.02518
-  tps: 29257.05972
+  dps: 28591.97749
+  tps: 28783.50768
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CrushingWeight-59506"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CrushingWeight-65118"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 27726.42683
-  tps: 27880.25425
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 29112.58397
-  tps: 29298.28972
+  dps: 28725.45437
+  tps: 28914.62519
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 29342.45967
-  tps: 29496.33118
+  dps: 29174.60313
+  tps: 29332.853
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 27897.18831
-  tps: 28050.01083
+  dps: 27817.4055
+  tps: 27954.97824
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 29131.23472
-  tps: 29237.07335
+  dps: 28995.84852
+  tps: 29079.18762
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 28456.3031
-  tps: 28564.66928
+  dps: 28211.83497
+  tps: 28313.07127
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 28232.71473
-  tps: 28383.03871
+  dps: 28181.35045
+  tps: 28315.24472
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 29065.09561
-  tps: 29169.14032
+  dps: 28923.74084
+  tps: 29008.2236
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 28241.85549
-  tps: 28407.37999
+  dps: 27872.59396
+  tps: 27979.77287
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 29391.76794
-  tps: 29522.87531
+  dps: 29015.37347
+  tps: 29149.89612
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 29131.23472
-  tps: 29237.07335
+  dps: 28995.84852
+  tps: 29079.18762
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 28179.79867
-  tps: 28358.79085
+  dps: 28063.63971
+  tps: 28212.75448
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 29065.09561
-  tps: 29169.14032
+  dps: 28923.74084
+  tps: 29008.2236
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FallofMortality-59500"
  value: {
-  dps: 29112.58397
-  tps: 29298.28972
+  dps: 28725.45437
+  tps: 28914.62519
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FallofMortality-65124"
  value: {
-  dps: 29112.93453
-  tps: 29290.85934
+  dps: 28949.81724
+  tps: 29132.66774
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 29025.00841
-  tps: 29177.91953
+  dps: 28596.0653
+  tps: 28704.84425
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 28047.4612
-  tps: 28202.53064
+  dps: 27837.24208
+  tps: 27939.21047
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 28907.87667
-  tps: 29112.27138
+  dps: 28426.22979
+  tps: 28615.56713
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 30021.74563
-  tps: 30194.10137
+  dps: 29527.51294
+  tps: 29684.71354
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 28014.32096
-  tps: 28172.46552
+  dps: 27764.05013
+  tps: 27889.95347
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FirehawkRobesofConflagration"
  value: {
-  dps: 27491.53717
-  tps: 26767.2003
+  dps: 27198.45244
+  tps: 26488.35716
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Firelord'sVestments"
  value: {
-  dps: 26108.92524
-  tps: 26169.71785
+  dps: 25678.28356
+  tps: 25729.47949
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 29141.55636
-  tps: 29245.60107
+  dps: 28998.52938
+  tps: 29083.01214
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FluidDeath-58181"
  value: {
-  dps: 28134.69909
-  tps: 28292.91214
+  dps: 27831.96549
+  tps: 27972.91566
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 29312.81005
-  tps: 29441.11986
+  dps: 29050.43195
+  tps: 29145.04647
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 27988.77315
-  tps: 28145.15078
+  dps: 28020.7331
+  tps: 28153.69928
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-GaleofShadows-56138"
  value: {
-  dps: 27912.79739
-  tps: 28052.12489
+  dps: 27644.22151
+  tps: 27738.17657
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-GaleofShadows-56462"
  value: {
-  dps: 27825.57708
-  tps: 27955.67314
+  dps: 27709.08609
+  tps: 27812.67708
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-GearDetector-61462"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 28419.34971
-  tps: 28590.56782
+  dps: 28240.94547
+  tps: 28418.59588
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-HarmlightToken-63839"
  value: {
-  dps: 28668.2267
-  tps: 28837.76597
+  dps: 28468.61709
+  tps: 28645.33026
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 29137.89709
-  tps: 29245.72314
+  dps: 28817.33747
+  tps: 28887.16925
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 29111.23397
-  tps: 29208.81373
+  dps: 28879.66277
+  tps: 28946.05571
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-HeartofRage-59224"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-HeartofRage-65072"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-HeartofSolace-55868"
  value: {
-  dps: 27912.79739
-  tps: 28052.12489
+  dps: 27644.22151
+  tps: 27738.17657
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-HeartofSolace-56393"
  value: {
-  dps: 27825.57708
-  tps: 27955.67314
+  dps: 27709.08609
+  tps: 27812.67708
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-HeartofThunder-55845"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-HeartofThunder-56370"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Heartpierce-50641"
  value: {
-  dps: 29728.82997
-  tps: 29852.26575
+  dps: 29466.66446
+  tps: 29555.98679
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 29131.23472
-  tps: 29237.07335
+  dps: 28995.84852
+  tps: 29079.18762
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 28063.75445
-  tps: 28221.89901
+  dps: 27812.35714
+  tps: 27938.26048
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 28063.75445
-  tps: 28221.89901
+  dps: 27812.35714
+  tps: 27938.26048
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 28069.14957
-  tps: 28222.77427
+  dps: 27916.12434
+  tps: 28050.83848
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 28114.02992
-  tps: 28267.65463
+  dps: 27959.60556
+  tps: 28094.3197
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 28548.11889
-  tps: 28705.72041
+  dps: 28443.26303
+  tps: 28598.64242
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 27995.26003
-  tps: 28184.68048
+  dps: 27677.79856
+  tps: 27878.56422
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 28029.70745
-  tps: 28232.47371
+  dps: 27687.8285
+  tps: 27888.15788
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 28039.54426
-  tps: 28210.46579
+  dps: 27931.53727
+  tps: 28097.92572
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 28134.69909
-  tps: 28292.91214
+  dps: 27831.96549
+  tps: 27972.91566
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 28134.69909
-  tps: 28292.91214
+  dps: 27831.96549
+  tps: 27972.91566
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 27952.12372
-  tps: 28097.30932
+  dps: 27466.00383
+  tps: 27568.71821
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 27952.12372
-  tps: 28097.30932
+  dps: 27466.00383
+  tps: 27568.71821
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 27726.05068
-  tps: 27872.03748
+  dps: 27756.84128
+  tps: 27863.92268
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-LeadenDespair-55816"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-LeadenDespair-56347"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 28134.69909
-  tps: 28292.91214
+  dps: 27831.96549
+  tps: 27972.91566
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 27739.7661
-  tps: 27910.68763
+  dps: 27638.0903
+  tps: 27804.47875
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 27739.7661
-  tps: 27910.68763
+  dps: 27638.0903
+  tps: 27804.47875
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 27673.78194
-  tps: 27839.46233
+  dps: 27618.15985
+  tps: 27756.75392
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 27673.78194
-  tps: 27839.46233
+  dps: 27618.15985
+  tps: 27756.75392
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 28161.63679
-  tps: 28332.55832
+  dps: 28055.56831
+  tps: 28221.95677
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 28216.01208
-  tps: 28386.93362
+  dps: 28109.61525
+  tps: 28276.00371
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 28177.14573
-  tps: 28339.30883
+  dps: 27787.13959
+  tps: 27951.23089
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 28177.14573
-  tps: 28339.30883
+  dps: 27787.13959
+  tps: 27951.23089
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 28162.99031
-  tps: 28316.61502
+  dps: 28007.03963
+  tps: 28141.75376
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 28162.99031
-  tps: 28316.61502
+  dps: 28007.03963
+  tps: 28141.75376
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MithrilStopwatch-71337"
  value: {
-  dps: 28952.37509
-  tps: 29084.12517
+  dps: 28994.72685
+  tps: 29104.29047
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 29981.61324
-  tps: 30183.50692
+  dps: 29444.66119
+  tps: 29629.3208
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 29204.75538
-  tps: 29389.33704
+  dps: 28960.04295
+  tps: 29139.31756
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 29367.56421
-  tps: 29555.53166
+  dps: 29151.04881
+  tps: 29331.10603
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 28009.41991
-  tps: 28170.77299
+  dps: 27705.43583
+  tps: 27831.98761
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PetrifiedPickledEgg-71336"
  value: {
-  dps: 29208.75084
-  tps: 29393.73531
+  dps: 28813.72323
+  tps: 28997.92919
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 27906.65864
-  tps: 28059.20728
+  dps: 27818.78367
+  tps: 27956.06078
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 29065.09561
-  tps: 29169.14032
+  dps: 28923.74084
+  tps: 29008.2236
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Rainsong-55854"
  value: {
-  dps: 27672.48569
-  tps: 27838.20138
+  dps: 27617.12509
+  tps: 27758.10392
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Rainsong-56377"
  value: {
-  dps: 27673.34171
-  tps: 27839.03408
+  dps: 27619.44955
+  tps: 27758.05389
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 29475.90264
-  tps: 29574.58415
+  dps: 29341.93538
+  tps: 29420.93685
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 29498.48422
-  tps: 29598.72061
+  dps: 29342.86878
+  tps: 29421.86257
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 28352.54018
-  tps: 28516.87579
+  dps: 28003.3598
+  tps: 28131.79963
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 28134.69909
-  tps: 28292.91214
+  dps: 27831.96549
+  tps: 27972.91566
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 28134.69909
-  tps: 28292.91214
+  dps: 27831.96549
+  tps: 27972.91566
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RuneofZeth-68998"
  value: {
-  dps: 29463.68274
-  tps: 29624.8654
+  dps: 29088.2219
+  tps: 29239.08017
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SeaStar-55256"
  value: {
-  dps: 28173.19199
-  tps: 28313.29726
+  dps: 28015.88181
+  tps: 28125.53886
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SeaStar-56290"
  value: {
-  dps: 28710.08778
-  tps: 28835.88915
+  dps: 28527.2769
+  tps: 28621.87571
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ShardofWoe-60233"
  value: {
-  dps: 29752.96724
-  tps: 29799.86113
+  dps: 29219.28891
+  tps: 29278.88407
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 28161.41978
-  tps: 28319.56434
+  dps: 27909.05923
+  tps: 28034.96257
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 28231.57781
-  tps: 28389.72237
+  dps: 27977.75303
+  tps: 28103.65637
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Sorrowsong-55879"
  value: {
-  dps: 28710.11474
-  tps: 28842.68379
+  dps: 28523.51485
+  tps: 28639.24016
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Sorrowsong-56400"
  value: {
-  dps: 28840.08324
-  tps: 28969.89501
+  dps: 28647.59426
+  tps: 28760.83294
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 28177.14573
-  tps: 28339.30883
+  dps: 27787.13959
+  tps: 27951.23089
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SoulCasket-58183"
  value: {
-  dps: 29574.46812
-  tps: 29689.32835
+  dps: 29326.35982
+  tps: 29408.45027
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 28774.11058
-  tps: 28942.45454
+  dps: 28592.03804
+  tps: 28762.60989
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-StumpofTime-62465"
  value: {
-  dps: 29124.55728
-  tps: 29256.7979
+  dps: 28789.7418
+  tps: 28906.82756
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-StumpofTime-62470"
  value: {
-  dps: 29173.26607
-  tps: 29305.10956
+  dps: 28837.01927
+  tps: 28954.11532
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 28887.33889
-  tps: 29056.83899
+  dps: 28781.40156
+  tps: 28955.98859
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TearofBlood-55819"
  value: {
-  dps: 28463.97823
-  tps: 28631.86651
+  dps: 28336.65669
+  tps: 28512.72172
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TearofBlood-56351"
  value: {
-  dps: 28832.60627
-  tps: 29012.56589
+  dps: 28656.61673
+  tps: 28849.6447
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 28667.14021
-  tps: 28806.10725
+  dps: 28507.09128
+  tps: 28626.4038
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 29013.94423
-  tps: 29143.56746
+  dps: 28837.54581
+  tps: 28946.12423
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TheHungerer-68927"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TheHungerer-69112"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 29728.45182
-  tps: 29914.15756
+  dps: 29338.47536
+  tps: 29525.71939
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 28069.14957
-  tps: 28222.77427
+  dps: 27916.12434
+  tps: 28050.83848
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 28114.02992
-  tps: 28267.65463
+  dps: 27959.60556
+  tps: 28094.3197
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TimeLord'sRegalia"
  value: {
-  dps: 25559.17624
-  tps: 25655.49176
+  dps: 25469.13153
+  tps: 25543.61142
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 28018.76231
-  tps: 28178.07801
+  dps: 27774.71004
+  tps: 27910.49711
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 28971.03268
-  tps: 29176.835
+  dps: 28525.05283
+  tps: 28743.29115
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-UnheededWarning-59520"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 27581.05491
-  tps: 27738.36055
+  dps: 27422.90278
+  tps: 27549.99021
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 28063.75445
-  tps: 28221.89901
+  dps: 27812.35714
+  tps: 27938.26048
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 28063.75445
-  tps: 28221.89901
+  dps: 27812.35714
+  tps: 27938.26048
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 28063.75445
-  tps: 28221.89901
+  dps: 27812.35714
+  tps: 27938.26048
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 29537.156
-  tps: 29719.78356
+  dps: 29251.62308
+  tps: 29433.74735
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 30119.98455
-  tps: 30297.9409
+  dps: 29975.37267
+  tps: 30159.46652
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 27726.42683
-  tps: 27880.05154
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 27622.97252
-  tps: 27781.11708
+  dps: 27381.61965
+  tps: 27507.52299
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 28864.8538
-  tps: 28986.92809
+  dps: 28626.57994
+  tps: 28715.97254
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 27622.97252
-  tps: 27781.11708
+  dps: 27381.61965
+  tps: 27507.52299
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 28134.69909
-  tps: 28292.5509
+  dps: 27831.96549
+  tps: 27972.91566
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 27998.42957
-  tps: 28123.06283
+  dps: 27818.07233
+  tps: 27915.74863
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 27991.36792
-  tps: 28147.35946
+  dps: 28023.05787
+  tps: 28155.69386
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 27726.42683
-  tps: 27880.25425
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 28188.83052
-  tps: 28342.65793
+  dps: 28032.07427
+  tps: 28166.78841
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 27726.42683
-  tps: 27880.25425
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 27726.42683
-  tps: 27880.25425
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 28714.51915
-  tps: 28848.06368
+  dps: 28566.12053
+  tps: 28678.88014
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 27726.42683
-  tps: 27879.56998
+  dps: 27584.0859
+  tps: 27718.80004
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 28597.58945
-  tps: 28770.96641
+  dps: 28420.29807
+  tps: 28583.24037
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 29307.48149
-  tps: 29475.74179
+  dps: 29019.02415
+  tps: 29175.2218
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 27923.73541
-  tps: 28081.97447
+  dps: 27675.48728
+  tps: 27801.39062
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 28107.2615
-  tps: 28278.18303
+  dps: 28001.52138
+  tps: 28167.90983
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 28107.2615
-  tps: 28278.18303
+  dps: 28001.52138
+  tps: 28167.90983
  }
 }
 dps_results: {
  key: "TestArcane-Average-Default"
  value: {
-  dps: 30263.10617
-  tps: 30360.83772
+  dps: 29900.6346
+  tps: 29982.11559
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_arcane-Arcane-arcane-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 29713.10335
-  tps: 45887.43485
+  dps: 29447.57005
+  tps: 45706.82203
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_arcane-Arcane-arcane-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 29728.82997
-  tps: 29852.26575
+  dps: 29466.66446
+  tps: 29555.98679
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p1_arcane-Arcane-arcane-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 44304.88826
-  tps: 44060.99468
+  dps: 43387.83752
+  tps: 43121.40079
  }
 }
 dps_results: {
@@ -1474,7 +1474,7 @@ dps_results: {
 dps_results: {
  key: "TestArcane-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 29728.82997
-  tps: 29852.26575
+  dps: 29466.66446
+  tps: 29555.98679
  }
 }

--- a/sim/mage/fire/TestFire.results
+++ b/sim/mage/fire/TestFire.results
@@ -38,1409 +38,1409 @@ character_stats_results: {
 dps_results: {
  key: "TestFire-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 30837.22878
-  tps: 30218.83321
+  dps: 30647.01355
+  tps: 30116.29024
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 28988.85245
-  tps: 28401.06448
+  dps: 28718.50445
+  tps: 28220.92708
  }
 }
 dps_results: {
  key: "TestFire-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 28692.60365
-  tps: 28124.87475
+  dps: 28470.37881
+  tps: 27980.93614
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 29610.66071
-  tps: 28999.10715
+  dps: 29147.04887
+  tps: 28615.41898
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 29701.36443
-  tps: 29079.06416
+  dps: 29311.3889
+  tps: 28771.65469
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 30254.99673
-  tps: 29645.73299
+  dps: 30035.04441
+  tps: 29512.92948
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 28177.27246
-  tps: 27624.30914
-  hps: 102.54039
+  dps: 27971.23649
+  tps: 27488.49988
+  hps: 102.6039
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 30453.03901
-  tps: 29860.95141
+  dps: 30048.59023
+  tps: 29521.00401
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 30716.63218
-  tps: 30113.75213
+  dps: 30456.9257
+  tps: 29923.83343
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BindingPromise-67037"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 28505.7893
-  tps: 27950.82394
+  dps: 28267.77906
+  tps: 27783.25467
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 28574.01225
-  tps: 28008.42885
+  dps: 28303.19452
+  tps: 27813.75185
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 28574.01225
-  tps: 28008.42885
+  dps: 28303.19452
+  tps: 27813.75185
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 29350.43085
-  tps: 28770.12385
+  dps: 29161.95546
+  tps: 28656.96367
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 29112.47897
-  tps: 28534.75435
+  dps: 28819.70398
+  tps: 28309.44185
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27999.9029
+  tps: 27517.44141
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 29065.04286
-  tps: 28478.27583
+  dps: 28939.84005
+  tps: 28427.27305
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BottledLightning-66879"
  value: {
-  dps: 29331.77302
-  tps: 28727.95566
+  dps: 29006.36129
+  tps: 28494.72752
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 30639.025
-  tps: 29406.92134
+  dps: 30403.13328
+  tps: 29271.28425
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Brawler'sTrophy-71338"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 31036.2947
-  tps: 30397.21178
+  dps: 30918.93247
+  tps: 30372.46888
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 31026.95536
-  tps: 30403.04655
+  dps: 30765.34213
+  tps: 30231.09489
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Coren'sChilledChromiumCoaster-71335"
  value: {
-  dps: 29142.73807
-  tps: 28559.73118
+  dps: 28933.40496
+  tps: 28425.11791
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 29613.5699
-  tps: 28985.26697
+  dps: 29302.60577
+  tps: 28784.15986
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CrushingWeight-59506"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CrushingWeight-65118"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 29613.5699
-  tps: 28985.26697
+  dps: 29302.60577
+  tps: 28784.15986
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 28887.49001
-  tps: 28323.60971
+  dps: 28577.10687
+  tps: 28088.55215
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 30493.42423
-  tps: 29873.60786
+  dps: 30215.94541
+  tps: 29685.2027
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 29054.65793
-  tps: 28490.33112
+  dps: 28881.69266
+  tps: 28388.97157
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 29033.70715
-  tps: 28444.7406
+  dps: 28872.73282
+  tps: 28360.24119
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 30254.99673
-  tps: 29645.73299
+  dps: 30035.04441
+  tps: 29512.92948
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 28676.95452
-  tps: 28100.8897
+  dps: 28411.71953
+  tps: 27914.80112
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 30640.75157
-  tps: 30006.53802
+  dps: 30233.90811
+  tps: 29702.2531
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 30493.42423
-  tps: 29873.60786
+  dps: 30215.94541
+  tps: 29685.2027
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 28692.60365
-  tps: 28124.87475
+  dps: 28470.37881
+  tps: 27980.93614
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 30254.99673
-  tps: 29645.73299
+  dps: 30035.04441
+  tps: 29512.92948
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FallofMortality-59500"
  value: {
-  dps: 29613.5699
-  tps: 28985.26697
+  dps: 29302.60577
+  tps: 28784.15986
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FallofMortality-65124"
  value: {
-  dps: 29752.02368
-  tps: 29120.75616
+  dps: 29400.94566
+  tps: 28873.81004
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 30079.59285
-  tps: 29463.60172
+  dps: 29813.72362
+  tps: 29304.57826
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 28781.26648
-  tps: 28195.88173
+  dps: 28385.2984
+  tps: 27882.18499
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 29433.14095
-  tps: 28811.62535
+  dps: 29061.94248
+  tps: 28545.98355
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 30404.41565
-  tps: 29761.52221
+  dps: 30021.36925
+  tps: 29489.31192
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 28574.01225
-  tps: 28008.42885
+  dps: 28303.19452
+  tps: 27813.75185
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FirehawkRobesofConflagration"
  value: {
-  dps: 28586.19602
-  tps: 27245.44268
+  dps: 28232.35925
+  tps: 26992.46641
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Firelord'sVestments"
  value: {
-  dps: 26815.95352
-  tps: 26386.15573
+  dps: 26698.95212
+  tps: 26283.06874
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 30355.76256
-  tps: 29746.49882
+  dps: 30135.54235
+  tps: 29613.42743
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FluidDeath-58181"
  value: {
-  dps: 28781.26648
-  tps: 28195.88173
+  dps: 28385.2984
+  tps: 27882.18499
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 30639.025
-  tps: 30004.93012
+  dps: 30403.13328
+  tps: 29864.45345
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 29114.2916
-  tps: 28541.72356
+  dps: 28840.781
+  tps: 28330.43475
  }
 }
 dps_results: {
  key: "TestFire-AllItems-GaleofShadows-56138"
  value: {
-  dps: 28939.07252
-  tps: 28406.82085
+  dps: 29001.52255
+  tps: 28503.52492
  }
 }
 dps_results: {
  key: "TestFire-AllItems-GaleofShadows-56462"
  value: {
-  dps: 29311.38028
-  tps: 28787.35905
+  dps: 29157.41841
+  tps: 28669.2741
  }
 }
 dps_results: {
  key: "TestFire-AllItems-GearDetector-61462"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 29030.65703
-  tps: 28441.93187
+  dps: 28753.37542
+  tps: 28253.82023
  }
 }
 dps_results: {
  key: "TestFire-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-HarmlightToken-63839"
  value: {
-  dps: 29254.04174
-  tps: 28659.9696
+  dps: 29023.23049
+  tps: 28518.19336
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 30148.72791
-  tps: 29572.46606
+  dps: 29922.76831
+  tps: 29407.13372
  }
 }
 dps_results: {
  key: "TestFire-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 29851.17919
-  tps: 29278.01274
+  dps: 30151.9035
+  tps: 29632.29151
  }
 }
 dps_results: {
  key: "TestFire-AllItems-HeartofRage-59224"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-HeartofRage-65072"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-HeartofSolace-55868"
  value: {
-  dps: 28049.9798
-  tps: 27541.0256
+  dps: 28214.01274
+  tps: 27734.41188
  }
 }
 dps_results: {
  key: "TestFire-AllItems-HeartofSolace-56393"
  value: {
-  dps: 28275.51403
-  tps: 27777.31453
+  dps: 28160.26516
+  tps: 27695.11512
  }
 }
 dps_results: {
  key: "TestFire-AllItems-HeartofThunder-55845"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-HeartofThunder-56370"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Heartpierce-50641"
  value: {
-  dps: 31036.2947
-  tps: 30397.21178
+  dps: 30918.93247
+  tps: 30372.46888
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 30493.42423
-  tps: 29873.60786
+  dps: 30215.94541
+  tps: 29685.2027
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 28608.63581
-  tps: 28040.90691
+  dps: 28386.78667
+  tps: 27897.34399
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 28608.63581
-  tps: 28040.90691
+  dps: 28386.78667
+  tps: 27897.34399
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 28574.01225
-  tps: 28008.42885
+  dps: 28303.19452
+  tps: 27813.75185
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 28574.01225
-  tps: 28008.42885
+  dps: 28303.19452
+  tps: 27813.75185
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 29129.60417
-  tps: 28552.64358
+  dps: 28921.594
+  tps: 28422.45672
  }
 }
 dps_results: {
  key: "TestFire-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 28434.10203
-  tps: 27870.16531
+  dps: 27991.29348
+  tps: 27509.26685
  }
 }
 dps_results: {
  key: "TestFire-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 28434.10203
-  tps: 27872.96531
+  dps: 28021.79554
+  tps: 27529.41457
  }
 }
 dps_results: {
  key: "TestFire-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 28505.7893
-  tps: 27950.82394
+  dps: 28267.77906
+  tps: 27783.25467
  }
 }
 dps_results: {
  key: "TestFire-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 28781.26648
-  tps: 28195.88173
+  dps: 28385.2984
+  tps: 27882.18499
  }
 }
 dps_results: {
  key: "TestFire-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 28781.26648
-  tps: 28195.88173
+  dps: 28385.2984
+  tps: 27882.18499
  }
 }
 dps_results: {
  key: "TestFire-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 28227.19254
-  tps: 27703.49099
+  dps: 27954.42451
+  tps: 27490.39111
  }
 }
 dps_results: {
  key: "TestFire-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 28227.19254
-  tps: 27703.49099
+  dps: 27954.42451
+  tps: 27490.39111
  }
 }
 dps_results: {
  key: "TestFire-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 27964.68353
-  tps: 27428.64096
+  dps: 27764.7533
+  tps: 27296.77136
  }
 }
 dps_results: {
  key: "TestFire-AllItems-LeadenDespair-55816"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-LeadenDespair-56347"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 28781.26648
-  tps: 28195.88173
+  dps: 28385.2984
+  tps: 27882.18499
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27999.9029
+  tps: 27517.44141
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27999.9029
+  tps: 27517.44141
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 28658.20167
-  tps: 28091.81131
+  dps: 28448.47658
+  tps: 27960.01248
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 28708.46481
-  tps: 28142.07445
+  dps: 28498.8884
+  tps: 28010.4243
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 28781.26648
-  tps: 28195.88173
+  dps: 28385.2984
+  tps: 27882.18499
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 28781.26648
-  tps: 28195.88173
+  dps: 28385.2984
+  tps: 27882.18499
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 28608.63581
-  tps: 28040.90691
+  dps: 28386.78667
+  tps: 27897.34399
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 28608.63581
-  tps: 28040.90691
+  dps: 28386.78667
+  tps: 27897.34399
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MithrilStopwatch-71337"
  value: {
-  dps: 30454.76713
-  tps: 29852.96849
+  dps: 30166.33543
+  tps: 29642.90156
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 30281.12754
-  tps: 29650.42353
+  dps: 29927.11123
+  tps: 29405.60061
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 30384.26515
-  tps: 29746.3249
+  dps: 29990.52478
+  tps: 29458.01701
  }
 }
 dps_results: {
  key: "TestFire-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 30699.4023
-  tps: 30061.76213
+  dps: 30365.45604
+  tps: 29831.46505
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 28777.04398
-  tps: 28203.85921
+  dps: 28601.82927
+  tps: 28110.04855
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PetrifiedPickledEgg-71336"
  value: {
-  dps: 29680.7824
-  tps: 29051.02825
+  dps: 29328.47005
+  tps: 28807.12818
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 29716.0229
-  tps: 29140.41695
+  dps: 29398.14035
+  tps: 28892.11501
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 30254.99673
-  tps: 29645.73299
+  dps: 30035.04441
+  tps: 29512.92948
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Rainsong-55854"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27999.9029
+  tps: 27517.44141
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Rainsong-56377"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27999.9029
+  tps: 27517.44141
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 30837.22878
-  tps: 30218.83321
+  dps: 30647.01355
+  tps: 30116.29024
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 30837.22878
-  tps: 30218.83321
+  dps: 30648.95544
+  tps: 30118.2207
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 29394.52084
-  tps: 28803.03316
+  dps: 29050.11081
+  tps: 28551.81278
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 28781.26648
-  tps: 28195.88173
+  dps: 28385.2984
+  tps: 27882.18499
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 28781.26648
-  tps: 28195.88173
+  dps: 28385.2984
+  tps: 27882.18499
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RuneofZeth-68998"
  value: {
-  dps: 30365.16512
-  tps: 29759.97843
+  dps: 29916.4634
+  tps: 29404.70412
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SeaStar-55256"
  value: {
-  dps: 28689.39875
-  tps: 28117.55059
+  dps: 28534.6452
+  tps: 28040.73198
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SeaStar-56290"
  value: {
-  dps: 29279.23925
-  tps: 28700.00122
+  dps: 29117.8565
+  tps: 28613.9242
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ShardofWoe-60233"
  value: {
-  dps: 28927.45677
-  tps: 28338.98682
+  dps: 28677.76377
+  tps: 28159.42843
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 28686.79657
-  tps: 28123.39779
+  dps: 28526.25904
+  tps: 28036.05721
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 28734.21994
-  tps: 28170.82116
+  dps: 28571.71872
+  tps: 28081.51689
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Sorrowsong-55879"
  value: {
-  dps: 29385.12972
-  tps: 28799.111
+  dps: 29127.65174
+  tps: 28621.53006
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Sorrowsong-56400"
  value: {
-  dps: 29497.58114
-  tps: 28909.46955
+  dps: 29235.82219
+  tps: 28727.80814
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 28781.26648
-  tps: 28195.88173
+  dps: 28385.2984
+  tps: 27882.18499
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SoulCasket-58183"
  value: {
-  dps: 30067.4647
-  tps: 29477.12027
+  dps: 29867.81208
+  tps: 29358.07613
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 29595.26837
-  tps: 28987.88002
+  dps: 29327.63305
+  tps: 28814.23685
  }
 }
 dps_results: {
  key: "TestFire-AllItems-StumpofTime-62465"
  value: {
-  dps: 30101.68496
-  tps: 29476.80464
+  dps: 29723.09989
+  tps: 29179.80193
  }
 }
 dps_results: {
  key: "TestFire-AllItems-StumpofTime-62470"
  value: {
-  dps: 30043.52355
-  tps: 29426.33484
+  dps: 29762.14917
+  tps: 29222.03477
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 29414.80023
-  tps: 28808.93363
+  dps: 29117.93485
+  tps: 28604.38069
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TearofBlood-55819"
  value: {
-  dps: 29119.0565
-  tps: 28525.40808
+  dps: 28899.93809
+  tps: 28395.23177
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TearofBlood-56351"
  value: {
-  dps: 29433.14095
-  tps: 28811.62535
+  dps: 29061.94248
+  tps: 28545.98355
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 29213.78838
-  tps: 28625.76948
+  dps: 28984.74899
+  tps: 28469.87346
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 29582.01763
-  tps: 28987.2852
+  dps: 29485.20465
+  tps: 28965.77756
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TheHungerer-68927"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TheHungerer-69112"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 30114.56879
-  tps: 29484.51332
+  dps: 29867.53776
+  tps: 29346.21616
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 28574.01225
-  tps: 28008.42885
+  dps: 28303.19452
+  tps: 27813.75185
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 28574.01225
-  tps: 28008.42885
+  dps: 28303.19452
+  tps: 27813.75185
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TimeLord'sRegalia"
  value: {
-  dps: 25755.48792
-  tps: 25230.71866
+  dps: 25687.67409
+  tps: 25264.37315
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 28293.54435
-  tps: 27729.86942
+  dps: 28058.73087
+  tps: 27558.66797
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 29843.66817
-  tps: 29252.62065
+  dps: 29610.1466
+  tps: 29063.87456
  }
 }
 dps_results: {
  key: "TestFire-AllItems-UnheededWarning-59520"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27999.9029
+  tps: 27517.44141
  }
 }
 dps_results: {
  key: "TestFire-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 28608.63581
-  tps: 28040.90691
+  dps: 28386.78667
+  tps: 27897.34399
  }
 }
 dps_results: {
  key: "TestFire-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 28608.63581
-  tps: 28040.90691
+  dps: 28386.78667
+  tps: 27897.34399
  }
 }
 dps_results: {
  key: "TestFire-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 28608.63581
-  tps: 28040.90691
+  dps: 28386.78667
+  tps: 27897.34399
  }
 }
 dps_results: {
  key: "TestFire-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 30210.88668
-  tps: 29581.74833
+  dps: 29694.6826
+  tps: 29169.46099
  }
 }
 dps_results: {
  key: "TestFire-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 31024.22152
-  tps: 30384.95257
+  dps: 30662.09682
+  tps: 30137.02353
  }
 }
 dps_results: {
  key: "TestFire-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 29414.1286
-  tps: 28832.86516
+  dps: 29223.72104
+  tps: 28717.85248
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 28781.26648
-  tps: 28195.88173
+  dps: 28385.2984
+  tps: 27882.18499
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 28255.68376
-  tps: 27747.24673
+  dps: 28189.40066
+  tps: 27718.49426
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 29142.73807
-  tps: 28559.73118
+  dps: 28933.40496
+  tps: 28425.11791
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 28608.63581
-  tps: 28040.90691
+  dps: 28386.78667
+  tps: 27897.34399
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 29145.05351
-  tps: 28554.59334
+  dps: 28964.24984
+  tps: 28451.29435
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 28226.59971
-  tps: 27672.91452
+  dps: 27980.06567
+  tps: 27497.51044
  }
 }
 dps_results: {
  key: "TestFire-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 29160.72074
-  tps: 28550.14244
+  dps: 28750.10032
+  tps: 28247.86986
  }
 }
 dps_results: {
  key: "TestFire-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 30041.13528
-  tps: 29428.32506
+  dps: 29656.17783
+  tps: 29138.15936
  }
 }
 dps_results: {
  key: "TestFire-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 28505.7893
-  tps: 27950.82394
+  dps: 28267.77906
+  tps: 27783.25467
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 28582.80697
-  tps: 28016.41661
+  dps: 28372.85886
+  tps: 27884.39476
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 28582.80697
-  tps: 28016.41661
+  dps: 28372.85886
+  tps: 27884.39476
  }
 }
 dps_results: {
  key: "TestFire-Average-Default"
  value: {
-  dps: 31679.75592
-  tps: 31045.09315
+  dps: 31269.57088
+  tps: 30740.06791
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-p1_fire-Fire-fire-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 49887.714
-  tps: 51242.61325
+  dps: 49311.43593
+  tps: 52733.08974
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-p1_fire-Fire-fire-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 31036.2947
-  tps: 30397.21178
+  dps: 30918.93247
+  tps: 30372.46888
  }
 }
 dps_results: {
@@ -1474,7 +1474,7 @@ dps_results: {
 dps_results: {
  key: "TestFire-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 31036.2947
-  tps: 30397.21178
+  dps: 30918.93247
+  tps: 30372.46888
  }
 }

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -38,1458 +38,1458 @@ character_stats_results: {
 dps_results: {
  key: "TestRetribution-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 31536.88348
-  tps: 31550.40968
+  dps: 31348.39886
+  tps: 31362.86743
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 29518.60495
-  tps: 29528.49214
+  dps: 29649.36183
+  tps: 29661.13956
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 30600.19699
-  tps: 30613.72319
+  dps: 30430.32338
+  tps: 30444.79196
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 29596.7408
-  tps: 29610.267
+  dps: 29455.33371
+  tps: 29469.80229
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 29593.4181
-  tps: 29606.9443
+  dps: 29452.06409
+  tps: 29466.53267
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 31671.11248
-  tps: 31684.63868
+  dps: 31491.54252
+  tps: 31506.0111
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 31951.35763
-  tps: 31964.88383
+  dps: 31766.67714
+  tps: 31781.14572
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 31143.18945
-  tps: 31156.71564
+  dps: 30981.63005
+  tps: 30996.09863
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BattlearmorofImmolation"
  value: {
-  dps: 26995.87784
-  tps: 27002.47928
+  dps: 27043.61408
+  tps: 27056.02173
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BattleplateofImmolation"
  value: {
-  dps: 30282.36712
-  tps: 30273.09391
+  dps: 30038.82526
+  tps: 30026.31564
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BattleplateofRadiantGlory"
  value: {
-  dps: 31065.84565
-  tps: 31078.58358
+  dps: 31155.11997
+  tps: 31172.63556
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 29571.6446
-  tps: 29585.17079
-  hps: 125.74785
+  dps: 29429.35498
+  tps: 29443.82356
+  hps: 125.50841
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 29570.37183
-  tps: 29583.89803
+  dps: 29428.30457
+  tps: 29442.77315
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 30164.74102
-  tps: 30178.26722
+  dps: 29982.43478
+  tps: 29996.90335
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 30239.62253
-  tps: 30253.14872
+  dps: 30050.06018
+  tps: 30064.52876
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BindingPromise-67037"
  value: {
-  dps: 29570.37183
-  tps: 29583.89803
+  dps: 29428.30457
+  tps: 29442.77315
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 30293.75807
-  tps: 30307.28427
+  dps: 30118.39629
+  tps: 30132.86487
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 29977.24906
-  tps: 29990.77526
+  dps: 29831.27003
+  tps: 29845.73861
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 30030.5306
-  tps: 30044.0568
+  dps: 29884.03932
+  tps: 29898.5079
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 30172.41491
-  tps: 30185.94111
+  dps: 30007.06952
+  tps: 30021.5381
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 29624.59596
-  tps: 29638.12216
+  dps: 29483.38924
+  tps: 29497.85782
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 30988.1958
-  tps: 31001.72199
+  dps: 30828.19611
+  tps: 30842.66469
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 30050.99475
-  tps: 30064.52095
+  dps: 29874.47744
+  tps: 29888.94602
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 29570.37183
-  tps: 29583.89803
+  dps: 29428.30457
+  tps: 29442.77315
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 29570.37183
-  tps: 29583.89803
+  dps: 29428.30457
+  tps: 29442.77315
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 30032.44084
-  tps: 30045.96704
+  dps: 29844.06288
+  tps: 29858.53146
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 29633.80305
-  tps: 29647.32925
+  dps: 29493.3649
+  tps: 29507.83347
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 30540.52466
-  tps: 30554.05086
+  dps: 30402.72284
+  tps: 30417.19142
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BottledLightning-66879"
  value: {
-  dps: 29815.14964
-  tps: 29825.03684
+  dps: 29930.95644
+  tps: 29942.73417
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 31103.90185
-  tps: 30500.25688
+  dps: 30963.76537
+  tps: 30362.37338
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Brawler'sTrophy-71338"
  value: {
-  dps: 29570.37183
-  tps: 29583.89803
+  dps: 29428.30457
+  tps: 29442.77315
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 32181.62284
-  tps: 32195.14904
+  dps: 32012.54137
+  tps: 32027.00995
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 31412.12548
-  tps: 31425.92644
+  dps: 31268.1492
+  tps: 31281.34737
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 31544.55194
-  tps: 31558.07814
+  dps: 31357.31797
+  tps: 31371.78655
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Coren'sChilledChromiumCoaster-71335"
  value: {
-  dps: 30671.06237
-  tps: 30684.58857
+  dps: 30463.46671
+  tps: 30477.93529
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 29699.19479
-  tps: 29709.51648
+  dps: 29688.96903
+  tps: 29697.85984
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 29570.37183
-  tps: 29583.89803
+  dps: 29428.30457
+  tps: 29442.77315
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CrushingWeight-59506"
  value: {
-  dps: 30806.82202
-  tps: 30818.58413
+  dps: 30802.60818
+  tps: 30812.62748
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CrushingWeight-65118"
  value: {
-  dps: 30945.92643
-  tps: 30948.46846
+  dps: 31004.7049
+  tps: 31011.42385
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 29570.37183
-  tps: 29583.89803
+  dps: 29428.30457
+  tps: 29442.77315
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 30851.24898
-  tps: 30860.70157
+  dps: 30707.74962
+  tps: 30717.90638
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 30339.01066
-  tps: 30348.46326
+  dps: 30178.83834
+  tps: 30188.9951
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 29572.82312
-  tps: 29584.18887
+  dps: 29579.00738
+  tps: 29592.76704
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 30102.18844
-  tps: 30118.61127
+  dps: 30135.16689
+  tps: 30150.77326
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 30217.88442
-  tps: 30228.97719
+  dps: 30250.41675
+  tps: 30264.67128
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 31229.96905
-  tps: 31243.49524
+  dps: 31048.46683
+  tps: 31062.9354
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 29833.04142
-  tps: 29843.43292
+  dps: 30096.62952
+  tps: 30105.11449
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 31165.59652
-  tps: 31179.12272
+  dps: 30954.90603
+  tps: 30969.37461
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 31143.18945
-  tps: 31156.71564
+  dps: 30981.63005
+  tps: 30996.09863
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 29611.95863
-  tps: 29624.99181
+  dps: 29465.24968
+  tps: 29478.63342
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 31093.32417
-  tps: 31106.25801
+  dps: 31039.75054
+  tps: 31048.76424
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 31229.96905
-  tps: 31243.49524
+  dps: 31048.46683
+  tps: 31062.9354
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 30444.71882
-  tps: 30458.24501
+  dps: 30269.0428
+  tps: 30283.51137
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 30556.90335
-  tps: 30570.42955
+  dps: 30392.2245
+  tps: 30406.69307
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 31082.63615
-  tps: 31096.16235
+  dps: 30924.76199
+  tps: 30939.23056
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 31143.18945
-  tps: 31156.71564
+  dps: 30981.63005
+  tps: 30996.09863
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FallofMortality-59500"
  value: {
-  dps: 29572.82312
-  tps: 29584.18887
+  dps: 29579.00738
+  tps: 29592.76704
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FallofMortality-65124"
  value: {
-  dps: 29630.79429
-  tps: 29640.71487
+  dps: 29579.78429
+  tps: 29593.15682
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 29490.04698
-  tps: 29512.49959
+  dps: 29509.78645
+  tps: 29526.60292
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 30127.22377
-  tps: 30140.74997
+  dps: 29961.5347
+  tps: 29976.00328
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 29582.01377
-  tps: 29591.59921
+  dps: 29589.96314
+  tps: 29604.09659
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 29570.37183
-  tps: 29583.89803
+  dps: 29428.30457
+  tps: 29442.77315
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 29651.73928
-  tps: 29663.35114
+  dps: 29525.56253
+  tps: 29542.0056
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 31384.47609
-  tps: 31398.00228
+  dps: 31220.52854
+  tps: 31234.99711
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 31234.10674
-  tps: 31247.63293
+  dps: 31071.60601
+  tps: 31086.07459
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FluidDeath-58181"
  value: {
-  dps: 30086.95559
-  tps: 30100.48179
+  dps: 29904.43737
+  tps: 29918.90595
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 31103.90185
-  tps: 31117.70281
+  dps: 30963.76537
+  tps: 30976.96353
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 31306.92299
-  tps: 31320.44919
+  dps: 31109.2078
+  tps: 31123.67637
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GaleofShadows-56138"
  value: {
-  dps: 30009.79899
-  tps: 30018.77549
+  dps: 30083.79694
+  tps: 30089.09791
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GaleofShadows-56462"
  value: {
-  dps: 29817.51852
-  tps: 29826.35584
+  dps: 29853.50047
+  tps: 29862.83849
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GearDetector-61462"
  value: {
-  dps: 29909.57271
-  tps: 29923.91815
+  dps: 29960.0207
+  tps: 29973.03907
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Gladiator'sVindication"
  value: {
-  dps: 25500.00984
-  tps: 25518.30169
+  dps: 25620.59315
+  tps: 25635.23283
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 29529.22438
-  tps: 29536.79458
+  dps: 29630.70927
+  tps: 29644.58395
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 30005.89632
-  tps: 30019.42252
+  dps: 29860.87903
+  tps: 29875.3476
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 30211.29532
-  tps: 30224.82152
+  dps: 30041.31831
+  tps: 30055.78688
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HarmlightToken-63839"
  value: {
-  dps: 29556.27322
-  tps: 29568.86214
+  dps: 29594.34069
+  tps: 29610.59345
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 30693.61261
-  tps: 30707.1388
+  dps: 30552.61489
+  tps: 30567.08346
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 29835.16101
-  tps: 29843.68257
+  dps: 29664.23519
+  tps: 29670.51533
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 29858.11491
-  tps: 29868.36142
+  dps: 29678.45822
+  tps: 29685.93318
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HeartofRage-59224"
  value: {
-  dps: 30751.05899
-  tps: 30764.58519
+  dps: 30611.26572
+  tps: 30625.73429
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HeartofSolace-55868"
  value: {
-  dps: 29947.18581
-  tps: 29956.16231
+  dps: 30022.33909
+  tps: 30027.64007
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HeartofSolace-56393"
  value: {
-  dps: 30791.42718
-  tps: 30800.2645
+  dps: 30830.57812
+  tps: 30839.91614
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HeartofThunder-55845"
  value: {
-  dps: 29570.37183
-  tps: 29583.89803
+  dps: 29428.30457
+  tps: 29442.77315
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HeartofThunder-56370"
  value: {
-  dps: 29570.37183
-  tps: 29583.89803
+  dps: 29428.30457
+  tps: 29442.77315
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 30037.17998
-  tps: 30050.70618
+  dps: 29888.4792
+  tps: 29902.94777
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 31229.96905
-  tps: 31243.49524
+  dps: 31048.46683
+  tps: 31062.9354
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 31617.14526
-  tps: 31630.67145
+  dps: 31450.34217
+  tps: 31464.81075
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 29977.24906
-  tps: 29990.77526
+  dps: 29831.27003
+  tps: 29845.73861
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 30030.5306
-  tps: 30044.0568
+  dps: 29884.03932
+  tps: 29898.5079
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 29570.37183
-  tps: 29583.89803
+  dps: 29428.30457
+  tps: 29442.77315
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 29904.15802
-  tps: 29917.68422
+  dps: 29759.38621
+  tps: 29773.85478
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 29506.12059
-  tps: 29538.48761
+  dps: 29527.6223
+  tps: 29563.81464
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 29516.65301
-  tps: 29553.93553
+  dps: 29472.30803
+  tps: 29512.11261
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 30293.75807
-  tps: 30307.28427
+  dps: 30118.39629
+  tps: 30132.86487
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 29954.57402
-  tps: 29968.10022
+  dps: 29771.30475
+  tps: 29785.77332
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 30017.81785
-  tps: 30031.34405
+  dps: 29877.04497
+  tps: 29891.51355
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 30116.43027
-  tps: 30127.00231
+  dps: 30376.69381
+  tps: 30384.48529
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 30116.43027
-  tps: 30127.00231
+  dps: 30376.69381
+  tps: 30384.48529
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 29869.14795
-  tps: 29880.39389
+  dps: 29801.04113
+  tps: 29810.39151
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LastWord-50708"
  value: {
-  dps: 31967.44715
-  tps: 31980.97335
+  dps: 31799.22777
+  tps: 31813.69635
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LeadenDespair-55816"
  value: {
-  dps: 29570.37183
-  tps: 29583.89803
+  dps: 29428.30457
+  tps: 29442.77315
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LeadenDespair-56347"
  value: {
-  dps: 29570.37183
-  tps: 29583.89803
+  dps: 29428.30457
+  tps: 29442.77315
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 29901.05762
-  tps: 29914.58382
+  dps: 29741.35033
+  tps: 29755.81891
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 29941.10836
-  tps: 29954.63456
+  dps: 29753.82266
+  tps: 29768.29124
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 30708.00959
-  tps: 30721.53578
+  dps: 30561.44789
+  tps: 30575.91647
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 30304.47715
-  tps: 30318.00335
+  dps: 30154.40345
+  tps: 30168.87203
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 30543.48819
-  tps: 30557.01439
+  dps: 30390.80774
+  tps: 30405.27632
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 29570.37183
-  tps: 29583.89803
+  dps: 29428.30457
+  tps: 29442.77315
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 29570.37183
-  tps: 29583.89803
+  dps: 29428.30457
+  tps: 29442.77315
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 30980.14694
-  tps: 30993.67314
+  dps: 30824.68726
+  tps: 30839.15584
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 31166.85893
-  tps: 31180.38513
+  dps: 31009.61177
+  tps: 31024.08034
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 31191.46374
-  tps: 31204.98993
+  dps: 30987.37503
+  tps: 31001.84361
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 31397.24583
-  tps: 31410.77203
+  dps: 31177.95934
+  tps: 31192.42792
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 30092.78167
-  tps: 30106.30786
+  dps: 29945.0168
+  tps: 29959.48538
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 30543.48819
-  tps: 30557.01439
+  dps: 30390.80774
+  tps: 30405.27632
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 30088.65592
-  tps: 30102.18212
+  dps: 29941.60581
+  tps: 29956.07439
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 30088.65592
-  tps: 30102.18212
+  dps: 29941.60581
+  tps: 29956.07439
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MithrilStopwatch-71337"
  value: {
-  dps: 30214.34835
-  tps: 30227.87455
+  dps: 30027.72998
+  tps: 30042.19855
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 30770.97578
-  tps: 30780.76762
+  dps: 30661.64295
+  tps: 30675.53628
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 29570.37183
-  tps: 29583.89803
+  dps: 29428.30457
+  tps: 29442.77315
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 30251.49754
-  tps: 30263.06749
+  dps: 30331.73122
+  tps: 30341.07043
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 30331.72539
-  tps: 30343.37189
+  dps: 30229.30874
+  tps: 30241.08282
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 30627.18799
-  tps: 30640.71419
+  dps: 30444.84604
+  tps: 30459.31462
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PetrifiedPickledEgg-71336"
  value: {
-  dps: 29625.38291
-  tps: 29635.17475
+  dps: 29563.22249
+  tps: 29577.11581
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 29570.37183
-  tps: 29583.89803
+  dps: 29428.30457
+  tps: 29442.77315
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 29933.00296
-  tps: 29946.52916
+  dps: 29773.17924
+  tps: 29787.64782
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 29968.21222
-  tps: 29981.73842
+  dps: 29823.46393
+  tps: 29837.93251
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 30281.04069
-  tps: 30294.56689
+  dps: 30128.68602
+  tps: 30143.15459
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 31143.18945
-  tps: 31156.71564
+  dps: 30981.63005
+  tps: 30996.09863
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 30372.02042
-  tps: 30381.9533
+  dps: 30221.67062
+  tps: 30233.84117
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 30444.48358
-  tps: 30453.71118
+  dps: 30241.48631
+  tps: 30250.38715
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Rainsong-55854"
  value: {
-  dps: 29570.37183
-  tps: 29583.89803
+  dps: 29428.30457
+  tps: 29442.77315
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Rainsong-56377"
  value: {
-  dps: 29570.37183
-  tps: 29583.89803
+  dps: 29428.30457
+  tps: 29442.77315
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ReinforcedSapphiriumBattlearmor"
  value: {
-  dps: 26720.44634
-  tps: 26606.5359
+  dps: 26612.74073
+  tps: 26501.4215
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ReinforcedSapphiriumBattleplate"
  value: {
-  dps: 28704.92868
-  tps: 28716.64107
+  dps: 28598.33676
+  tps: 28612.63601
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 31617.14526
-  tps: 31630.67145
+  dps: 31450.34217
+  tps: 31464.81075
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 31452.37883
-  tps: 31465.90503
+  dps: 31286.24078
+  tps: 31300.70936
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 30744.67199
-  tps: 30758.19819
+  dps: 30550.90829
+  tps: 30565.37687
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 30341.02636
-  tps: 30354.55256
+  dps: 30180.88685
+  tps: 30195.35543
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 30417.73828
-  tps: 30431.26448
+  dps: 30278.70837
+  tps: 30293.17695
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-RuneofZeth-68998"
  value: {
-  dps: 30183.0699
-  tps: 30200.83408
+  dps: 30011.63314
+  tps: 30031.33465
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 30337.80576
-  tps: 30351.33195
+  dps: 30178.29479
+  tps: 30192.76337
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SeaStar-55256"
  value: {
-  dps: 29597.66226
-  tps: 29611.18846
+  dps: 29456.02811
+  tps: 29470.49668
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SeaStar-56290"
  value: {
-  dps: 29621.20695
-  tps: 29634.73315
+  dps: 29479.94645
+  tps: 29494.41502
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Shadowmourne-49623"
  value: {
-  dps: 33544.43612
-  tps: 33555.56053
+  dps: 33345.31541
+  tps: 33363.3801
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ShardofWoe-60233"
  value: {
-  dps: 29874.93776
-  tps: 29869.62601
+  dps: 30015.51919
+  tps: 30013.69432
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 30445.45768
-  tps: 30457.82325
+  dps: 30585.04926
+  tps: 30597.65622
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 29570.37183
-  tps: 29583.89803
+  dps: 29428.30457
+  tps: 29442.77315
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 30806.44106
-  tps: 30819.96726
+  dps: 30613.01379
+  tps: 30627.48237
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 30958.31894
-  tps: 30971.84514
+  dps: 30760.23378
+  tps: 30774.70236
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Sorrowsong-55879"
  value: {
-  dps: 30029.74822
-  tps: 30043.27442
+  dps: 29885.90704
+  tps: 29900.37561
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Sorrowsong-56400"
  value: {
-  dps: 30089.90465
-  tps: 30103.43085
+  dps: 29945.83117
+  tps: 29960.29974
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 30092.78167
-  tps: 30106.30786
+  dps: 29945.0168
+  tps: 29959.48538
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SoulCasket-58183"
  value: {
-  dps: 30157.3636
-  tps: 30170.88979
+  dps: 30011.40388
+  tps: 30025.87246
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 29737.33058
-  tps: 29745.65289
+  dps: 29770.50894
+  tps: 29784.88819
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-StumpofTime-62465"
  value: {
-  dps: 29649.56013
-  tps: 29663.08633
+  dps: 29502.73218
+  tps: 29517.20076
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-StumpofTime-62470"
  value: {
-  dps: 29646.83899
-  tps: 29660.36519
+  dps: 29505.61134
+  tps: 29520.07992
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 29570.37183
-  tps: 29583.89803
+  dps: 29428.30457
+  tps: 29442.77315
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 29570.37183
-  tps: 29583.89803
+  dps: 29428.30457
+  tps: 29442.77315
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 29852.84811
-  tps: 29865.26917
+  dps: 29842.40479
+  tps: 29855.15958
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 30494.34849
-  tps: 30503.93305
+  dps: 30695.60442
+  tps: 30707.84259
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TearofBlood-55819"
  value: {
-  dps: 29483.53134
-  tps: 29494.33964
+  dps: 29498.48119
+  tps: 29515.82817
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TearofBlood-56351"
  value: {
-  dps: 29600.15974
-  tps: 29611.7716
+  dps: 29473.98917
+  tps: 29490.43224
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 29940.43776
-  tps: 29953.96395
+  dps: 29797.13479
+  tps: 29811.60337
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 30064.91867
-  tps: 30078.44486
+  dps: 29918.17172
+  tps: 29932.6403
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TheHungerer-68927"
  value: {
-  dps: 30543.00189
-  tps: 30544.68738
+  dps: 30682.56475
+  tps: 30688.55513
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TheHungerer-69112"
  value: {
-  dps: 30667.35486
-  tps: 30674.203
+  dps: 30534.28303
+  tps: 30541.3582
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 29840.00147
-  tps: 29851.36723
+  dps: 29857.44411
+  tps: 29871.20377
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 29961.77984
-  tps: 29971.70042
+  dps: 29910.99647
+  tps: 29924.36901
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 29570.37183
-  tps: 29583.89803
+  dps: 29428.30457
+  tps: 29442.77315
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 29570.37183
-  tps: 29583.89803
+  dps: 29428.30457
+  tps: 29442.77315
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 30414.1648
-  tps: 30427.691
+  dps: 30235.25843
+  tps: 30249.72701
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 30513.79525
-  tps: 30527.32145
+  dps: 30326.18253
+  tps: 30340.65111
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 30580.29321
-  tps: 30592.9332
+  dps: 30499.82364
+  tps: 30513.57471
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 29736.08528
-  tps: 29762.84564
+  dps: 29639.62017
+  tps: 29667.87963
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-UnheededWarning-59520"
  value: {
-  dps: 30472.89763
-  tps: 30486.42383
+  dps: 30290.42649
+  tps: 30304.89507
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 29585.32465
-  tps: 29597.27811
+  dps: 29463.62101
+  tps: 29479.16821
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 30719.84563
-  tps: 30733.37183
+  dps: 30552.41016
+  tps: 30566.87874
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 30719.84563
-  tps: 30733.37183
+  dps: 30552.41016
+  tps: 30566.87874
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 30719.84563
-  tps: 30733.37183
+  dps: 30552.41016
+  tps: 30566.87874
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 16822.352
-  tps: 16809.15775
+  dps: 16780.3494
+  tps: 16770.2679
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 29860.16179
-  tps: 29871.2706
+  dps: 29882.91883
+  tps: 29892.65866
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 30172.17047
-  tps: 30182.83221
+  dps: 30113.8939
+  tps: 30126.55207
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 31448.477
-  tps: 31462.0032
+  dps: 31238.01099
+  tps: 31252.47957
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 31679.86743
-  tps: 31693.39363
+  dps: 31462.05584
+  tps: 31476.52442
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 29570.37183
-  tps: 29583.89803
+  dps: 29428.30457
+  tps: 29442.77315
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 29570.37183
-  tps: 29583.89803
+  dps: 29428.30457
+  tps: 29442.77315
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 30189.30519
-  tps: 30202.83139
+  dps: 30027.07055
+  tps: 30041.53913
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 29627.62823
-  tps: 29641.15443
+  dps: 29486.46963
+  tps: 29500.93821
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 31067.482
-  tps: 31081.0082
+  dps: 30906.47952
+  tps: 30920.9481
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 29570.37183
-  tps: 29583.89803
+  dps: 29428.30457
+  tps: 29442.77315
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 29866.48227
-  tps: 29878.37162
+  dps: 29753.06243
+  tps: 29769.05595
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 30130.87014
-  tps: 30144.39634
+  dps: 29943.70983
+  tps: 29958.17841
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 29570.37183
-  tps: 29583.89803
+  dps: 29428.30457
+  tps: 29442.77315
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 30119.33317
-  tps: 30132.85937
+  dps: 29971.98813
+  tps: 29986.45671
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 29570.37183
-  tps: 29583.89803
+  dps: 29428.30457
+  tps: 29442.77315
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 30005.99955
-  tps: 30019.52575
+  dps: 29841.53457
+  tps: 29856.00314
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 29612.54176
-  tps: 29626.06796
+  dps: 29471.38469
+  tps: 29485.85327
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 30597.69835
-  tps: 30611.22455
+  dps: 30446.00503
+  tps: 30460.4736
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 29667.29621
-  tps: 29681.93247
+  dps: 29653.90759
+  tps: 29674.32939
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 29810.26157
-  tps: 29825.25589
+  dps: 29811.60932
+  tps: 29826.87187
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 29923.96752
-  tps: 29937.49372
+  dps: 29778.50075
+  tps: 29792.96932
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 30125.59772
-  tps: 30139.12392
+  dps: 29974.67991
+  tps: 29989.14848
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 30125.59772
-  tps: 30139.12392
+  dps: 29974.67991
+  tps: 29989.14848
  }
 }
 dps_results: {
  key: "TestRetribution-Average-Default"
  value: {
-  dps: 31617.60384
-  tps: 31620.02798
+  dps: 31592.36908
+  tps: 31595.79639
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 31009.30138
-  tps: 35365.8963
+  dps: 30610.202
+  tps: 35060.81937
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26379.2591
-  tps: 26390.04124
+  dps: 26426.42809
+  tps: 26433.42968
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 35127.23418
-  tps: 34188.80385
+  dps: 35126.50994
+  tps: 34190.43781
  }
 }
 dps_results: {
@@ -1517,21 +1517,21 @@ dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Seal of Insight-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 25406.01002
-  tps: 31953.98921
+  tps: 32053.85631
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Seal of Insight-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 20469.07682
-  tps: 20595.14774
+  tps: 20600.82514
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Seal of Insight-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 27735.84007
-  tps: 26950.86669
+  tps: 26955.95726
  }
 }
 dps_results: {
@@ -1558,22 +1558,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Seal of Justice-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 26179.92242
-  tps: 30531.87855
+  dps: 25752.45838
+  tps: 30198.23616
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Seal of Justice-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 21536.07606
-  tps: 21547.93468
+  dps: 21572.85294
+  tps: 21581.27989
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Seal of Justice-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 29606.2214
-  tps: 28671.70975
+  dps: 29605.49716
+  tps: 28673.34371
  }
 }
 dps_results: {
@@ -1600,22 +1600,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Seal of Righteousness-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 79840.61878
-  tps: 84195.05864
+  dps: 79482.31615
+  tps: 83931.37505
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Seal of Righteousness-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 22986.9864
-  tps: 22998.84502
+  dps: 23024.22885
+  tps: 23032.65579
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Seal of Righteousness-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 31574.7122
-  tps: 30640.20055
+  dps: 31573.98796
+  tps: 30641.83451
  }
 }
 dps_results: {
@@ -1642,22 +1642,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Snapshot Guardian-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 31061.99785
-  tps: 35279.95657
+  dps: 30830.14771
+  tps: 35145.00118
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Snapshot Guardian-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26577.52686
-  tps: 26464.08304
+  dps: 26587.89725
+  tps: 26472.6116
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-preraid-Snapshot Guardian-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 36289.93845
-  tps: 34740.61224
+  dps: 36289.21421
+  tps: 34742.2314
  }
 }
 dps_results: {
@@ -1684,22 +1684,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 36671.97877
-  tps: 41036.43632
+  dps: 36428.28881
+  tps: 40883.11252
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 31617.14526
-  tps: 31630.67145
+  dps: 31450.34217
+  tps: 31464.81075
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 41369.53389
-  tps: 40439.83085
+  dps: 41358.79354
+  tps: 40431.12473
  }
 }
 dps_results: {
@@ -1727,21 +1727,21 @@ dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Seal of Insight-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 29995.84394
-  tps: 36581.07083
+  tps: 36687.97408
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Seal of Insight-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 24663.34436
-  tps: 24793.54343
+  tps: 24799.22528
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Seal of Insight-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 33336.4568
-  tps: 32563.915
+  tps: 32569.86036
  }
 }
 dps_results: {
@@ -1768,22 +1768,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Seal of Justice-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 30879.10554
-  tps: 35236.82132
+  dps: 30604.42505
+  tps: 35053.56386
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Seal of Justice-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26083.56919
-  tps: 26095.54221
+  dps: 25933.94742
+  tps: 25946.12335
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Seal of Justice-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 35102.28158
-  tps: 34164.10612
+  dps: 35096.85058
+  tps: 34160.70935
  }
 }
 dps_results: {
@@ -1810,22 +1810,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Seal of Righteousness-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 92298.79004
-  tps: 96658.84121
+  dps: 91989.33349
+  tps: 96440.5749
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Seal of Righteousness-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 27739.90847
-  tps: 27751.88149
+  dps: 27598.06079
+  tps: 27610.23672
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Seal of Righteousness-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 37354.65627
-  tps: 36416.48082
+  dps: 37348.07744
+  tps: 36411.93621
  }
 }
 dps_results: {
@@ -1852,22 +1852,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Snapshot Guardian-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 36933.04691
-  tps: 41130.04269
+  dps: 36658.08718
+  tps: 40926.34717
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Snapshot Guardian-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 31883.9992
-  tps: 31776.26698
+  dps: 31742.25984
+  tps: 31633.62728
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-BloodElf-t11_bis-Snapshot Guardian-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 42797.97488
-  tps: 41259.78681
+  dps: 42787.165
+  tps: 41251.01117
  }
 }
 dps_results: {
@@ -1894,22 +1894,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 30799.1439
-  tps: 35056.5174
+  dps: 30552.91043
+  tps: 34877.79158
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26564.42672
-  tps: 26567.54485
+  dps: 26428.88497
+  tps: 26433.25195
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 35139.16042
-  tps: 34191.32132
+  dps: 35146.17408
+  tps: 34200.46458
  }
 }
 dps_results: {
@@ -1937,21 +1937,21 @@ dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Seal of Insight-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 25415.70238
-  tps: 31943.72934
+  tps: 32043.77459
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Seal of Insight-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 20476.83859
-  tps: 20601.99926
+  tps: 20607.64518
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Seal of Insight-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 27745.37164
-  tps: 26958.63264
+  tps: 26963.54904
  }
 }
 dps_results: {
@@ -1978,22 +1978,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Seal of Justice-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 25969.22561
-  tps: 30221.6409
+  dps: 25588.72064
+  tps: 29909.32233
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Seal of Justice-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 21549.67119
-  tps: 21553.48945
+  dps: 21489.81039
+  tps: 21495.25331
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Seal of Justice-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 29614.41605
-  tps: 28670.49562
+  dps: 29621.42971
+  tps: 28679.63889
  }
 }
 dps_results: {
@@ -2020,22 +2020,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Seal of Righteousness-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 79630.97647
-  tps: 83887.48614
+  dps: 79316.67596
+  tps: 83639.83127
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Seal of Righteousness-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 23001.71028
-  tps: 23005.52853
+  dps: 22934.49846
+  tps: 22939.94138
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Seal of Righteousness-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 31583.44619
-  tps: 30639.52577
+  dps: 31590.45986
+  tps: 30648.66904
  }
 }
 dps_results: {
@@ -2062,22 +2062,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Snapshot Guardian-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 30962.74595
-  tps: 35084.73781
+  dps: 30890.75453
+  tps: 35079.66742
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Snapshot Guardian-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26697.92377
-  tps: 26576.30342
+  dps: 26661.19307
+  tps: 26544.60989
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-preraid-Snapshot Guardian-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 36302.39323
-  tps: 34743.65841
+  dps: 36309.4069
+  tps: 34752.78669
  }
 }
 dps_results: {
@@ -2104,22 +2104,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 36598.76925
-  tps: 40877.16246
+  dps: 36113.78781
+  tps: 40431.48387
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 31882.8775
-  tps: 31886.29668
+  dps: 31556.2423
+  tps: 31565.72244
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 41355.60175
-  tps: 40418.35096
+  dps: 41379.78374
+  tps: 40444.34563
  }
 }
 dps_results: {
@@ -2147,21 +2147,21 @@ dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Seal of Insight-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 30006.50566
-  tps: 36576.88088
+  tps: 36683.21308
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Seal of Insight-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 24671.94542
-  tps: 24801.26776
+  tps: 24806.77634
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Seal of Insight-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 33347.02014
-  tps: 32573.81728
+  tps: 32578.93861
  }
 }
 dps_results: {
@@ -2188,22 +2188,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Seal of Justice-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 30710.0161
-  tps: 34981.65001
+  dps: 30394.31005
+  tps: 34705.71448
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Seal of Justice-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26126.305
-  tps: 26127.40067
+  dps: 26033.19723
+  tps: 26040.76558
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Seal of Justice-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 35121.30881
-  tps: 34175.5856
+  dps: 35110.11591
+  tps: 34166.20538
  }
 }
 dps_results: {
@@ -2230,22 +2230,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Seal of Righteousness-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 92172.24327
-  tps: 96446.05456
+  dps: 91702.38169
+  tps: 96015.93322
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Seal of Righteousness-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 27786.16398
-  tps: 27787.25965
+  dps: 27699.71243
+  tps: 27707.28078
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Seal of Righteousness-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 37373.03868
-  tps: 36427.31548
+  dps: 37363.05656
+  tps: 36419.14603
  }
 }
 dps_results: {
@@ -2272,22 +2272,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Snapshot Guardian-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 37025.1238
-  tps: 41113.66044
+  dps: 36490.66417
+  tps: 40636.22147
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Snapshot Guardian-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 32219.76878
-  tps: 32098.20543
+  dps: 31842.52532
+  tps: 31729.79263
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Draenei-t11_bis-Snapshot Guardian-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 42788.74239
-  tps: 41243.00658
+  dps: 42808.87767
+  tps: 41264.95454
  }
 }
 dps_results: {
@@ -2314,22 +2314,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 30835.94493
-  tps: 35095.40902
+  dps: 30564.73928
+  tps: 34889.63466
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26574.38616
-  tps: 26577.50465
+  dps: 26467.8446
+  tps: 26472.16325
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 35152.25492
-  tps: 34204.41799
+  dps: 35159.27157
+  tps: 34213.56338
  }
 }
 dps_results: {
@@ -2357,21 +2357,21 @@ dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Seal of Insight-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 25426.13058
-  tps: 31954.24742
+  tps: 32054.2648
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Seal of Insight-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 20484.8375
-  tps: 20610.00322
+  tps: 20615.64736
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Seal of Insight-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 27755.15682
-  tps: 26968.4215
+  tps: 26973.33684
  }
 }
 dps_results: {
@@ -2398,22 +2398,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Seal of Justice-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 26016.7334
-  tps: 30271.12235
+  dps: 25596.65519
+  tps: 29917.27111
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Seal of Justice-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 21557.90717
-  tps: 21561.72578
+  dps: 21494.51748
+  tps: 21499.91207
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Seal of Justice-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 29625.04254
-  tps: 28681.12429
+  dps: 29632.05919
+  tps: 28690.26968
  }
 }
 dps_results: {
@@ -2440,22 +2440,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Seal of Righteousness-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 79671.97718
-  tps: 83930.55399
+  dps: 79348.37431
+  tps: 83671.54385
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Seal of Righteousness-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 23009.87108
-  tps: 23013.68969
+  dps: 22938.72594
+  tps: 22944.12054
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Seal of Righteousness-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 31594.94055
-  tps: 30651.02231
+  dps: 31601.9572
+  tps: 30660.16769
  }
 }
 dps_results: {
@@ -2482,22 +2482,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Snapshot Guardian-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 31000.42365
-  tps: 35124.46696
+  dps: 30874.26288
+  tps: 35064.17964
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Snapshot Guardian-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26708.17797
-  tps: 26586.55798
+  dps: 26702.85023
+  tps: 26586.21842
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-preraid-Snapshot Guardian-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 36315.99801
-  tps: 34757.26541
+  dps: 36323.01466
+  tps: 34766.39576
  }
 }
 dps_results: {
@@ -2524,22 +2524,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 36539.9391
-  tps: 40819.509
+  dps: 36122.95042
+  tps: 40429.92162
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 31894.95298
-  tps: 31898.37283
+  dps: 31568.1952
+  tps: 31577.67582
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 41369.75598
-  tps: 40432.50842
+  dps: 41393.9481
+  tps: 40458.51125
  }
 }
 dps_results: {
@@ -2567,21 +2567,21 @@ dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Seal of Insight-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 30017.95599
-  tps: 36588.41752
+  tps: 36694.72814
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Seal of Insight-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 24680.79337
-  tps: 24810.12152
+  tps: 24815.62745
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Seal of Insight-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 33357.84491
-  tps: 32584.64683
+  tps: 32589.7666
  }
 }
 dps_results: {
@@ -2608,22 +2608,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Seal of Justice-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 30656.99
-  tps: 34929.87219
+  dps: 30343.96243
+  tps: 34644.642
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Seal of Justice-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26135.82467
-  tps: 26136.92102
+  dps: 26042.6759
+  tps: 26050.24472
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Seal of Justice-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 35132.8732
-  tps: 34187.15322
+  dps: 35121.67612
+  tps: 34177.76686
  }
 }
 dps_results: {
@@ -2650,22 +2650,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Seal of Righteousness-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 92157.61609
-  tps: 96432.74086
+  dps: 91724.50348
+  tps: 96027.33016
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Seal of Righteousness-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 27796.43774
-  tps: 27797.53408
+  dps: 27709.94823
+  tps: 27717.51705
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Seal of Righteousness-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 37385.51517
-  tps: 36439.79519
+  dps: 37375.52956
+  tps: 36431.6203
  }
 }
 dps_results: {
@@ -2692,22 +2692,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Snapshot Guardian-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 36902.49113
-  tps: 40989.81673
+  dps: 36486.58817
+  tps: 40620.43791
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Snapshot Guardian-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 32231.98598
-  tps: 32110.42395
+  dps: 31854.60414
+  tps: 31741.87157
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Dwarf-t11_bis-Snapshot Guardian-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 42803.53023
-  tps: 41257.79764
+  dps: 42823.67505
+  tps: 41279.75318
  }
 }
 dps_results: {
@@ -2734,22 +2734,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 30796.62012
-  tps: 35053.99362
+  dps: 30550.42775
+  tps: 34875.3089
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26562.51462
-  tps: 26565.63276
+  dps: 26428.27057
+  tps: 26432.63754
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 35135.83129
-  tps: 34187.99219
+  dps: 35142.84426
+  tps: 34197.13476
  }
 }
 dps_results: {
@@ -2777,21 +2777,21 @@ dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Seal of Insight-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 25413.02554
-  tps: 31941.0525
+  tps: 32041.09776
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Seal of Insight-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 20474.80922
-  tps: 20599.96989
+  tps: 20605.61581
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Seal of Insight-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 27742.89364
-  tps: 26956.15464
+  tps: 26961.07104
  }
 }
 dps_results: {
@@ -2818,22 +2818,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Seal of Justice-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 25966.49237
-  tps: 30218.90766
+  dps: 25586.03643
+  tps: 29906.63812
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Seal of Justice-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 21547.50149
-  tps: 21551.31975
+  dps: 21487.64867
+  tps: 21493.09159
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Seal of Justice-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 29611.726
-  tps: 28667.80557
+  dps: 29618.73897
+  tps: 28676.94815
  }
 }
 dps_results: {
@@ -2860,22 +2860,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Seal of Righteousness-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 79632.11289
-  tps: 83888.62256
+  dps: 79317.82233
+  tps: 83640.97764
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Seal of Righteousness-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 22999.32653
-  tps: 23003.14478
+  dps: 22932.1236
+  tps: 22937.56652
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Seal of Righteousness-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 31580.49811
-  tps: 30636.57769
+  dps: 31587.51108
+  tps: 30645.72026
  }
 }
 dps_results: {
@@ -2902,22 +2902,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Snapshot Guardian-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 30960.35179
-  tps: 35082.34365
+  dps: 30888.23366
+  tps: 35077.14656
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Snapshot Guardian-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26695.9943
-  tps: 26574.37394
+  dps: 26659.26607
+  tps: 26542.68289
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-preraid-Snapshot Guardian-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 36298.93882
-  tps: 34740.20399
+  dps: 36305.95179
+  tps: 34749.33158
  }
 }
 dps_results: {
@@ -2944,22 +2944,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 36606.89731
-  tps: 40885.29052
+  dps: 36111.48203
+  tps: 40429.17809
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 31881.05282
-  tps: 31884.47199
+  dps: 31554.23986
+  tps: 31563.72001
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 41352.00571
-  tps: 40414.75492
+  dps: 41376.18504
+  tps: 40440.74694
  }
 }
 dps_results: {
@@ -2987,21 +2987,21 @@ dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Seal of Insight-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 30003.60471
-  tps: 36573.97994
+  tps: 36680.31213
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Seal of Insight-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 24669.70257
-  tps: 24799.02492
+  tps: 24804.53349
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Seal of Insight-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 33344.28127
-  tps: 32571.07841
+  tps: 32576.19973
  }
 }
 dps_results: {
@@ -3028,22 +3028,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Seal of Justice-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 30714.52948
-  tps: 34986.16339
+  dps: 30398.63667
+  tps: 34710.0411
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Seal of Justice-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26130.87962
-  tps: 26131.97529
+  dps: 26037.62141
+  tps: 26045.18976
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Seal of Justice-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 35118.38375
-  tps: 34172.66054
+  dps: 35107.19183
+  tps: 34163.2813
  }
 }
 dps_results: {
@@ -3070,22 +3070,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Seal of Righteousness-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 92176.05861
-  tps: 96449.86989
+  dps: 91706.29837
+  tps: 96019.8499
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Seal of Righteousness-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 27790.76834
-  tps: 27791.86401
+  dps: 27704.16546
+  tps: 27711.73381
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Seal of Righteousness-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 37369.84227
-  tps: 36424.11906
+  dps: 37359.86092
+  tps: 36415.9504
  }
 }
 dps_results: {
@@ -3112,22 +3112,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Snapshot Guardian-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 37022.70188
-  tps: 41111.23852
+  dps: 36488.31723
+  tps: 40633.87453
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Snapshot Guardian-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 32217.92067
-  tps: 32096.35733
+  dps: 31840.48092
+  tps: 31727.74823
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Human-t11_bis-Snapshot Guardian-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 42784.99044
-  tps: 41239.25463
+  dps: 42805.12321
+  tps: 41261.20008
  }
 }
 dps_results: {
@@ -3154,22 +3154,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 30847.3533
-  tps: 35070.28006
+  dps: 30483.44995
+  tps: 34796.5521
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26573.73061
-  tps: 26576.85015
+  dps: 26510.5114
+  tps: 26515.17264
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 35151.58889
-  tps: 34203.7585
+  dps: 35158.60618
+  tps: 34212.90193
  }
 }
 dps_results: {
@@ -3197,21 +3197,21 @@ dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Seal of Insight-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 25425.20259
-  tps: 31953.58907
+  tps: 32053.52282
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Seal of Insight-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 20484.48179
-  tps: 20609.66265
+  tps: 20615.30144
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Seal of Insight-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 27754.77639
-  tps: 26968.0521
+  tps: 26972.96424
  }
 }
 dps_results: {
@@ -3238,22 +3238,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Seal of Justice-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 26013.83013
-  tps: 30231.94449
+  dps: 25568.35537
+  tps: 29876.89321
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Seal of Justice-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 21557.54517
-  tps: 21561.36484
+  dps: 21475.77369
+  tps: 21481.44994
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Seal of Justice-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 29624.64139
-  tps: 28680.72967
+  dps: 29631.65867
+  tps: 28689.8731
  }
 }
 dps_results: {
@@ -3280,22 +3280,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Seal of Righteousness-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 79688.39988
-  tps: 83909.2584
+  dps: 79297.24018
+  tps: 83608.49941
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Seal of Righteousness-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 23009.07945
-  tps: 23012.89912
+  dps: 22923.17307
+  tps: 22928.84932
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Seal of Righteousness-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 31594.04662
-  tps: 30650.13491
+  dps: 31601.0639
+  tps: 30659.27833
  }
 }
 dps_results: {
@@ -3322,22 +3322,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Snapshot Guardian-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 31034.77601
-  tps: 35132.07898
+  dps: 30781.58495
+  tps: 34975.40564
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Snapshot Guardian-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26707.52979
-  tps: 26585.91089
+  dps: 26759.92229
+  tps: 26642.08715
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-preraid-Snapshot Guardian-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 36315.35939
-  tps: 34756.63348
+  dps: 36322.37668
+  tps: 34765.76167
  }
 }
 dps_results: {
@@ -3364,22 +3364,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 36498.61153
-  tps: 40799.9089
+  dps: 36122.03703
+  tps: 40429.06367
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 31910.4613
-  tps: 31912.04886
+  dps: 31567.51191
+  tps: 31576.99394
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 41369.06627
-  tps: 40431.8284
+  dps: 41393.25683
+  tps: 40457.82376
  }
 }
 dps_results: {
@@ -3407,21 +3407,21 @@ dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Seal of Insight-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 30016.89691
-  tps: 36587.61737
+  tps: 36693.86326
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Seal of Insight-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 24677.9163
-  tps: 24807.26185
+  tps: 24812.75986
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Seal of Insight-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 33357.45276
-  tps: 32584.26902
+  tps: 32589.38409
  }
 }
 dps_results: {
@@ -3448,22 +3448,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Seal of Justice-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 30645.66618
-  tps: 34940.21155
+  dps: 30343.34299
+  tps: 34644.07801
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Seal of Justice-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26121.96352
-  tps: 26121.21567
+  dps: 26042.29732
+  tps: 26049.86755
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Seal of Justice-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 35132.46562
-  tps: 34186.75533
+  dps: 35121.26779
+  tps: 34177.3623
  }
 }
 dps_results: {
@@ -3490,22 +3490,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Seal of Righteousness-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 92089.54173
-  tps: 96386.25336
+  dps: 91714.8791
+  tps: 96017.76122
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Seal of Righteousness-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 27783.37551
-  tps: 27782.62767
+  dps: 27709.11306
+  tps: 27716.68328
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Seal of Righteousness-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 37384.58762
-  tps: 36438.87733
+  dps: 37374.60097
+  tps: 36430.69548
  }
 }
 dps_results: {
@@ -3532,22 +3532,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Snapshot Guardian-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 36863.8138
-  tps: 40973.61797
+  dps: 36482.94752
+  tps: 40616.83459
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Snapshot Guardian-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 32235.42859
-  tps: 32112.21859
+  dps: 31853.68963
+  tps: 31740.95739
  }
 }
 dps_results: {
  key: "TestRetribution-Settings-Tauren-t11_bis-Snapshot Guardian-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 42802.8704
-  tps: 41257.1475
+  dps: 42823.01366
+  tps: 41279.09557
  }
 }
 dps_results: {
@@ -3574,7 +3574,7 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 29000.99572
-  tps: 29028.64758
+  dps: 29164.2182
+  tps: 29193.49362
  }
 }

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -39,63 +39,63 @@ dps_results: {
  key: "TestShadow-AllItems-AgileShadowspiritDiamond"
  value: {
   dps: 29580.54306
-  tps: 27407.7363
+  tps: 27430.82451
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Althor'sAbacus-50366"
  value: {
   dps: 28332.8225
-  tps: 26348.64804
+  tps: 26382.73499
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-AncientPetrifiedSeed-69001"
  value: {
   dps: 28439.89878
-  tps: 26500.80274
+  tps: 26531.54923
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Anhuur'sHymnal-55889"
  value: {
   dps: 28349.73723
-  tps: 26338.64534
+  tps: 26372.10364
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Anhuur'sHymnal-56407"
  value: {
   dps: 28426.67596
-  tps: 26400.55102
+  tps: 26434.00932
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-AustereShadowspiritDiamond"
  value: {
   dps: 29108.56212
-  tps: 26945.85599
+  tps: 26968.9442
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BaubleofTrueBlood-50726"
  value: {
   dps: 27674.39881
-  tps: 25730.48016
+  tps: 25763.86546
   hps: 97.44006
  }
 }
@@ -103,1497 +103,1497 @@ dps_results: {
  key: "TestShadow-AllItems-BedrockTalisman-58182"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BellofEnragingResonance-59326"
  value: {
   dps: 29439.56728
-  tps: 27253.25526
+  tps: 27279.05676
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BindingPromise-67037"
  value: {
   dps: 27666.83157
-  tps: 25732.19464
+  tps: 25765.61947
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Blood-SoakedAleMug-63843"
  value: {
   dps: 28036.84273
-  tps: 26115.52362
+  tps: 26142.47677
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodofIsiset-55995"
  value: {
   dps: 28062.60592
-  tps: 26124.13294
+  tps: 26157.59124
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodofIsiset-56414"
  value: {
   dps: 28221.41959
-  tps: 26282.94661
+  tps: 26316.40491
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
   dps: 27655.86616
-  tps: 25740.8457
+  tps: 25767.65505
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
   dps: 28586.09095
-  tps: 26535.03635
+  tps: 26562.55132
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
   dps: 27644.49197
-  tps: 25716.95592
+  tps: 25744.47089
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
   dps: 28210.91408
-  tps: 26174.4329
+  tps: 26200.87799
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
   dps: 27658.97731
-  tps: 25732.19464
+  tps: 25765.61947
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
   dps: 27658.97731
-  tps: 25732.19464
+  tps: 25765.61947
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
   dps: 27680.70677
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
   dps: 28626.22607
-  tps: 26585.29555
+  tps: 26618.75385
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
   dps: 27679.10906
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BottledLightning-66879"
  value: {
   dps: 28517.39435
-  tps: 26455.74961
+  tps: 26484.6879
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BracingShadowspiritDiamond"
  value: {
   dps: 29341.04131
-  tps: 26628.85484
+  tps: 26652.98479
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Brawler'sTrophy-71338"
  value: {
   dps: 27666.83157
-  tps: 25732.19464
+  tps: 25765.61947
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BurningShadowspiritDiamond"
  value: {
   dps: 29821.45061
-  tps: 27627.87342
+  tps: 27652.00338
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ChaoticShadowspiritDiamond"
  value: {
   dps: 29676.31453
-  tps: 27489.47406
+  tps: 27513.93302
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Coren'sChilledChromiumCoaster-71335"
  value: {
   dps: 28242.75253
-  tps: 26211.89941
+  tps: 26237.54815
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CoreofRipeness-58184"
  value: {
   dps: 28860.27214
-  tps: 26814.43127
+  tps: 26848.13235
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CorpseTongueCoin-50349"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CrimsonAcolyte'sRaiment"
  value: {
-  dps: 21872.46657
-  tps: 20613.16299
+  dps: 21719.81567
+  tps: 20512.35657
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CrimsonAcolyte'sRegalia"
  value: {
-  dps: 23621.1793
-  tps: 22315.15053
+  dps: 23434.73851
+  tps: 22161.86255
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CrushingWeight-59506"
  value: {
   dps: 27874.83893
-  tps: 25930.36671
+  tps: 25959.91098
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CrushingWeight-65118"
  value: {
   dps: 27887.55934
-  tps: 25942.11553
+  tps: 25974.11096
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
   dps: 27658.97731
-  tps: 25732.19464
+  tps: 25765.61947
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
   dps: 28838.50928
-  tps: 26769.3011
+  tps: 26799.49962
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Deathbringer'sWill-50363"
  value: {
   dps: 27970.60884
-  tps: 25937.49903
+  tps: 25967.33
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DestructiveShadowspiritDiamond"
  value: {
   dps: 29197.23912
-  tps: 27020.75916
+  tps: 27045.21812
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DislodgedForeignObject-50348"
  value: {
   dps: 28604.52035
-  tps: 26640.28207
+  tps: 26669.06138
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Dwyer'sCaber-70141"
  value: {
   dps: 28278.75972
-  tps: 26169.98291
+  tps: 26197.04332
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EffulgentShadowspiritDiamond"
  value: {
   dps: 29108.56212
-  tps: 26945.85599
+  tps: 26968.9442
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ElectrosparkHeartstarter-67118"
  value: {
   dps: 28120.79973
-  tps: 26149.00376
+  tps: 26172.59114
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EmberShadowspiritDiamond"
  value: {
   dps: 29341.04131
-  tps: 27166.79748
+  tps: 27190.30876
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EnigmaticShadowspiritDiamond"
  value: {
   dps: 29197.23912
-  tps: 27020.75916
+  tps: 27045.21812
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EssenceoftheCyclone-59473"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EssenceoftheCyclone-65140"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EssenceoftheEternalFlame-69002"
  value: {
   dps: 28439.89878
-  tps: 26500.80274
+  tps: 26531.54923
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EternalShadowspiritDiamond"
  value: {
   dps: 29108.56212
-  tps: 26945.85599
+  tps: 26968.9442
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FallofMortality-59500"
  value: {
   dps: 28838.50928
-  tps: 26769.3011
+  tps: 26799.49962
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FallofMortality-65124"
  value: {
   dps: 28977.66116
-  tps: 26894.42855
+  tps: 26924.2696
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FieryQuintessence-69000"
  value: {
   dps: 28970.30558
-  tps: 26950.94834
+  tps: 26974.31848
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Figurine-DemonPanther-52199"
  value: {
   dps: 27644.49197
-  tps: 25716.95592
+  tps: 25744.47089
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Figurine-DreamOwl-52354"
  value: {
   dps: 28752.93939
-  tps: 26711.1422
+  tps: 26744.23981
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Figurine-EarthenGuardian-52352"
  value: {
   dps: 27666.83157
-  tps: 25732.19464
+  tps: 25765.61947
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Figurine-JeweledSerpent-52353"
  value: {
   dps: 29647.47151
-  tps: 27481.94338
+  tps: 27515.04099
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Figurine-KingofBoars-52351"
  value: {
   dps: 28178.06266
-  tps: 26250.52661
+  tps: 26278.04158
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FleetShadowspiritDiamond"
  value: {
   dps: 29285.18243
-  tps: 27122.4763
+  tps: 27145.56451
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FluidDeath-58181"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForlornShadowspiritDiamond"
  value: {
   dps: 29341.04131
-  tps: 27157.60982
+  tps: 27181.73978
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FuryofAngerforge-59461"
  value: {
   dps: 28232.35588
-  tps: 26186.82889
+  tps: 26212.63039
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GaleofShadows-56138"
  value: {
   dps: 28980.47045
-  tps: 27020.19728
+  tps: 27049.2726
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GaleofShadows-56462"
  value: {
   dps: 29069.97548
-  tps: 27081.86339
+  tps: 27111.58715
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GearDetector-61462"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Gladiator'sInvestiture"
  value: {
-  dps: 23655.57424
-  tps: 22218.59122
+  dps: 23661.84075
+  tps: 22257.0657
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Gladiator'sRaiment"
  value: {
   dps: 27118.76706
-  tps: 25378.97317
+  tps: 25411.16447
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GlowingTwilightScale-54589"
  value: {
   dps: 28367.25863
-  tps: 26348.04374
+  tps: 26382.04607
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GraceoftheHerald-55266"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GraceoftheHerald-56295"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-HarmlightToken-63839"
  value: {
   dps: 28426.10297
-  tps: 26423.67765
+  tps: 26452.30646
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-HeartofIgnacious-59514"
  value: {
   dps: 29154.26596
-  tps: 27147.71625
+  tps: 27171.89014
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-HeartofIgnacious-65110"
  value: {
   dps: 29445.12675
-  tps: 27373.42852
+  tps: 27401.6985
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-HeartofRage-59224"
  value: {
   dps: 27688.4446
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-HeartofRage-65072"
  value: {
   dps: 27687.84273
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-HeartofSolace-55868"
  value: {
   dps: 28249.55807
-  tps: 26312.19794
+  tps: 26341.27326
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-HeartofSolace-56393"
  value: {
   dps: 28235.30697
-  tps: 26281.63538
+  tps: 26311.35914
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-HeartofThunder-55845"
  value: {
   dps: 27674.92902
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-HeartofThunder-56370"
  value: {
   dps: 27674.92902
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-HeartoftheVile-66969"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Heartpierce-50641"
  value: {
   dps: 29821.45061
-  tps: 27627.87342
+  tps: 27652.00338
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpassiveShadowspiritDiamond"
  value: {
   dps: 29197.23912
-  tps: 27020.75916
+  tps: 27045.21812
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpatienceofYouth-62464"
  value: {
   dps: 28197.09087
-  tps: 26269.55482
+  tps: 26297.06978
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpatienceofYouth-62469"
  value: {
   dps: 28197.09087
-  tps: 26269.55482
+  tps: 26297.06978
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpetuousQuery-55881"
  value: {
   dps: 28048.6261
-  tps: 26124.13294
+  tps: 26157.59124
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpetuousQuery-56406"
  value: {
   dps: 28207.43977
-  tps: 26282.94661
+  tps: 26316.40491
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-InsigniaofDiplomacy-61433"
  value: {
   dps: 27674.92902
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
   dps: 28661.52265
-  tps: 26663.45557
+  tps: 26690.40872
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-JarofAncientRemedies-59354"
  value: {
   dps: 27675.98187
-  tps: 25744.775
+  tps: 25778.14957
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-JarofAncientRemedies-65029"
  value: {
   dps: 27675.98187
-  tps: 25746.11145
+  tps: 25779.5882
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-JujuofNimbleness-63840"
  value: {
   dps: 28036.84273
-  tps: 26115.52362
+  tps: 26142.47677
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-KeytotheEndlessChamber-55795"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-KeytotheEndlessChamber-56328"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-KvaldirBattleStandard-59685"
  value: {
   dps: 28096.04895
-  tps: 26174.60894
+  tps: 26199.91819
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-KvaldirBattleStandard-59689"
  value: {
   dps: 28096.04895
-  tps: 26174.60894
+  tps: 26199.91819
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
   dps: 28067.4369
-  tps: 26101.04881
+  tps: 26127.86365
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-LastWord-50708"
  value: {
   dps: 29821.45061
-  tps: 27627.87342
+  tps: 27652.00338
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-LeadenDespair-55816"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-LeadenDespair-56347"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-LeftEyeofRajh-56102"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-LeftEyeofRajh-56427"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-LicensetoSlay-58180"
  value: {
   dps: 27673.8049
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MagnetiteMirror-55814"
  value: {
   dps: 27660.81044
-  tps: 25739.49132
+  tps: 25766.44448
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MagnetiteMirror-56345"
  value: {
   dps: 27660.81044
-  tps: 25739.49132
+  tps: 25766.44448
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MandalaofStirringPatterns-62467"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MandalaofStirringPatterns-62472"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MarkofKhardros-56132"
  value: {
   dps: 28171.06634
-  tps: 26249.74723
+  tps: 26276.70038
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MarkofKhardros-56458"
  value: {
   dps: 28219.73308
-  tps: 26298.41397
+  tps: 26325.36712
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MatrixRestabilizer-68994"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MatrixRestabilizer-69150"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MercurialRegalia"
  value: {
-  dps: 26685.0059
-  tps: 24802.36355
+  dps: 26695.15314
+  tps: 24830.63636
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MightoftheOcean-55251"
  value: {
   dps: 27660.81044
-  tps: 25739.49132
+  tps: 25766.44448
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MightoftheOcean-56285"
  value: {
   dps: 27660.81044
-  tps: 25739.49132
+  tps: 25766.44448
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MirrorofBrokenImages-62466"
  value: {
   dps: 28226.34315
-  tps: 26301.84999
+  tps: 26335.30829
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MirrorofBrokenImages-62471"
  value: {
   dps: 28226.34315
-  tps: 26301.84999
+  tps: 26335.30829
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MithrilStopwatch-71337"
  value: {
   dps: 29600.70591
-  tps: 27408.63694
+  tps: 27434.28568
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MoonwellChalice-70142"
  value: {
   dps: 29608.65889
-  tps: 27552.88207
+  tps: 27586.09941
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MoonwellPhial-70143"
  value: {
   dps: 27666.83157
-  tps: 25732.19464
+  tps: 25765.61947
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-NecromanticFocus-68982"
  value: {
   dps: 29731.1752
-  tps: 27690.49117
+  tps: 27720.29578
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-NecromanticFocus-69139"
  value: {
   dps: 29907.2383
-  tps: 27849.97625
+  tps: 27879.31209
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Oremantle'sFavor-61448"
  value: {
   dps: 28050.41244
-  tps: 26033.91637
+  tps: 26062.10112
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PetrifiedPickledEgg-71336"
  value: {
   dps: 28902.20012
-  tps: 26827.56629
+  tps: 26857.53721
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PetrifiedTwilightScale-54591"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
   dps: 28732.616
-  tps: 26614.33941
+  tps: 26644.47234
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PorcelainCrab-55237"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PorcelainCrab-56280"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PowerfulShadowspiritDiamond"
  value: {
   dps: 29108.56212
-  tps: 26945.85599
+  tps: 26968.9442
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Rainsong-55854"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Rainsong-56377"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RegaliaoftheCleansingFlame"
  value: {
   dps: 29242.81427
-  tps: 26817.12625
+  tps: 26847.74389
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ReverberatingShadowspiritDiamond"
  value: {
   dps: 29580.54306
-  tps: 27407.7363
+  tps: 27430.82451
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RevitalizingShadowspiritDiamond"
  value: {
   dps: 29580.54306
-  tps: 27407.7363
+  tps: 27430.82451
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Ricket'sMagneticFireball-70144"
  value: {
   dps: 28305.59605
-  tps: 26210.81747
+  tps: 26236.93316
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RightEyeofRajh-56100"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RightEyeofRajh-56431"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RuneofZeth-68998"
  value: {
   dps: 29590.78472
-  tps: 27383.94578
+  tps: 27406.24536
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SeaStar-55256"
  value: {
   dps: 28118.38883
-  tps: 26128.68719
+  tps: 26156.20216
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SeaStar-56290"
  value: {
   dps: 28527.24102
-  tps: 26483.90632
+  tps: 26511.42129
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ShardofWoe-60233"
  value: {
   dps: 28210.51168
-  tps: 26258.50138
+  tps: 26282.24255
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Shrine-CleansingPurifier-63838"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
   dps: 27675.28058
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Skardyn'sGrace-56115"
  value: {
   dps: 28128.92213
-  tps: 26201.38608
+  tps: 26228.90105
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Skardyn'sGrace-56440"
  value: {
   dps: 28175.82937
-  tps: 26248.29332
+  tps: 26275.80829
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Sorrowsong-55879"
  value: {
   dps: 28789.52401
-  tps: 26792.31478
+  tps: 26825.77308
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Sorrowsong-56400"
  value: {
   dps: 29048.68415
-  tps: 27043.1406
+  tps: 27076.5989
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Soul'sAnguish-66994"
  value: {
   dps: 27660.81044
-  tps: 25739.49132
+  tps: 25766.44448
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SoulCasket-58183"
  value: {
   dps: 29412.31149
-  tps: 27328.26443
+  tps: 27355.7794
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Stonemother'sKiss-61411"
  value: {
   dps: 28677.34503
-  tps: 26624.83839
+  tps: 26655.76146
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-StumpofTime-62465"
  value: {
   dps: 28761.36555
-  tps: 26711.91052
+  tps: 26745.36882
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-StumpofTime-62470"
  value: {
   dps: 28807.71096
-  tps: 26750.08465
+  tps: 26783.54295
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SymbioticWorm-59332"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SymbioticWorm-65048"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TalismanofSinisterOrder-65804"
  value: {
   dps: 28904.4311
-  tps: 26873.86658
+  tps: 26906.80535
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Tank-CommanderInsignia-63841"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TearofBlood-55819"
  value: {
   dps: 28484.39593
-  tps: 26464.87011
+  tps: 26498.5493
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TearofBlood-56351"
  value: {
   dps: 28748.78375
-  tps: 26693.15491
+  tps: 26725.98398
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TendrilsofBurrowingDark-55810"
  value: {
   dps: 28682.00753
-  tps: 26684.10826
+  tps: 26717.56656
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TendrilsofBurrowingDark-56339"
  value: {
   dps: 29116.92174
-  tps: 27091.0253
+  tps: 27124.4836
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TheHungerer-68927"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TheHungerer-69112"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Theralion'sMirror-59519"
  value: {
   dps: 29483.62025
-  tps: 27419.10665
+  tps: 27449.30518
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Theralion'sMirror-65105"
  value: {
   dps: 29665.62421
-  tps: 27586.66748
+  tps: 27616.50853
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Throngus'sFinger-56121"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Throngus'sFinger-56449"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Tia'sGrace-55874"
  value: {
   dps: 28062.60592
-  tps: 26124.13294
+  tps: 26157.59124
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Tia'sGrace-56394"
  value: {
   dps: 28221.41959
-  tps: 26282.94661
+  tps: 26316.40491
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TinyAbominationinaJar-50706"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
   dps: 28516.32854
-  tps: 26477.03688
+  tps: 26506.92913
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-UnheededWarning-59520"
  value: {
   dps: 27689.2604
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-UnquenchableFlame-67101"
  value: {
   dps: 27644.49197
-  tps: 25716.95592
+  tps: 25744.47089
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-UnsolvableRiddle-62463"
  value: {
   dps: 28197.09087
-  tps: 26269.55482
+  tps: 26297.06978
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-UnsolvableRiddle-62468"
  value: {
   dps: 28197.09087
-  tps: 26269.55482
+  tps: 26297.06978
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-UnsolvableRiddle-68709"
  value: {
   dps: 28197.09087
-  tps: 26269.55482
+  tps: 26297.06978
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
   dps: 24678.963
-  tps: 22940.99573
+  tps: 22971.39051
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
   dps: 29374.08565
-  tps: 27286.39214
+  tps: 27316.2537
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
   dps: 30091.65924
-  tps: 27982.28013
+  tps: 28011.50944
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-VesselofAcceleration-68995"
  value: {
   dps: 27718.84604
-  tps: 25779.73443
+  tps: 25813.00344
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-VesselofAcceleration-69167"
  value: {
   dps: 27719.72366
-  tps: 25777.31925
+  tps: 25810.78243
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-VialofStolenMemories-59515"
  value: {
   dps: 27666.83157
-  tps: 25732.19464
+  tps: 25765.61947
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-VialofStolenMemories-65109"
  value: {
   dps: 27666.83157
-  tps: 25732.19464
+  tps: 25765.61947
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
   dps: 27644.49197
-  tps: 25716.95592
+  tps: 25744.47089
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
   dps: 28638.74616
-  tps: 26580.78427
+  tps: 26608.29924
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
   dps: 27644.49197
-  tps: 25716.95592
+  tps: 25744.47089
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
   dps: 27658.97731
-  tps: 25732.19464
+  tps: 25765.61947
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
   dps: 28435.52256
-  tps: 26447.69541
+  tps: 26474.53009
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
   dps: 28225.44444
-  tps: 26211.89941
+  tps: 26237.54815
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
   dps: 27658.97731
-  tps: 25732.19464
+  tps: 25765.61947
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
   dps: 28219.07805
-  tps: 26292.29538
+  tps: 26325.72021
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
   dps: 27658.97731
-  tps: 25732.19464
+  tps: 25765.61947
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
   dps: 27681.51363
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
   dps: 28597.13267
-  tps: 26548.98494
+  tps: 26582.44324
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
   dps: 27682.09013
-  tps: 25750.78742
+  tps: 25784.24572
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-WitchingHourglass-55787"
  value: {
   dps: 28905.98604
-  tps: 26858.03449
+  tps: 26884.58093
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-WitchingHourglass-56320"
  value: {
   dps: 29172.51193
-  tps: 27119.19074
+  tps: 27148.6511
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-World-QuellerFocus-63842"
  value: {
   dps: 28027.37428
-  tps: 26091.2742
+  tps: 26118.78917
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
   dps: 28083.39569
-  tps: 26162.07657
+  tps: 26189.02973
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
   dps: 28083.39569
-  tps: 26162.07657
+  tps: 26189.02973
  }
 }
 dps_results: {
  key: "TestShadow-Average-Default"
  value: {
   dps: 29793.6543
-  tps: 27669.76984
+  tps: 27697.0452
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 29267.89652
-  tps: 40440.39551
+  tps: 41088.98101
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 29267.89652
-  tps: 27040.99126
+  tps: 27073.42053
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 37319.26072
-  tps: 33816.41389
+  tps: 33828.78672
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17129.25536
-  tps: 27484.76822
+  dps: 16676.92924
+  tps: 26930.89659
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 17129.25536
-  tps: 16305.31848
+  dps: 16676.92924
+  tps: 15824.04656
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Draenei-p1-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 18420.23866
-  tps: 16996.5324
+  tps: 16996.625
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 29267.89652
-  tps: 40440.39551
+  tps: 41088.98101
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 29267.89652
-  tps: 27040.99126
+  tps: 27073.42053
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 37319.26072
-  tps: 33816.41389
+  tps: 33828.78672
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17129.25536
-  tps: 27484.76822
+  dps: 16676.92924
+  tps: 26930.89659
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 17129.25536
-  tps: 16305.31848
+  dps: 16676.92924
+  tps: 15824.04656
  }
 }
 dps_results: {
  key: "TestShadow-Settings-NightElf-p1-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 18420.23866
-  tps: 16996.5324
+  tps: 16996.625
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Troll-p1-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 29821.45061
-  tps: 41305.22432
+  tps: 41787.82341
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Troll-p1-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 29821.45061
-  tps: 27627.87342
+  tps: 27652.00338
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Troll-p1-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 39234.88318
-  tps: 35515.08032
+  tps: 35531.63482
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Troll-p1-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17479.85545
-  tps: 28126.02004
+  dps: 16773.04821
+  tps: 27134.50483
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Troll-p1-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 17479.85545
-  tps: 16677.22764
+  dps: 16773.04821
+  tps: 15975.96666
  }
 }
 dps_results: {
  key: "TestShadow-Settings-Troll-p1-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 19462.7962
-  tps: 18214.07067
+  tps: 18214.18422
  }
 }
 dps_results: {
  key: "TestShadow-SwitchInFrontOfTarget-Default"
  value: {
   dps: 29786.48182
-  tps: 27627.87342
+  tps: 27652.00338
  }
 }

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -39,77 +39,77 @@ dps_results: {
  key: "TestElemental-AllItems-AgileShadowspiritDiamond"
  value: {
   dps: 32087.57387
-  tps: 574.6354
+  tps: 585.52032
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-AgonyandTorment"
  value: {
   dps: 23231.08393
-  tps: 533.27284
+  tps: 546.03187
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Althor'sAbacus-50366"
  value: {
   dps: 30530.37879
-  tps: 578.47024
+  tps: 589.81797
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-AncientPetrifiedSeed-69001"
  value: {
   dps: 30198.63195
-  tps: 580.40894
+  tps: 592.31769
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Anhuur'sHymnal-55889"
  value: {
   dps: 30669.19549
-  tps: 571.28815
+  tps: 582.15797
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Anhuur'sHymnal-56407"
  value: {
   dps: 31045.70709
-  tps: 568.4868
+  tps: 579.10666
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-AustereShadowspiritDiamond"
  value: {
   dps: 31377.21251
-  tps: 573.73046
+  tps: 584.61538
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BattlegearoftheRagingElements"
  value: {
   dps: 22806.92935
-  tps: 412.0581
+  tps: 415.49731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BaubleofTrueBlood-50726"
  value: {
   dps: 29921.53187
-  tps: 569.65577
+  tps: 580.62132
   hps: 101.38655
  }
 }
@@ -117,1393 +117,1393 @@ dps_results: {
  key: "TestElemental-AllItems-BedrockTalisman-58182"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BellofEnragingResonance-59326"
  value: {
   dps: 31875.66083
-  tps: 568.69291
+  tps: 580.2173
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BindingPromise-67037"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BlackBruise-50692"
  value: {
   dps: 24197.89288
-  tps: 540.63201
+  tps: 553.19243
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Blood-SoakedAleMug-63843"
  value: {
   dps: 30116.15171
-  tps: 576.23996
+  tps: 587.98499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodofIsiset-55995"
  value: {
   dps: 30103.84755
-  tps: 576.49283
+  tps: 588.91158
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodofIsiset-56414"
  value: {
   dps: 30211.22781
-  tps: 579.17642
+  tps: 590.82815
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
   dps: 31097.0279
-  tps: 570.72653
+  tps: 581.46946
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
   dps: 30227.05252
-  tps: 570.13268
+  tps: 581.13852
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
   dps: 29910.71044
-  tps: 570.4573
+  tps: 581.30947
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
   dps: 30958.57373
-  tps: 569.61412
+  tps: 579.80805
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BottledLightning-66879"
  value: {
   dps: 30632.93326
-  tps: 578.28291
+  tps: 589.59379
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BracingShadowspiritDiamond"
  value: {
   dps: 31567.4212
-  tps: 574.53179
+  tps: 585.58159
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Brawler'sTrophy-71338"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
   dps: 32282.88807
-  tps: 577.11404
+  tps: 588.16384
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-BurningShadowspiritDiamond"
  value: {
   dps: 32282.88807
-  tps: 577.11404
+  tps: 588.16384
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ChaoticShadowspiritDiamond"
  value: {
   dps: 32130.83694
-  tps: 574.80819
+  tps: 585.67575
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Coren'sChilledChromiumCoaster-71335"
  value: {
   dps: 30263.16559
-  tps: 570.11483
+  tps: 581.13852
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CoreofRipeness-58184"
  value: {
   dps: 31090.57227
-  tps: 585.4266
+  tps: 597.07834
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CorpseTongueCoin-50349"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CrushingWeight-59506"
  value: {
   dps: 30351.84835
-  tps: 577.35777
+  tps: 589.84352
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CrushingWeight-65118"
  value: {
   dps: 30333.61718
-  tps: 581.6725
+  tps: 592.80383
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
   dps: 31090.57227
-  tps: 585.4266
+  tps: 597.07834
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Deathbringer'sWill-50363"
  value: {
   dps: 30182.16263
-  tps: 572.54102
+  tps: 584.34271
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DestructiveShadowspiritDiamond"
  value: {
   dps: 31417.25643
-  tps: 573.87864
+  tps: 584.7462
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-DislodgedForeignObject-50348"
  value: {
   dps: 30886.17356
-  tps: 578.54316
+  tps: 591.21587
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Dwyer'sCaber-70141"
  value: {
   dps: 30335.67558
-  tps: 569.4132
+  tps: 580.34346
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EffulgentShadowspiritDiamond"
  value: {
   dps: 31377.21251
-  tps: 573.73046
+  tps: 584.61538
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ElectrosparkHeartstarter-67118"
  value: {
   dps: 30520.02004
-  tps: 582.88313
+  tps: 593.90994
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EmberShadowspiritDiamond"
  value: {
   dps: 31567.4212
-  tps: 583.40458
+  tps: 594.58464
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EnigmaticShadowspiritDiamond"
  value: {
   dps: 31417.25643
-  tps: 573.87864
+  tps: 584.7462
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EssenceoftheCyclone-59473"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EssenceoftheCyclone-65140"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EssenceoftheEternalFlame-69002"
  value: {
   dps: 30198.63195
-  tps: 580.40894
+  tps: 592.31769
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-EternalShadowspiritDiamond"
  value: {
   dps: 31377.21251
-  tps: 573.73046
+  tps: 584.61538
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FallofMortality-59500"
  value: {
   dps: 31090.57227
-  tps: 585.4266
+  tps: 597.07834
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FallofMortality-65124"
  value: {
   dps: 31249.91825
-  tps: 587.37916
+  tps: 599.10691
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FieryQuintessence-69000"
  value: {
   dps: 31542.66491
-  tps: 599.37903
+  tps: 609.42605
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-DemonPanther-52199"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-DreamOwl-52354"
  value: {
   dps: 30955.34269
-  tps: 583.7777
+  tps: 595.37212
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-EarthenGuardian-52352"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-JeweledSerpent-52353"
  value: {
   dps: 32074.19925
-  tps: 584.17174
+  tps: 595.44156
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Figurine-KingofBoars-52351"
  value: {
   dps: 30211.22781
-  tps: 579.17642
+  tps: 590.82815
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FleetShadowspiritDiamond"
  value: {
   dps: 31439.15208
-  tps: 574.49754
+  tps: 586.54052
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FluidDeath-58181"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ForlornShadowspiritDiamond"
  value: {
   dps: 31567.4212
-  tps: 576.20656
+  tps: 587.25636
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-FuryofAngerforge-59461"
  value: {
   dps: 30238.89203
-  tps: 570.13105
+  tps: 581.13852
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GaleofShadows-56138"
  value: {
   dps: 31144.49014
-  tps: 578.5964
+  tps: 590.48875
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GaleofShadows-56462"
  value: {
   dps: 31266.95496
-  tps: 582.70854
+  tps: 593.43304
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GearDetector-61462"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GlowingTwilightScale-54589"
  value: {
   dps: 30569.86804
-  tps: 579.02575
+  tps: 590.42907
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GraceoftheHerald-55266"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-GraceoftheHerald-56295"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HarmlightToken-63839"
  value: {
   dps: 30867.72979
-  tps: 739.22008
+  tps: 750.78534
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofIgnacious-59514"
  value: {
   dps: 31407.74865
-  tps: 582.05359
+  tps: 594.63308
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofIgnacious-65110"
  value: {
   dps: 31525.38768
-  tps: 580.7244
+  tps: 592.15759
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofRage-59224"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofRage-65072"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofSolace-55868"
  value: {
   dps: 30378.48421
-  tps: 577.60053
+  tps: 589.49288
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofSolace-56393"
  value: {
   dps: 30315.13744
-  tps: 584.89089
+  tps: 595.9587
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofThunder-55845"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartofThunder-56370"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-HeartoftheVile-66969"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Heartpierce-50641"
  value: {
   dps: 32282.88807
-  tps: 577.11404
+  tps: 588.16384
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpassiveShadowspiritDiamond"
  value: {
   dps: 31417.25643
-  tps: 573.87864
+  tps: 584.7462
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpatienceofYouth-62464"
  value: {
   dps: 30238.58281
-  tps: 578.54903
+  tps: 590.45165
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpatienceofYouth-62469"
  value: {
   dps: 30238.58281
-  tps: 578.54903
+  tps: 590.45165
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpetuousQuery-55881"
  value: {
   dps: 30103.84755
-  tps: 576.49283
+  tps: 588.91158
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ImpetuousQuery-56406"
  value: {
   dps: 30211.22781
-  tps: 579.17642
+  tps: 590.82815
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-InsigniaofDiplomacy-61433"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
   dps: 30869.02762
-  tps: 578.46934
+  tps: 589.83141
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-JarofAncientRemedies-59354"
  value: {
   dps: 29910.71044
-  tps: 591.42556
+  tps: 602.11235
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-JarofAncientRemedies-65029"
  value: {
   dps: 29910.71044
-  tps: 593.90554
+  tps: 604.73016
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-JujuofNimbleness-63840"
  value: {
   dps: 30116.15171
-  tps: 576.23996
+  tps: 587.98499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-KeytotheEndlessChamber-55795"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-KeytotheEndlessChamber-56328"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-KvaldirBattleStandard-59685"
  value: {
   dps: 30153.73517
-  tps: 575.97357
+  tps: 588.58027
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-KvaldirBattleStandard-59689"
  value: {
   dps: 30153.73517
-  tps: 575.97357
+  tps: 588.58027
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
   dps: 30182.44397
-  tps: 571.77642
+  tps: 583.24339
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LastWord-50708"
  value: {
   dps: 32282.88807
-  tps: 577.11404
+  tps: 588.16384
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LeadenDespair-55816"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LeadenDespair-56347"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LeftEyeofRajh-56102"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LeftEyeofRajh-56427"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-LicensetoSlay-58180"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MagnetiteMirror-55814"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MagnetiteMirror-56345"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MandalaofStirringPatterns-62467"
  value: {
   dps: 29910.71044
-  tps: 570.45637
+  tps: 581.30762
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MandalaofStirringPatterns-62472"
  value: {
   dps: 29910.71044
-  tps: 570.45637
+  tps: 581.30762
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MarkofKhardros-56132"
  value: {
   dps: 30289.30836
-  tps: 578.56819
+  tps: 590.63183
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MarkofKhardros-56458"
  value: {
   dps: 30303.12886
-  tps: 582.20668
+  tps: 594.53366
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MatrixRestabilizer-68994"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MatrixRestabilizer-69150"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MightoftheOcean-55251"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MightoftheOcean-56285"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MirrorofBrokenImages-62466"
  value: {
   dps: 30238.58281
-  tps: 578.54903
+  tps: 590.45165
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MirrorofBrokenImages-62471"
  value: {
   dps: 30238.58281
-  tps: 578.54903
+  tps: 590.45165
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MithrilStopwatch-71337"
  value: {
   dps: 32009.10639
-  tps: 570.34068
+  tps: 581.5679
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MoonwellChalice-70142"
  value: {
   dps: 31676.58418
-  tps: 603.87537
+  tps: 617.82253
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-MoonwellPhial-70143"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-NecromanticFocus-68982"
  value: {
   dps: 31648.39901
-  tps: 595.16234
+  tps: 608.26738
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-NecromanticFocus-69139"
  value: {
   dps: 32014.53575
-  tps: 601.52799
+  tps: 613.33498
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Oremantle'sFavor-61448"
  value: {
   dps: 30112.01985
-  tps: 570.14922
+  tps: 580.88729
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PetrifiedPickledEgg-71336"
  value: {
   dps: 31159.65187
-  tps: 586.30669
+  tps: 597.99121
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PetrifiedTwilightScale-54591"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
   dps: 30916.43149
-  tps: 570.75745
+  tps: 581.54842
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PorcelainCrab-55237"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PorcelainCrab-56280"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-PowerfulShadowspiritDiamond"
  value: {
   dps: 31377.21251
-  tps: 573.73046
+  tps: 584.61538
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Rainsong-55854"
  value: {
   dps: 29910.71044
-  tps: 570.46127
+  tps: 581.31742
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Rainsong-56377"
  value: {
   dps: 29910.71044
-  tps: 570.45804
+  tps: 581.31095
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RegaliaoftheRagingElements"
  value: {
   dps: 28108.89803
-  tps: 541.6199
+  tps: 551.74336
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ReverberatingShadowspiritDiamond"
  value: {
   dps: 32087.57387
-  tps: 574.6354
+  tps: 585.52032
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RevitalizingShadowspiritDiamond"
  value: {
   dps: 32087.57387
-  tps: 574.6354
+  tps: 585.52032
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Ricket'sMagneticFireball-70144"
  value: {
   dps: 30285.24012
-  tps: 570.41035
+  tps: 581.30333
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RightEyeofRajh-56100"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RightEyeofRajh-56431"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-RuneofZeth-68998"
  value: {
   dps: 31796.53972
-  tps: 596.57531
+  tps: 606.25892
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SeaStar-55256"
  value: {
   dps: 30505.50543
-  tps: 571.03454
+  tps: 581.89139
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SeaStar-56290"
  value: {
   dps: 31024.83923
-  tps: 570.69585
+  tps: 581.42188
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Shadowmourne-49623"
  value: {
   dps: 32282.88807
-  tps: 577.11404
+  tps: 588.16384
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ShardofWoe-60233"
  value: {
   dps: 30403.51605
-  tps: 556.73823
+  tps: 568.30589
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Shrine-CleansingPurifier-63838"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Skardyn'sGrace-56115"
  value: {
   dps: 30176.76267
-  tps: 582.48666
+  tps: 595.88445
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Skardyn'sGrace-56440"
  value: {
   dps: 30328.85837
-  tps: 582.44931
+  tps: 596.447
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Sorrowsong-55879"
  value: {
   dps: 30790.71306
-  tps: 577.61818
+  tps: 590.03693
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Sorrowsong-56400"
  value: {
   dps: 31199.72167
-  tps: 572.81725
+  tps: 584.25413
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Soul'sAnguish-66994"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SoulCasket-58183"
  value: {
   dps: 31663.92354
-  tps: 577.83005
+  tps: 589.66909
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Spiritwalker'sRegalia"
  value: {
   dps: 29158.72356
-  tps: 537.69457
+  tps: 549.36738
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Stonemother'sKiss-61411"
  value: {
   dps: 30853.9679
-  tps: 579.25217
+  tps: 590.61767
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-StumpofTime-62465"
  value: {
   dps: 31376.52353
-  tps: 567.72341
+  tps: 578.38624
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-StumpofTime-62470"
  value: {
   dps: 31382.25623
-  tps: 570.84605
+  tps: 581.68913
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SymbioticWorm-59332"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-SymbioticWorm-65048"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TalismanofSinisterOrder-65804"
  value: {
   dps: 31057.07183
-  tps: 585.06402
+  tps: 596.93953
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Tank-CommanderInsignia-63841"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TearofBlood-55819"
  value: {
   dps: 30692.37362
-  tps: 580.36337
+  tps: 591.87957
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TearofBlood-56351"
  value: {
   dps: 30955.34269
-  tps: 583.7777
+  tps: 595.37212
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TendrilsofBurrowingDark-55810"
  value: {
   dps: 30815.70876
-  tps: 577.18382
+  tps: 588.92886
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TendrilsofBurrowingDark-56339"
  value: {
   dps: 31486.27716
-  tps: 577.03181
+  tps: 589.43338
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TheHungerer-68927"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TheHungerer-69112"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Theralion'sMirror-59519"
  value: {
   dps: 31533.05789
-  tps: 601.08863
+  tps: 614.04528
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Theralion'sMirror-65105"
  value: {
   dps: 31908.9813
-  tps: 604.16433
+  tps: 616.92886
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Throngus'sFinger-56121"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Throngus'sFinger-56449"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Tia'sGrace-55874"
  value: {
   dps: 30103.84755
-  tps: 576.49283
+  tps: 588.91158
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Tia'sGrace-56394"
  value: {
   dps: 30211.22781
-  tps: 579.17642
+  tps: 590.82815
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TidefuryRaiment"
  value: {
   dps: 19844.04619
-  tps: 387.64702
+  tps: 387.79852
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-TinyAbominationinaJar-50706"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
   dps: 31131.62391
-  tps: 673.30662
+  tps: 685.41111
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-UnheededWarning-59520"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-UnquenchableFlame-67101"
  value: {
   dps: 29910.71044
-  tps: 570.46326
+  tps: 581.3214
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-UnsolvableRiddle-62463"
  value: {
   dps: 30238.58281
-  tps: 578.54903
+  tps: 590.45165
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-UnsolvableRiddle-62468"
  value: {
   dps: 30238.58281
-  tps: 578.54903
+  tps: 590.45165
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-UnsolvableRiddle-68709"
  value: {
   dps: 30238.58281
-  tps: 578.54903
+  tps: 590.45165
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
   dps: 26615.99927
-  tps: 548.5411
+  tps: 560.56291
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
   dps: 31734.61179
-  tps: 920.48621
+  tps: 932.33833
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
   dps: 32538.50221
-  tps: 1531.48296
+  tps: 1543.69563
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-VesselofAcceleration-68995"
  value: {
   dps: 30164.68654
-  tps: 569.84235
+  tps: 580.84209
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-VesselofAcceleration-69167"
  value: {
   dps: 30188.31418
-  tps: 569.79552
+  tps: 580.68121
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-VialofStolenMemories-59515"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-VialofStolenMemories-65109"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
   dps: 31161.61777
-  tps: 570.74552
+  tps: 581.48845
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
   dps: 30425.43559
-  tps: 584.92852
+  tps: 597.01876
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
   dps: 30263.16559
-  tps: 570.11483
+  tps: 581.13852
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
   dps: 30182.93062
-  tps: 580.5559
+  tps: 591.94496
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
   dps: 31111.07885
-  tps: 569.47009
+  tps: 580.9476
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
   dps: 29910.71044
-  tps: 570.46749
+  tps: 581.33731
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-VolcanicRegalia"
  value: {
   dps: 27992.47535
-  tps: 524.51603
+  tps: 534.40269
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WitchingHourglass-55787"
  value: {
   dps: 30886.76199
-  tps: 587.57556
+  tps: 599.09485
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-WitchingHourglass-56320"
  value: {
   dps: 31419.30615
-  tps: 594.81754
+  tps: 607.61259
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-World-QuellerFocus-63842"
  value: {
   dps: 30116.15171
-  tps: 576.23996
+  tps: 587.98499
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
   dps: 30161.56153
-  tps: 581.04248
+  tps: 592.91208
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
   dps: 30161.56153
-  tps: 581.04248
+  tps: 592.91208
  }
 }
 dps_results: {
  key: "TestElemental-Average-Default"
  value: {
   dps: 32231.3721
-  tps: 569.68031
+  tps: 581.70178
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-DefaultTalents-Standard-aoe-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 72387.8098
-  tps: 37437.21024
+  tps: 37812.53519
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-DefaultTalents-Standard-aoe-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 10140.01613
-  tps: 244.17498
+  dps: 9318.09623
+  tps: 212.89803
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-DefaultTalents-Standard-aoe-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 22113.61066
-  tps: 580.08508
+  dps: 21470.55938
+  tps: 560.23211
  }
 }
 dps_results: {
@@ -1531,21 +1531,21 @@ dps_results: {
  key: "TestElemental-Settings-Orc-p1-DefaultTalents-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 54320.87097
-  tps: 9893.03869
+  tps: 10139.03636
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-DefaultTalents-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 32541.13755
-  tps: 577.44789
+  tps: 589.88295
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-DefaultTalents-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 39666.97192
-  tps: 723.24793
+  tps: 729.00342
  }
 }
 dps_results: {
@@ -1573,21 +1573,21 @@ dps_results: {
  key: "TestElemental-Settings-Orc-p1-TalentsImprovedShields-Standard-aoe-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 103802.14477
-  tps: 72471.65636
+  tps: 72763.6128
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-TalentsImprovedShields-Standard-aoe-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 8163.31375
-  tps: 236.7742
+  dps: 7510.018
+  tps: 207.66941
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-TalentsImprovedShields-Standard-aoe-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 20300.80992
-  tps: 570.196
+  dps: 19777.4791
+  tps: 551.96504
  }
 }
 dps_results: {
@@ -1615,21 +1615,21 @@ dps_results: {
  key: "TestElemental-Settings-Orc-p1-TalentsImprovedShields-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 46155.04069
-  tps: 9635.87663
+  tps: 9887.91557
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-TalentsImprovedShields-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 30279.67512
-  tps: 557.4627
+  tps: 570.32963
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p1-TalentsImprovedShields-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 38147.10336
-  tps: 704.63205
+  tps: 709.46776
  }
 }
 dps_results: {
@@ -1657,21 +1657,21 @@ dps_results: {
  key: "TestElemental-Settings-Troll-p1-DefaultTalents-Standard-aoe-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 70276.34221
-  tps: 37861.39549
+  tps: 38255.9134
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-DefaultTalents-Standard-aoe-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 9717.3166
-  tps: 244.39877
+  dps: 8916.7317
+  tps: 216.40934
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-DefaultTalents-Standard-aoe-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 21212.7591
-  tps: 577.63757
+  dps: 20615.12831
+  tps: 559.66672
  }
 }
 dps_results: {
@@ -1699,21 +1699,21 @@ dps_results: {
  key: "TestElemental-Settings-Troll-p1-DefaultTalents-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 52329.35344
-  tps: 9904.9364
+  tps: 10138.23324
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-DefaultTalents-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 32282.88807
-  tps: 577.11404
+  tps: 588.16384
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-DefaultTalents-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 39634.01341
-  tps: 715.66636
+  tps: 721.38246
  }
 }
 dps_results: {
@@ -1741,21 +1741,21 @@ dps_results: {
  key: "TestElemental-Settings-Troll-p1-TalentsImprovedShields-Standard-aoe-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 101471.19062
-  tps: 72283.84697
+  tps: 72584.76585
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-TalentsImprovedShields-Standard-aoe-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 7797.67383
-  tps: 233.77365
+  dps: 7174.15649
+  tps: 207.60733
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-TalentsImprovedShields-Standard-aoe-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 19476.67077
-  tps: 570.81458
+  dps: 18965.0701
+  tps: 549.18138
  }
 }
 dps_results: {
@@ -1783,21 +1783,21 @@ dps_results: {
  key: "TestElemental-Settings-Troll-p1-TalentsImprovedShields-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 44700.53302
-  tps: 9698.15659
+  tps: 9956.61101
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-TalentsImprovedShields-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 29853.25762
-  tps: 565.43667
+  tps: 577.92307
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p1-TalentsImprovedShields-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 37621.62473
-  tps: 698.53573
+  tps: 706.58349
  }
 }
 dps_results: {
@@ -1825,6 +1825,6 @@ dps_results: {
  key: "TestElemental-SwitchInFrontOfTarget-Default"
  value: {
   dps: 32116.5891
-  tps: 577.11404
+  tps: 588.16384
  }
 }

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -39,77 +39,77 @@ dps_results: {
  key: "TestEnhancement-AllItems-AgileShadowspiritDiamond"
  value: {
   dps: 29763.24984
-  tps: 19812.58644
+  tps: 19817.12337
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AgonyandTorment"
  value: {
   dps: 27602.90531
-  tps: 18219.20057
+  tps: 18223.61027
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Althor'sAbacus-50366"
  value: {
   dps: 27841.44725
-  tps: 18573.94344
+  tps: 18579.07877
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AncientPetrifiedSeed-69001"
  value: {
   dps: 29714.29776
-  tps: 19668.02298
+  tps: 19672.65734
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Anhuur'sHymnal-55889"
  value: {
   dps: 28167.45071
-  tps: 18818.58409
+  tps: 18823.21512
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Anhuur'sHymnal-56407"
  value: {
   dps: 28179.72614
-  tps: 18793.93174
+  tps: 18798.49447
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
   dps: 28867.12808
-  tps: 19152.4189
+  tps: 19157.08416
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
   dps: 29008.30684
-  tps: 19235.05295
+  tps: 19239.71822
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-AustereShadowspiritDiamond"
  value: {
   dps: 29118.89661
-  tps: 19374.62625
+  tps: 19379.12335
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BattlegearoftheRagingElements"
  value: {
   dps: 26750.42088
-  tps: 17840.01729
+  tps: 17844.49995
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BaubleofTrueBlood-50726"
  value: {
   dps: 27882.63581
-  tps: 18545.0082
+  tps: 18549.79499
   hps: 96.77966
  }
 }
@@ -117,1393 +117,1393 @@ dps_results: {
  key: "TestEnhancement-AllItems-BedrockTalisman-58182"
  value: {
   dps: 27820.26765
-  tps: 18562.26555
+  tps: 18567.02518
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BellofEnragingResonance-59326"
  value: {
   dps: 28158.13514
-  tps: 18814.51692
+  tps: 18819.16951
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BellofEnragingResonance-65053"
  value: {
   dps: 28176.72696
-  tps: 18800.17809
+  tps: 18804.7895
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BindingPromise-67037"
  value: {
   dps: 27820.26765
-  tps: 18562.26555
+  tps: 18567.02518
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BlackBruise-50692"
  value: {
   dps: 27558.82403
-  tps: 18313.49619
+  tps: 18317.95339
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Blood-SoakedAleMug-63843"
  value: {
   dps: 28998.09503
-  tps: 19266.2439
+  tps: 19270.87745
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodofIsiset-55995"
  value: {
   dps: 28220.56236
-  tps: 18756.91147
+  tps: 18761.6711
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodofIsiset-56414"
  value: {
   dps: 28272.9819
-  tps: 18782.40082
+  tps: 18787.16045
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
   dps: 29380.20682
-  tps: 19596.74363
+  tps: 19601.28378
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
   dps: 27820.26765
-  tps: 18562.26555
+  tps: 18567.02518
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
   dps: 28331.13265
-  tps: 18876.65398
+  tps: 18881.41361
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
   dps: 28124.34301
-  tps: 18788.09006
+  tps: 18792.77973
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
   dps: 27882.63581
-  tps: 18544.97823
+  tps: 18549.76636
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
   dps: 27820.26765
-  tps: 18562.26555
+  tps: 18567.02518
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
   dps: 29001.23044
-  tps: 19316.49667
+  tps: 19321.15401
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
   dps: 27820.26765
-  tps: 18562.26555
+  tps: 18567.02518
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
   dps: 28306.27169
-  tps: 18861.69334
+  tps: 18866.45297
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BottledLightning-66879"
  value: {
   dps: 27950.02666
-  tps: 18644.51248
+  tps: 18649.56875
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BracingShadowspiritDiamond"
  value: {
   dps: 29122.48562
-  tps: 18991.85264
+  tps: 18996.46867
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Brawler'sTrophy-71338"
  value: {
   dps: 27820.26765
-  tps: 18562.26555
+  tps: 18567.02518
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
   dps: 29609.28025
-  tps: 19714.8883
+  tps: 19719.41861
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-BurningShadowspiritDiamond"
  value: {
   dps: 29550.93908
-  tps: 19676.92924
+  tps: 19681.54527
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ChaoticShadowspiritDiamond"
  value: {
   dps: 29609.28025
-  tps: 19714.8883
+  tps: 19719.41861
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Coren'sChilledChromiumCoaster-71335"
  value: {
   dps: 29173.68075
-  tps: 19437.84483
+  tps: 19442.43568
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CoreofRipeness-58184"
  value: {
   dps: 27783.85412
-  tps: 18510.02498
+  tps: 18515.44274
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CorpseTongueCoin-50349"
  value: {
   dps: 27820.26765
-  tps: 18562.26555
+  tps: 18567.02518
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CrushingWeight-59506"
  value: {
   dps: 28609.45333
-  tps: 19047.10366
+  tps: 19051.79015
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CrushingWeight-65118"
  value: {
   dps: 28573.66731
-  tps: 19091.75424
+  tps: 19096.38959
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
   dps: 27820.26765
-  tps: 18562.26555
+  tps: 18567.02518
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
   dps: 28830.38786
-  tps: 19457.18835
+  tps: 19462.02822
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
   dps: 29546.22851
-  tps: 19902.99649
+  tps: 19907.81073
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
   dps: 27860.17837
-  tps: 18580.48001
+  tps: 18585.92403
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DarkmoonCard:Volcano-62047"
  value: {
   dps: 28405.68541
-  tps: 18968.00508
+  tps: 18971.27276
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Deathbringer'sWill-50363"
  value: {
   dps: 28588.0904
-  tps: 19087.23937
+  tps: 19091.88934
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DestructiveShadowspiritDiamond"
  value: {
   dps: 29177.02116
-  tps: 19410.346
+  tps: 19414.87631
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-DislodgedForeignObject-50348"
  value: {
   dps: 27857.4626
-  tps: 18587.89402
+  tps: 18592.45677
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Dwyer'sCaber-70141"
  value: {
   dps: 28777.56837
-  tps: 19203.96016
+  tps: 19208.61404
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EffulgentShadowspiritDiamond"
  value: {
   dps: 29118.89661
-  tps: 19374.62625
+  tps: 19379.12335
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ElectrosparkHeartstarter-67118"
  value: {
   dps: 27899.07189
-  tps: 18582.72358
+  tps: 18588.28386
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EmberShadowspiritDiamond"
  value: {
   dps: 29122.48562
-  tps: 19375.1653
+  tps: 19379.85795
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EnigmaticShadowspiritDiamond"
  value: {
   dps: 29177.02116
-  tps: 19410.346
+  tps: 19414.87631
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EssenceoftheCyclone-59473"
  value: {
   dps: 29334.24779
-  tps: 19565.8338
+  tps: 19570.43453
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EssenceoftheEternalFlame-69002"
  value: {
   dps: 28973.69303
-  tps: 19191.61916
+  tps: 19196.3788
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-EternalShadowspiritDiamond"
  value: {
   dps: 29118.89661
-  tps: 19374.62625
+  tps: 19379.12335
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FallofMortality-59500"
  value: {
   dps: 27860.17837
-  tps: 18580.48001
+  tps: 18585.92403
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FallofMortality-65124"
  value: {
   dps: 27862.76832
-  tps: 18581.0819
+  tps: 18586.61042
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FieryQuintessence-69000"
  value: {
   dps: 27928.5003
-  tps: 18634.30071
+  tps: 18640.15547
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-DemonPanther-52199"
  value: {
   dps: 29247.89556
-  tps: 19506.67774
+  tps: 19511.29465
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-DreamOwl-52354"
  value: {
   dps: 27779.74177
-  tps: 18509.04631
+  tps: 18514.39335
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-EarthenGuardian-52352"
  value: {
   dps: 27820.26765
-  tps: 18562.26555
+  tps: 18567.02518
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-JeweledSerpent-52353"
  value: {
   dps: 27857.98657
-  tps: 18579.94386
+  tps: 18585.31515
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Figurine-KingofBoars-52351"
  value: {
   dps: 28759.89051
-  tps: 19080.86763
+  tps: 19085.62727
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FleetShadowspiritDiamond"
  value: {
   dps: 29208.09183
-  tps: 19418.03882
+  tps: 19422.53592
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ForlornShadowspiritDiamond"
  value: {
   dps: 29122.48562
-  tps: 19375.33888
+  tps: 19379.95491
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-FuryofAngerforge-59461"
  value: {
   dps: 28773.35173
-  tps: 19196.64841
+  tps: 19201.30101
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GaleofShadows-56138"
  value: {
   dps: 27978.6457
-  tps: 18681.91445
+  tps: 18686.45799
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GaleofShadows-56462"
  value: {
   dps: 28020.78942
-  tps: 18728.74469
+  tps: 18733.29927
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GearDetector-61462"
  value: {
   dps: 28601.36483
-  tps: 19064.67503
+  tps: 19069.41695
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GlowingTwilightScale-54589"
  value: {
   dps: 27842.55264
-  tps: 18574.74511
+  tps: 18579.90643
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GraceoftheHerald-55266"
  value: {
   dps: 28653.12331
-  tps: 19098.24293
+  tps: 19102.9608
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-GraceoftheHerald-56295"
  value: {
   dps: 29037.47149
-  tps: 19384.31454
+  tps: 19389.00193
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HarmlightToken-63839"
  value: {
   dps: 28036.07433
-  tps: 18760.9351
+  tps: 18766.17087
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
   dps: 28481.45422
-  tps: 18928.21297
+  tps: 18932.97261
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartofIgnacious-59514"
  value: {
   dps: 28144.46475
-  tps: 18844.20475
+  tps: 18848.77095
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartofIgnacious-65110"
  value: {
   dps: 28023.54757
-  tps: 18700.13796
+  tps: 18704.87545
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartofRage-59224"
  value: {
   dps: 28430.9877
-  tps: 18938.91473
+  tps: 18943.67436
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartofRage-65072"
  value: {
   dps: 28513.49187
-  tps: 18984.76668
+  tps: 18989.52632
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartofSolace-55868"
  value: {
   dps: 27978.6457
-  tps: 18681.91445
+  tps: 18686.45799
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartofSolace-56393"
  value: {
   dps: 28555.45072
-  tps: 19056.64048
+  tps: 19061.19506
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartofThunder-55845"
  value: {
   dps: 27820.26765
-  tps: 18562.26555
+  tps: 18567.02518
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartofThunder-56370"
  value: {
   dps: 27820.26765
-  tps: 18562.26555
+  tps: 18567.02518
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-HeartoftheVile-66969"
  value: {
   dps: 28759.35884
-  tps: 19162.90428
+  tps: 19167.59867
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Heartpierce-50641"
  value: {
   dps: 29609.28025
-  tps: 19714.8883
+  tps: 19719.41861
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpassiveShadowspiritDiamond"
  value: {
   dps: 29177.02116
-  tps: 19410.346
+  tps: 19414.87631
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpatienceofYouth-62464"
  value: {
   dps: 28879.71399
-  tps: 19146.9056
+  tps: 19151.66524
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpatienceofYouth-62469"
  value: {
   dps: 28879.71399
-  tps: 19146.9056
+  tps: 19151.66524
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpetuousQuery-55881"
  value: {
   dps: 28220.56236
-  tps: 18756.91147
+  tps: 18761.6711
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ImpetuousQuery-56406"
  value: {
   dps: 28272.9819
-  tps: 18782.40082
+  tps: 18787.16045
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InsigniaofDiplomacy-61433"
  value: {
   dps: 27820.26765
-  tps: 18562.26555
+  tps: 18567.02518
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
   dps: 28128.43104
-  tps: 18712.11201
+  tps: 18716.87165
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-JarofAncientRemedies-59354"
  value: {
   dps: 27820.26765
-  tps: 18567.16074
+  tps: 18571.71981
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-JarofAncientRemedies-65029"
  value: {
   dps: 27820.26765
-  tps: 18567.22378
+  tps: 18571.82916
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-JujuofNimbleness-63840"
  value: {
   dps: 28998.09503
-  tps: 19266.2439
+  tps: 19270.87745
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-KeytotheEndlessChamber-55795"
  value: {
   dps: 29100.21419
-  tps: 19400.71296
+  tps: 19405.22412
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-KeytotheEndlessChamber-56328"
  value: {
   dps: 29468.45381
-  tps: 19632.4616
+  tps: 19637.04764
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-KvaldirBattleStandard-59685"
  value: {
   dps: 28076.0271
-  tps: 18721.32398
+  tps: 18726.03548
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-KvaldirBattleStandard-59689"
  value: {
   dps: 28076.0271
-  tps: 18721.32398
+  tps: 18726.03548
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
   dps: 27987.70363
-  tps: 18660.05519
+  tps: 18664.66123
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LastWord-50708"
  value: {
   dps: 29609.28025
-  tps: 19714.8883
+  tps: 19719.41861
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LeadenDespair-55816"
  value: {
   dps: 27820.26765
-  tps: 18562.26555
+  tps: 18567.02518
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LeadenDespair-56347"
  value: {
   dps: 27820.26765
-  tps: 18562.26555
+  tps: 18567.02518
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LeftEyeofRajh-56102"
  value: {
   dps: 28890.20724
-  tps: 19255.59849
+  tps: 19260.33306
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LeftEyeofRajh-56427"
  value: {
   dps: 29073.62184
-  tps: 19390.70092
+  tps: 19395.39328
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-LicensetoSlay-58180"
  value: {
   dps: 28721.45417
-  tps: 19148.93253
+  tps: 19153.47212
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MagnetiteMirror-55814"
  value: {
   dps: 28163.92484
-  tps: 18775.88823
+  tps: 18780.64786
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MagnetiteMirror-56345"
  value: {
   dps: 28275.81322
-  tps: 18845.43979
+  tps: 18850.19943
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MandalaofStirringPatterns-62467"
  value: {
   dps: 27882.63581
-  tps: 18544.97362
+  tps: 18549.76204
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MandalaofStirringPatterns-62472"
  value: {
   dps: 27882.63581
-  tps: 18544.97362
+  tps: 18549.76204
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MarkofKhardros-56132"
  value: {
   dps: 28642.50457
-  tps: 19014.0796
+  tps: 19018.83924
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MarkofKhardros-56458"
  value: {
   dps: 28751.12282
-  tps: 19073.67704
+  tps: 19078.43667
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MatrixRestabilizer-68994"
  value: {
   dps: 30065.09846
-  tps: 19961.80431
+  tps: 19966.52539
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MatrixRestabilizer-69150"
  value: {
   dps: 30312.69827
-  tps: 20142.07162
+  tps: 20146.71564
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MightoftheOcean-55251"
  value: {
   dps: 28291.70395
-  tps: 18903.52333
+  tps: 18908.07004
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MightoftheOcean-56285"
  value: {
   dps: 28649.98346
-  tps: 19087.52443
+  tps: 19092.08716
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MirrorofBrokenImages-62466"
  value: {
   dps: 28330.16686
-  tps: 18810.20738
+  tps: 18814.96701
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MirrorofBrokenImages-62471"
  value: {
   dps: 28330.16686
-  tps: 18810.20738
+  tps: 18814.96701
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MithrilStopwatch-71337"
  value: {
   dps: 28148.33022
-  tps: 18794.73474
+  tps: 18799.32559
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MoonwellChalice-70142"
  value: {
   dps: 28446.40985
-  tps: 18870.13896
+  tps: 18875.62137
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-MoonwellPhial-70143"
  value: {
   dps: 27820.26765
-  tps: 18562.26555
+  tps: 18567.02518
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-NecromanticFocus-68982"
  value: {
   dps: 28449.48853
-  tps: 18866.39078
+  tps: 18871.9594
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-NecromanticFocus-69139"
  value: {
   dps: 28530.59139
-  tps: 18904.02547
+  tps: 18909.69208
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Oremantle'sFavor-61448"
  value: {
   dps: 28328.93651
-  tps: 18895.46808
+  tps: 18900.04922
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PetrifiedPickledEgg-71336"
  value: {
   dps: 27861.06297
-  tps: 18580.96613
+  tps: 18586.44854
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PetrifiedTwilightScale-54591"
  value: {
   dps: 27820.26765
-  tps: 18562.26555
+  tps: 18567.02518
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
   dps: 28012.58704
-  tps: 18707.85063
+  tps: 18712.70436
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PorcelainCrab-55237"
  value: {
   dps: 28122.97588
-  tps: 18709.56986
+  tps: 18714.32949
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PorcelainCrab-56280"
  value: {
   dps: 28383.69293
-  tps: 18829.67154
+  tps: 18834.43117
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-PowerfulShadowspiritDiamond"
  value: {
   dps: 29118.89661
-  tps: 19374.62625
+  tps: 19379.12335
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
   dps: 29224.40323
-  tps: 19541.57338
+  tps: 19545.8852
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
   dps: 29435.53422
-  tps: 19616.48077
+  tps: 19620.98559
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Rainsong-55854"
  value: {
   dps: 27882.63581
-  tps: 18544.99805
+  tps: 18549.78495
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Rainsong-56377"
  value: {
   dps: 27882.63581
-  tps: 18544.98192
+  tps: 18549.76982
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RegaliaoftheRagingElements"
  value: {
   dps: 20303.61227
-  tps: 13509.34515
+  tps: 13516.36771
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ReverberatingShadowspiritDiamond"
  value: {
   dps: 29630.78066
-  tps: 19728.38213
+  tps: 19732.87923
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RevitalizingShadowspiritDiamond"
  value: {
   dps: 29547.02706
-  tps: 19676.11605
+  tps: 19680.61206
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Ricket'sMagneticFireball-70144"
  value: {
   dps: 29418.24565
-  tps: 19663.56995
+  tps: 19668.05465
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RightEyeofRajh-56100"
  value: {
   dps: 28650.64159
-  tps: 19126.94136
+  tps: 19131.5724
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RightEyeofRajh-56431"
  value: {
   dps: 28715.33988
-  tps: 19132.87479
+  tps: 19137.43752
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-RuneofZeth-68998"
  value: {
   dps: 28244.64623
-  tps: 18948.8397
+  tps: 18953.80348
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
   dps: 28989.52251
-  tps: 19277.23752
+  tps: 19282.09461
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SeaStar-55256"
  value: {
   dps: 27882.63581
-  tps: 18545.00151
+  tps: 18549.78819
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SeaStar-56290"
  value: {
   dps: 27882.63581
-  tps: 18544.98192
+  tps: 18549.76982
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Shadowmourne-49623"
  value: {
   dps: 29609.28025
-  tps: 19714.8883
+  tps: 19719.41861
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ShardofWoe-60233"
  value: {
   dps: 28017.89917
-  tps: 18692.843
+  tps: 18696.16207
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Shrine-CleansingPurifier-63838"
  value: {
   dps: 28403.39988
-  tps: 18930.26952
+  tps: 18934.50005
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
   dps: 27820.26765
-  tps: 18562.26555
+  tps: 18567.02518
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Skardyn'sGrace-56115"
  value: {
   dps: 29189.39533
-  tps: 19394.53016
+  tps: 19399.38725
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Skardyn'sGrace-56440"
  value: {
   dps: 29372.845
-  tps: 19510.33425
+  tps: 19515.18798
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Sorrowsong-55879"
  value: {
   dps: 28220.56236
-  tps: 18756.91147
+  tps: 18761.6711
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Sorrowsong-56400"
  value: {
   dps: 28272.9819
-  tps: 18782.40082
+  tps: 18787.16045
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Soul'sAnguish-66994"
  value: {
   dps: 28419.73036
-  tps: 18977.2568
+  tps: 18981.88783
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SoulCasket-58183"
  value: {
   dps: 28330.16686
-  tps: 18810.20738
+  tps: 18814.96701
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Spiritwalker'sRegalia"
  value: {
   dps: 20529.1586
-  tps: 13431.73945
+  tps: 13439.56234
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Stonemother'sKiss-61411"
  value: {
   dps: 28108.78693
-  tps: 18775.48418
+  tps: 18780.42067
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-StumpofTime-62465"
  value: {
   dps: 28140.71096
-  tps: 18786.30985
+  tps: 18790.84944
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-StumpofTime-62470"
  value: {
   dps: 28140.71096
-  tps: 18786.30985
+  tps: 18790.84944
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SymbioticWorm-59332"
  value: {
   dps: 27820.26765
-  tps: 18562.26555
+  tps: 18567.02518
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-SymbioticWorm-65048"
  value: {
   dps: 27820.26765
-  tps: 18562.26555
+  tps: 18567.02518
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TalismanofSinisterOrder-65804"
  value: {
   dps: 28153.10262
-  tps: 18724.1095
+  tps: 18729.37708
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Tank-CommanderInsignia-63841"
  value: {
   dps: 28427.39767
-  tps: 18959.87749
+  tps: 18964.3616
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TearofBlood-55819"
  value: {
   dps: 27847.96685
-  tps: 18575.82481
+  tps: 18581.05211
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TearofBlood-56351"
  value: {
   dps: 27857.98657
-  tps: 18579.94386
+  tps: 18585.31515
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TendrilsofBurrowingDark-55810"
  value: {
   dps: 28161.78893
-  tps: 18728.33251
+  tps: 18733.09214
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TendrilsofBurrowingDark-56339"
  value: {
   dps: 28272.9819
-  tps: 18782.40082
+  tps: 18787.16045
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheHungerer-68927"
  value: {
   dps: 29582.82067
-  tps: 19780.83457
+  tps: 19785.30587
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TheHungerer-69112"
  value: {
   dps: 29775.72327
-  tps: 19823.54863
+  tps: 19827.83257
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Theralion'sMirror-59519"
  value: {
   dps: 28429.07639
-  tps: 18859.17129
+  tps: 18864.61531
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Theralion'sMirror-65105"
  value: {
   dps: 28527.57129
-  tps: 18911.14706
+  tps: 18916.67558
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Throngus'sFinger-56121"
  value: {
   dps: 27820.26765
-  tps: 18562.26555
+  tps: 18567.02518
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Throngus'sFinger-56449"
  value: {
   dps: 27820.26765
-  tps: 18562.26555
+  tps: 18567.02518
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Tia'sGrace-55874"
  value: {
   dps: 29317.3155
-  tps: 19483.22329
+  tps: 19488.04831
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Tia'sGrace-56394"
  value: {
   dps: 29525.32057
-  tps: 19607.3195
+  tps: 19612.1398
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TidefuryRaiment"
  value: {
   dps: 18456.05693
-  tps: 12454.38913
+  tps: 12459.32932
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-TinyAbominationinaJar-50706"
  value: {
   dps: 28786.27013
-  tps: 19314.85849
+  tps: 19319.11441
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
   dps: 27889.45006
-  tps: 18638.62358
+  tps: 18643.89044
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-UnheededWarning-59520"
  value: {
   dps: 29541.501
-  tps: 19691.52507
+  tps: 19696.35009
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-UnquenchableFlame-67101"
  value: {
   dps: 27882.63581
-  tps: 18545.00797
+  tps: 18549.79474
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-UnsolvableRiddle-62463"
  value: {
   dps: 29702.91327
-  tps: 19688.30292
+  tps: 19692.83829
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-UnsolvableRiddle-62468"
  value: {
   dps: 29702.91327
-  tps: 19688.30292
+  tps: 19692.83829
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-UnsolvableRiddle-68709"
  value: {
   dps: 29702.91327
-  tps: 19688.30292
+  tps: 19692.83829
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
   dps: 25030.32617
-  tps: 16455.42254
+  tps: 16460.06459
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
   dps: 28032.96825
-  tps: 18778.12158
+  tps: 18783.62043
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
   dps: 28638.29187
-  tps: 19333.98922
+  tps: 19339.80417
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-VesselofAcceleration-68995"
  value: {
   dps: 28839.16656
-  tps: 19236.02915
+  tps: 19240.7022
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-VesselofAcceleration-69167"
  value: {
   dps: 28956.69258
-  tps: 19305.14138
+  tps: 19309.79121
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-VialofStolenMemories-59515"
  value: {
   dps: 27820.26765
-  tps: 18562.26555
+  tps: 18567.02518
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-VialofStolenMemories-65109"
  value: {
   dps: 27820.26765
-  tps: 18562.26555
+  tps: 18567.02518
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
   dps: 29170.47782
-  tps: 19429.90686
+  tps: 19434.44223
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
   dps: 27820.26765
-  tps: 18562.26555
+  tps: 18567.02518
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
   dps: 28359.70076
-  tps: 18894.23491
+  tps: 18898.99454
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
   dps: 28148.0437
-  tps: 18824.2053
+  tps: 18828.72901
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
   dps: 27962.19311
-  tps: 18689.38802
+  tps: 18693.8746
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
   dps: 28148.33022
-  tps: 18794.73474
+  tps: 18799.32559
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
   dps: 27820.26765
-  tps: 18562.26555
+  tps: 18567.02518
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
   dps: 28360.34781
-  tps: 18824.88306
+  tps: 18829.64269
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
   dps: 27820.26765
-  tps: 18562.26555
+  tps: 18567.02518
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
   dps: 29117.8656
-  tps: 19402.22193
+  tps: 19406.84728
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
   dps: 27820.26765
-  tps: 18562.26555
+  tps: 18567.02518
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
   dps: 28353.94974
-  tps: 18894.20089
+  tps: 18898.96052
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-VolcanicRegalia"
  value: {
   dps: 20502.38776
-  tps: 13638.42614
+  tps: 13646.1756
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WitchingHourglass-55787"
  value: {
   dps: 27960.49296
-  tps: 18676.20754
+  tps: 18681.35388
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-WitchingHourglass-56320"
  value: {
   dps: 28053.1297
-  tps: 18740.94384
+  tps: 18746.14555
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-World-QuellerFocus-63842"
  value: {
   dps: 28168.14281
-  tps: 18731.42212
+  tps: 18736.18176
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
   dps: 28195.56179
-  tps: 18744.31931
+  tps: 18749.07894
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
   dps: 28195.56179
-  tps: 18744.31931
+  tps: 18749.07894
  }
 }
 dps_results: {
  key: "TestEnhancement-Average-Default"
  value: {
   dps: 29803.90627
-  tps: 19843.53965
+  tps: 19848.1216
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1draenei-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 30047.38604
-  tps: 23983.44729
+  tps: 24074.05354
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1draenei-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 29609.28025
-  tps: 19714.8883
+  tps: 19719.41861
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Draenei-p1draenei-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 34042.64232
-  tps: 22164.56829
+  tps: 22169.80831
  }
 }
 dps_results: {
@@ -1531,21 +1531,21 @@ dps_results: {
  key: "TestEnhancement-Settings-Orc-p1draenei-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 30370.07659
-  tps: 24116.32633
+  tps: 24207.69013
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1draenei-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 29925.61757
-  tps: 19835.49014
+  tps: 19840.05833
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p1draenei-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 34614.61418
-  tps: 22401.00168
+  tps: 22406.23983
  }
 }
 dps_results: {
@@ -1573,21 +1573,21 @@ dps_results: {
  key: "TestEnhancement-Settings-Troll-p1draenei-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 30045.8375
-  tps: 23971.76418
+  tps: 24064.34285
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1draenei-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
   dps: 29622.16249
-  tps: 19667.96396
+  tps: 19672.6326
  }
 }
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p1draenei-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
   dps: 34089.03861
-  tps: 22148.76359
+  tps: 22153.84311
  }
 }
 dps_results: {
@@ -1615,6 +1615,6 @@ dps_results: {
  key: "TestEnhancement-SwitchInFrontOfTarget-Default"
  value: {
   dps: 27666.88064
-  tps: 17982.92296
+  tps: 17987.6872
  }
 }

--- a/sim/warlock/affliction/TestAffliction.results
+++ b/sim/warlock/affliction/TestAffliction.results
@@ -38,1395 +38,1395 @@ character_stats_results: {
 dps_results: {
  key: "TestAffliction-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 27533.91574
-  tps: 20598.26752
+  dps: 27680.83086
+  tps: 20689.87416
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 26580.60833
-  tps: 19840.86847
+  dps: 26547.56379
+  tps: 19848.84803
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 26155.32721
-  tps: 19660.46892
+  dps: 26261.14251
+  tps: 19774.80515
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 26653.01769
-  tps: 19933.49247
+  dps: 26768.85953
+  tps: 20065.75473
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 26697.44126
-  tps: 19963.80868
+  dps: 26815.16592
+  tps: 20094.16219
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 27332.04503
-  tps: 20377.68714
+  dps: 27347.00494
+  tps: 20360.85654
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 25995.19559
-  tps: 19459.92779
-  hps: 101.40915
+  dps: 26002.99422
+  tps: 19503.89226
+  hps: 100.63102
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 27332.39539
-  tps: 20359.12603
+  dps: 27471.27001
+  tps: 20527.59106
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BindingPromise-67037"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 26113.84256
-  tps: 19617.4578
+  dps: 26093.67393
+  tps: 19610.6177
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 26105.36673
-  tps: 19562.21053
+  dps: 26238.55435
+  tps: 19724.5727
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 26105.36673
-  tps: 19562.21053
+  dps: 26238.55435
+  tps: 19724.5727
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 25889.79496
-  tps: 19373.34679
+  dps: 25915.64735
+  tps: 19441.28086
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 26792.06458
-  tps: 20046.35417
+  dps: 26803.81635
+  tps: 20075.7356
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 25912.86233
-  tps: 19408.25369
+  dps: 25931.95255
+  tps: 19449.56118
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 26271.88062
-  tps: 19631.93895
+  dps: 26338.9469
+  tps: 19730.94751
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 25947.74479
-  tps: 19401.11673
+  dps: 26011.23635
+  tps: 19493.93678
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 25947.74479
-  tps: 19401.11673
+  dps: 26011.23635
+  tps: 19493.93678
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 26685.53324
-  tps: 19931.63055
+  dps: 26815.88888
+  tps: 20091.83967
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BottledLightning-66879"
  value: {
-  dps: 26704.17512
-  tps: 19947.12829
+  dps: 26643.82426
+  tps: 19963.68126
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 27544.95808
-  tps: 20145.71501
+  dps: 27541.53998
+  tps: 20119.60443
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Brawler'sTrophy-71338"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 27839.61727
-  tps: 20836.21243
+  dps: 27832.51211
+  tps: 20804.39172
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 27627.59465
-  tps: 20669.58972
+  dps: 27767.3429
+  tps: 20749.7843
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Coren'sChilledChromiumCoaster-71335"
  value: {
-  dps: 26275.33452
-  tps: 19622.68247
+  dps: 26399.1324
+  tps: 19776.3636
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 26955.34671
-  tps: 20120.54277
+  dps: 26920.28665
+  tps: 20154.17527
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CrushingWeight-59506"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CrushingWeight-65118"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 25947.74479
-  tps: 19401.15669
+  dps: 26010.03532
+  tps: 19490.6276
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 27044.92649
-  tps: 20171.64225
+  dps: 26967.2505
+  tps: 20155.47846
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 26083.9119
-  tps: 19498.47939
+  dps: 26212.8933
+  tps: 19649.32675
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 27336.94748
-  tps: 20387.92343
+  dps: 27474.17216
+  tps: 20465.58018
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 26689.87019
-  tps: 20021.45339
+  dps: 26612.42934
+  tps: 19948.92187
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 26257.65687
-  tps: 19614.37164
+  dps: 26381.97482
+  tps: 19780.59326
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 27332.04503
-  tps: 20377.68714
+  dps: 27347.00494
+  tps: 20360.85654
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 26359.70645
-  tps: 19690.18468
+  dps: 26362.58315
+  tps: 19767.86265
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 27697.72403
-  tps: 20629.12829
+  dps: 27524.36205
+  tps: 20533.00261
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 27336.94748
-  tps: 20387.92343
+  dps: 27474.17216
+  tps: 20465.58018
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 26155.32721
-  tps: 19660.46892
+  dps: 26261.14251
+  tps: 19774.80515
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 27332.04503
-  tps: 20377.68714
+  dps: 27347.00494
+  tps: 20360.85654
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FallofMortality-59500"
  value: {
-  dps: 27044.92649
-  tps: 20171.64225
+  dps: 26967.2505
+  tps: 20155.47846
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FallofMortality-65124"
  value: {
-  dps: 27091.85823
-  tps: 20206.24432
+  dps: 27137.60876
+  tps: 20291.99334
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 27002.34876
-  tps: 20143.07301
+  dps: 26972.6845
+  tps: 20184.94843
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 26068.42641
-  tps: 19493.94672
+  dps: 26124.49316
+  tps: 19570.26272
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 26849.72906
-  tps: 20098.0421
+  dps: 26743.86195
+  tps: 20000.93337
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 26036.62604
-  tps: 19447.75709
+  dps: 25983.52607
+  tps: 19492.20745
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 27686.04673
-  tps: 20703.61806
+  dps: 27568.03602
+  tps: 20594.50162
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 26109.30646
-  tps: 19604.69782
+  dps: 26128.41325
+  tps: 19646.02187
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 27349.02899
-  tps: 20422.25006
+  dps: 27493.43345
+  tps: 20511.28753
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FluidDeath-58181"
  value: {
-  dps: 26110.47229
-  tps: 19555.08807
+  dps: 26207.39367
+  tps: 19670.83471
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 27544.95808
-  tps: 20550.47352
+  dps: 27541.53998
+  tps: 20522.47401
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 26250.29285
-  tps: 19606.32569
+  dps: 26381.61924
+  tps: 19766.96832
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GaleofShadows-56138"
  value: {
-  dps: 27086.39832
-  tps: 20356.92041
+  dps: 26922.0874
+  tps: 20224.21014
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GaleofShadows-56462"
  value: {
-  dps: 27120.57387
-  tps: 20329.04749
+  dps: 27157.42688
+  tps: 20413.52625
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GearDetector-61462"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 22936.72322
-  tps: 17090.95398
+  dps: 22792.62552
+  tps: 16973.6794
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 26652.03663
-  tps: 19905.9461
+  dps: 26497.07332
+  tps: 19802.7539
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HarmlightToken-63839"
  value: {
-  dps: 27096.64534
-  tps: 20162.54244
+  dps: 26973.23547
+  tps: 20094.45548
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 27187.7975
-  tps: 20544.18313
+  dps: 27172.87113
+  tps: 20490.86798
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 27285.89373
-  tps: 20649.58118
+  dps: 27337.59621
+  tps: 20676.93872
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofRage-59224"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofRage-65072"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofSolace-55868"
  value: {
-  dps: 26408.89482
-  tps: 19840.83393
+  dps: 26249.15461
+  tps: 19713.16052
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofSolace-56393"
  value: {
-  dps: 26353.31264
-  tps: 19746.27911
+  dps: 26390.49947
+  tps: 19830.81441
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofThunder-55845"
  value: {
-  dps: 25896.97233
-  tps: 19365.84782
+  dps: 26017.551
+  tps: 19522.84199
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofThunder-56370"
  value: {
-  dps: 25919.0741
-  tps: 19369.84509
+  dps: 26006.49553
+  tps: 19514.87845
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 27336.94748
-  tps: 20387.92343
+  dps: 27474.17216
+  tps: 20465.58018
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 26207.52853
-  tps: 19702.91988
+  dps: 26226.64359
+  tps: 19744.25222
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 26207.52853
-  tps: 19702.91988
+  dps: 26226.64359
+  tps: 19744.25222
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 26099.79382
-  tps: 19560.20704
+  dps: 26248.34147
+  tps: 19734.44387
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 26099.79382
-  tps: 19560.20704
+  dps: 26248.34147
+  tps: 19734.44387
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 25890.96432
-  tps: 19360.83901
+  dps: 26025.25531
+  tps: 19534.39437
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 26537.83352
-  tps: 19893.2213
+  dps: 26509.73912
+  tps: 19881.43487
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 26089.38469
-  tps: 19521.34376
+  dps: 26033.60529
+  tps: 19528.66048
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 26053.60099
-  tps: 19515.88454
+  dps: 26096.05375
+  tps: 19590.35862
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 26113.84256
-  tps: 19617.4578
+  dps: 26093.67393
+  tps: 19610.6177
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 26110.47229
-  tps: 19555.08807
+  dps: 26207.39367
+  tps: 19670.83471
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 26110.47229
-  tps: 19555.08807
+  dps: 26207.39367
+  tps: 19670.83471
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 26172.39127
-  tps: 19635.9431
+  dps: 26086.10974
+  tps: 19610.80255
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 26172.39127
-  tps: 19635.9431
+  dps: 26086.10974
+  tps: 19610.80255
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 26176.74483
-  tps: 19601.0183
+  dps: 26026.83159
+  tps: 19524.38624
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LeadenDespair-55816"
  value: {
-  dps: 26035.02967
-  tps: 19470.84552
+  dps: 26028.32232
+  tps: 19511.5979
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LeadenDespair-56347"
  value: {
-  dps: 26036.62604
-  tps: 19447.75709
+  dps: 25983.52607
+  tps: 19492.20745
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 26110.47229
-  tps: 19555.08807
+  dps: 26207.39367
+  tps: 19670.83471
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 25917.65614
-  tps: 19421.27138
+  dps: 25898.07969
+  tps: 19415.02346
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 25917.65614
-  tps: 19421.27138
+  dps: 25898.07969
+  tps: 19415.02346
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 26155.01086
-  tps: 19658.6261
+  dps: 26132.05803
+  tps: 19649.0018
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 26198.16626
-  tps: 19701.78151
+  dps: 26174.59954
+  tps: 19691.54332
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 26070.24188
-  tps: 19515.42725
+  dps: 26130.33132
+  tps: 19655.68848
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 26070.24188
-  tps: 19515.42725
+  dps: 26130.33132
+  tps: 19655.68848
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 26197.50095
-  tps: 19657.91417
+  dps: 26347.22564
+  tps: 19833.32804
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 26197.50095
-  tps: 19657.91417
+  dps: 26347.22564
+  tps: 19833.32804
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MithrilStopwatch-71337"
  value: {
-  dps: 27369.48857
-  tps: 20422.38115
+  dps: 27499.17366
+  tps: 20571.98396
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 27421.68165
-  tps: 20615.33307
+  dps: 27412.83383
+  tps: 20624.0029
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 26021.47335
-  tps: 19453.97257
+  dps: 26031.86453
+  tps: 19552.95543
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 27472.30264
-  tps: 20563.10376
+  dps: 27447.43966
+  tps: 20587.15915
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 27765.00186
-  tps: 20832.28644
+  dps: 27650.97446
+  tps: 20803.07399
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 26190.83191
-  tps: 19584.62215
+  dps: 26249.54415
+  tps: 19667.38389
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PetrifiedPickledEgg-71336"
  value: {
-  dps: 27066.87961
-  tps: 20181.11479
+  dps: 27084.41208
+  tps: 20261.02478
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 26724.55843
-  tps: 19958.17979
+  dps: 26851.11668
+  tps: 20108.20775
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 27332.04503
-  tps: 20377.68714
+  dps: 27347.00494
+  tps: 20360.85654
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Rainsong-55854"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Rainsong-56377"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 27533.91574
-  tps: 20598.26752
+  dps: 27680.83086
+  tps: 20689.87416
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 27533.91574
-  tps: 20598.26752
+  dps: 27680.83086
+  tps: 20689.87416
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 26418.65197
-  tps: 19722.22176
+  dps: 26430.73316
+  tps: 19781.18818
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 26110.47229
-  tps: 19555.08807
+  dps: 26207.39367
+  tps: 19670.83471
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 26110.47229
-  tps: 19555.08807
+  dps: 26207.39367
+  tps: 19670.83471
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuneofZeth-68998"
  value: {
-  dps: 27392.1932
-  tps: 20392.10191
+  dps: 27350.92597
+  tps: 20422.26897
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SeaStar-55256"
  value: {
-  dps: 26355.35557
-  tps: 19729.40295
+  dps: 26370.75243
+  tps: 19764.70817
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SeaStar-56290"
  value: {
-  dps: 26737.11444
-  tps: 20006.47289
+  dps: 26749.32486
+  tps: 20036.5997
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ShadowflameRegalia"
  value: {
-  dps: 25320.76777
-  tps: 18937.21966
+  dps: 25267.47357
+  tps: 18954.54693
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ShardofWoe-60233"
  value: {
-  dps: 26468.05128
-  tps: 19837.8397
+  dps: 26405.66589
+  tps: 19800.84217
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 25990.32565
-  tps: 19445.81601
+  dps: 25963.14475
+  tps: 19451.54228
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 26181.86266
-  tps: 19677.25401
+  dps: 26195.43986
+  tps: 19713.04848
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 26230.77181
-  tps: 19726.16316
+  dps: 26243.34664
+  tps: 19760.95527
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Sorrowsong-55879"
  value: {
-  dps: 26725.00172
-  tps: 20034.03081
+  dps: 26852.29182
+  tps: 20184.48661
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Sorrowsong-56400"
  value: {
-  dps: 26806.1444
-  tps: 20095.8168
+  dps: 26932.6622
+  tps: 20244.71343
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 26070.24188
-  tps: 19515.42725
+  dps: 26130.33132
+  tps: 19655.68848
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SoulCasket-58183"
  value: {
-  dps: 27334.30227
-  tps: 20524.19232
+  dps: 27343.77412
+  tps: 20550.06844
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 26893.90106
-  tps: 20066.24829
+  dps: 26754.26499
+  tps: 19991.71989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StumpofTime-62465"
  value: {
-  dps: 27144.96186
-  tps: 20330.35708
+  dps: 27220.5711
+  tps: 20423.23455
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StumpofTime-62470"
  value: {
-  dps: 27151.00321
-  tps: 20302.02157
+  dps: 27245.76297
+  tps: 20417.28377
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 26016.47175
-  tps: 19476.23167
+  dps: 26010.92919
+  tps: 19527.16122
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 26010.93854
-  tps: 19420.80755
+  dps: 25926.98973
+  tps: 19473.91301
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 26963.91469
-  tps: 20177.58367
+  dps: 26871.27137
+  tps: 20138.45385
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TearofBlood-55819"
  value: {
-  dps: 26707.80543
-  tps: 19936.88911
+  dps: 26656.58217
+  tps: 19936.59338
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TearofBlood-56351"
  value: {
-  dps: 26915.01291
-  tps: 20108.99246
+  dps: 26847.89993
+  tps: 20072.05166
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 26606.55584
-  tps: 19914.64841
+  dps: 26750.75822
+  tps: 20089.29405
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 26755.82213
-  tps: 20019.11576
+  dps: 26905.31879
+  tps: 20194.23513
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TheHungerer-68927"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TheHungerer-69112"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 27365.44325
-  tps: 20492.159
+  dps: 27289.6523
+  tps: 20477.88026
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 27446.31319
-  tps: 20560.69928
+  dps: 27499.04897
+  tps: 20653.43355
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 26105.36673
-  tps: 19562.21053
+  dps: 26238.55435
+  tps: 19724.5727
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 26105.36673
-  tps: 19562.21053
+  dps: 26238.55435
+  tps: 19724.5727
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 25998.16885
-  tps: 19436.09845
+  dps: 26113.16613
+  tps: 19588.46488
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 26750.13967
-  tps: 19991.25175
+  dps: 26748.11662
+  tps: 20089.10678
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnheededWarning-59520"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 25912.86233
-  tps: 19408.25369
+  dps: 25931.95255
+  tps: 19449.56118
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 26207.52853
-  tps: 19702.91988
+  dps: 26226.64359
+  tps: 19744.25222
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 26207.52853
-  tps: 19702.91988
+  dps: 26226.64359
+  tps: 19744.25222
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 26207.52853
-  tps: 19702.91988
+  dps: 26226.64359
+  tps: 19744.25222
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 27588.26274
-  tps: 20762.1846
+  dps: 27377.79723
+  tps: 20602.84337
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 28204.74306
-  tps: 21275.40526
+  dps: 28082.2565
+  tps: 21267.3472
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 26016.47175
-  tps: 19476.23167
+  dps: 26010.92919
+  tps: 19527.16122
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 26010.93854
-  tps: 19420.80755
+  dps: 25926.98973
+  tps: 19473.91301
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 25912.86233
-  tps: 19408.25369
+  dps: 25931.95255
+  tps: 19449.56118
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 26841.23049
-  tps: 20082.03742
+  dps: 26852.57189
+  tps: 20110.75193
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 25912.86233
-  tps: 19408.25369
+  dps: 25931.95255
+  tps: 19449.56118
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 26137.44365
-  tps: 19557.35056
+  dps: 26219.53001
+  tps: 19669.97924
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 26511.18865
-  tps: 19864.20424
+  dps: 26411.22042
+  tps: 19838.25018
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 26349.47006
-  tps: 19697.73847
+  dps: 26317.69411
+  tps: 19711.01269
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 25980.51492
-  tps: 19435.35608
+  dps: 25966.59192
+  tps: 19461.35482
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 26275.5282
-  tps: 19730.36935
+  dps: 26261.31101
+  tps: 19756.07391
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 25980.51492
-  tps: 19435.35608
+  dps: 25966.59192
+  tps: 19461.35482
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 26645.81389
-  tps: 19890.49714
+  dps: 26780.06161
+  tps: 20052.27381
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 25909.94116
-  tps: 19366.78496
+  dps: 26040.85305
+  tps: 19526.8714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 26632.50401
-  tps: 19902.61306
+  dps: 26654.15136
+  tps: 19950.88097
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 27207.82376
-  tps: 20424.39329
+  dps: 27267.90086
+  tps: 20565.40571
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 26109.30646
-  tps: 19604.69782
+  dps: 26128.41325
+  tps: 19646.02187
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 26144.71066
-  tps: 19660.28807
+  dps: 26073.53892
+  tps: 19636.81264
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 26144.71066
-  tps: 19660.28807
+  dps: 26073.53892
+  tps: 19636.81264
  }
 }
 dps_results: {
  key: "TestAffliction-Average-Default"
  value: {
-  dps: 28170.80239
-  tps: 21107.09022
+  dps: 28117.15886
+  tps: 21111.63823
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 28377.00081
-  tps: 27889.9457
+  dps: 28413.4585
+  tps: 29211.11679
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 27391.21367
-  tps: 20681.48324
+  dps: 27436.88952
+  tps: 20811.32111
  }
 }
 dps_results: {
@@ -1460,15 +1460,15 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Settings-Human-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 28220.26776
-  tps: 27508.84473
+  dps: 28159.25935
+  tps: 28813.57574
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 27267.89479
-  tps: 20643.25928
+  dps: 27267.13739
+  tps: 20623.82545
  }
 }
 dps_results: {
@@ -1502,15 +1502,15 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Settings-Orc-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 28795.61845
-  tps: 27702.27915
+  dps: 28724.42209
+  tps: 28992.93466
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 27839.61727
-  tps: 20836.21243
+  dps: 27832.51211
+  tps: 20804.39172
  }
 }
 dps_results: {
@@ -1544,15 +1544,15 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Settings-Troll-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 28607.04272
-  tps: 27963.31527
+  dps: 28467.67235
+  tps: 29188.79265
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 27652.93899
-  tps: 20937.42863
+  dps: 27532.47247
+  tps: 20906.8622
  }
 }
 dps_results: {
@@ -1586,7 +1586,7 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 27725.24947
-  tps: 20836.21243
+  dps: 27719.45483
+  tps: 20804.39172
  }
 }

--- a/sim/warlock/demonology/TestDemonology.results
+++ b/sim/warlock/demonology/TestDemonology.results
@@ -38,1402 +38,1402 @@ character_stats_results: {
 dps_results: {
  key: "TestDemonology-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 29211.59992
-  tps: 15346.32315
+  dps: 29232.88469
+  tps: 15385.26127
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 27345.13014
-  tps: 14472.156
+  dps: 27327.08662
+  tps: 14499.19307
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 25713.98331
-  tps: 14516.13718
+  dps: 25747.45035
+  tps: 14546.81203
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 27716.27089
-  tps: 14687.54279
+  dps: 27732.42009
+  tps: 14731.08376
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 27793.64724
-  tps: 14719.38081
+  dps: 27815.12205
+  tps: 14766.33906
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 29012.49469
-  tps: 15194.21489
+  dps: 29033.89991
+  tps: 15233.06057
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 26820.59493
-  tps: 14230.18719
-  hps: 97.61977
+  dps: 26806.17199
+  tps: 14249.83419
+  hps: 98.14692
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 28451.54122
-  tps: 15087.90111
+  dps: 28474.86191
+  tps: 15093.38341
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BindingPromise-67037"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 25516.97776
-  tps: 14441.30308
+  dps: 25499.70132
+  tps: 14457.48124
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 27202.24512
-  tps: 14379.7816
+  dps: 27200.5433
+  tps: 14393.70243
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 27333.38552
-  tps: 14431.27848
+  dps: 27331.70283
+  tps: 14445.02788
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 25169.2171
-  tps: 14282.82637
+  dps: 25147.9925
+  tps: 14289.96386
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 26133.17204
-  tps: 14858.14936
+  dps: 26121.72081
+  tps: 14865.58793
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 25143.35501
-  tps: 14254.78683
+  dps: 25133.10042
+  tps: 14267.13778
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 27192.51982
-  tps: 14464.73972
+  dps: 27208.45179
+  tps: 14472.90414
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 26808.80196
-  tps: 14224.88169
+  dps: 26814.44964
+  tps: 14242.45434
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 26808.80196
-  tps: 14225.269
+  dps: 26807.04278
+  tps: 14239.70411
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 26808.80196
-  tps: 14225.269
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 27685.62834
-  tps: 14684.99193
+  dps: 27684.53368
+  tps: 14694.21777
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 26808.80196
-  tps: 14225.269
+  dps: 26807.04278
+  tps: 14239.70411
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BottledLightning-66879"
  value: {
-  dps: 25794.77582
-  tps: 14596.82235
+  dps: 25803.03177
+  tps: 14626.89123
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 29185.58608
-  tps: 15007.80777
+  dps: 29195.15763
+  tps: 15022.66727
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Brawler'sTrophy-71338"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 29387.34064
-  tps: 15457.71566
+  dps: 29395.84932
+  tps: 15470.77051
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 29279.92325
-  tps: 15378.49087
+  dps: 29301.76783
+  tps: 15417.82803
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Coren'sChilledChromiumCoaster-71335"
  value: {
-  dps: 27256.68069
-  tps: 14494.20787
+  dps: 27278.5954
+  tps: 14497.72724
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 26042.88471
-  tps: 14726.27966
+  dps: 26065.33689
+  tps: 14773.91865
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CrushingWeight-59506"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CrushingWeight-65118"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 26808.80196
-  tps: 14225.269
+  dps: 26807.04278
+  tps: 14239.70411
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 27736.04274
-  tps: 14703.02656
+  dps: 27753.27287
+  tps: 14743.05852
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 27007.22632
-  tps: 14330.73645
+  dps: 26995.28163
+  tps: 14336.14061
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 29078.22989
-  tps: 15224.81294
+  dps: 29100.16234
+  tps: 15264.05767
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 27713.53392
-  tps: 14737.54897
+  dps: 27655.7123
+  tps: 14752.38434
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 27262.79489
-  tps: 14452.11915
+  dps: 27290.89009
+  tps: 14491.24987
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 29012.49469
-  tps: 15194.21489
+  dps: 29033.89991
+  tps: 15233.06057
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 25622.28373
-  tps: 14543.8916
+  dps: 25620.12265
+  tps: 14547.33351
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 29178.28673
-  tps: 15281.39802
+  dps: 29195.15763
+  tps: 15323.2176
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 29078.22989
-  tps: 15224.81294
+  dps: 29100.16234
+  tps: 15264.05767
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 25713.98331
-  tps: 14516.13718
+  dps: 25747.45035
+  tps: 14546.81203
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 29012.49469
-  tps: 15194.21489
+  dps: 29033.89991
+  tps: 15233.06057
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FallofMortality-59500"
  value: {
-  dps: 27736.04274
-  tps: 14703.02656
+  dps: 27753.27287
+  tps: 14743.05852
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FallofMortality-65124"
  value: {
-  dps: 27853.03639
-  tps: 14771.52587
+  dps: 27881.1279
+  tps: 14822.01794
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 26159.54918
-  tps: 14840.72346
+  dps: 26142.20016
+  tps: 14851.63763
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 25430.43607
-  tps: 14383.49153
+  dps: 25402.42362
+  tps: 14400.7022
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 25945.04845
-  tps: 14670.74787
+  dps: 25963.30639
+  tps: 14718.38418
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 26808.82391
-  tps: 14225.91236
+  dps: 26814.1458
+  tps: 14243.97383
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 26876.9728
-  tps: 15235.89992
+  dps: 26896.45239
+  tps: 15284.31476
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 25619.3914
-  tps: 14461.659
+  dps: 25608.62174
+  tps: 14473.36521
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 29012.49469
-  tps: 15194.19524
+  dps: 29033.89991
+  tps: 15233.04092
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FluidDeath-58181"
  value: {
-  dps: 27087.86285
-  tps: 14381.22223
+  dps: 27105.87074
+  tps: 14426.04198
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 29185.58608
-  tps: 15302.96342
+  dps: 29195.15763
+  tps: 15317.3298
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 27234.38659
-  tps: 14487.33537
+  dps: 27255.88362
+  tps: 14495.06121
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GaleofShadows-56138"
  value: {
-  dps: 27920.82591
-  tps: 14822.43481
+  dps: 27869.73442
+  tps: 14854.2899
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GaleofShadows-56462"
  value: {
-  dps: 27996.10564
-  tps: 14926.28009
+  dps: 27989.01884
+  tps: 14920.56141
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GearDetector-61462"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 23660.76357
-  tps: 12343.11824
+  dps: 23745.01714
+  tps: 12377.22603
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 27376.75937
-  tps: 14488.48233
+  dps: 27358.7095
+  tps: 14515.52605
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HarmlightToken-63839"
  value: {
-  dps: 27879.86341
-  tps: 14744.09487
+  dps: 27876.48473
+  tps: 14764.44585
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 27962.34104
-  tps: 14853.85262
+  dps: 27979.46256
+  tps: 14890.2525
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 28122.93582
-  tps: 14953.17102
+  dps: 28120.55252
+  tps: 14976.01745
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofRage-59224"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofRage-65072"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofSolace-55868"
  value: {
-  dps: 27284.81395
-  tps: 14483.88419
+  dps: 27234.96599
+  tps: 14515.41063
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofSolace-56393"
  value: {
-  dps: 27276.31041
-  tps: 14540.35581
+  dps: 27269.39531
+  tps: 14536.06709
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofThunder-55845"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofThunder-56370"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 29078.22989
-  tps: 15224.81294
+  dps: 29100.16234
+  tps: 15264.05767
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 25619.3914
-  tps: 14461.659
+  dps: 25608.62174
+  tps: 14473.36521
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 25619.3914
-  tps: 14461.659
+  dps: 25608.62174
+  tps: 14473.36521
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 27202.24512
-  tps: 14379.7816
+  dps: 27200.5433
+  tps: 14393.70243
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 27333.38552
-  tps: 14431.27848
+  dps: 27331.70283
+  tps: 14445.02788
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 25960.56305
-  tps: 14695.10804
+  dps: 25941.30078
+  tps: 14710.519
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 26805.32025
-  tps: 14226.11263
+  dps: 26812.29739
+  tps: 14251.06427
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 26785.05295
-  tps: 14218.93912
+  dps: 26818.36318
+  tps: 14255.79424
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 25516.97776
-  tps: 14441.30308
+  dps: 25499.70132
+  tps: 14457.48124
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 27087.86285
-  tps: 14381.22223
+  dps: 27105.87074
+  tps: 14426.04198
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 27087.86285
-  tps: 14381.22223
+  dps: 27105.87074
+  tps: 14426.04198
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 27239.40258
-  tps: 14476.36574
+  dps: 27105.73358
+  tps: 14440.36307
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 27239.40258
-  tps: 14476.36574
+  dps: 27105.73358
+  tps: 14440.36307
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 25512.6917
-  tps: 14498.18811
+  dps: 25544.98028
+  tps: 14534.24209
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-LeadenDespair-55816"
  value: {
-  dps: 26808.82391
-  tps: 14225.76101
+  dps: 26814.1458
+  tps: 14243.62067
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-LeadenDespair-56347"
  value: {
-  dps: 26808.82391
-  tps: 14225.91236
+  dps: 26814.1458
+  tps: 14243.97383
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 27087.86285
-  tps: 14381.22223
+  dps: 27105.87074
+  tps: 14426.04198
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 25159.62691
-  tps: 14285.52383
+  dps: 25142.81175
+  tps: 14302.08749
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 25159.62691
-  tps: 14285.52383
+  dps: 25142.81175
+  tps: 14302.08749
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 26808.82391
-  tps: 14224.8779
+  dps: 26814.47159
+  tps: 14242.45554
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 26808.82391
-  tps: 14224.8779
+  dps: 26814.47159
+  tps: 14242.45554
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 25325.81947
-  tps: 14285.52383
+  dps: 25308.14385
+  tps: 14302.08749
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 25346.59354
-  tps: 14285.52383
+  dps: 25328.81036
+  tps: 14302.08749
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 25469.00152
-  tps: 14444.82974
+  dps: 25397.26412
+  tps: 14425.56777
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 25469.00152
-  tps: 14444.82974
+  dps: 25397.26412
+  tps: 14425.56777
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 27333.38552
-  tps: 14431.27848
+  dps: 27331.70283
+  tps: 14445.02788
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 27333.38552
-  tps: 14431.27848
+  dps: 27331.70283
+  tps: 14445.02788
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MithrilStopwatch-71337"
  value: {
-  dps: 28342.46359
-  tps: 15030.82176
+  dps: 28359.59816
+  tps: 15037.04031
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 26430.00523
-  tps: 14800.90433
+  dps: 26453.44427
+  tps: 14849.16448
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 26802.53813
-  tps: 14226.60407
+  dps: 26814.1458
+  tps: 14244.25567
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 28397.94212
-  tps: 14956.58705
+  dps: 28412.20116
+  tps: 14984.34626
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 28654.11335
-  tps: 15084.22478
+  dps: 28681.48283
+  tps: 15108.09342
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 25423.1754
-  tps: 14409.58892
+  dps: 25415.41399
+  tps: 14419.76268
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PetrifiedPickledEgg-71336"
  value: {
-  dps: 27783.60321
-  tps: 14735.29197
+  dps: 27801.97692
+  tps: 14769.84516
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 27711.84523
-  tps: 14690.63802
+  dps: 27695.95347
+  tps: 14697.84011
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 29012.49469
-  tps: 15194.21489
+  dps: 29033.89991
+  tps: 15233.06057
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Rainsong-55854"
  value: {
-  dps: 26808.82391
-  tps: 14225.0143
+  dps: 26807.06473
+  tps: 14239.50296
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Rainsong-56377"
  value: {
-  dps: 26808.82391
-  tps: 14224.92423
+  dps: 26814.47159
+  tps: 14242.49289
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 29211.59992
-  tps: 15346.32315
+  dps: 29232.88469
+  tps: 15385.26127
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 29211.59992
-  tps: 15346.2206
+  dps: 29232.88469
+  tps: 15385.17879
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 25678.48154
-  tps: 14566.13523
+  dps: 25666.51491
+  tps: 14574.70415
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 27087.86285
-  tps: 14381.22223
+  dps: 27105.87074
+  tps: 14426.04198
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 27087.86285
-  tps: 14381.22223
+  dps: 27105.87074
+  tps: 14426.04198
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RuneofZeth-68998"
  value: {
-  dps: 26506.54841
-  tps: 15046.16581
+  dps: 26519.77895
+  tps: 15055.99478
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SeaStar-55256"
  value: {
-  dps: 25641.5195
-  tps: 14558.18369
+  dps: 25627.35735
+  tps: 14565.71058
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SeaStar-56290"
  value: {
-  dps: 26052.1808
-  tps: 14813.27019
+  dps: 26058.52021
+  tps: 14825.12914
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ShadowflameRegalia"
  value: {
-  dps: 26690.72919
-  tps: 13974.47463
+  dps: 26645.55928
+  tps: 14014.321
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ShardofWoe-60233"
  value: {
-  dps: 27608.45214
-  tps: 14633.01768
+  dps: 27525.16677
+  tps: 14649.02623
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 26808.82391
-  tps: 14225.66642
+  dps: 26814.1458
+  tps: 14243.39995
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 25374.8173
-  tps: 14288.29916
+  dps: 25367.36362
+  tps: 14300.4523
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 25403.75008
-  tps: 14292.4882
+  dps: 25396.64652
+  tps: 14304.61661
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Sorrowsong-55879"
  value: {
-  dps: 27780.45801
-  tps: 14686.89956
+  dps: 27772.11393
+  tps: 14696.07147
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Sorrowsong-56400"
  value: {
-  dps: 27990.3637
-  tps: 14779.83541
+  dps: 27981.12223
+  tps: 14788.18491
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 25469.00152
-  tps: 14444.82974
+  dps: 25397.26412
+  tps: 14425.56777
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SoulCasket-58183"
  value: {
-  dps: 26906.49807
-  tps: 15245.62297
+  dps: 26894.19164
+  tps: 15250.94607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 27762.09338
-  tps: 14698.29008
+  dps: 27754.87456
+  tps: 14734.21471
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-StumpofTime-62465"
  value: {
-  dps: 28151.07727
-  tps: 14956.51649
+  dps: 28167.68905
+  tps: 14998.72572
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-StumpofTime-62470"
  value: {
-  dps: 28208.28756
-  tps: 14947.0452
+  dps: 28225.86905
+  tps: 14993.83456
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 26802.88285
-  tps: 14226.3204
+  dps: 26814.1458
+  tps: 14244.16059
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 26802.53813
-  tps: 14226.67004
+  dps: 26814.1458
+  tps: 14244.37112
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 27979.35434
-  tps: 14768.99472
+  dps: 27961.88087
+  tps: 14791.78915
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TearofBlood-55819"
  value: {
-  dps: 27469.20559
-  tps: 14548.31725
+  dps: 27455.36608
+  tps: 14571.98187
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TearofBlood-56351"
  value: {
-  dps: 27632.45791
-  tps: 14654.38421
+  dps: 27646.51275
+  tps: 14689.01152
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 27788.17072
-  tps: 14676.21821
+  dps: 27784.87396
+  tps: 14688.28591
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 28160.35639
-  tps: 14835.72015
+  dps: 28160.66568
+  tps: 14850.55856
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TheHungerer-68927"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TheHungerer-69112"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 28298.08395
-  tps: 14856.59865
+  dps: 28288.60456
+  tps: 14878.33024
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 28502.81686
-  tps: 14959.38361
+  dps: 28575.38025
+  tps: 15053.88562
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 27202.24512
-  tps: 14379.7816
+  dps: 27200.5433
+  tps: 14393.70243
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 27333.38552
-  tps: 14431.27848
+  dps: 27331.70283
+  tps: 14445.02788
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 27039.10052
-  tps: 14295.78048
+  dps: 27003.34639
+  tps: 14329.27555
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 26090.00182
-  tps: 14831.14306
+  dps: 26059.61646
+  tps: 14834.19722
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-UnheededWarning-59520"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 25143.35501
-  tps: 14254.5537
+  dps: 25129.84524
+  tps: 14264.61703
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 25619.3914
-  tps: 14461.659
+  dps: 25608.62174
+  tps: 14473.36521
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 25619.3914
-  tps: 14461.659
+  dps: 25608.62174
+  tps: 14473.36521
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 25619.3914
-  tps: 14461.659
+  dps: 25608.62174
+  tps: 14473.36521
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 28337.46255
-  tps: 15124.67585
+  dps: 28278.20029
+  tps: 15145.31818
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 29055.67285
-  tps: 15879.62091
+  dps: 29035.41224
+  tps: 15917.91152
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.06473
+  tps: 14239.72607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 26802.88285
-  tps: 14226.3204
+  dps: 26814.1458
+  tps: 14244.16059
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 26802.53813
-  tps: 14226.67004
+  dps: 26814.1458
+  tps: 14244.37112
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 25143.35501
-  tps: 14254.78683
+  dps: 25133.10042
+  tps: 14267.13778
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 26188.52366
-  tps: 14891.89003
+  dps: 26177.0055
+  tps: 14899.05389
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 25143.35501
-  tps: 14254.78683
+  dps: 25133.10042
+  tps: 14267.13778
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 27087.8409
-  tps: 14381.20028
+  dps: 27105.84879
+  tps: 14426.02003
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 27413.05065
-  tps: 14611.02423
+  dps: 27415.73123
+  tps: 14625.20762
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 27256.65874
-  tps: 14494.18592
+  dps: 27278.57345
+  tps: 14497.70529
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 26808.80196
-  tps: 14225.269
+  dps: 26807.04278
+  tps: 14239.70411
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 27333.36301
-  tps: 14431.25597
+  dps: 27331.68031
+  tps: 14445.00537
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 26808.80196
-  tps: 14225.269
+  dps: 26807.04278
+  tps: 14239.70411
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.04278
+  tps: 14239.70411
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 27706.15991
-  tps: 14678.77026
+  dps: 27704.49252
+  tps: 14691.44996
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 26808.82391
-  tps: 14225.29095
+  dps: 26807.08669
+  tps: 14239.74802
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 27829.66348
-  tps: 14783.0282
+  dps: 27828.15956
+  tps: 14826.27842
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 28357.97819
-  tps: 15115.30241
+  dps: 28323.60853
+  tps: 15144.30218
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 25500.3823
-  tps: 14409.94096
+  dps: 25489.74141
+  tps: 14421.80835
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 25305.0454
-  tps: 14286.00262
+  dps: 25293.76262
+  tps: 14305.38221
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 25305.0454
-  tps: 14286.00262
+  dps: 25293.76262
+  tps: 14305.38221
  }
 }
 dps_results: {
  key: "TestDemonology-Average-Default"
  value: {
-  dps: 29539.27212
-  tps: 15613.28374
+  dps: 29525.91707
+  tps: 15633.00034
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p1-Demonology Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 44220.64417
-  tps: 40990.12256
+  dps: 44163.95178
+  tps: 41407.16204
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p1-Demonology Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28639.2689
-  tps: 15358.18416
+  dps: 28675.53578
+  tps: 15418.87771
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p1-Demonology Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
   dps: 46267.01668
-  tps: 22970.60247
+  tps: 22978.61929
  }
 }
 dps_results: {
@@ -1460,22 +1460,22 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Settings-Human-p1-Demonology Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 43629.99808
-  tps: 39855.09687
+  dps: 43653.88662
+  tps: 40817.9796
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p1-Demonology Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28502.96934
-  tps: 15249.20851
+  dps: 28509.06541
+  tps: 15260.10254
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p1-Demonology Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
   dps: 45737.12589
-  tps: 22746.44865
+  tps: 22769.38437
  }
 }
 dps_results: {
@@ -1502,22 +1502,22 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Settings-Orc-p1-Demonology Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 44981.72278
-  tps: 40611.68596
+  dps: 44985.94593
+  tps: 41395.43916
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p1-Demonology Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29387.34064
-  tps: 15457.71566
+  dps: 29395.84932
+  tps: 15470.77051
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p1-Demonology Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
   dps: 47439.66002
-  tps: 23084.44001
+  tps: 23107.34368
  }
 }
 dps_results: {
@@ -1544,22 +1544,22 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Settings-Troll-p1-Demonology Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 45642.40663
-  tps: 42206.59388
+  dps: 45618.16439
+  tps: 42672.64108
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p1-Demonology Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28893.71137
-  tps: 15605.38942
+  dps: 28871.11315
+  tps: 15630.56934
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p1-Demonology Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
   dps: 47363.901
-  tps: 23911.38595
+  tps: 23931.76368
  }
 }
 dps_results: {
@@ -1586,7 +1586,7 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 29239.48128
-  tps: 15457.71566
+  dps: 29246.5803
+  tps: 15470.77051
  }
 }

--- a/sim/warlock/destruction/TestDestruction.results
+++ b/sim/warlock/destruction/TestDestruction.results
@@ -38,1402 +38,1402 @@ character_stats_results: {
 dps_results: {
  key: "TestDestruction-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 28530.86959
-  tps: 19051.30696
+  dps: 28529.60957
+  tps: 19058.72038
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 27092.72482
-  tps: 18134.53422
+  dps: 27076.81107
+  tps: 18128.72249
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 26965.38207
-  tps: 18096.31824
+  dps: 26911.11595
+  tps: 18052.68847
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 27531.32544
-  tps: 18423.03342
+  dps: 27514.76145
+  tps: 18433.60801
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 27593.49757
-  tps: 18466.11758
+  dps: 27569.85931
+  tps: 18474.71034
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 28258.79155
-  tps: 18839.30652
+  dps: 28257.227
+  tps: 18850.10297
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 26632.76647
-  tps: 17824.85106
-  hps: 98.90295
+  dps: 26568.96511
+  tps: 17782.7722
+  hps: 98.89602
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 28024.69702
-  tps: 18705.82111
+  dps: 27983.66178
+  tps: 18677.55604
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BindingPromise-67037"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 26790.98157
-  tps: 17966.88619
+  dps: 26734.36081
+  tps: 17921.16132
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 26858.41882
-  tps: 17995.45999
+  dps: 26796.73968
+  tps: 17945.6862
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 26893.6573
-  tps: 18021.67445
+  dps: 26831.84753
+  tps: 17971.76032
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 26552.87197
-  tps: 17798.3725
+  dps: 26480.31945
+  tps: 17732.09829
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 27446.77496
-  tps: 18331.19797
+  dps: 27375.82907
+  tps: 18267.95744
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 26551.34536
-  tps: 17796.56464
+  dps: 26481.07506
+  tps: 17733.35682
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 26915.35261
-  tps: 18017.88089
+  dps: 26879.51045
+  tps: 17991.27418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 26589.32496
-  tps: 17795.44403
+  dps: 26528.64333
+  tps: 17746.97165
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 26589.32496
-  tps: 17795.50656
+  dps: 26528.64333
+  tps: 17747.03418
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 27423.98343
-  tps: 18318.12052
+  dps: 27363.68801
+  tps: 18269.58272
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BottledLightning-66879"
  value: {
-  dps: 27228.41235
-  tps: 18251.65098
+  dps: 27203.84111
+  tps: 18241.67626
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 28430.20343
-  tps: 18597.92163
+  dps: 28404.91461
+  tps: 18585.63873
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Brawler'sTrophy-71338"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 28704.93312
-  tps: 19176.33865
+  dps: 28678.82505
+  tps: 19162.63042
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 28584.43777
-  tps: 19089.18178
+  dps: 28586.0514
+  tps: 19100.76502
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Coren'sChilledChromiumCoaster-71335"
  value: {
-  dps: 26976.62608
-  tps: 18061.61401
+  dps: 26935.84489
+  tps: 18034.56708
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 27507.22344
-  tps: 18435.19895
+  dps: 27482.86115
+  tps: 18417.48753
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CrushingWeight-59506"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CrushingWeight-65118"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 26589.32496
-  tps: 17795.50934
+  dps: 26528.64333
+  tps: 17747.03973
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 27546.27355
-  tps: 18440.79349
+  dps: 27524.16501
+  tps: 18423.93377
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 26775.98893
-  tps: 17917.5096
+  dps: 26732.3709
+  tps: 17891.26064
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 28309.79529
-  tps: 18875.13291
+  dps: 28310.86724
+  tps: 18886.46491
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 27440.6394
-  tps: 18446.52323
+  dps: 27404.97705
+  tps: 18435.25527
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 27034.75551
-  tps: 18097.97122
+  dps: 27022.16284
+  tps: 18103.99844
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 28258.79155
-  tps: 18839.30652
+  dps: 28257.227
+  tps: 18850.10297
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 26969.05032
-  tps: 18052.36938
+  dps: 26937.75524
+  tps: 18038.60516
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 28430.72619
-  tps: 18973.91697
+  dps: 28429.30192
+  tps: 18984.38885
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 28309.79529
-  tps: 18875.13291
+  dps: 28310.86724
+  tps: 18886.46491
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 26965.38207
-  tps: 18096.31824
+  dps: 26911.11595
+  tps: 18052.68847
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 28258.79155
-  tps: 18839.30652
+  dps: 28257.227
+  tps: 18850.10297
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FallofMortality-59500"
  value: {
-  dps: 27546.27355
-  tps: 18440.79349
+  dps: 27524.16501
+  tps: 18423.93377
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FallofMortality-65124"
  value: {
-  dps: 27672.99878
-  tps: 18526.70551
+  dps: 27667.75495
+  tps: 18520.63725
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 27660.98901
-  tps: 18510.75751
+  dps: 27633.28432
+  tps: 18495.44066
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 26871.47337
-  tps: 18036.214
+  dps: 26857.28341
+  tps: 18061.52031
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 27404.9537
-  tps: 18368.48823
+  dps: 27379.43538
+  tps: 18351.27163
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 26589.32496
-  tps: 17795.65345
+  dps: 26520.38907
+  tps: 17736.90188
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 28244.38103
-  tps: 18868.76063
+  dps: 28220.14781
+  tps: 18851.5128
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 26855.46639
-  tps: 18022.92234
+  dps: 26783.76289
+  tps: 17958.15257
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 28319.32294
-  tps: 18884.43203
+  dps: 28317.74408
+  tps: 18891.80717
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FluidDeath-58181"
  value: {
-  dps: 26910.08676
-  tps: 18032.05814
+  dps: 26892.60883
+  tps: 18044.28216
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 28430.20343
-  tps: 18962.04607
+  dps: 28404.91461
+  tps: 18949.29228
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 26947.65118
-  tps: 18044.96803
+  dps: 26908.00519
+  tps: 18018.39116
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GaleofShadows-56138"
  value: {
-  dps: 27720.45146
-  tps: 18584.83995
+  dps: 27690.38151
+  tps: 18572.28546
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GaleofShadows-56462"
  value: {
-  dps: 27807.28259
-  tps: 18661.65902
+  dps: 27751.79686
+  tps: 18649.01667
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GearDetector-61462"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Gladiator'sFelshroud"
  value: {
   dps: 21439.26119
-  tps: 13509.95828
+  tps: 13524.54725
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 27128.80925
-  tps: 18156.14205
+  dps: 27105.09058
+  tps: 18143.83866
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HarmlightToken-63839"
  value: {
-  dps: 27356.70764
-  tps: 18348.99908
+  dps: 27342.56555
+  tps: 18351.33294
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 27853.6134
-  tps: 18653.81614
+  dps: 27821.70968
+  tps: 18670.32807
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 28016.18203
-  tps: 18772.44543
+  dps: 27986.13111
+  tps: 18791.46586
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofRage-59224"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofRage-65072"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofSolace-55868"
  value: {
-  dps: 27036.98382
-  tps: 18136.01529
+  dps: 27007.93501
+  tps: 18124.99529
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofSolace-56393"
  value: {
-  dps: 27033.71391
-  tps: 18153.26193
+  dps: 26979.72104
+  tps: 18141.69789
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofThunder-55845"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26525.81358
+  tps: 17744.61067
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofThunder-56370"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26525.81358
+  tps: 17744.64847
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 28309.79529
-  tps: 18875.13291
+  dps: 28310.86724
+  tps: 18886.46491
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 26893.88168
-  tps: 18051.51489
+  dps: 26821.99714
+  tps: 17986.54782
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 26893.88168
-  tps: 18051.51489
+  dps: 26821.99714
+  tps: 17986.54782
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 26858.41882
-  tps: 17995.45999
+  dps: 26796.73968
+  tps: 17945.6862
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 26893.6573
-  tps: 18021.67445
+  dps: 26831.84753
+  tps: 17971.76032
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26525.81358
+  tps: 17744.59935
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 27278.41569
-  tps: 18253.81064
+  dps: 27219.78185
+  tps: 18204.80266
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 26579.1277
-  tps: 17810.88698
+  dps: 26551.55728
+  tps: 17795.03201
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 26581.16776
-  tps: 17816.38176
+  dps: 26567.05391
+  tps: 17806.01049
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 26790.98157
-  tps: 17966.88619
+  dps: 26734.36081
+  tps: 17921.16132
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 26910.08676
-  tps: 18032.05814
+  dps: 26892.60883
+  tps: 18044.28216
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 26910.08676
-  tps: 18032.05814
+  dps: 26892.60883
+  tps: 18044.28216
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 26801.00867
-  tps: 18035.52379
+  dps: 26782.89455
+  tps: 18044.6902
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 26801.00867
-  tps: 18035.52379
+  dps: 26782.89455
+  tps: 18044.6902
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 26764.62568
-  tps: 17941.24438
+  dps: 26749.66824
+  tps: 17949.96554
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LeadenDespair-55816"
  value: {
-  dps: 26589.32496
-  tps: 17795.56172
+  dps: 26525.81358
+  tps: 17745.49168
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LeadenDespair-56347"
  value: {
-  dps: 26589.32496
-  tps: 17795.65345
+  dps: 26520.38907
+  tps: 17736.90188
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 26910.08676
-  tps: 18032.05814
+  dps: 26892.60883
+  tps: 18044.28216
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 26557.27766
-  tps: 17793.04691
+  dps: 26501.46436
+  tps: 17748.24191
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 26557.27766
-  tps: 17793.04691
+  dps: 26501.46436
+  tps: 17748.24191
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 26589.32496
-  tps: 17795.21015
+  dps: 26528.64333
+  tps: 17746.50805
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 26589.32496
-  tps: 17795.21015
+  dps: 26528.64333
+  tps: 17746.50805
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 26856.08054
-  tps: 18018.15905
+  dps: 26797.3784
+  tps: 17970.1843
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 26895.20949
-  tps: 18047.63802
+  dps: 26836.12904
+  tps: 17999.24819
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 26880.17988
-  tps: 18032.94778
+  dps: 26878.59645
+  tps: 18064.47896
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 26880.17988
-  tps: 18032.94778
+  dps: 26878.59645
+  tps: 18064.47896
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 26932.09928
-  tps: 18050.27205
+  dps: 26870.14701
+  tps: 18000.20482
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 26932.09928
-  tps: 18050.27205
+  dps: 26870.14701
+  tps: 18000.20482
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MithrilStopwatch-71337"
  value: {
-  dps: 28100.13507
-  tps: 18766.95842
+  dps: 28054.58514
+  tps: 18736.13887
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 28080.18522
-  tps: 18854.07824
+  dps: 28063.61699
+  tps: 18844.27514
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 26589.32496
-  tps: 17795.72666
+  dps: 26522.81089
+  tps: 17738.62526
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 28147.55346
-  tps: 18876.64984
+  dps: 28142.18682
+  tps: 18870.62368
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 28356.28428
-  tps: 19018.6872
+  dps: 28359.02635
+  tps: 19024.45138
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 26838.08767
-  tps: 17975.61897
+  dps: 26801.66624
+  tps: 17958.10588
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PetrifiedPickledEgg-71336"
  value: {
-  dps: 27603.86957
-  tps: 18479.14341
+  dps: 27585.5161
+  tps: 18466.20797
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 27441.44749
-  tps: 18329.10857
+  dps: 27397.63046
+  tps: 18302.36068
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 28258.79155
-  tps: 18839.30652
+  dps: 28257.227
+  tps: 18850.10297
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Rainsong-55854"
  value: {
-  dps: 26589.32496
-  tps: 17795.23217
+  dps: 26528.64333
+  tps: 17746.53007
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Rainsong-56377"
  value: {
-  dps: 26589.32496
-  tps: 17795.21763
+  dps: 26528.64333
+  tps: 17746.51553
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 28530.86959
-  tps: 19051.30696
+  dps: 28529.60957
+  tps: 19058.72038
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 28523.65353
-  tps: 19043.15182
+  dps: 28529.60957
+  tps: 19058.71145
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 27014.05966
-  tps: 18073.00256
+  dps: 26988.076
+  tps: 18062.06967
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 26910.08676
-  tps: 18032.05814
+  dps: 26892.60883
+  tps: 18044.28216
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 26910.08676
-  tps: 18032.05814
+  dps: 26892.60883
+  tps: 18044.28216
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RuneofZeth-68998"
  value: {
-  dps: 28066.17762
-  tps: 18786.88765
+  dps: 28058.92101
+  tps: 18790.14574
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SeaStar-55256"
  value: {
-  dps: 27002.00565
-  tps: 18065.59842
+  dps: 26931.39534
+  tps: 18002.37413
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SeaStar-56290"
  value: {
-  dps: 27390.81061
-  tps: 18297.72418
+  dps: 27319.90695
+  tps: 18234.48569
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ShadowflameRegalia"
  value: {
-  dps: 26000.18025
-  tps: 17379.12245
+  dps: 25951.42205
+  tps: 17341.77937
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ShardofWoe-60233"
  value: {
-  dps: 27250.94814
-  tps: 18278.35641
+  dps: 27234.99095
+  tps: 18274.99669
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 26589.32496
-  tps: 17795.50439
+  dps: 26531.42496
+  tps: 17749.63746
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 26921.98695
-  tps: 18069.27046
+  dps: 26851.24858
+  tps: 18005.8277
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 26970.52335
-  tps: 18104.98194
+  dps: 26899.72369
+  tps: 18041.50842
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Sorrowsong-55879"
  value: {
-  dps: 27458.33766
-  tps: 18389.2229
+  dps: 27390.29509
+  tps: 18330.88043
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Sorrowsong-56400"
  value: {
-  dps: 27573.0699
-  tps: 18467.71511
+  dps: 27504.0447
+  tps: 18408.0888
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 26880.17988
-  tps: 18032.94778
+  dps: 26878.59645
+  tps: 18064.47896
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SoulCasket-58183"
  value: {
-  dps: 28042.89362
-  tps: 18739.50228
+  dps: 27970.13686
+  tps: 18674.4944
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 27459.73685
-  tps: 18381.55337
+  dps: 27440.88678
+  tps: 18376.89523
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-StumpofTime-62465"
  value: {
-  dps: 27898.9589
-  tps: 18659.41997
+  dps: 27877.01839
+  tps: 18669.91522
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-StumpofTime-62470"
  value: {
-  dps: 27936.93879
-  tps: 18674.20142
+  dps: 27917.55314
+  tps: 18684.55492
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 26589.32496
-  tps: 17795.70196
+  dps: 26522.81089
+  tps: 17738.54499
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 26589.32496
-  tps: 17795.75664
+  dps: 26527.51617
+  tps: 17744.87887
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 27527.82082
-  tps: 18445.35345
+  dps: 27506.0096
+  tps: 18434.50744
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TearofBlood-55819"
  value: {
-  dps: 27223.61333
-  tps: 18220.36534
+  dps: 27224.06623
+  tps: 18229.28706
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TearofBlood-56351"
  value: {
-  dps: 27435.53616
-  tps: 18364.13074
+  dps: 27424.81576
+  tps: 18363.41629
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 27414.83521
-  tps: 18345.54382
+  dps: 27350.82539
+  tps: 18293.00973
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 27699.83171
-  tps: 18527.80844
+  dps: 27632.51635
+  tps: 18472.67164
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TheHungerer-68927"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TheHungerer-69112"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 28037.38525
-  tps: 18809.6895
+  dps: 28013.23569
+  tps: 18791.42607
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 28216.67028
-  tps: 18930.15524
+  dps: 28212.57528
+  tps: 18924.51202
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 26858.41882
-  tps: 17995.45999
+  dps: 26796.73968
+  tps: 17945.6862
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 26893.6573
-  tps: 18021.67445
+  dps: 26831.84753
+  tps: 17971.76032
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 26790.99841
-  tps: 17962.04995
+  dps: 26793.5732
+  tps: 17994.78265
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 27404.67093
-  tps: 18402.8114
+  dps: 27390.40175
+  tps: 18398.01243
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-UnheededWarning-59520"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 26551.34536
-  tps: 17796.52891
+  dps: 26481.07506
+  tps: 17733.32108
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 26893.88168
-  tps: 18051.51489
+  dps: 26821.99714
+  tps: 17986.54782
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 26893.88168
-  tps: 18051.51489
+  dps: 26821.99714
+  tps: 17986.54782
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 26893.88168
-  tps: 18051.51489
+  dps: 26821.99714
+  tps: 17986.54782
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 28072.40034
-  tps: 18888.28562
+  dps: 28038.38109
+  tps: 18862.67978
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 28688.54232
-  tps: 19446.18568
+  dps: 28674.42333
+  tps: 19453.92673
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 26589.32496
-  tps: 17795.70196
+  dps: 26522.81089
+  tps: 17738.54499
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 26589.32496
-  tps: 17795.75664
+  dps: 26527.51617
+  tps: 17744.87887
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 26551.34536
-  tps: 17796.56464
+  dps: 26481.07506
+  tps: 17733.35682
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 27496.84833
-  tps: 18361.09522
+  dps: 27425.86466
+  tps: 18297.85287
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 26551.34536
-  tps: 17796.56464
+  dps: 26481.07506
+  tps: 17733.35682
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 26910.08676
-  tps: 18032.05814
+  dps: 26892.60883
+  tps: 18044.5251
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 27056.28822
-  tps: 18113.88807
+  dps: 27067.9404
+  tps: 18172.3816
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 26976.62608
-  tps: 18061.85695
+  dps: 26935.84489
+  tps: 18034.56708
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 26589.32496
-  tps: 17795.51978
+  dps: 26528.64333
+  tps: 17747.06061
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 26952.38811
-  tps: 18065.60816
+  dps: 26890.36062
+  tps: 18015.70307
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 26589.32496
-  tps: 17795.51978
+  dps: 26528.64333
+  tps: 17747.06061
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 27414.11302
-  tps: 18305.14009
+  dps: 27351.7851
+  tps: 18255.92543
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 26589.32496
-  tps: 17795.27684
+  dps: 26528.64333
+  tps: 17746.57473
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 27582.93574
-  tps: 18560.8482
+  dps: 27547.29731
+  tps: 18555.62326
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 27909.51016
-  tps: 18722.42871
+  dps: 27883.69489
+  tps: 18695.33144
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 26785.03836
-  tps: 17970.50266
+  dps: 26713.66676
+  tps: 17906.09461
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 26816.95159
-  tps: 17988.82517
+  dps: 26768.5927
+  tps: 17952.90402
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 26816.95159
-  tps: 17988.82517
+  dps: 26768.5927
+  tps: 17952.90402
  }
 }
 dps_results: {
  key: "TestDestruction-Average-Default"
  value: {
-  dps: 29068.03793
-  tps: 19508.95477
+  dps: 29061.71928
+  tps: 19514.13465
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Goblin-p1-Destruction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 30037.8331
-  tps: 35343.69806
+  dps: 30013.00924
+  tps: 35541.89148
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Goblin-p1-Destruction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28352.79267
-  tps: 19132.84289
+  dps: 28324.41671
+  tps: 19117.10108
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Goblin-p1-Destruction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
   dps: 38402.81045
-  tps: 23800.44565
+  tps: 23801.93289
  }
 }
 dps_results: {
@@ -1460,22 +1460,22 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Settings-Human-p1-Destruction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 29882.63465
-  tps: 35170.48949
+  dps: 29874.12182
+  tps: 35337.1296
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p1-Destruction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28177.5929
-  tps: 19027.33538
+  dps: 28147.63051
+  tps: 19008.29735
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p1-Destruction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
   dps: 38426.43631
-  tps: 23775.7274
+  tps: 23777.76919
  }
 }
 dps_results: {
@@ -1502,22 +1502,22 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Settings-Orc-p1-Destruction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 30415.13203
-  tps: 35320.89493
+  dps: 30406.8572
+  tps: 35487.325
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p1-Destruction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28704.93312
-  tps: 19176.33865
+  dps: 28678.82505
+  tps: 19162.63042
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p1-Destruction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
   dps: 39506.64537
-  tps: 24075.92936
+  tps: 24077.93527
  }
 }
 dps_results: {
@@ -1544,22 +1544,22 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Settings-Troll-p1-Destruction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 30214.4442
-  tps: 35460.48794
+  dps: 30164.05293
+  tps: 35900.76435
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p1-Destruction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28518.03346
-  tps: 19273.04953
+  dps: 28481.59427
+  tps: 19261.63135
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p1-Destruction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
   dps: 39123.56804
-  tps: 24188.47395
+  tps: 24191.55259
  }
 }
 dps_results: {
@@ -1586,7 +1586,7 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 28697.77425
-  tps: 19176.33865
+  dps: 28671.66618
+  tps: 19162.63042
  }
 }

--- a/ui/paladin/retribution/sim.ts
+++ b/ui/paladin/retribution/sim.ts
@@ -125,7 +125,9 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecRetributionPaladin, {
 			communion: true,
 		}),
 		partyBuffs: PartyBuffs.create({}),
-		individualBuffs: IndividualBuffs.create({}),
+		individualBuffs: IndividualBuffs.create({
+			communion: true,
+		}),
 		debuffs: Debuffs.create({
 			exposeArmor: true,
 			bloodFrenzy: true,
@@ -149,7 +151,10 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecRetributionPaladin, {
 		BuffDebuffInputs.SpellHasteBuff,
 		BuffDebuffInputs.PowerInfusion,
 	],
-	excludeBuffDebuffInputs: [BuffDebuffInputs.BleedDebuff],
+	excludeBuffDebuffInputs: [
+		BuffDebuffInputs.BleedDebuff,
+		BuffDebuffInputs.DamagePercentBuff,
+	],
 	// Inputs to include in the 'Other' section on the settings tab.
 	otherInputs: {
 		inputs: [OtherInputs.InputDelay, OtherInputs.TankAssignment, OtherInputs.InFrontOfTarget],


### PR DESCRIPTION
Replenishment was changed from 1% per 5sec to 1% over 10sec in cata but this was never reflected in code.

If one would be pedantic, it should be 0.1% per second but adding that many events is probably a perf degradation. The downside to having it as mp5 is that it's not trackable in the resource breakdown, and specs like Ret which *technically* run oom for ~0.1-0.2s probably wouldn't if mana ticked continuously (I think, who knows).