### PR TITLE
Generalized Feral bleed snapshotting algorithm

### DIFF
--- a/sim/core/aura_helpers.go
+++ b/sim/core/aura_helpers.go
@@ -267,6 +267,10 @@ func (character *Character) NewTemporaryStatsAuraWrapped(auraLabel string, actio
 			if includesHealthBuff {
 				character.UpdateMaxHealth(sim, amountHealed, healthMetrics)
 			}
+
+			for i := range character.OnTemporaryStatsChanges {
+				character.OnTemporaryStatsChanges[i](sim, aura, buffs)
+			}
 		},
 		OnExpire: func(aura *Aura, sim *Simulation) {
 			if sim.Log != nil {
@@ -276,6 +280,10 @@ func (character *Character) NewTemporaryStatsAuraWrapped(auraLabel string, actio
 
 			if includesHealthBuff {
 				character.UpdateMaxHealth(sim, -amountHealed, healthMetrics)
+			}
+
+			for i := range character.OnTemporaryStatsChanges {
+				character.OnTemporaryStatsChanges[i](sim, aura, buffs.Invert())
 			}
 		},
 	}

--- a/sim/druid/druid.go
+++ b/sim/druid/druid.go
@@ -31,7 +31,6 @@ type Druid struct {
 	AssumeBleedActive bool
 	LeatherSpecActive bool
 	Feral4pT12Active  bool
-	RipTfSnapshot     bool
 
 	MHAutoSpell       *core.Spell
 	ReplaceBearMHFunc core.ReplaceMHSwing
@@ -387,6 +386,11 @@ func New(char *core.Character, form DruidForm, selfBuffs SelfBuffs, talents stri
 type DruidSpell struct {
 	*core.Spell
 	FormMask DruidForm
+
+	// Optional fields used in snapshotting calculations
+	CurrentSnapshotPower float64
+	NewSnapshotPower     float64
+	ShortName            string
 }
 
 func (ds *DruidSpell) IsReady(sim *core.Simulation) bool {
@@ -408,6 +412,31 @@ func (ds *DruidSpell) IsEqual(s *core.Spell) bool {
 		return false
 	}
 	return ds.Spell == s
+}
+
+func (druid *Druid) UpdateBleedPower(bleedSpell *DruidSpell, sim *core.Simulation, target *core.Unit, updateCurrent bool, updateNew bool) {
+	snapshotPower := bleedSpell.ExpectedTickDamage(sim, target)
+
+	// Assume that Mangle will be up soon if not currently active.
+	if !druid.BleedCategories.Get(target).AnyActive() {
+		snapshotPower *= 1.3
+	}
+
+	if updateCurrent {
+		bleedSpell.CurrentSnapshotPower = snapshotPower
+
+		if sim.Log != nil {
+			druid.Log(sim, "%s Snapshot Power: %.1f", bleedSpell.ShortName, snapshotPower)
+		}
+	}
+
+	if updateNew {
+		bleedSpell.NewSnapshotPower = snapshotPower
+
+		if (sim.Log != nil) && !updateCurrent {
+			druid.Log(sim, "%s Projected Power: %.1f", bleedSpell.ShortName, snapshotPower)
+		}
+	}
 }
 
 // Agent is a generic way to access underlying druid on any of the agents (for example balance druid.)

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -38,1423 +38,1423 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 26994.5104
-  tps: 37204.67091
+  dps: 27117.59734
+  tps: 37966.87896
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 25482.71999
-  tps: 35340.18038
+  dps: 25439.58027
+  tps: 36362.43687
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 27460.73946
-  tps: 37649.05689
+  dps: 27428.1848
+  tps: 38151.40258
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 25487.63324
-  tps: 35352.69466
+  dps: 25434.71204
+  tps: 36340.73736
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 25488.60354
-  tps: 35357.58614
+  dps: 25434.67118
+  tps: 36366.36021
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 26394.87797
-  tps: 36817.42403
+  dps: 26410.97375
+  tps: 37575.16941
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 26529.74236
-  tps: 36983.73479
+  dps: 26546.72332
+  tps: 37742.67844
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 26357.71148
-  tps: 36413.81933
+  dps: 26416.91831
+  tps: 37045.52983
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 25482.71999
-  tps: 35340.31301
+  dps: 25439.58027
+  tps: 36362.5747
   hps: 88.86807
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 25482.71999
-  tps: 35340.31301
+  dps: 25439.58027
+  tps: 36362.5747
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 25789.72421
-  tps: 35773.93863
+  dps: 25849.43547
+  tps: 36666.39859
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 25821.54787
-  tps: 35724.18323
+  dps: 25964.51456
+  tps: 36699.59064
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BindingPromise-67037"
  value: {
-  dps: 25471.42079
-  tps: 35335.39926
+  dps: 25449.81767
+  tps: 36392.68362
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 26772.48499
-  tps: 36804.52823
+  dps: 26867.90737
+  tps: 38343.95344
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 25769.48396
-  tps: 35789.53273
+  dps: 25728.16047
+  tps: 36832.39858
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 25807.03638
-  tps: 35848.35913
+  dps: 25765.95073
+  tps: 36893.92313
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 27290.5854
-  tps: 37423.7252
+  dps: 27369.35469
+  tps: 38585.72826
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 25471.42079
-  tps: 35335.39926
+  dps: 25449.81767
+  tps: 36392.68362
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 25978.72179
-  tps: 35971.58918
+  dps: 25956.86935
+  tps: 36966.16061
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 25741.59852
-  tps: 35575.29411
+  dps: 25829.51377
+  tps: 36684.98563
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 25471.42079
-  tps: 35335.39926
+  dps: 25439.86289
+  tps: 36333.51673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 25471.42079
-  tps: 35335.39926
+  dps: 25439.86289
+  tps: 36333.51673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 26714.68822
-  tps: 36267.05688
+  dps: 26669.09709
+  tps: 36986.17173
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 25482.71999
-  tps: 35340.31301
+  dps: 25439.58027
+  tps: 36362.5747
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 25846.01243
-  tps: 35355.93658
+  dps: 25844.8467
+  tps: 36304.7726
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledLightning-66879"
  value: {
-  dps: 25569.7114
-  tps: 35213.67311
+  dps: 25550.70536
+  tps: 36681.11551
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 26357.71148
-  tps: 35685.75953
+  dps: 26416.91831
+  tps: 36304.83538
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Brawler'sTrophy-71338"
  value: {
-  dps: 25471.42079
-  tps: 35335.39926
+  dps: 25449.81767
+  tps: 36392.68362
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 26783.22456
-  tps: 36988.22556
+  dps: 26841.18382
+  tps: 37615.25567
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 26895.29134
-  tps: 37143.91097
+  dps: 26957.68572
+  tps: 37690.61418
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Coren'sChilledChromiumCoaster-71335"
  value: {
-  dps: 26794.76815
-  tps: 37234.09542
+  dps: 26875.14384
+  tps: 37745.40322
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 25471.42079
-  tps: 35335.152
+  dps: 25449.81767
+  tps: 36392.42557
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 25482.71999
-  tps: 35340.31301
+  dps: 25439.58027
+  tps: 36362.5747
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-59506"
  value: {
-  dps: 26313.60391
-  tps: 35359.16535
+  dps: 26405.9156
+  tps: 36381.84814
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-65118"
  value: {
-  dps: 26260.23427
-  tps: 35845.12424
+  dps: 26269.22975
+  tps: 36142.93612
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 25471.42079
-  tps: 35335.39926
+  dps: 25439.86289
+  tps: 36333.51673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 26128.07431
-  tps: 35663.9753
+  dps: 26193.99931
+  tps: 36675.41024
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 26845.96647
-  tps: 37036.3264
+  dps: 26979.3342
+  tps: 37948.38698
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 25482.71999
-  tps: 35340.06574
+  dps: 25439.58027
+  tps: 36362.31772
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 25835.83935
-  tps: 35985.06644
+  dps: 25804.25858
+  tps: 36944.03955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 26155.63669
-  tps: 36059.85431
+  dps: 26168.4273
+  tps: 36840.89281
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 26464.32874
-  tps: 36566.31354
+  dps: 26527.38014
+  tps: 37113.64859
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 25487.8655
-  tps: 34417.57864
+  dps: 25644.41074
+  tps: 35922.43022
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 26462.69184
-  tps: 36371.06903
+  dps: 26378.09933
+  tps: 37481.73971
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 26357.71148
-  tps: 36413.81933
+  dps: 26416.91831
+  tps: 37045.52983
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 25471.42079
-  tps: 35369.2631
+  dps: 25449.81767
+  tps: 36427.12674
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 26357.71148
-  tps: 36413.7555
+  dps: 26416.91831
+  tps: 37045.47233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 26464.32874
-  tps: 36566.31354
+  dps: 26527.38014
+  tps: 37113.64859
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 27167.56531
-  tps: 37296.14107
+  dps: 27151.41645
+  tps: 38506.52192
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 27364.28778
-  tps: 38193.86949
+  dps: 27233.77301
+  tps: 38891.88621
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 26501.77475
-  tps: 36806.41333
+  dps: 26518.69651
+  tps: 37835.33269
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 26357.71148
-  tps: 36413.81933
+  dps: 26416.91831
+  tps: 37045.52983
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-59500"
  value: {
-  dps: 25482.71999
-  tps: 35340.06574
+  dps: 25439.58027
+  tps: 36362.31772
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-65124"
  value: {
-  dps: 25482.71999
-  tps: 35340.03343
+  dps: 25439.58027
+  tps: 36362.28414
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 25456.89196
-  tps: 35411.86889
+  dps: 25424.51864
+  tps: 36443.4194
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 26748.35183
-  tps: 36919.69261
+  dps: 26704.74135
+  tps: 37155.5852
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 25471.42079
-  tps: 35335.1797
+  dps: 25449.81767
+  tps: 36392.45448
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 25471.42079
-  tps: 35335.39926
+  dps: 25449.81767
+  tps: 36392.68362
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 25471.42079
-  tps: 35335.1797
+  dps: 25449.81767
+  tps: 36392.45448
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 26277.35498
-  tps: 36448.61114
+  dps: 26257.57289
+  tps: 37467.62333
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 26421.14369
-  tps: 36513.98683
+  dps: 26481.21041
+  tps: 37147.92499
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 26357.71148
-  tps: 36413.77724
+  dps: 26416.91831
+  tps: 37045.49191
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 26439.39696
-  tps: 36553.39724
+  dps: 26524.71505
+  tps: 37446.76441
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56138"
  value: {
-  dps: 25650.15062
-  tps: 34931.20081
+  dps: 25705.16072
+  tps: 35704.45007
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56462"
  value: {
-  dps: 25676.08122
-  tps: 35177.0554
+  dps: 25759.93617
+  tps: 36105.56868
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GearDetector-61462"
  value: {
-  dps: 26264.98782
-  tps: 35664.09674
+  dps: 26205.30586
+  tps: 36269.50093
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 23097.61798
-  tps: 30855.74759
+  dps: 23299.99831
+  tps: 31989.53815
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 25482.71999
-  tps: 35340.17115
+  dps: 25439.58027
+  tps: 36362.42728
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 26283.14805
-  tps: 36218.98223
+  dps: 26346.92596
+  tps: 37715.90733
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 26759.52779
-  tps: 36750.16084
+  dps: 26798.8043
+  tps: 38224.83302
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HarmlightToken-63839"
  value: {
-  dps: 25485.33132
-  tps: 35346.82957
+  dps: 25457.98094
+  tps: 36417.18737
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 26062.01704
-  tps: 36022.75111
+  dps: 25955.96702
+  tps: 36697.48996
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 25482.71999
-  tps: 35340.31301
+  dps: 25439.58027
+  tps: 36362.5747
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 25482.71999
-  tps: 35340.31301
+  dps: 25439.58027
+  tps: 36362.5747
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-59224"
  value: {
-  dps: 26386.7016
-  tps: 36284.09674
+  dps: 26348.23371
+  tps: 36741.18803
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-65072"
  value: {
-  dps: 26515.80935
-  tps: 36266.01989
+  dps: 26449.72842
+  tps: 37203.87998
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-55868"
  value: {
-  dps: 25650.15062
-  tps: 34931.20081
+  dps: 25705.16072
+  tps: 35704.45007
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-56393"
  value: {
-  dps: 26193.90275
-  tps: 35232.16715
+  dps: 26171.25611
+  tps: 35543.36665
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-55845"
  value: {
-  dps: 25482.71999
-  tps: 35340.31301
+  dps: 25439.58027
+  tps: 36362.5747
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-56370"
  value: {
-  dps: 25482.71999
-  tps: 35340.31301
+  dps: 25439.58027
+  tps: 36362.5747
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 26430.73626
-  tps: 36142.07228
+  dps: 26480.67758
+  tps: 37438.08798
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-50641"
  value: {
-  dps: 27519.81368
-  tps: 37720.39828
+  dps: 27651.84066
+  tps: 38997.04255
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 26464.32874
-  tps: 36566.31354
+  dps: 26527.38014
+  tps: 37113.64859
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 26380.05449
-  tps: 36590.53416
+  dps: 26398.39412
+  tps: 37353.56432
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 26380.05449
-  tps: 36590.53416
+  dps: 26398.39412
+  tps: 37353.56432
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 25757.23687
-  tps: 35803.98473
+  dps: 25782.75931
+  tps: 36883.34508
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 25794.76425
-  tps: 35862.74925
+  dps: 25820.60659
+  tps: 36945.03714
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 25482.71999
-  tps: 35340.31301
+  dps: 25439.58027
+  tps: 36362.5747
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 25702.91775
-  tps: 35677.30274
+  dps: 25646.74997
+  tps: 36715.8876
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 25482.71999
-  tps: 35340.65472
+  dps: 25439.58027
+  tps: 36362.85441
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 25482.71999
-  tps: 35340.65472
+  dps: 25439.58027
+  tps: 36362.85441
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 26772.48499
-  tps: 36804.52823
+  dps: 26867.90737
+  tps: 38343.95344
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 26563.3768
-  tps: 36327.65816
+  dps: 26510.29762
+  tps: 37207.01591
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 26913.75639
-  tps: 36698.45962
+  dps: 26939.59884
+  tps: 37933.39036
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 25773.82373
-  tps: 34847.79118
+  dps: 25856.13405
+  tps: 36380.45716
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 25773.82373
-  tps: 34847.79118
+  dps: 25856.13405
+  tps: 36380.45716
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 25483.55872
-  tps: 34924.88608
+  dps: 25640.70942
+  tps: 35455.27998
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50708"
  value: {
-  dps: 27164.33196
-  tps: 37438.85226
+  dps: 27287.99943
+  tps: 38206.37864
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-55816"
  value: {
-  dps: 25482.71999
-  tps: 35340.31301
+  dps: 25439.58027
+  tps: 36362.5747
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-56347"
  value: {
-  dps: 25482.71999
-  tps: 35340.31301
+  dps: 25439.58027
+  tps: 36362.5747
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 26721.43451
-  tps: 36355.67322
+  dps: 26938.12959
+  tps: 37871.87396
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 26040.21573
-  tps: 36127.23156
+  dps: 25987.28359
+  tps: 37161.08312
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 25949.56086
-  tps: 36057.451
+  dps: 26005.42503
+  tps: 36798.9814
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 26082.44923
-  tps: 36380.69738
+  dps: 26331.03034
+  tps: 37062.07428
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 25482.71999
-  tps: 35340.31301
+  dps: 25439.58027
+  tps: 36362.5747
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 25482.71999
-  tps: 35340.31301
+  dps: 25439.58027
+  tps: 36362.5747
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 26220.73674
-  tps: 36325.89312
+  dps: 26206.05748
+  tps: 37323.36498
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 26308.70248
-  tps: 36480.16533
+  dps: 26373.89865
+  tps: 37564.07626
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 27582.2155
-  tps: 37429.83253
+  dps: 27629.7268
+  tps: 38022.22153
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 27905.52795
-  tps: 38233.6433
+  dps: 27931.24489
+  tps: 38939.0687
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 25769.80715
-  tps: 35723.24175
+  dps: 25704.65023
+  tps: 36740.33347
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 26010.45953
-  tps: 36008.57388
+  dps: 25948.13639
+  tps: 37032.91181
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 25835.70321
-  tps: 35926.85599
+  dps: 25861.89454
+  tps: 37012.33756
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 25835.70321
-  tps: 35926.85599
+  dps: 25861.89454
+  tps: 37012.33756
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MithrilStopwatch-71337"
  value: {
-  dps: 25798.9797
-  tps: 35702.07879
+  dps: 25930.70983
+  tps: 36712.41311
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 25957.0923
-  tps: 36039.75771
+  dps: 25911.26962
+  tps: 36273.09352
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 25471.42079
-  tps: 35335.39926
+  dps: 25449.81767
+  tps: 36392.68362
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 25482.71999
-  tps: 35340.01804
+  dps: 25439.58027
+  tps: 36362.26815
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 25482.71999
-  tps: 35339.97957
+  dps: 25439.58027
+  tps: 36362.22816
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ObsidianArborweaveBattlegarb"
  value: {
-  dps: 26718.44092
-  tps: 35564.57715
+  dps: 26695.45744
+  tps: 34717.4876
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ObsidianArborweaveRegalia"
  value: {
-  dps: 19367.48573
-  tps: 26183.23596
+  dps: 19506.14642
+  tps: 25899.78735
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 25966.75224
-  tps: 35940.0541
+  dps: 25930.88075
+  tps: 37211.47575
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedPickledEgg-71336"
  value: {
-  dps: 25482.71999
-  tps: 35340.05112
+  dps: 25439.58027
+  tps: 36362.30253
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 25482.71999
-  tps: 35340.31301
+  dps: 25439.58027
+  tps: 36362.5747
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 25637.72985
-  tps: 35429.2272
+  dps: 25670.87752
+  tps: 36797.91777
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 25657.6923
-  tps: 35394.36416
+  dps: 25618.58318
+  tps: 36033.14043
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 25850.38492
-  tps: 35709.53663
+  dps: 25800.43709
+  tps: 35891.48157
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 26357.71148
-  tps: 36413.81933
+  dps: 26416.91831
+  tps: 37045.52983
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 27041.71143
-  tps: 35885.28484
+  dps: 27074.77605
+  tps: 37726.12505
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 27286.85824
-  tps: 36905.68517
+  dps: 27287.5818
+  tps: 37012.43918
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-55854"
  value: {
-  dps: 25482.71999
-  tps: 35340.31301
+  dps: 25439.58027
+  tps: 36362.5747
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-56377"
  value: {
-  dps: 25482.71999
-  tps: 35340.31301
+  dps: 25439.58027
+  tps: 36362.5747
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 26863.56153
-  tps: 37098.88017
+  dps: 26921.51831
+  tps: 37727.80686
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 26783.22456
-  tps: 36988.26765
+  dps: 26841.18382
+  tps: 37615.29359
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 27155.55327
-  tps: 37158.11762
+  dps: 27230.8375
+  tps: 38926.52082
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 25937.94818
-  tps: 35844.13603
+  dps: 25914.57094
+  tps: 36833.62379
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 25979.48326
-  tps: 35820.10453
+  dps: 25941.73358
+  tps: 36701.51705
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuneofZeth-68998"
  value: {
-  dps: 25822.98203
-  tps: 35853.27232
+  dps: 25999.4946
+  tps: 37063.6913
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 26552.24544
-  tps: 36806.67737
+  dps: 26587.05699
+  tps: 37538.98575
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-55256"
  value: {
-  dps: 25471.42079
-  tps: 35335.39926
+  dps: 25449.81767
+  tps: 36392.68362
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-56290"
  value: {
-  dps: 25471.42079
-  tps: 35335.39926
+  dps: 25449.81767
+  tps: 36392.68362
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShardofWoe-60233"
  value: {
-  dps: 25702.30577
-  tps: 35532.11542
+  dps: 25770.84818
+  tps: 36218.53411
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 25978.39765
-  tps: 35584.09655
+  dps: 26172.188
+  tps: 36542.0688
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 25470.66414
-  tps: 35355.23753
+  dps: 25493.74368
+  tps: 36412.24213
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 26723.08922
-  tps: 37072.34495
+  dps: 26774.40265
+  tps: 37840.7704
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 26945.77814
-  tps: 37241.2164
+  dps: 26935.40182
+  tps: 37887.888
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-55879"
  value: {
-  dps: 25749.65168
-  tps: 35779.20907
+  dps: 25704.44242
+  tps: 36674.76845
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-56400"
  value: {
-  dps: 25787.16874
-  tps: 35837.98499
+  dps: 25742.20156
+  tps: 36735.98651
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 25769.80715
-  tps: 35723.24175
+  dps: 25704.65023
+  tps: 36740.33347
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulCasket-58183"
  value: {
-  dps: 25836.38375
-  tps: 35907.11561
+  dps: 25817.49748
+  tps: 36991.58004
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 25509.60193
-  tps: 35369.74361
+  dps: 25477.60379
+  tps: 36335.36711
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stormrider'sBattlegarb"
  value: {
-  dps: 25059.71668
-  tps: 33837.89769
+  dps: 25206.99239
+  tps: 33792.51756
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stormrider'sRegalia"
  value: {
-  dps: 19137.22968
-  tps: 25108.47855
+  dps: 19296.63209
+  tps: 25678.67406
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62465"
  value: {
-  dps: 25489.57383
-  tps: 35362.47761
+  dps: 25435.64147
+  tps: 36371.25168
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62470"
  value: {
-  dps: 25489.57383
-  tps: 35362.47761
+  dps: 25431.6945
+  tps: 36378.35799
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 25482.71999
-  tps: 35340.31301
+  dps: 25439.58027
+  tps: 36362.5747
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 25482.71999
-  tps: 35340.31301
+  dps: 25439.58027
+  tps: 36362.5747
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 25513.724
-  tps: 35390.29492
+  dps: 25466.21494
+  tps: 36405.09909
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 26021.19166
-  tps: 35182.98901
+  dps: 26081.04766
+  tps: 35851.1981
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-55819"
  value: {
-  dps: 25482.71999
-  tps: 35340.1473
+  dps: 25439.58027
+  tps: 36362.40249
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-56351"
  value: {
-  dps: 25482.71999
-  tps: 35340.09344
+  dps: 25439.58027
+  tps: 36362.34651
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 25727.37972
-  tps: 35723.57587
+  dps: 25673.83718
+  tps: 36756.18981
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 25809.05229
-  tps: 35845.17051
+  dps: 25769.70007
+  tps: 36909.39495
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheHungerer-68927"
  value: {
-  dps: 27304.21809
-  tps: 36835.90015
+  dps: 27287.01243
+  tps: 37838.34621
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheHungerer-69112"
  value: {
-  dps: 27520.75873
-  tps: 37464.12914
+  dps: 27619.66075
+  tps: 37844.18594
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 25518.48699
-  tps: 35402.74346
+  dps: 25483.06768
+  tps: 36448.72078
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 25528.12024
-  tps: 35423.7147
+  dps: 25502.52438
+  tps: 36467.16714
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 25482.71999
-  tps: 35340.31301
+  dps: 25439.58027
+  tps: 36362.5747
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 25482.71999
-  tps: 35340.31301
+  dps: 25439.58027
+  tps: 36362.5747
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 26882.38781
-  tps: 37183.97055
+  dps: 26901.46856
+  tps: 38604.79563
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 27062.86517
-  tps: 37567.6773
+  dps: 27125.11465
+  tps: 38824.14419
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 25578.05579
-  tps: 35015.32626
+  dps: 25748.28994
+  tps: 36792.40894
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 25521.39313
-  tps: 35559.51399
+  dps: 25565.39578
+  tps: 36534.82903
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnheededWarning-59520"
  value: {
-  dps: 27246.26082
-  tps: 37797.56383
+  dps: 27277.15596
+  tps: 38725.54254
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 25471.42079
-  tps: 35335.39926
+  dps: 25449.81767
+  tps: 36392.68362
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 27266.02562
-  tps: 37613.96728
+  dps: 27248.49994
+  tps: 37975.46124
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 27266.02562
-  tps: 37613.96728
+  dps: 27248.49994
+  tps: 37975.46124
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 27266.02562
-  tps: 37613.96728
+  dps: 27248.49994
+  tps: 37975.46124
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 22499.54583
-  tps: 31303.13795
+  dps: 22543.77488
+  tps: 31645.23487
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 25482.92391
-  tps: 35341.01994
+  dps: 25440.2205
+  tps: 36365.45089
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 25471.01106
-  tps: 35365.66545
+  dps: 25442.14595
+  tps: 36370.85154
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 26455.74346
-  tps: 36521.23475
+  dps: 26652.78214
+  tps: 37835.7638
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 26588.72923
-  tps: 36710.07374
+  dps: 26788.2995
+  tps: 38017.09863
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 25471.42079
-  tps: 35335.39926
+  dps: 25449.81767
+  tps: 36392.68362
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 25471.42079
-  tps: 35335.39926
+  dps: 25449.81767
+  tps: 36392.68362
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 26880.32573
-  tps: 37014.54918
+  dps: 26857.75887
+  tps: 37356.37923
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 25471.42079
-  tps: 35335.39926
+  dps: 25449.81767
+  tps: 36392.68362
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 26007.0906
-  tps: 36007.1656
+  dps: 25985.47066
+  tps: 37000.70835
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 25478.27463
-  tps: 35357.56387
+  dps: 25435.9241
+  tps: 36342.19371
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 25738.70052
-  tps: 35146.40511
+  dps: 25843.37488
+  tps: 35929.04859
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 25785.51107
-  tps: 35702.50333
+  dps: 25912.30303
+  tps: 36692.58626
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 25833.21925
-  tps: 35755.51727
+  dps: 25844.02127
+  tps: 37248.10701
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 25857.98592
-  tps: 35940.95551
+  dps: 25828.88043
+  tps: 36966.00707
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 25471.42079
-  tps: 35335.39926
+  dps: 25439.86289
+  tps: 36333.51673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 26774.17961
-  tps: 36833.52193
+  dps: 26806.869
+  tps: 37280.27716
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 25482.71999
-  tps: 35340.31301
+  dps: 25438.43372
+  tps: 36275.94736
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 25944.00742
-  tps: 35775.57316
+  dps: 25948.5179
+  tps: 36811.51681
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 25527.35319
-  tps: 35359.31055
+  dps: 25452.75795
+  tps: 36203.88475
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 25499.9045
-  tps: 35236.99688
+  dps: 25457.44808
+  tps: 36263.02242
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 25731.93153
-  tps: 35730.70634
+  dps: 25690.37021
+  tps: 36770.87402
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 25798.42567
-  tps: 35748.06887
+  dps: 25780.79785
+  tps: 36726.4235
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 25798.42567
-  tps: 35748.06887
+  dps: 25780.79785
+  tps: 36726.4235
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 27298.93891
-  tps: 37272.3284
+  dps: 27428.86995
+  tps: 38099.78544
  }
 }
 dps_results: {
@@ -1502,85 +1502,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 34006.38857
-  tps: 51049.66939
+  dps: 34147.15539
+  tps: 51467.00617
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 30472.92691
-  tps: 41902.94172
+  dps: 30596.73369
+  tps: 42742.1699
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 37481.92569
-  tps: 36529.92107
+  dps: 37555.94487
+  tps: 38887.67166
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 21344.28993
-  tps: 32862.29634
+  dps: 21423.66892
+  tps: 33129.29656
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 19507.27401
-  tps: 28316.01818
+  dps: 19508.92026
+  tps: 28537.42221
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 20821.66853
-  tps: 23045.29552
+  dps: 20822.92874
+  tps: 23263.7434
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 30322.53312
-  tps: 21531.25916
+  dps: 30294.38525
+  tps: 21511.27417
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29542.1156
-  tps: 20974.90207
+  dps: 29699.93003
+  tps: 21086.95032
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 36622.40916
-  tps: 26001.9105
+  dps: 36710.76641
+  tps: 26064.64415
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 18542.72918
-  tps: 13167.7006
+  dps: 18558.3292
+  tps: 13178.77661
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 18712.83132
-  tps: 13286.3204
+  dps: 18714.01678
+  tps: 13287.16207
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 20419.52551
-  tps: 14498.43112
+  dps: 20431.50102
+  tps: 14506.93372
  }
 }
 dps_results: {
@@ -1628,85 +1628,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 33384.81145
-  tps: 50234.59959
+  dps: 33209.34787
+  tps: 49380.19404
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29771.28038
-  tps: 40382.45778
+  dps: 29663.76428
+  tps: 40864.36479
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 36394.61456
-  tps: 33925.03217
+  dps: 36353.12147
+  tps: 35915.94927
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 20959.39914
-  tps: 32623.12098
+  dps: 20973.38885
+  tps: 32671.99402
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 18953.12888
-  tps: 27563.20731
+  dps: 18937.84517
+  tps: 27531.40002
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 20142.91006
-  tps: 22328.97058
+  dps: 20127.66711
+  tps: 21995.38784
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 29655.6893
-  tps: 21057.80004
+  dps: 29730.60375
+  tps: 21110.98931
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28949.68992
-  tps: 20554.27985
+  dps: 28838.33016
+  tps: 20475.21442
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 35967.51806
-  tps: 25536.93782
+  dps: 35991.27017
+  tps: 25553.80182
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 18023.36917
-  tps: 12798.95499
+  dps: 18034.50985
+  tps: 12806.86487
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 18143.15872
-  tps: 12881.85285
+  dps: 18131.26428
+  tps: 12873.4078
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 19797.57994
-  tps: 14056.84976
+  dps: 19777.98396
+  tps: 14042.93661
  }
 }
 dps_results: {
@@ -1754,85 +1754,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 30294.63851
-  tps: 45934.05652
+  dps: 30401.03656
+  tps: 45592.54925
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 26994.5104
-  tps: 37204.67091
+  dps: 27117.59734
+  tps: 37966.87896
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 33009.8008
-  tps: 29399.02713
+  dps: 33513.87546
+  tps: 33600.15854
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 19033.05043
-  tps: 29725.51476
+  dps: 19196.21634
+  tps: 30495.70905
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 17016.89236
-  tps: 25048.3203
+  dps: 17087.17917
+  tps: 24668.83484
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 18398.12008
-  tps: 21435.24267
+  dps: 18444.31047
+  tps: 21616.62274
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 26904.04595
-  tps: 19104.13327
+  dps: 26876.9224
+  tps: 19084.87555
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 26211.283
-  tps: 18610.01093
+  dps: 26430.93816
+  tps: 18765.96609
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 32674.20994
-  tps: 23198.68906
+  dps: 32897.21141
+  tps: 23357.0201
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 16206.02435
-  tps: 11508.64017
+  dps: 16278.60418
+  tps: 11560.17185
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 16340.02482
-  tps: 11601.62778
+  dps: 16359.11748
+  tps: 11615.18357
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 17999.60172
-  tps: 12780.28522
+  dps: 18045.08158
+  tps: 12812.57592
  }
 }
 dps_results: {
@@ -1880,91 +1880,91 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 29330.1639
-  tps: 43672.27354
+  dps: 29312.50173
+  tps: 42915.95354
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 26436.74647
-  tps: 35476.92855
+  dps: 26490.75263
+  tps: 36549.96154
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 32345.83246
-  tps: 30027.5295
+  dps: 32523.52515
+  tps: 31534.69274
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 18565.99543
-  tps: 28797.3336
+  dps: 18527.65508
+  tps: 27808.17759
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 16564.05553
-  tps: 23834.36424
+  dps: 16595.54488
+  tps: 23527.36025
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 17888.59041
-  tps: 20265.04411
+  dps: 17957.61252
+  tps: 20286.37962
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 26282.29094
-  tps: 18662.6872
+  dps: 26279.70562
+  tps: 18660.85163
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25646.08314
-  tps: 18208.71903
+  dps: 25704.79038
+  tps: 18250.40117
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 31955.21257
-  tps: 22688.20092
+  dps: 32106.35315
+  tps: 22795.51074
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 15831.72914
-  tps: 11242.89057
+  dps: 15891.64128
+  tps: 11285.42819
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 15885.77663
-  tps: 11279.11157
+  dps: 15894.26701
+  tps: 11285.13974
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 17572.88116
-  tps: 12477.31363
+  dps: 17605.22479
+  tps: 12500.2776
  }
 }
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 23765.74091
-  tps: 33227.488
+  dps: 23881.08683
+  tps: 34366.74946
  }
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -1710,6 +1710,258 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFeral-Settings-Tauren-p3-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
+ value: {
+  dps: 85262.71727
+  tps: 117150.37946
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p3-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
+ value: {
+  dps: 20696.85666
+  tps: 36480.42335
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p3-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
+ value: {
+  dps: 24192.69987
+  tps: 34000.04722
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p3-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
+ value: {
+  dps: 58365.60254
+  tps: 83205.38779
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p3-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
+ value: {
+  dps: 12778.60373
+  tps: 23543.10009
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p3-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-ShortSingleTarget"
+ value: {
+  dps: 12933.66963
+  tps: 23018.86113
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
+ value: {
+  dps: 40228.85838
+  tps: 55899.35104
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
+ value: {
+  dps: 37109.49205
+  tps: 48718.16087
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
+ value: {
+  dps: 46306.8583
+  tps: 43956.97764
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
+ value: {
+  dps: 26010.41107
+  tps: 37359.71965
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
+ value: {
+  dps: 24152.16981
+  tps: 31450.59016
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
+ value: {
+  dps: 26126.82357
+  tps: 21252.12537
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
+ value: {
+  dps: 36786.32328
+  tps: 26120.55017
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
+ value: {
+  dps: 36301.70475
+  tps: 25774.21037
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
+ value: {
+  dps: 46263.30038
+  tps: 32846.94327
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
+ value: {
+  dps: 23200.03157
+  tps: 16474.3853
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
+ value: {
+  dps: 23399.75827
+  tps: 16614.03853
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
+ value: {
+  dps: 26155.20169
+  tps: 18570.7612
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p3-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
+ value: {
+  dps: 84750.38614
+  tps: 118261.56235
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p3-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
+ value: {
+  dps: 20626.36766
+  tps: 36019.40722
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p3-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
+ value: {
+  dps: 23954.63881
+  tps: 31651.29393
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p3-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
+ value: {
+  dps: 58240.99598
+  tps: 84035.27773
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p3-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
+ value: {
+  dps: 12783.70923
+  tps: 22784.48027
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p3-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-ShortSingleTarget"
+ value: {
+  dps: 12963.24902
+  tps: 23277.67817
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
+ value: {
+  dps: 39652.25348
+  tps: 56419.12785
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
+ value: {
+  dps: 36285.88477
+  tps: 46785.71751
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
+ value: {
+  dps: 45575.20636
+  tps: 42333.86973
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
+ value: {
+  dps: 24808.52561
+  tps: 34415.9473
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
+ value: {
+  dps: 23525.65546
+  tps: 31140.34294
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
+ value: {
+  dps: 25578.14659
+  tps: 23097.48397
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
+ value: {
+  dps: 36062.39058
+  tps: 25606.55795
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
+ value: {
+  dps: 35484.72305
+  tps: 25194.15337
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
+ value: {
+  dps: 45107.31909
+  tps: 32026.19655
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
+ value: {
+  dps: 22616.47062
+  tps: 16060.05702
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
+ value: {
+  dps: 22807.27714
+  tps: 16193.37693
+ }
+}
+dps_results: {
+ key: "TestFeral-Settings-Tauren-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
+ value: {
+  dps: 25341.66489
+  tps: 17993.15008
+ }
+}
+dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
   dps: 64291.34925

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -38,1423 +38,1423 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 27043.69587
-  tps: 36819.01316
+  dps: 26994.5104
+  tps: 37204.67091
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 25468.54846
-  tps: 35200.12638
+  dps: 25482.71999
+  tps: 35340.18038
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 27450.14999
-  tps: 37709.30155
+  dps: 27460.73946
+  tps: 37649.05689
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 25473.46172
-  tps: 35212.64124
+  dps: 25487.63324
+  tps: 35352.69466
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 25474.43201
-  tps: 35217.53271
+  dps: 25488.60354
+  tps: 35357.58614
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 26401.36579
-  tps: 36922.92746
+  dps: 26394.87797
+  tps: 36817.42403
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 26522.54035
-  tps: 37126.77499
+  dps: 26529.74236
+  tps: 36983.73479
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 26404.85655
-  tps: 35967.56568
+  dps: 26357.71148
+  tps: 36413.81933
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 25468.54846
-  tps: 35200.25959
+  dps: 25482.71999
+  tps: 35340.31301
   hps: 88.86807
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 25468.54846
-  tps: 35200.25959
+  dps: 25482.71999
+  tps: 35340.31301
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 25828.55531
-  tps: 35977.5427
+  dps: 25789.72421
+  tps: 35773.93863
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 25864.36891
-  tps: 35828.69449
+  dps: 25821.54787
+  tps: 35724.18323
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BindingPromise-67037"
  value: {
-  dps: 25468.54846
-  tps: 35200.25959
+  dps: 25471.42079
+  tps: 35335.39926
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 26728.42312
-  tps: 36475.59653
+  dps: 26772.48499
+  tps: 36804.52823
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 25754.99592
-  tps: 35648.30507
+  dps: 25769.48396
+  tps: 35789.53273
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 25792.5069
-  tps: 35706.97769
+  dps: 25807.03638
+  tps: 35848.35913
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 27229.51168
-  tps: 37036.37463
+  dps: 27290.5854
+  tps: 37423.7252
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 25468.54846
-  tps: 35200.25959
+  dps: 25471.42079
+  tps: 35335.39926
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 25983.01738
-  tps: 35850.18123
+  dps: 25978.72179
+  tps: 35971.58918
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 25795.54989
-  tps: 35727.30234
+  dps: 25741.59852
+  tps: 35575.29411
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 25468.54846
-  tps: 35200.25959
+  dps: 25471.42079
+  tps: 35335.39926
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 25468.54846
-  tps: 35200.25959
+  dps: 25471.42079
+  tps: 35335.39926
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 26770.2172
-  tps: 36731.78592
+  dps: 26714.68822
+  tps: 36267.05688
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 25468.54846
-  tps: 35200.25959
+  dps: 25482.71999
+  tps: 35340.31301
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 25941.98432
-  tps: 35794.25693
+  dps: 25846.01243
+  tps: 35355.93658
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledLightning-66879"
  value: {
-  dps: 25574.71336
-  tps: 34966.67159
+  dps: 25569.7114
+  tps: 35213.67311
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 26404.85655
-  tps: 35248.45225
+  dps: 26357.71148
+  tps: 35685.75953
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Brawler'sTrophy-71338"
  value: {
-  dps: 25468.54846
-  tps: 35200.25959
+  dps: 25471.42079
+  tps: 35335.39926
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 26832.63975
-  tps: 36526.10564
+  dps: 26783.22456
+  tps: 36988.22556
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 26905.24979
-  tps: 36592.2798
+  dps: 26895.29134
+  tps: 37143.91097
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Coren'sChilledChromiumCoaster-71335"
  value: {
-  dps: 26775.4097
-  tps: 36975.29809
+  dps: 26794.76815
+  tps: 37234.09542
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 25468.54846
-  tps: 35200.01124
+  dps: 25471.42079
+  tps: 35335.152
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 25468.54846
-  tps: 35200.25959
+  dps: 25482.71999
+  tps: 35340.31301
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-59506"
  value: {
-  dps: 26285.54798
-  tps: 35716.3148
+  dps: 26313.60391
+  tps: 35359.16535
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-65118"
  value: {
-  dps: 26395.79113
-  tps: 35856.89053
+  dps: 26260.23427
+  tps: 35845.12424
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 25468.54846
-  tps: 35200.25959
+  dps: 25471.42079
+  tps: 35335.39926
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 26096.20808
-  tps: 35754.70257
+  dps: 26128.07431
+  tps: 35663.9753
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 26823.30338
-  tps: 37109.35949
+  dps: 26845.96647
+  tps: 37036.3264
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 25468.54846
-  tps: 35200.01124
+  dps: 25482.71999
+  tps: 35340.06574
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 25840.06258
-  tps: 35893.99074
+  dps: 25835.83935
+  tps: 35985.06644
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 26180.72991
-  tps: 36344.36982
+  dps: 26155.63669
+  tps: 36059.85431
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 26473.3294
-  tps: 36031.7995
+  dps: 26464.32874
+  tps: 36566.31354
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 25449.52799
-  tps: 34539.6205
+  dps: 25487.8655
+  tps: 34417.57864
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 26417.74827
-  tps: 36476.63865
+  dps: 26462.69184
+  tps: 36371.06903
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 26404.85655
-  tps: 35967.56568
+  dps: 26357.71148
+  tps: 36413.81933
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 25468.54846
-  tps: 35234.54991
+  dps: 25471.42079
+  tps: 35369.2631
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 26404.85655
-  tps: 35967.49965
+  dps: 26357.71148
+  tps: 36413.7555
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 26473.3294
-  tps: 36031.7995
+  dps: 26464.32874
+  tps: 36566.31354
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 27157.11761
-  tps: 37504.47747
+  dps: 27167.56531
+  tps: 37296.14107
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 27312.90629
-  tps: 37845.01929
+  dps: 27364.28778
+  tps: 38193.86949
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 26502.40273
-  tps: 36711.69143
+  dps: 26501.77475
+  tps: 36806.41333
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 26404.85655
-  tps: 35967.56568
+  dps: 26357.71148
+  tps: 36413.81933
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-59500"
  value: {
-  dps: 25468.54846
-  tps: 35200.01124
+  dps: 25482.71999
+  tps: 35340.06574
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-65124"
  value: {
-  dps: 25468.54846
-  tps: 35199.97878
+  dps: 25482.71999
+  tps: 35340.03343
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 25450.27975
-  tps: 35211.95046
+  dps: 25456.89196
+  tps: 35411.86889
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 26718.32258
-  tps: 36604.81004
+  dps: 26748.35183
+  tps: 36919.69261
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 25468.54846
-  tps: 35200.03906
+  dps: 25471.42079
+  tps: 35335.1797
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 25468.54846
-  tps: 35200.25959
+  dps: 25471.42079
+  tps: 35335.39926
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 25468.54846
-  tps: 35200.03906
+  dps: 25471.42079
+  tps: 35335.1797
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 26281.23939
-  tps: 36325.86107
+  dps: 26277.35498
+  tps: 36448.61114
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 26468.13186
-  tps: 36065.63818
+  dps: 26421.14369
+  tps: 36513.98683
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 26404.85655
-  tps: 35967.52214
+  dps: 26357.71148
+  tps: 36413.77724
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 26457.91448
-  tps: 36779.88406
+  dps: 26439.39696
+  tps: 36553.39724
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56138"
  value: {
-  dps: 25586.57138
-  tps: 34970.76602
+  dps: 25650.15062
+  tps: 34931.20081
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56462"
  value: {
-  dps: 25690.76048
-  tps: 34473.27113
+  dps: 25676.08122
+  tps: 35177.0554
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GearDetector-61462"
  value: {
-  dps: 26235.79664
-  tps: 35425.97592
+  dps: 26264.98782
+  tps: 35664.09674
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 23031.13815
-  tps: 30831.92297
+  dps: 23097.61798
+  tps: 30855.74759
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 25468.54846
-  tps: 35200.11711
+  dps: 25482.71999
+  tps: 35340.17115
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 26281.48181
-  tps: 35950.2001
+  dps: 26283.14805
+  tps: 36218.98223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 26754.89887
-  tps: 36802.39163
+  dps: 26759.52779
+  tps: 36750.16084
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HarmlightToken-63839"
  value: {
-  dps: 25473.85748
-  tps: 35242.12849
+  dps: 25485.33132
+  tps: 35346.82957
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 26040.75213
-  tps: 35991.04481
+  dps: 26062.01704
+  tps: 36022.75111
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 25468.54846
-  tps: 35200.25959
+  dps: 25482.71999
+  tps: 35340.31301
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 25468.54846
-  tps: 35200.25959
+  dps: 25482.71999
+  tps: 35340.31301
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-59224"
  value: {
-  dps: 26381.81159
-  tps: 36155.75779
+  dps: 26386.7016
+  tps: 36284.09674
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-65072"
  value: {
-  dps: 26416.35021
-  tps: 36290.62485
+  dps: 26515.80935
+  tps: 36266.01989
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-55868"
  value: {
-  dps: 25586.57138
-  tps: 34970.76602
+  dps: 25650.15062
+  tps: 34931.20081
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-56393"
  value: {
-  dps: 26230.10373
-  tps: 35124.23308
+  dps: 26193.90275
+  tps: 35232.16715
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-55845"
  value: {
-  dps: 25468.54846
-  tps: 35200.25959
+  dps: 25482.71999
+  tps: 35340.31301
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-56370"
  value: {
-  dps: 25468.54846
-  tps: 35200.25959
+  dps: 25482.71999
+  tps: 35340.31301
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 26438.95387
-  tps: 36277.09418
+  dps: 26430.73626
+  tps: 36142.07228
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-50641"
  value: {
-  dps: 27457.76715
-  tps: 37405.98814
+  dps: 27519.81368
+  tps: 37720.39828
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 26473.3294
-  tps: 36031.7995
+  dps: 26464.32874
+  tps: 36566.31354
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 26384.80817
-  tps: 36469.40554
+  dps: 26380.05449
+  tps: 36590.53416
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 26384.80817
-  tps: 36469.40554
+  dps: 26380.05449
+  tps: 36590.53416
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 25766.77655
-  tps: 35772.19339
+  dps: 25757.23687
+  tps: 35803.98473
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 25804.28867
-  tps: 35830.88563
+  dps: 25794.76425
+  tps: 35862.74925
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 25468.54846
-  tps: 35200.25959
+  dps: 25482.71999
+  tps: 35340.31301
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 25689.06754
-  tps: 35545.18349
+  dps: 25702.91775
+  tps: 35677.30274
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 25468.54846
-  tps: 35200.57016
+  dps: 25482.71999
+  tps: 35340.65472
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 25468.54846
-  tps: 35200.57016
+  dps: 25482.71999
+  tps: 35340.65472
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 26728.42312
-  tps: 36475.59653
+  dps: 26772.48499
+  tps: 36804.52823
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 26533.48395
-  tps: 36718.47036
+  dps: 26563.3768
+  tps: 36327.65816
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 26871.92201
-  tps: 36881.80385
+  dps: 26913.75639
+  tps: 36698.45962
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 25734.19883
-  tps: 34824.19764
+  dps: 25773.82373
+  tps: 34847.79118
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 25734.19883
-  tps: 34824.19764
+  dps: 25773.82373
+  tps: 34847.79118
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 25544.19895
-  tps: 35314.40918
+  dps: 25483.55872
+  tps: 34924.88608
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50708"
  value: {
-  dps: 27213.86298
-  tps: 37051.68023
+  dps: 27164.33196
+  tps: 37438.85226
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-55816"
  value: {
-  dps: 25468.54846
-  tps: 35200.25959
+  dps: 25482.71999
+  tps: 35340.31301
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-56347"
  value: {
-  dps: 25468.54846
-  tps: 35200.25959
+  dps: 25482.71999
+  tps: 35340.31301
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 26765.16108
-  tps: 37032.98773
+  dps: 26721.43451
+  tps: 36355.67322
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 26025.41933
-  tps: 35984.51763
+  dps: 26040.21573
+  tps: 36127.23156
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 25926.64846
-  tps: 36021.86664
+  dps: 25949.56086
+  tps: 36057.451
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 26138.9867
-  tps: 36017.54353
+  dps: 26082.44923
+  tps: 36380.69738
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 25468.54846
-  tps: 35200.25959
+  dps: 25482.71999
+  tps: 35340.31301
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 25468.54846
-  tps: 35200.25959
+  dps: 25482.71999
+  tps: 35340.31301
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 26182.37404
-  tps: 36143.81404
+  dps: 26220.73674
+  tps: 36325.89312
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 26276.64279
-  tps: 36268.39554
+  dps: 26308.70248
+  tps: 36480.16533
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 27634.63059
-  tps: 38380.31197
+  dps: 27582.2155
+  tps: 37429.83253
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 27937.83669
-  tps: 38758.52474
+  dps: 27905.52795
+  tps: 38233.6433
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 25746.54258
-  tps: 35521.99849
+  dps: 25769.80715
+  tps: 35723.24175
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 25983.11204
-  tps: 35793.78642
+  dps: 26010.45953
+  tps: 36008.57388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 25845.21097
-  tps: 35894.91353
+  dps: 25835.70321
+  tps: 35926.85599
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 25845.21097
-  tps: 35894.91353
+  dps: 25835.70321
+  tps: 35926.85599
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MithrilStopwatch-71337"
  value: {
-  dps: 25839.9013
-  tps: 35809.24798
+  dps: 25798.9797
+  tps: 35702.07879
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 25904.95621
-  tps: 35835.41055
+  dps: 25957.0923
+  tps: 36039.75771
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 25468.54846
-  tps: 35200.25959
+  dps: 25471.42079
+  tps: 35335.39926
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 25468.54846
-  tps: 35199.96333
+  dps: 25482.71999
+  tps: 35340.01804
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 25468.54846
-  tps: 35199.92469
+  dps: 25482.71999
+  tps: 35339.97957
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ObsidianArborweaveBattlegarb"
  value: {
-  dps: 26574.58712
-  tps: 34930.8927
+  dps: 26718.44092
+  tps: 35564.57715
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ObsidianArborweaveRegalia"
  value: {
-  dps: 19338.53852
-  tps: 26284.6086
+  dps: 19367.48573
+  tps: 26183.23596
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 25963.57025
-  tps: 35706.81626
+  dps: 25966.75224
+  tps: 35940.0541
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedPickledEgg-71336"
  value: {
-  dps: 25468.54846
-  tps: 35199.99656
+  dps: 25482.71999
+  tps: 35340.05112
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 25468.54846
-  tps: 35200.25959
+  dps: 25482.71999
+  tps: 35340.31301
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 25657.75465
-  tps: 35510.13394
+  dps: 25637.72985
+  tps: 35429.2272
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 25678.57712
-  tps: 35492.45558
+  dps: 25657.6923
+  tps: 35394.36416
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 25854.22713
-  tps: 35741.36202
+  dps: 25850.38492
+  tps: 35709.53663
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 26404.85655
-  tps: 35967.56568
+  dps: 26357.71148
+  tps: 36413.81933
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 26964.81325
-  tps: 35680.13576
+  dps: 27041.71143
+  tps: 35885.28484
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 27235.85412
-  tps: 36723.15334
+  dps: 27286.85824
+  tps: 36905.68517
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-55854"
  value: {
-  dps: 25468.54846
-  tps: 35200.25959
+  dps: 25482.71999
+  tps: 35340.31301
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-56377"
  value: {
-  dps: 25468.54846
-  tps: 35200.25959
+  dps: 25482.71999
+  tps: 35340.31301
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 26913.24266
-  tps: 36635.77471
+  dps: 26863.56153
+  tps: 37098.88017
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 26832.63975
-  tps: 36526.14918
+  dps: 26783.22456
+  tps: 36988.26765
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 27166.22017
-  tps: 37326.81583
+  dps: 27155.55327
+  tps: 37158.11762
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 25934.41703
-  tps: 35828.17324
+  dps: 25937.94818
+  tps: 35844.13603
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 25987.09753
-  tps: 35870.71711
+  dps: 25979.48326
+  tps: 35820.10453
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuneofZeth-68998"
  value: {
-  dps: 25878.70195
-  tps: 35825.44047
+  dps: 25822.98203
+  tps: 35853.27232
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 26572.06912
-  tps: 36852.0544
+  dps: 26552.24544
+  tps: 36806.67737
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-55256"
  value: {
-  dps: 25468.54846
-  tps: 35200.25959
+  dps: 25471.42079
+  tps: 35335.39926
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-56290"
  value: {
-  dps: 25468.54846
-  tps: 35200.25959
+  dps: 25471.42079
+  tps: 35335.39926
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShardofWoe-60233"
  value: {
-  dps: 25661.4529
-  tps: 35062.57497
+  dps: 25702.30577
+  tps: 35532.11542
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 25938.23601
-  tps: 35671.00717
+  dps: 25978.39765
+  tps: 35584.09655
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 25480.32043
-  tps: 35323.99807
+  dps: 25470.66414
+  tps: 35355.23753
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 26731.24395
-  tps: 37111.37793
+  dps: 26723.08922
+  tps: 37072.34495
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 26938.74876
-  tps: 37289.21906
+  dps: 26945.77814
+  tps: 37241.2164
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-55879"
  value: {
-  dps: 25754.99592
-  tps: 35648.30507
+  dps: 25749.65168
+  tps: 35779.20907
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-56400"
  value: {
-  dps: 25792.5069
-  tps: 35706.97769
+  dps: 25787.16874
+  tps: 35837.98499
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 25746.54258
-  tps: 35521.99849
+  dps: 25769.80715
+  tps: 35723.24175
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulCasket-58183"
  value: {
-  dps: 25833.42796
-  tps: 35770.98418
+  dps: 25836.38375
+  tps: 35907.11561
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 25492.83956
-  tps: 35223.81312
+  dps: 25509.60193
+  tps: 35369.74361
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stormrider'sBattlegarb"
  value: {
-  dps: 24980.01191
-  tps: 33854.91771
+  dps: 25059.71668
+  tps: 33837.89769
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stormrider'sRegalia"
  value: {
-  dps: 19205.74996
-  tps: 25533.32892
+  dps: 19137.22968
+  tps: 25108.47855
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62465"
  value: {
-  dps: 25475.40231
-  tps: 35222.42419
+  dps: 25489.57383
+  tps: 35362.47761
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62470"
  value: {
-  dps: 25475.40231
-  tps: 35222.42419
+  dps: 25489.57383
+  tps: 35362.47761
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 25468.54846
-  tps: 35200.25959
+  dps: 25482.71999
+  tps: 35340.31301
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 25468.54846
-  tps: 35200.25959
+  dps: 25482.71999
+  tps: 35340.31301
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 25489.64667
-  tps: 35231.69722
+  dps: 25513.724
+  tps: 35390.29492
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 26013.16766
-  tps: 35351.56513
+  dps: 26021.19166
+  tps: 35182.98901
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-55819"
  value: {
-  dps: 25468.54846
-  tps: 35200.09315
+  dps: 25482.71999
+  tps: 35340.1473
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-56351"
  value: {
-  dps: 25468.54846
-  tps: 35200.03906
+  dps: 25482.71999
+  tps: 35340.09344
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 25712.93816
-  tps: 35582.52061
+  dps: 25727.37972
+  tps: 35723.57587
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 25792.5069
-  tps: 35706.97769
+  dps: 25809.05229
+  tps: 35845.17051
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheHungerer-68927"
  value: {
-  dps: 27350.67731
-  tps: 36692.1323
+  dps: 27304.21809
+  tps: 36835.90015
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheHungerer-69112"
  value: {
-  dps: 27450.9628
-  tps: 37301.992
+  dps: 27520.75873
+  tps: 37464.12914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 25493.39056
-  tps: 35239.34816
+  dps: 25518.48699
+  tps: 35402.74346
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 25510.34832
-  tps: 35272.17655
+  dps: 25528.12024
+  tps: 35423.7147
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 25468.54846
-  tps: 35200.25959
+  dps: 25482.71999
+  tps: 35340.31301
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 25468.54846
-  tps: 35200.25959
+  dps: 25482.71999
+  tps: 35340.31301
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 26900.35192
-  tps: 37266.9146
+  dps: 26882.38781
+  tps: 37183.97055
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 27067.93758
-  tps: 37636.78715
+  dps: 27062.86517
+  tps: 37567.6773
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 25631.64572
-  tps: 34924.9802
+  dps: 25578.05579
+  tps: 35015.32626
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 25465.82221
-  tps: 35365.21595
+  dps: 25521.39313
+  tps: 35559.51399
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnheededWarning-59520"
  value: {
-  dps: 27251.77168
-  tps: 37652.65902
+  dps: 27246.26082
+  tps: 37797.56383
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 25468.54846
-  tps: 35200.25959
+  dps: 25471.42079
+  tps: 35335.39926
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 27233.97069
-  tps: 37306.09239
+  dps: 27266.02562
+  tps: 37613.96728
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 27233.97069
-  tps: 37306.09239
+  dps: 27266.02562
+  tps: 37613.96728
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 27233.97069
-  tps: 37306.09239
+  dps: 27266.02562
+  tps: 37613.96728
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 22452.57096
-  tps: 31334.85187
+  dps: 22499.54583
+  tps: 31303.13795
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 25468.75238
-  tps: 35200.96516
+  dps: 25482.92391
+  tps: 35341.01994
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 25468.71904
-  tps: 35249.38445
+  dps: 25471.01106
+  tps: 35365.66545
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 26497.85643
-  tps: 36560.54422
+  dps: 26455.74346
+  tps: 36521.23475
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 26629.57983
-  tps: 36749.91781
+  dps: 26588.72923
+  tps: 36710.07374
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 25468.54846
-  tps: 35200.25959
+  dps: 25471.42079
+  tps: 35335.39926
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 25468.54846
-  tps: 35200.25959
+  dps: 25471.42079
+  tps: 35335.39926
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 26848.53031
-  tps: 36708.55224
+  dps: 26880.32573
+  tps: 37014.54918
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 25468.54846
-  tps: 35200.25959
+  dps: 25471.42079
+  tps: 35335.39926
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 26011.78703
-  tps: 35886.52553
+  dps: 26007.0906
+  tps: 36007.1656
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 25475.40231
-  tps: 35222.42419
+  dps: 25478.27463
+  tps: 35357.56387
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 25783.24874
-  tps: 35105.53597
+  dps: 25738.70052
+  tps: 35146.40511
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 25839.9013
-  tps: 35809.24798
+  dps: 25785.51107
+  tps: 35702.50333
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 25788.31196
-  tps: 35284.64497
+  dps: 25833.21925
+  tps: 35755.51727
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 25855.02519
-  tps: 35804.76539
+  dps: 25857.98592
+  tps: 35940.95551
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 25468.54846
-  tps: 35200.25959
+  dps: 25471.42079
+  tps: 35335.39926
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 26819.8911
-  tps: 36848.77141
+  dps: 26774.17961
+  tps: 36833.52193
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 25468.54846
-  tps: 35200.25959
+  dps: 25482.71999
+  tps: 35340.31301
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 25985.19269
-  tps: 35832.42862
+  dps: 25944.00742
+  tps: 35775.57316
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 25502.76739
-  tps: 35299.49837
+  dps: 25527.35319
+  tps: 35359.31055
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 25495.74269
-  tps: 35108.38972
+  dps: 25499.9045
+  tps: 35236.99688
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 25717.48494
-  tps: 35589.63244
+  dps: 25731.93153
+  tps: 35730.70634
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 25762.83426
-  tps: 35571.95612
+  dps: 25798.42567
+  tps: 35748.06887
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 25762.83426
-  tps: 35571.95612
+  dps: 25798.42567
+  tps: 35748.06887
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 27289.86957
-  tps: 37404.39537
+  dps: 27298.93891
+  tps: 37272.3284
  }
 }
 dps_results: {
@@ -1502,85 +1502,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 33980.05885
-  tps: 51569.22771
+  dps: 34006.38857
+  tps: 51049.66939
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 30491.04801
-  tps: 41559.55083
+  dps: 30472.92691
+  tps: 41902.94172
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 37344.34382
-  tps: 35997.00705
+  dps: 37481.92569
+  tps: 36529.92107
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 21588.45163
-  tps: 33257.86053
+  dps: 21344.28993
+  tps: 32862.29634
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 19527.53257
-  tps: 28502.60004
+  dps: 19507.27401
+  tps: 28316.01818
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 20843.74939
-  tps: 23327.72263
+  dps: 20821.66853
+  tps: 23045.29552
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 30312.72862
-  tps: 21524.29796
+  dps: 30322.53312
+  tps: 21531.25916
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29467.8506
-  tps: 20922.17392
+  dps: 29542.1156
+  tps: 20974.90207
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 36579.98649
-  tps: 25971.79041
+  dps: 36622.40916
+  tps: 26001.9105
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 18556.3448
-  tps: 13177.36769
+  dps: 18542.72918
+  tps: 13167.7006
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 18702.78633
-  tps: 13279.18845
+  dps: 18712.83132
+  tps: 13286.3204
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 20378.60476
-  tps: 14469.37738
+  dps: 20419.52551
+  tps: 14498.43112
  }
 }
 dps_results: {
@@ -1628,85 +1628,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 33411.68105
-  tps: 50621.55189
+  dps: 33384.81145
+  tps: 50234.59959
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29807.68403
-  tps: 40458.20808
+  dps: 29771.28038
+  tps: 40382.45778
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 36340.87092
-  tps: 33283.17584
+  dps: 36394.61456
+  tps: 33925.03217
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 20820.67703
-  tps: 32310.24918
+  dps: 20959.39914
+  tps: 32623.12098
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 18923.29609
-  tps: 27824.04196
+  dps: 18953.12888
+  tps: 27563.20731
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 20139.47994
-  tps: 22268.79431
+  dps: 20142.91006
+  tps: 22328.97058
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 29582.79859
-  tps: 21006.04764
+  dps: 29655.6893
+  tps: 21057.80004
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28966.08816
-  tps: 20565.9226
+  dps: 28949.68992
+  tps: 20554.27985
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 35880.74658
-  tps: 25475.33007
+  dps: 35967.51806
+  tps: 25536.93782
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 18061.66731
-  tps: 12826.14667
+  dps: 18023.36917
+  tps: 12798.95499
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 18153.81556
-  tps: 12889.4192
+  dps: 18143.15872
+  tps: 12881.85285
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 19769.0837
-  tps: 14036.61743
+  dps: 19797.57994
+  tps: 14056.84976
  }
 }
 dps_results: {
@@ -1754,85 +1754,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 30343.391
-  tps: 45892.05954
+  dps: 30294.63851
+  tps: 45934.05652
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 27043.69587
-  tps: 36819.01316
+  dps: 26994.5104
+  tps: 37204.67091
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 32949.63847
-  tps: 29752.26365
+  dps: 33009.8008
+  tps: 29399.02713
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 18906.2162
-  tps: 29907.51667
+  dps: 19033.05043
+  tps: 29725.51476
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 17052.63331
-  tps: 25725.06386
+  dps: 17016.89236
+  tps: 25048.3203
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 18470.95867
-  tps: 21689.95496
+  dps: 18398.12008
+  tps: 21435.24267
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 26922.49769
-  tps: 19117.234
+  dps: 26904.04595
+  tps: 19104.13327
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 26109.29215
-  tps: 18537.59743
+  dps: 26211.283
+  tps: 18610.01093
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 32595.46955
-  tps: 23142.78338
+  dps: 32674.20994
+  tps: 23198.68906
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 16188.77438
-  tps: 11496.39269
+  dps: 16206.02435
+  tps: 11508.64017
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 16302.64884
-  tps: 11575.09083
+  dps: 16340.02482
+  tps: 11601.62778
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 18026.96539
-  tps: 12799.71343
+  dps: 17999.60172
+  tps: 12780.28522
  }
 }
 dps_results: {
@@ -1880,91 +1880,91 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 29941.51477
-  tps: 45634.63208
+  dps: 29330.1639
+  tps: 43672.27354
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 26328.61013
-  tps: 36271.72112
+  dps: 26436.74647
+  tps: 35476.92855
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 32319.35065
-  tps: 29943.61305
+  dps: 32345.83246
+  tps: 30027.5295
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 18601.11752
-  tps: 28917.54206
+  dps: 18565.99543
+  tps: 28797.3336
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 16602.77617
-  tps: 24285.01594
+  dps: 16564.05553
+  tps: 23834.36424
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 17893.64199
-  tps: 20290.93994
+  dps: 17888.59041
+  tps: 20265.04411
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 26288.42148
-  tps: 18667.03989
+  dps: 26282.29094
+  tps: 18662.6872
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25556.67913
-  tps: 18145.24218
+  dps: 25646.08314
+  tps: 18208.71903
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 31820.71777
-  tps: 22592.70962
+  dps: 31955.21257
+  tps: 22688.20092
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 15864.47459
-  tps: 11266.13984
+  dps: 15831.72914
+  tps: 11242.89057
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 15870.49539
-  tps: 11268.26189
+  dps: 15885.77663
+  tps: 11279.11157
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 17589.61391
-  tps: 12489.19387
+  dps: 17572.88116
+  tps: 12477.31363
  }
 }
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 23742.30881
-  tps: 33893.8831
+  dps: 23765.74091
+  tps: 33227.488
  }
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -501,8 +501,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 23032.76562
-  tps: 30973.8538
+  dps: 23031.13815
+  tps: 30831.92297
  }
 }
 dps_results: {
@@ -1096,8 +1096,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-Stormrider'sBattlegarb"
  value: {
-  dps: 25066.2667
-  tps: 34904.10733
+  dps: 24980.01191
+  tps: 33854.91771
  }
 }
 dps_results: {

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -38,1423 +38,1423 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 27119.18803
-  tps: 37598.07184
+  dps: 27043.69587
+  tps: 36819.01316
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 25450.96886
-  tps: 35195.78233
+  dps: 25468.54846
+  tps: 35200.12638
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 27405.61133
-  tps: 37615.19573
+  dps: 27450.14999
+  tps: 37709.30155
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 25447.50762
-  tps: 35203.99365
+  dps: 25473.46172
+  tps: 35212.64124
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 25448.47792
-  tps: 35208.88513
+  dps: 25474.43201
+  tps: 35217.53271
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 26321.87262
-  tps: 36706.35668
+  dps: 26401.36579
+  tps: 36922.92746
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 26439.80151
-  tps: 36905.42068
+  dps: 26522.54035
+  tps: 37126.77499
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 26463.57539
-  tps: 36625.40027
+  dps: 26404.85655
+  tps: 35967.56568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 25450.96886
-  tps: 35195.91525
+  dps: 25468.54846
+  tps: 35200.25959
   hps: 88.86807
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 25450.96886
-  tps: 35195.91525
+  dps: 25468.54846
+  tps: 35200.25959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 25784.30641
-  tps: 35975.45294
+  dps: 25828.55531
+  tps: 35977.5427
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 25819.49827
-  tps: 35995.13514
+  dps: 25864.36891
+  tps: 35828.69449
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BindingPromise-67037"
  value: {
-  dps: 25450.96886
-  tps: 35195.91525
+  dps: 25468.54846
+  tps: 35200.25959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 26756.15
-  tps: 36476.6673
+  dps: 26728.42312
+  tps: 36475.59653
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 25736.92385
-  tps: 35644.81294
+  dps: 25754.99592
+  tps: 35648.30507
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 25774.37034
-  tps: 35703.59716
+  dps: 25792.5069
+  tps: 35706.97769
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 27220.33829
-  tps: 36957.08241
+  dps: 27229.51168
+  tps: 37036.37463
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 25450.96886
-  tps: 35195.91525
+  dps: 25468.54846
+  tps: 35200.25959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 25962.03263
-  tps: 35834.96538
+  dps: 25983.01738
+  tps: 35850.18123
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 25758.53711
-  tps: 35845.80235
+  dps: 25795.54989
+  tps: 35727.30234
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 25450.96886
-  tps: 35195.91525
+  dps: 25468.54846
+  tps: 35200.25959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 25450.96886
-  tps: 35195.91525
+  dps: 25468.54846
+  tps: 35200.25959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 26759.208
-  tps: 37215.25684
+  dps: 26770.2172
+  tps: 36731.78592
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 25450.96886
-  tps: 35195.91525
+  dps: 25468.54846
+  tps: 35200.25959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 25923.94782
-  tps: 35783.69696
+  dps: 25941.98432
+  tps: 35794.25693
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledLightning-66879"
  value: {
-  dps: 25521.19094
-  tps: 35301.8968
+  dps: 25574.71336
+  tps: 34966.67159
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 26463.57539
-  tps: 35893.11477
+  dps: 26404.85655
+  tps: 35248.45225
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Brawler'sTrophy-71338"
  value: {
-  dps: 25450.96886
-  tps: 35195.91525
+  dps: 25468.54846
+  tps: 35200.25959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 26893.27743
-  tps: 37197.07119
+  dps: 26832.63975
+  tps: 36526.10564
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 27012.04684
-  tps: 37151.96647
+  dps: 26905.24979
+  tps: 36592.2798
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Coren'sChilledChromiumCoaster-71335"
  value: {
-  dps: 26711.85909
-  tps: 37102.95206
+  dps: 26775.4097
+  tps: 36975.29809
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 25450.96886
-  tps: 35195.66719
+  dps: 25468.54846
+  tps: 35200.01124
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 25450.96886
-  tps: 35195.91525
+  dps: 25468.54846
+  tps: 35200.25959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-59506"
  value: {
-  dps: 26254.66296
-  tps: 35768.49639
+  dps: 26285.54798
+  tps: 35716.3148
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-65118"
  value: {
-  dps: 26309.9802
-  tps: 35350.28357
+  dps: 26395.79113
+  tps: 35856.89053
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 25450.96886
-  tps: 35195.91525
+  dps: 25468.54846
+  tps: 35200.25959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 26079.56154
-  tps: 35989.94697
+  dps: 26096.20808
+  tps: 35754.70257
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 26744.40406
-  tps: 36672.09109
+  dps: 26823.30338
+  tps: 37109.35949
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 25450.96886
-  tps: 35195.66719
+  dps: 25468.54846
+  tps: 35200.01124
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 25809.76634
-  tps: 35736.39234
+  dps: 25840.06258
+  tps: 35893.99074
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 26124.46097
-  tps: 36120.55599
+  dps: 26180.72991
+  tps: 36344.36982
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 26575.64051
-  tps: 36574.98562
+  dps: 26473.3294
+  tps: 36031.7995
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 25393.51118
-  tps: 34827.43299
+  dps: 25449.52799
+  tps: 34539.6205
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 26348.37573
-  tps: 36465.40026
+  dps: 26417.74827
+  tps: 36476.63865
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 26463.57539
-  tps: 36625.40027
+  dps: 26404.85655
+  tps: 35967.56568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 25450.96886
-  tps: 35230.16733
+  dps: 25468.54846
+  tps: 35234.54991
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 26463.57539
-  tps: 36625.33616
+  dps: 26404.85655
+  tps: 35967.49965
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 26575.64051
-  tps: 36574.98562
+  dps: 26473.3294
+  tps: 36031.7995
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 27097.97312
-  tps: 37401.37653
+  dps: 27157.11761
+  tps: 37504.47747
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 27286.85911
-  tps: 38289.88494
+  dps: 27312.90629
+  tps: 37845.01929
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 26474.34544
-  tps: 36615.28297
+  dps: 26502.40273
+  tps: 36711.69143
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 26463.57539
-  tps: 36625.40027
+  dps: 26404.85655
+  tps: 35967.56568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-59500"
  value: {
-  dps: 25450.96886
-  tps: 35195.66719
+  dps: 25468.54846
+  tps: 35200.01124
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-65124"
  value: {
-  dps: 25450.96886
-  tps: 35195.63473
+  dps: 25468.54846
+  tps: 35199.97878
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 25433.75778
-  tps: 35212.47544
+  dps: 25450.27975
+  tps: 35211.95046
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 26686.57744
-  tps: 36811.78222
+  dps: 26718.32258
+  tps: 36604.81004
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 25450.96886
-  tps: 35195.69501
+  dps: 25468.54846
+  tps: 35200.03906
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 25450.96886
-  tps: 35195.91525
+  dps: 25468.54846
+  tps: 35200.25959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 25450.96886
-  tps: 35195.69501
+  dps: 25468.54846
+  tps: 35200.03906
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 26259.79955
-  tps: 36312.16166
+  dps: 26281.23939
+  tps: 36325.86107
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 26526.88212
-  tps: 36725.66279
+  dps: 26468.13186
+  tps: 36065.63818
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 26463.57539
-  tps: 36625.358
+  dps: 26404.85655
+  tps: 35967.52214
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 26402.2129
-  tps: 36774.64558
+  dps: 26457.91448
+  tps: 36779.88406
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56138"
  value: {
-  dps: 25595.83346
-  tps: 34959.12476
+  dps: 25586.57138
+  tps: 34970.76602
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56462"
  value: {
-  dps: 25609.48632
-  tps: 34715.49204
+  dps: 25690.76048
+  tps: 34473.27113
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GearDetector-61462"
  value: {
-  dps: 26244.26961
-  tps: 35987.36649
+  dps: 26235.79664
+  tps: 35425.97592
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 23097.47364
-  tps: 30827.90083
+  dps: 23032.76562
+  tps: 30973.8538
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 25450.96886
-  tps: 35195.77306
+  dps: 25468.54846
+  tps: 35200.11711
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 26283.4406
-  tps: 36473.66523
+  dps: 26281.48181
+  tps: 35950.2001
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 26713.16179
-  tps: 36940.3432
+  dps: 26754.89887
+  tps: 36802.39163
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HarmlightToken-63839"
  value: {
-  dps: 25460.41251
-  tps: 35187.45537
+  dps: 25473.85748
+  tps: 35242.12849
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 26018.64462
-  tps: 35984.62221
+  dps: 26040.75213
+  tps: 35991.04481
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 25450.96886
-  tps: 35195.91525
+  dps: 25468.54846
+  tps: 35200.25959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 25450.96886
-  tps: 35195.91525
+  dps: 25468.54846
+  tps: 35200.25959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-59224"
  value: {
-  dps: 26384.95469
-  tps: 36337.32067
+  dps: 26381.81159
+  tps: 36155.75779
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-65072"
  value: {
-  dps: 26381.62091
-  tps: 36290.47858
+  dps: 26416.35021
+  tps: 36290.62485
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-55868"
  value: {
-  dps: 25595.83346
-  tps: 34959.12476
+  dps: 25586.57138
+  tps: 34970.76602
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-56393"
  value: {
-  dps: 26160.92507
-  tps: 35384.25216
+  dps: 26230.10373
+  tps: 35124.23308
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-55845"
  value: {
-  dps: 25450.96886
-  tps: 35195.91525
+  dps: 25468.54846
+  tps: 35200.25959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-56370"
  value: {
-  dps: 25450.96886
-  tps: 35195.91525
+  dps: 25468.54846
+  tps: 35200.25959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 26458.75129
-  tps: 36862.66963
+  dps: 26438.95387
+  tps: 36277.09418
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-50641"
  value: {
-  dps: 27489.82907
-  tps: 37661.75893
+  dps: 27457.76715
+  tps: 37405.98814
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 26575.64051
-  tps: 36574.98562
+  dps: 26473.3294
+  tps: 36031.7995
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 26362.86493
-  tps: 36454.50638
+  dps: 26384.80817
+  tps: 36469.40554
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 26362.86493
-  tps: 36454.50638
+  dps: 26384.80817
+  tps: 36469.40554
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 25741.86338
-  tps: 35689.07919
+  dps: 25766.77655
+  tps: 35772.19339
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 25779.32586
-  tps: 35747.87846
+  dps: 25804.28867
+  tps: 35830.88563
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 25450.96886
-  tps: 35195.91525
+  dps: 25468.54846
+  tps: 35200.25959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 25671.10881
-  tps: 35541.49522
+  dps: 25689.06754
+  tps: 35545.18349
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 25450.96886
-  tps: 35196.34982
+  dps: 25468.54846
+  tps: 35200.57016
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 25450.96886
-  tps: 35196.34982
+  dps: 25468.54846
+  tps: 35200.57016
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 26756.15
-  tps: 36476.6673
+  dps: 26728.42312
+  tps: 36475.59653
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 26549.42498
-  tps: 36576.95792
+  dps: 26533.48395
+  tps: 36718.47036
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 26861.1895
-  tps: 37080.94589
+  dps: 26871.92201
+  tps: 36881.80385
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 25710.99229
-  tps: 35324.14465
+  dps: 25734.19883
+  tps: 34824.19764
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 25710.99229
-  tps: 35324.14465
+  dps: 25734.19883
+  tps: 34824.19764
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 25531.49946
-  tps: 34832.8987
+  dps: 25544.19895
+  tps: 35314.40918
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50708"
  value: {
-  dps: 27289.91791
-  tps: 37835.52028
+  dps: 27213.86298
+  tps: 37051.68023
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-55816"
  value: {
-  dps: 25450.96886
-  tps: 35195.91525
+  dps: 25468.54846
+  tps: 35200.25959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-56347"
  value: {
-  dps: 25450.96886
-  tps: 35195.91525
+  dps: 25468.54846
+  tps: 35200.25959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 26718.61107
-  tps: 36887.93257
+  dps: 26765.16108
+  tps: 37032.98773
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 25999.21934
-  tps: 35976.75065
+  dps: 26025.41933
+  tps: 35984.51763
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 25884.75618
-  tps: 35752.02566
+  dps: 25926.64846
+  tps: 36021.86664
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 26136.3476
-  tps: 35966.23746
+  dps: 26138.9867
+  tps: 36017.54353
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 25450.96886
-  tps: 35195.91525
+  dps: 25468.54846
+  tps: 35200.25959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 25450.96886
-  tps: 35195.91525
+  dps: 25468.54846
+  tps: 35200.25959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 26188.71098
-  tps: 36188.14024
+  dps: 26182.37404
+  tps: 36143.81404
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 26286.16499
-  tps: 36319.19958
+  dps: 26276.64279
+  tps: 36268.39554
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 27586.12484
-  tps: 38515.33782
+  dps: 27634.63059
+  tps: 38380.31197
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 27895.60056
-  tps: 38863.20356
+  dps: 27937.83669
+  tps: 38758.52474
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 25724.78041
-  tps: 35524.7761
+  dps: 25746.54258
+  tps: 35521.99849
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 25964.96645
-  tps: 35806.42106
+  dps: 25983.11204
+  tps: 35793.78642
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 25820.19402
-  tps: 35812.02311
+  dps: 25845.21097
+  tps: 35894.91353
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 25820.19402
-  tps: 35812.02311
+  dps: 25845.21097
+  tps: 35894.91353
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MithrilStopwatch-71337"
  value: {
-  dps: 25792.69905
-  tps: 35973.83492
+  dps: 25839.9013
+  tps: 35809.24798
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 25880.65029
-  tps: 35824.8033
+  dps: 25904.95621
+  tps: 35835.41055
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 25450.96886
-  tps: 35195.91525
+  dps: 25468.54846
+  tps: 35200.25959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 25450.96886
-  tps: 35195.61928
+  dps: 25468.54846
+  tps: 35199.96333
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 25450.96886
-  tps: 35195.58064
+  dps: 25468.54846
+  tps: 35199.92469
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ObsidianArborweaveBattlegarb"
  value: {
-  dps: 26518.95905
-  tps: 34825.16855
+  dps: 26574.58712
+  tps: 34930.8927
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ObsidianArborweaveRegalia"
  value: {
-  dps: 19316.40579
-  tps: 25837.61672
+  dps: 19338.53852
+  tps: 26284.6086
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 25933.548
-  tps: 35795.69365
+  dps: 25963.57025
+  tps: 35706.81626
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedPickledEgg-71336"
  value: {
-  dps: 25450.96886
-  tps: 35195.65251
+  dps: 25468.54846
+  tps: 35199.99656
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 25450.96886
-  tps: 35195.91525
+  dps: 25468.54846
+  tps: 35200.25959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 25626.72362
-  tps: 35620.2474
+  dps: 25657.75465
+  tps: 35510.13394
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 25667.17977
-  tps: 35498.35159
+  dps: 25678.57712
+  tps: 35492.45558
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 25835.92323
-  tps: 35749.62926
+  dps: 25854.22713
+  tps: 35741.36202
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 26463.57539
-  tps: 36625.40027
+  dps: 26404.85655
+  tps: 35967.56568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 26953.84001
-  tps: 35419.54947
+  dps: 26964.81325
+  tps: 35680.13576
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 27211.94805
-  tps: 36183.70048
+  dps: 27235.85412
+  tps: 36723.15334
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-55854"
  value: {
-  dps: 25450.96886
-  tps: 35195.91525
+  dps: 25468.54846
+  tps: 35200.25959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-56377"
  value: {
-  dps: 25450.96886
-  tps: 35195.91525
+  dps: 25468.54846
+  tps: 35200.25959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 26974.03201
-  tps: 37308.68059
+  dps: 26913.24266
+  tps: 36635.77471
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 26893.27743
-  tps: 37197.11347
+  dps: 26832.63975
+  tps: 36526.14918
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 27127.97856
-  tps: 37850.57765
+  dps: 27166.22017
+  tps: 37326.81583
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 25900.26005
-  tps: 35809.72113
+  dps: 25934.41703
+  tps: 35828.17324
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 25958.25269
-  tps: 35863.02874
+  dps: 25987.09753
+  tps: 35870.71711
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuneofZeth-68998"
  value: {
-  dps: 25864.30876
-  tps: 36155.55617
+  dps: 25878.70195
+  tps: 35825.44047
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 26547.26864
-  tps: 37060.63392
+  dps: 26572.06912
+  tps: 36852.0544
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-55256"
  value: {
-  dps: 25450.96886
-  tps: 35195.91525
+  dps: 25468.54846
+  tps: 35200.25959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-56290"
  value: {
-  dps: 25450.96886
-  tps: 35195.91525
+  dps: 25468.54846
+  tps: 35200.25959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShardofWoe-60233"
  value: {
-  dps: 25628.70153
-  tps: 34985.02806
+  dps: 25661.4529
+  tps: 35062.57497
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 25931.29524
-  tps: 35141.37586
+  dps: 25938.23601
+  tps: 35671.00717
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 25455.78629
-  tps: 35240.06659
+  dps: 25480.32043
+  tps: 35323.99807
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 26706.14639
-  tps: 37310.26832
+  dps: 26731.24395
+  tps: 37111.37793
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 26875.20232
-  tps: 37358.12945
+  dps: 26938.74876
+  tps: 37289.21906
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-55879"
  value: {
-  dps: 25736.92385
-  tps: 35644.81294
+  dps: 25754.99592
+  tps: 35648.30507
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-56400"
  value: {
-  dps: 25774.37034
-  tps: 35703.59716
+  dps: 25792.5069
+  tps: 35706.97769
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 25724.78041
-  tps: 35524.7761
+  dps: 25746.54258
+  tps: 35521.99849
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulCasket-58183"
  value: {
-  dps: 25815.22105
-  tps: 35767.72541
+  dps: 25833.42796
+  tps: 35770.98418
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 25506.0095
-  tps: 35159.41117
+  dps: 25492.83956
+  tps: 35223.81312
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stormrider'sBattlegarb"
  value: {
-  dps: 25021.6888
-  tps: 34734.69355
+  dps: 25066.2667
+  tps: 34904.10733
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stormrider'sRegalia"
  value: {
-  dps: 19232.97277
-  tps: 25644.99657
+  dps: 19205.74996
+  tps: 25533.32892
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62465"
  value: {
-  dps: 25449.44821
-  tps: 35213.7766
+  dps: 25475.40231
+  tps: 35222.42419
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62470"
  value: {
-  dps: 25449.44821
-  tps: 35213.7766
+  dps: 25475.40231
+  tps: 35222.42419
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 25450.96886
-  tps: 35195.91525
+  dps: 25468.54846
+  tps: 35200.25959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 25450.96886
-  tps: 35195.91525
+  dps: 25468.54846
+  tps: 35200.25959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 25471.41004
-  tps: 35225.70416
+  dps: 25489.64667
+  tps: 35231.69722
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 25950.00867
-  tps: 35066.31404
+  dps: 26013.16766
+  tps: 35351.56513
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-55819"
  value: {
-  dps: 25450.96886
-  tps: 35195.7491
+  dps: 25468.54846
+  tps: 35200.09315
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-56351"
  value: {
-  dps: 25450.96886
-  tps: 35195.69501
+  dps: 25468.54846
+  tps: 35200.03906
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 25694.9384
-  tps: 35578.90336
+  dps: 25712.93816
+  tps: 35582.52061
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 25774.37034
-  tps: 35703.59716
+  dps: 25792.5069
+  tps: 35706.97769
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheHungerer-68927"
  value: {
-  dps: 27192.43854
-  tps: 36470.43951
+  dps: 27350.67731
+  tps: 36692.1323
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheHungerer-69112"
  value: {
-  dps: 27546.74333
-  tps: 37752.93033
+  dps: 27450.9628
+  tps: 37301.992
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 25474.56238
-  tps: 35232.46268
+  dps: 25493.39056
+  tps: 35239.34816
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 25498.55369
-  tps: 35265.80392
+  dps: 25510.34832
+  tps: 35272.17655
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 25450.96886
-  tps: 35195.91525
+  dps: 25468.54846
+  tps: 35200.25959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 25450.96886
-  tps: 35195.91525
+  dps: 25468.54846
+  tps: 35200.25959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 26852.29399
-  tps: 37360.95805
+  dps: 26900.35192
+  tps: 37266.9146
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 27010.58543
-  tps: 37736.9806
+  dps: 27067.93758
+  tps: 37636.78715
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 25502.10602
-  tps: 34918.59629
+  dps: 25631.64572
+  tps: 34924.9802
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 25513.77907
-  tps: 35321.90515
+  dps: 25465.82221
+  tps: 35365.21595
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnheededWarning-59520"
  value: {
-  dps: 27197.13331
-  tps: 37754.90561
+  dps: 27251.77168
+  tps: 37652.65902
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 25450.96886
-  tps: 35195.91525
+  dps: 25468.54846
+  tps: 35200.25959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 27202.2596
-  tps: 37434.66394
+  dps: 27233.97069
+  tps: 37306.09239
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 27202.2596
-  tps: 37434.66394
+  dps: 27233.97069
+  tps: 37306.09239
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 27202.2596
-  tps: 37434.66394
+  dps: 27233.97069
+  tps: 37306.09239
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 22507.88233
-  tps: 31896.11599
+  dps: 22452.57096
+  tps: 31334.85187
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 25452.14308
-  tps: 35201.51258
+  dps: 25468.75238
+  tps: 35200.96516
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 25454.61475
-  tps: 35213.83075
+  dps: 25468.71904
+  tps: 35249.38445
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 26475.46253
-  tps: 36868.26299
+  dps: 26497.85643
+  tps: 36560.54422
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 26603.66709
-  tps: 37063.33826
+  dps: 26629.57983
+  tps: 36749.91781
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 25450.96886
-  tps: 35195.91525
+  dps: 25468.54846
+  tps: 35200.25959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 25450.96886
-  tps: 35195.91525
+  dps: 25468.54846
+  tps: 35200.25959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 26818.9786
-  tps: 36836.42863
+  dps: 26848.53031
+  tps: 36708.55224
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 25450.96886
-  tps: 35195.91525
+  dps: 25468.54846
+  tps: 35200.25959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 25990.61186
-  tps: 35870.70174
+  dps: 26011.78703
+  tps: 35886.52553
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 25449.44821
-  tps: 35213.7766
+  dps: 25475.40231
+  tps: 35222.42419
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 25732.05494
-  tps: 35048.13947
+  dps: 25783.24874
+  tps: 35105.53597
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 25792.69905
-  tps: 35973.83492
+  dps: 25839.9013
+  tps: 35809.24798
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 25760.43272
-  tps: 35531.37753
+  dps: 25788.31196
+  tps: 35284.64497
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 25836.78115
-  tps: 35801.57087
+  dps: 25855.02519
+  tps: 35804.76539
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 25450.96886
-  tps: 35195.91525
+  dps: 25468.54846
+  tps: 35200.25959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 26823.90132
-  tps: 37126.83736
+  dps: 26819.8911
+  tps: 36848.77141
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 25450.96886
-  tps: 35195.91525
+  dps: 25468.54846
+  tps: 35200.25959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 25968.56915
-  tps: 35832.58955
+  dps: 25985.19269
+  tps: 35832.42862
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 25495.02925
-  tps: 35276.88749
+  dps: 25502.76739
+  tps: 35299.49837
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 25488.62338
-  tps: 35184.83218
+  dps: 25495.74269
+  tps: 35108.38972
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 25699.47737
-  tps: 35586.02872
+  dps: 25717.48494
+  tps: 35589.63244
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 25765.71244
-  tps: 35608.59302
+  dps: 25762.83426
+  tps: 35571.95612
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 25765.71244
-  tps: 35608.59302
+  dps: 25762.83426
+  tps: 35571.95612
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 27288.79276
-  tps: 37253.61722
+  dps: 27289.86957
+  tps: 37404.39537
  }
 }
 dps_results: {
@@ -1502,85 +1502,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 33620.98087
-  tps: 50269.47472
+  dps: 33980.05885
+  tps: 51569.22771
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 30620.78709
-  tps: 41996.72155
+  dps: 30491.04801
+  tps: 41559.55083
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 37320.58526
-  tps: 36114.06678
+  dps: 37344.34382
+  tps: 35997.00705
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 21448.28422
-  tps: 32457.40302
+  dps: 21588.45163
+  tps: 33257.86053
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 19423.21711
-  tps: 28137.18053
+  dps: 19527.53257
+  tps: 28502.60004
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 20784.0776
-  tps: 22878.83892
+  dps: 20843.74939
+  tps: 23327.72263
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 30293.56162
-  tps: 21510.68939
+  dps: 30312.72862
+  tps: 21524.29796
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29489.75309
-  tps: 20937.72469
+  dps: 29467.8506
+  tps: 20922.17392
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 36551.5798
-  tps: 25951.62166
+  dps: 36579.98649
+  tps: 25971.79041
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 18540.72647
-  tps: 13166.27867
+  dps: 18556.3448
+  tps: 13177.36769
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 18693.33193
-  tps: 13272.47583
+  dps: 18702.78633
+  tps: 13279.18845
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 20367.17323
-  tps: 14461.261
+  dps: 20378.60476
+  tps: 14469.37738
  }
 }
 dps_results: {
@@ -1628,85 +1628,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 33545.9488
-  tps: 51346.62718
+  dps: 33411.68105
+  tps: 50621.55189
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29716.04571
-  tps: 39830.4119
+  dps: 29807.68403
+  tps: 40458.20808
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 36513.58928
-  tps: 34393.04153
+  dps: 36340.87092
+  tps: 33283.17584
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 20895.2485
-  tps: 31978.31976
+  dps: 20820.67703
+  tps: 32310.24918
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 18893.53393
-  tps: 27361.66578
+  dps: 18923.29609
+  tps: 27824.04196
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 20200.31087
-  tps: 22431.68421
+  dps: 20139.47994
+  tps: 22268.79431
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 29618.70117
-  tps: 21031.53847
+  dps: 29582.79859
+  tps: 21006.04764
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28997.87019
-  tps: 20588.48784
+  dps: 28966.08816
+  tps: 20565.9226
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 35865.45114
-  tps: 25464.47031
+  dps: 35880.74658
+  tps: 25475.33007
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 18079.31006
-  tps: 12838.67302
+  dps: 18061.66731
+  tps: 12826.14667
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 18149.23213
-  tps: 12886.16497
+  dps: 18153.81556
+  tps: 12889.4192
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-p1-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 19820.39266
-  tps: 14073.04679
+  dps: 19769.0837
+  tps: 14036.61743
  }
 }
 dps_results: {
@@ -1754,85 +1754,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 30350.22019
-  tps: 45826.32614
+  dps: 30343.391
+  tps: 45892.05954
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 27119.18803
-  tps: 37598.07184
+  dps: 27043.69587
+  tps: 36819.01316
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 32961.51429
-  tps: 30317.90067
+  dps: 32949.63847
+  tps: 29752.26365
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 18918.31014
-  tps: 29322.00373
+  dps: 18906.2162
+  tps: 29907.51667
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 17006.46706
-  tps: 25255.29463
+  dps: 17052.63331
+  tps: 25725.06386
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 18436.73327
-  tps: 21532.25817
+  dps: 18470.95867
+  tps: 21689.95496
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 26931.4035
-  tps: 19123.55713
+  dps: 26922.49769
+  tps: 19117.234
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 26137.59674
-  tps: 18557.69368
+  dps: 26109.29215
+  tps: 18537.59743
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 32562.90652
-  tps: 23119.66363
+  dps: 32595.46955
+  tps: 23142.78338
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 16229.08957
-  tps: 11525.01647
+  dps: 16188.77438
+  tps: 11496.39269
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 16294.77939
-  tps: 11569.50353
+  dps: 16302.64884
+  tps: 11575.09083
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 17983.91661
-  tps: 12769.14879
+  dps: 18026.96539
+  tps: 12799.71343
  }
 }
 dps_results: {
@@ -1880,91 +1880,91 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 29975.67308
-  tps: 45843.91029
+  dps: 29941.51477
+  tps: 45634.63208
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 26367.77664
-  tps: 35350.88867
+  dps: 26328.61013
+  tps: 36271.72112
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 32446.80145
-  tps: 29914.81393
+  dps: 32319.35065
+  tps: 29943.61305
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 18265.0067
-  tps: 27712.15959
+  dps: 18601.11752
+  tps: 28917.54206
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 16584.94606
-  tps: 24201.5895
+  dps: 16602.77617
+  tps: 24285.01594
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 17931.31787
-  tps: 20269.16498
+  dps: 17893.64199
+  tps: 20290.93994
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 26286.04526
-  tps: 18665.35278
+  dps: 26288.42148
+  tps: 18667.03989
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25650.69461
-  tps: 18211.99317
+  dps: 25556.67913
+  tps: 18145.24218
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 31930.51231
-  tps: 22670.66374
+  dps: 31820.71777
+  tps: 22592.70962
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 15799.19132
-  tps: 11219.78872
+  dps: 15864.47459
+  tps: 11266.13984
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 15860.51769
-  tps: 11261.17772
+  dps: 15870.49539
+  tps: 11268.26189
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Tauren-preraid-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 17611.83319
-  tps: 12504.96957
+  dps: 17589.61391
+  tps: 12489.19387
  }
 }
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 23779.06358
-  tps: 33371.44773
+  dps: 23742.30881
+  tps: 33893.8831
  }
 }

--- a/sim/druid/feral/feral.go
+++ b/sim/druid/feral/feral.go
@@ -84,13 +84,16 @@ func (cat *FeralDruid) Initialize() {
 	cat.RegisterFeralCatSpells()
 
 	snapshotHandler := func(aura *core.Aura, sim *core.Simulation) {
-		previousSnapshotPower := core.TernaryFloat64(cat.tempSnapshotAura.IsActive(), cat.Rip.NewSnapshotPower, cat.Rip.CurrentSnapshotPower)
+		previousRipSnapshotPower := core.TernaryFloat64(cat.tempSnapshotAura.IsActive(), cat.Rip.NewSnapshotPower, cat.Rip.CurrentSnapshotPower)
+		previousRakeSnapshotPower := core.TernaryFloat64(cat.tempSnapshotAura.IsActive(), cat.Rake.NewSnapshotPower, cat.Rake.CurrentSnapshotPower)
 		cat.UpdateBleedPower(cat.Rip, sim, cat.CurrentTarget, false, true)
+		cat.UpdateBleedPower(cat.Rake, sim, cat.CurrentTarget, false, true)
 
-		if cat.Rip.NewSnapshotPower > previousSnapshotPower {
+		if cat.Rip.NewSnapshotPower > previousRipSnapshotPower {
 			cat.tempSnapshotAura = aura
 		} else if cat.tempSnapshotAura.IsActive() {
-			cat.Rip.NewSnapshotPower = previousSnapshotPower
+			cat.Rip.NewSnapshotPower = previousRipSnapshotPower
+			cat.Rake.NewSnapshotPower = previousRakeSnapshotPower
 		} else {
 			cat.tempSnapshotAura = nil
 		}

--- a/sim/druid/feral/feral_test.go
+++ b/sim/druid/feral/feral_test.go
@@ -33,8 +33,8 @@ func TestFeral(t *testing.T) {
 
 		GearSet: core.GetGearSet("../../../ui/druid/feral/gear_sets", "preraid"),
 		OtherGearSets: []core.GearSetCombo{
-			core.GetGearSet("../../../ui/druid/feral/gear_sets", "p1"),
 			core.GetGearSet("../../../ui/druid/feral/gear_sets", "p3"),
+			core.GetGearSet("../../../ui/druid/feral/gear_sets", "p1"),
 		},
 		Talents:         StandardTalents,
 		Glyphs:          StandardGlyphs,

--- a/sim/druid/feral/feral_test.go
+++ b/sim/druid/feral/feral_test.go
@@ -34,6 +34,7 @@ func TestFeral(t *testing.T) {
 		GearSet: core.GetGearSet("../../../ui/druid/feral/gear_sets", "preraid"),
 		OtherGearSets: []core.GearSetCombo{
 			core.GetGearSet("../../../ui/druid/feral/gear_sets", "p1"),
+			core.GetGearSet("../../../ui/druid/feral/gear_sets", "p3"),
 		},
 		Talents:         StandardTalents,
 		Glyphs:          StandardGlyphs,

--- a/sim/druid/feral/feral_test.go
+++ b/sim/druid/feral/feral_test.go
@@ -34,7 +34,6 @@ func TestFeral(t *testing.T) {
 		GearSet: core.GetGearSet("../../../ui/druid/feral/gear_sets", "preraid"),
 		OtherGearSets: []core.GearSetCombo{
 			core.GetGearSet("../../../ui/druid/feral/gear_sets", "p3"),
-			core.GetGearSet("../../../ui/druid/feral/gear_sets", "p1"),
 		},
 		Talents:         StandardTalents,
 		Glyphs:          StandardGlyphs,

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -302,47 +302,65 @@ func (cat *FeralDruid) postRotation(sim *core.Simulation, nextAction time.Durati
 	}
 }
 
-func (cat *FeralDruid) calcRipRefreshTime(sim *core.Simulation, ripDot *core.Dot, isExecutePhase bool) time.Duration {
-	if !ripDot.IsActive() {
+func (cat *FeralDruid) calcBleedRefreshTime(sim *core.Simulation, bleedSpell *druid.DruidSpell, bleedDot *core.Dot, isExecutePhase bool, isRip bool) time.Duration {
+	if !bleedDot.IsActive() {
 		return sim.CurrentTime - cat.ReactionTime
 	}
 
-	// If we're not gaining a stronger snapshot, then use the standard 1 tick refresh window
-	ripEnd := ripDot.ExpiresAt()
-	standardRefreshTime := ripEnd - ripDot.BaseTickLength
+	// If we're not gaining a stronger snapshot, then use the standard 1
+	// tick refresh window.
+	bleedEnd := bleedDot.ExpiresAt()
+	standardRefreshTime := bleedEnd - bleedDot.BaseTickLength
 
-	if !cat.tempSnapshotAura.IsActive() || isExecutePhase || (cat.ComboPoints() < cat.Rotation.MinCombosForRip) {
+	if !cat.tempSnapshotAura.IsActive() {
 		return standardRefreshTime
 	}
 
-	// Likewise, if the existing buff will still be up at the start of the normal window, then don't clip unnecessarily
-	buffRemains := cat.tempSnapshotAura.RemainingDuration(sim)
-	maxRipDur := ripDot.BaseTickLength * time.Duration(cat.maxRipTicks)
-	numCastsCovered := buffRemains / maxRipDur
-	buffEnd := cat.tempSnapshotAura.ExpiresAt() - numCastsCovered * maxRipDur
+	// For Rip specifically, also bypass clipping calculations during Execute phase or
+	// if CP count is too low for the calculation to be relevant.
+	if isRip && (isExecutePhase || (cat.ComboPoints() < cat.Rotation.MinCombosForRip)) {
+		return standardRefreshTime
+	}
 
-	if buffEnd > standardRefreshTime+cat.ReactionTime {
+	// Likewise, if the existing buff will still be up at the start of the normal
+	// window, then don't clip unnecessarily. For long buffs that cover a full bleed
+	// duration, project "buffEnd" forward in time such that we block clips if we are
+	// already maxing out the number of full durations we can snapshot.
+	buffRemains := cat.tempSnapshotAura.RemainingDuration(sim)
+	maxTickCount := core.TernaryInt32(isRip, cat.maxRipTicks, bleedDot.BaseTickCount)
+	maxBleedDur := bleedDot.BaseTickLength * time.Duration(maxTickCount)
+	numCastsCovered := buffRemains / maxBleedDur
+	buffEnd := cat.tempSnapshotAura.ExpiresAt() - numCastsCovered * maxBleedDur
+
+	if buffEnd > standardRefreshTime + cat.ReactionTime {
 		return standardRefreshTime
 	}
 
 	// Potential clips for a buff snapshot should be done as late as possible
-	latestPossibleSnapshot := buffEnd - cat.ReactionTime*time.Duration(2)
-	numClippedTicks := (ripEnd - latestPossibleSnapshot) / ripDot.BaseTickLength
-	targetClipTime := standardRefreshTime - numClippedTicks * ripDot.BaseTickLength
+	latestPossibleSnapshot := buffEnd - cat.ReactionTime * time.Duration(2)
+	numClippedTicks := (bleedEnd - latestPossibleSnapshot) / bleedDot.BaseTickLength
+	targetClipTime := standardRefreshTime - numClippedTicks * bleedDot.BaseTickLength
 
-	// If the clip costs us a Rip cast (30 Energy), then we need to determine whether the damage gain is worth the spend.
-	// First calculate the maximum number of buffed Rip ticks we can get out before the fight ends.
-	buffedTickCount := min(cat.maxRipTicks, int32((sim.Duration-targetClipTime)/ripDot.BaseTickLength))
+	// Since the clip can cost us 30-35 Energy, we need to determine whether the damage gain is worth the
+	// spend. First calculate the maximum number of buffed bleed ticks we can get out before the fight
+	// ends.
+	buffedTickCount := min(maxTickCount, int32((sim.Duration - targetClipTime) / bleedDot.BaseTickLength))
 
 	// Perform a DPE comparison vs. Shred
-	expectedDamageGain := (cat.Rip.NewSnapshotPower - cat.Rip.CurrentSnapshotPower) * float64(buffedTickCount)
+	expectedDamageGain := (bleedSpell.NewSnapshotPower - bleedSpell.CurrentSnapshotPower) * float64(buffedTickCount)
+
+	// For Rake specifically, we get 1 free "tick" immediately upon cast.
+	if !isRip {
+		expectedDamageGain += bleedSpell.NewSnapshotPower
+	}
+
 	energyEquivalent := expectedDamageGain / cat.Shred.ExpectedInitialDamage(sim, cat.CurrentTarget) * cat.Shred.DefaultCast.Cost
 
 	if sim.Log != nil {
-		cat.Log(sim, "Rip buff snapshot is worth %.1f Energy", energyEquivalent)
+		cat.Log(sim, "%s buff snapshot is worth %.1f Energy", bleedSpell.ShortName, energyEquivalent)
 	}
 
-	return core.TernaryDuration(energyEquivalent > cat.Rip.DefaultCast.Cost, targetClipTime, standardRefreshTime)
+	return core.TernaryDuration(energyEquivalent > bleedSpell.DefaultCast.Cost, targetClipTime, standardRefreshTime)
 }
 
 func (cat *FeralDruid) canMeleeWeave(sim *core.Simulation, regenRate float64, currentEnergy float64, isClearcast bool, upcomingTimers *PoolingActions) bool {
@@ -476,7 +494,7 @@ func (cat *FeralDruid) doRotation(sim *core.Simulation) (bool, time.Duration) {
 	baseEndThresh := cat.calcRipEndThresh(sim)
 	finalTickLeeway := core.TernaryDuration(ripDot.IsActive(), ripDot.TimeUntilNextTick(sim), 0)
 	endThreshForClip := baseEndThresh + finalTickLeeway
-	ripRefreshTime := cat.calcRipRefreshTime(sim, ripDot, isExecutePhase)
+	ripRefreshTime := cat.calcBleedRefreshTime(sim, cat.Rip, ripDot, isExecutePhase, true)
 	ripNow := (curCp >= rotation.MinCombosForRip) && (!ripDot.IsActive() || ((sim.CurrentTime > ripRefreshTime) && !isExecutePhase)) && (simTimeRemain >= endThreshForClip) && ripCcCheck
 	biteAtEnd := (curCp >= rotation.MinCombosForBite) && ((simTimeRemain < endThreshForClip) || (ripDot.IsActive() && (simTimeRemain-ripDot.RemainingDuration(sim) < baseEndThresh)))
 
@@ -521,7 +539,8 @@ func (cat *FeralDruid) doRotation(sim *core.Simulation) (bool, time.Duration) {
 	biteNow = (biteNow || emergencyBiteNow) && !t11RefreshNext
 
 	// Rake calcs
-	rakeNow := rotation.UseRake && (!rakeDot.IsActive() || (rakeDot.RemainingDuration(sim) < rakeDot.BaseTickLength)) && (simTimeRemain > rakeDot.BaseTickLength) && rakeCcCheck
+	rakeRefreshTime := cat.calcBleedRefreshTime(sim, cat.Rake, rakeDot, isExecutePhase, false)
+	rakeNow := rotation.UseRake && (!rakeDot.IsActive() || (sim.CurrentTime > rakeRefreshTime)) && (simTimeRemain > rakeDot.BaseTickLength) && rakeCcCheck
 
 	// Additionally, don't Rake if the current Shred DPE is higher due to
 	// trinket procs etc.
@@ -575,8 +594,7 @@ func (cat *FeralDruid) doRotation(sim *core.Simulation) (bool, time.Duration) {
 		refreshCost := core.Ternary(cat.berserkExpectedAt(sim, ripRefreshTime), baseCost*0.5, baseCost)
 		pendingPool.addAction(ripRefreshTime, refreshCost)
 	}
-	if rakeRefreshPending && (rakeDot.RemainingDuration(sim) > rakeDot.BaseTickLength) {
-		rakeRefreshTime := rakeDot.ExpiresAt() - rakeDot.BaseTickLength
+	if rakeRefreshPending && (sim.CurrentTime < rakeRefreshTime) {
 		rakeCost := core.Ternary(cat.berserkExpectedAt(sim, rakeRefreshTime), cat.Rake.DefaultCast.Cost*0.5, cat.Rake.DefaultCast.Cost)
 		pendingPool.addAction(rakeRefreshTime, rakeCost)
 	}

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -329,7 +329,7 @@ func (cat *FeralDruid) calcRipRefreshTime(sim *core.Simulation, ripDot *core.Dot
 
 	// If the clip costs us a Rip cast (30 Energy), then we need to determine whether the damage gain is worth the spend.
 	// First calculate the maximum number of buffed Rip ticks we can get out before the fight ends.
-	buffedTickCount := min(cat.maxRipTicks+1, int32((sim.Duration-targetClipTime)/ripDot.BaseTickLength))
+	buffedTickCount := min(cat.maxRipTicks, int32((sim.Duration-targetClipTime)/ripDot.BaseTickLength))
 
 	// Subtract out any ticks that would already be buffed by an existing snapshot
 	if cat.RipTfSnapshot {

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -331,13 +331,9 @@ func (cat *FeralDruid) calcRipRefreshTime(sim *core.Simulation, ripDot *core.Dot
 	// First calculate the maximum number of buffed Rip ticks we can get out before the fight ends.
 	buffedTickCount := min(cat.maxRipTicks, int32((sim.Duration-targetClipTime)/ripDot.BaseTickLength))
 
-	// Subtract out any ticks that would already be buffed by an existing snapshot
-	if cat.RipTfSnapshot {
-		buffedTickCount -= ripDot.RemainingTicks()
-	}
-
 	// Perform a DPE comparison vs. Shred
-	expectedDamageGain := cat.Rip.ExpectedTickDamage(sim, cat.CurrentTarget) * (1.0 - 1.0/1.15) * float64(buffedTickCount)
+	bleedPowerRatio := core.TernaryFloat64(cat.RipTfSnapshot, 1.0, 1.0/1.15)
+	expectedDamageGain := cat.Rip.ExpectedTickDamage(sim, cat.CurrentTarget) * (1.0 - bleedPowerRatio) * float64(buffedTickCount)
 	energyEquivalent := expectedDamageGain / cat.Shred.ExpectedInitialDamage(sim, cat.CurrentTarget) * cat.Shred.DefaultCast.Cost
 
 	if sim.Log != nil {

--- a/sim/druid/rake.go
+++ b/sim/druid/rake.go
@@ -51,6 +51,9 @@ func (druid *Druid) registerRakeSpell() {
 				attackTable := dot.Spell.Unit.AttackTables[target.UnitIndex]
 				dot.SnapshotCritChance = dot.Spell.PhysicalCritChance(attackTable)
 				dot.SnapshotAttackerMultiplier = dot.Spell.AttackerDamageMultiplier(attackTable, true)
+
+				// Store snapshot power parameters for later use.
+				druid.UpdateBleedPower(druid.Rake, sim, target, true, true)
 			},
 			OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
 				dot.CalcAndDealPeriodicSnapshotDamage(sim, target, dot.OutcomeSnapshotCrit)
@@ -99,6 +102,8 @@ func (druid *Druid) registerRakeSpell() {
 	druid.AddOnMasteryStatChanged(func(sim *core.Simulation, oldMastery float64, newMastery float64) {
 		druid.Rake.DamageMultiplier *= druid.RazorClawsMultiplier(newMastery) / druid.RazorClawsMultiplier(oldMastery)
 	})
+
+	druid.Rake.ShortName = "Rake"
 }
 
 func (druid *Druid) CurrentRakeCost() float64 {


### PR DESCRIPTION
Generalizes the existing analytical logic used for clipping Rip situationally to snapshot Tiger's Fury (when doing so is a net DPE gain), and applies it to arbitrary temporary bleed power buffs implemented via TemporaryStatsAura helpers. Also applies the same logic to Rake snapshotting.

Net DPS impacts of this PR under default settings:
P1 gear, mono-cat talents = +142 DPS
P1 gear, hybrid talents = +85 DPS
P3 gear, mono-cat talents = +52 DPS
P3 gear, hybrid talents = +127 DPS