### PR TITLE
[DK] Minor T12 implementation fixes

### DIFF
--- a/sim/core/runic_power.go
+++ b/sim/core/runic_power.go
@@ -171,13 +171,13 @@ func (rp *runicPowerBar) maybeFireChange(sim *Simulation, changeType RuneChangeT
 	}
 }
 
-func (rp *runicPowerBar) addRunicPowerInternal(sim *Simulation, amount float64, metrics *ResourceMetrics, shouldScale bool) {
+func (rp *runicPowerBar) addRunicPowerInternal(sim *Simulation, amount float64, metrics *ResourceMetrics, withMultiplier bool) {
 	if amount < 0 {
 		panic("Trying to add negative runic power!")
 	}
 
 	runicRegenMultiplier := rp.runicRegenMultiplier
-	if !shouldScale {
+	if !withMultiplier {
 		runicRegenMultiplier = 1.0
 	}
 	newRunicPower := min(rp.currentRunicPower+(amount*runicRegenMultiplier), rp.maxRunicPower)

--- a/sim/death_knight/blood/TestBlood.results
+++ b/sim/death_knight/blood/TestBlood.results
@@ -414,8 +414,8 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-ElementiumDeathplateBattlearmor"
  value: {
-  dps: 13660.39377
-  tps: 66627.0652
+  dps: 13682.51911
+  tps: 66746.16372
   hps: 3461.04681
  }
 }

--- a/sim/death_knight/frost/TestFrost.results
+++ b/sim/death_knight/frost/TestFrost.results
@@ -414,8 +414,8 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-ElementiumDeathplateBattlearmor"
  value: {
-  dps: 18974.0291
-  tps: 17159.17864
+  dps: 18988.77758
+  tps: 17173.92712
   hps: 232.60539
  }
 }

--- a/sim/death_knight/items.go
+++ b/sim/death_knight/items.go
@@ -98,11 +98,7 @@ var ItemSetElementiumDeathplateBattlegear = core.NewItemSet(core.ItemSet{
 					pa = core.StartPeriodicAction(sim, core.PeriodicActionOptions{
 						Period: time.Second * 5,
 						OnAction: func(sim *core.Simulation) {
-							// Make sure the multiplier is always 1 as this effect doesn't seem to scale
-							runicMulti := dk.GetRunicRegenMultiplier()
-							dk.MultiplyRunicRegen(1 / runicMulti)
-							dk.AddRunicPower(sim, 3, rpMetrics)
-							dk.MultiplyRunicRegen(runicMulti)
+							dk.AddUnscaledRunicPower(sim, 3, rpMetrics)
 						},
 					})
 				},
@@ -178,7 +174,7 @@ var ItemSetElementiumDeathplateBattlearmor = core.NewItemSet(core.ItemSet{
 			dk.BurningBloodSpell = dk.RegisterSpell(core.SpellConfig{
 				ActionID:         core.ActionID{SpellID: 98957},
 				SpellSchool:      core.SpellSchoolFire,
-				Flags:            core.SpellFlagIgnoreModifiers | core.SpellFlagAPL | core.SpellFlagPassiveSpell,
+				Flags:            core.SpellFlagAPL | core.SpellFlagPassiveSpell,
 				ProcMask:         core.ProcMaskEmpty,
 				DamageMultiplier: 1,
 				CritMultiplier:   dk.DefaultMeleeCritMultiplier(),
@@ -193,9 +189,6 @@ var ItemSetElementiumDeathplateBattlearmor = core.NewItemSet(core.ItemSet{
 
 					OnSnapshot: func(sim *core.Simulation, target *core.Unit, dot *core.Dot, isRollover bool) {
 						baseDamage := 800.0
-						if target.HasActiveAuraWithTag(core.SpellDamageEffectAuraTag) {
-							baseDamage *= 1.08
-						}
 						dot.Snapshot(target, baseDamage)
 					},
 					OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {

--- a/sim/death_knight/unholy/TestUnholy.results
+++ b/sim/death_knight/unholy/TestUnholy.results
@@ -414,8 +414,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ElementiumDeathplateBattlearmor"
  value: {
-  dps: 27761.66056
-  tps: 20670.48197
+  dps: 27776.45224
+  tps: 20685.27365
   hps: 519.07712
  }
 }


### PR DESCRIPTION
- Add `AddUnscaledRunicPower` for adding non-scaling runic power to prevent updating the multiplier every tick
- Remove the modifiers flag from Blood T12 Burning Blood spell until we have proof only CoE like abilities affect it.