### PR TITLE
[DEMONOLOGY][UI] Add post prepull snapshot mana

### DIFF
--- a/proto/common.proto
+++ b/proto/common.proto
@@ -956,6 +956,7 @@ enum OtherAction {
 	OtherActionSolarEnergyGain = 18; // For balance druid solar energy
 	OtherActionLunarEnergyGain = 19; // For balance druid lunar energy
 	OtherActionMove = 20; // Used by movement to be able to show it in timeline
+	OtherActionPrepull = 21; // Indicated prepull specific action
 }
 
 message ActionID {

--- a/proto/warlock.proto
+++ b/proto/warlock.proto
@@ -125,6 +125,7 @@ message WarlockOptions {
 	Summon summon = 1;
 	bool detonate_seed = 2;
 	int32 prepull_mastery = 3;
+	int32 prepull_post_snapshot_mana = 4;
 }
 
 message AfflictionWarlock {

--- a/sim/warlock/demonology/demonology.go
+++ b/sim/warlock/demonology/demonology.go
@@ -29,8 +29,9 @@ func NewDemonologyWarlock(character *core.Character, options *proto.Player) *Dem
 	demoOptions := options.GetDemonologyWarlock().Options
 
 	demonology := &DemonologyWarlock{
-		Warlock:        warlock.NewWarlock(character, options, demoOptions.ClassOptions),
-		prepullMastery: demoOptions.ClassOptions.PrepullMastery,
+		Warlock:                 warlock.NewWarlock(character, options, demoOptions.ClassOptions),
+		prepullMastery:          demoOptions.ClassOptions.PrepullMastery,
+		prepullPostSnapshotMana: demoOptions.ClassOptions.PrepullPostSnapshotMana,
 	}
 
 	return demonology
@@ -39,7 +40,8 @@ func NewDemonologyWarlock(character *core.Character, options *proto.Player) *Dem
 type DemonologyWarlock struct {
 	*warlock.Warlock
 
-	prepullMastery int32
+	prepullMastery          int32
+	prepullPostSnapshotMana int32
 }
 
 func (demonology *DemonologyWarlock) GetWarlock() *warlock.Warlock {

--- a/sim/warlock/demonology/metamorphosis.go
+++ b/sim/warlock/demonology/metamorphosis.go
@@ -27,6 +27,19 @@ func (demonology *DemonologyWarlock) registerMetamorphosis() {
 			if sim.CurrentTime <= 0 && demonology.prepullMastery > 0 {
 				masteryPoints := core.MasteryRatingToMasteryPoints(float64(demonology.prepullMastery))
 				metaDmgMod = 1.2 + math.Floor(18.4+2.3*masteryPoints)/100.0
+
+				if demonology.prepullPostSnapshotMana > 0 {
+					prepullPostSnapshotManaMetric := demonology.NewManaMetrics(core.ActionID{OtherID: proto.OtherAction_OtherActionPrepull})
+					maxMana := demonology.MaxMana()
+					currentMana := demonology.CurrentMana()
+					postSnapshotMana := currentMana - float64(demonology.prepullPostSnapshotMana)
+					if postSnapshotMana < 0 {
+						postSnapshotMana = currentMana
+					} else if postSnapshotMana > maxMana {
+						postSnapshotMana = maxMana
+					}
+					demonology.SpendMana(sim, postSnapshotMana, prepullPostSnapshotManaMetric)
+				}
 			}
 			aura.Unit.PseudoStats.DamageDealtMultiplier *= metaDmgMod
 

--- a/ui/core/proto_utils/action_id.ts
+++ b/ui/core/proto_utils/action_id.ts
@@ -130,6 +130,10 @@ export class ActionId {
 				baseName = 'Moving';
 				iconUrl = 'https://wow.zamimg.com/images/wow/icons/medium/inv_boots_cloth_03.jpg';
 				break;
+			case OtherAction.OtherActionPrepull:
+				baseName = 'Prepull';
+				iconUrl = 'https://wow.zamimg.com/images/wow/icons/medium/inv_misc_pocketwatch_02.jpg';
+				break;
 		}
 		this.baseName = baseName;
 		this.name = name || baseName;
@@ -400,10 +404,10 @@ export class ActionId {
 				}
 				break;
 			case 'Crescendo of Suffering':
-				if (this.tag == 1){
-					name += ' (Pre-Pull)'
+				if (this.tag == 1) {
+					name += ' (Pre-Pull)';
 				}
-			break;
+				break;
 			case 'Shadowflame':
 			case 'Moonfire':
 			case 'Sunfire':

--- a/ui/warlock/demonology/presets.ts
+++ b/ui/warlock/demonology/presets.ts
@@ -79,6 +79,7 @@ export const DefaultOptions = WarlockOptions.create({
 		summon: Summon.Felguard,
 		detonateSeed: false,
 		prepullMastery: 0,
+		prepullPostSnapshotMana: 0,
 	},
 });
 

--- a/ui/warlock/demonology/sim.ts
+++ b/ui/warlock/demonology/sim.ts
@@ -117,6 +117,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecDemonologyWarlock, {
 		inputs: [
 			WarlockInputs.DetonateSeed(),
 			WarlockInputs.PrepullMastery,
+			WarlockInputs.PrepullPostSnapshotMana,
 			OtherInputs.InputDelay,
 			OtherInputs.DistanceFromTarget,
 			OtherInputs.DarkIntentUptime,

--- a/ui/warlock/inputs.ts
+++ b/ui/warlock/inputs.ts
@@ -39,3 +39,10 @@ export const PrepullMastery =
 	label: 'Prepull Mastery',
 	labelTooltip: 'Mastery in the prepull set equipped at the start. Only applies if it\'s value is > 0 and only before combat.',
 });
+
+export const PrepullPostSnapshotMana =
+	InputHelpers.makeClassOptionsNumberInput<Spec.SpecDemonologyWarlock>({
+	fieldName: 'prepullPostSnapshotMana',
+	label: 'Mana after prepull Mastery snapshot',
+	labelTooltip: 'Total starting mana after swapping from the prepull set to your normal set. Only applies if the \'Prepull Mastery\' value is > 0.',
+});


### PR DESCRIPTION
- Allows to adjust mana after swapping from prepull set
- Added UI for post prepull mana
- Added OtherID for Prepull specific actions

![image](https://github.com/user-attachments/assets/aa0ce786-c462-47d0-a0ec-1300c150299b)
![image](https://github.com/user-attachments/assets/9be372e0-3f58-473d-9751-c0dd29a77fa1)
![image](https://github.com/user-attachments/assets/0a5ec7c0-058d-42d7-8d50-493311b8f3dc)
