### PR TITLE
Feature/fix default spell multiplier

### DIFF
--- a/sim/common/cata/damage_procs.go
+++ b/sim/common/cata/damage_procs.go
@@ -7,10 +7,6 @@ import (
 	"github.com/wowsims/cata/sim/core"
 )
 
-type SpellCritProvider interface {
-	DefaultSpellCritMultiplier() float64
-}
-
 func init() {
 	shared.NewProcDamageEffect(shared.ProcDamageEffect{
 		ItemID:  62049,

--- a/sim/common/cata/damage_procs.go
+++ b/sim/common/cata/damage_procs.go
@@ -7,6 +7,10 @@ import (
 	"github.com/wowsims/cata/sim/core"
 )
 
+type SpellCritProvider interface {
+	DefaultSpellCritMultiplier() float64
+}
+
 func init() {
 	shared.NewProcDamageEffect(shared.ProcDamageEffect{
 		ItemID:  62049,
@@ -60,7 +64,7 @@ func init() {
 			ProcMask:         core.ProcMaskEmpty,
 			Flags:            core.SpellFlagNoOnDamageDealt,
 			DamageMultiplier: 1,
-			CritMultiplier:   character.DefaultSpellCritMultiplier(),
+			CritMultiplier:   agent.GetDefaultSpellValueProvider().DefaultSpellCritMultiplier(),
 			ThreatMultiplier: 1,
 
 			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
@@ -107,7 +111,7 @@ func init() {
 			ProcMask:         core.ProcMaskEmpty,
 			Flags:            core.SpellFlagNoOnDamageDealt,
 			DamageMultiplier: 1,
-			CritMultiplier:   character.DefaultSpellCritMultiplier(),
+			CritMultiplier:   agent.GetDefaultSpellValueProvider().DefaultSpellCritMultiplier(),
 			ThreatMultiplier: 1,
 
 			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/common/cata/enchant_effects.go
+++ b/sim/common/cata/enchant_effects.go
@@ -22,7 +22,7 @@ func init() {
 			Flags:       core.SpellFlagIgnoreModifiers | core.SpellFlagHelpful | core.SpellFlagNoOnCastComplete,
 
 			DamageMultiplier: 1,
-			CritMultiplier:   character.DefaultSpellCritMultiplier(),
+			CritMultiplier:   agent.GetDefaultSpellValueProvider().DefaultSpellCritMultiplier(),
 			ThreatMultiplier: 1,
 
 			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
@@ -58,7 +58,7 @@ func init() {
 			ProcMask:    core.ProcMaskProc,
 
 			DamageMultiplier: 1,
-			CritMultiplier:   character.DefaultSpellCritMultiplier(),
+			CritMultiplier:   agent.GetDefaultSpellValueProvider().DefaultSpellCritMultiplier(),
 			ThreatMultiplier: 1,
 
 			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
@@ -126,7 +126,7 @@ func init() {
 			ProcMask:    core.ProcMaskProc,
 
 			DamageMultiplier: 1,
-			CritMultiplier:   character.DefaultSpellCritMultiplier(),
+			CritMultiplier:   agent.GetDefaultSpellValueProvider().DefaultSpellCritMultiplier(),
 			ThreatMultiplier: 1,
 
 			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/common/cata/other_effects.go
+++ b/sim/common/cata/other_effects.go
@@ -71,7 +71,7 @@ func init() {
 			DamageMultiplier:         1,
 			DamageMultiplierAdditive: 1,
 			ThreatMultiplier:         1,
-			CritMultiplier:           character.DefaultSpellCritMultiplier(),
+			CritMultiplier:           agent.GetDefaultSpellValueProvider().DefaultSpellCritMultiplier(),
 			ProcMask:                 core.ProcMaskEmpty,
 			Flags:                    core.SpellFlagNoOnCastComplete,
 			Dot: core.DotConfig{
@@ -113,7 +113,7 @@ func init() {
 			ThreatMultiplier:         1,
 			ProcMask:                 core.ProcMaskEmpty,
 			Flags:                    core.SpellFlagNoOnCastComplete,
-			CritMultiplier:           character.DefaultSpellCritMultiplier(),
+			CritMultiplier:           agent.GetDefaultSpellValueProvider().DefaultSpellCritMultiplier(),
 			Dot: core.DotConfig{
 				Aura: core.Aura{
 					Label: "Vengful Wisp - 1",
@@ -179,7 +179,7 @@ func init() {
 			DamageMultiplier:         1,
 			DamageMultiplierAdditive: 1,
 			ThreatMultiplier:         1,
-			CritMultiplier:           character.DefaultSpellCritMultiplier(),
+			CritMultiplier:           agent.GetDefaultSpellValueProvider().DefaultSpellCritMultiplier(),
 			Cast: core.CastConfig{
 				CD: core.Cooldown{
 					Duration: time.Minute * 1,

--- a/sim/common/shared/shared_utils.go
+++ b/sim/common/shared/shared_utils.go
@@ -50,7 +50,7 @@ func NewProcStatBonusEffectWithDamageProc(config ProcStatBonusEffect, damage Dam
 			ProcMask:                 core.ProcMaskEmpty,
 			Flags:                    core.SpellFlagNoOnCastComplete | core.SpellFlagPassiveSpell,
 			DamageMultiplier:         1,
-			CritMultiplier:           character.DefaultSpellCritMultiplier(),
+			CritMultiplier:           agent.GetDefaultSpellValueProvider().DefaultSpellCritMultiplier(),
 			DamageMultiplierAdditive: 1,
 			ThreatMultiplier:         1,
 			BonusCoefficient:         damage.BonusCoefficient,
@@ -430,7 +430,7 @@ func NewProcDamageEffect(config ProcDamageEffect) {
 			Flags:       config.Flags,
 
 			DamageMultiplier: 1,
-			CritMultiplier:   character.DefaultSpellCritMultiplier(),
+			CritMultiplier:   agent.GetDefaultSpellValueProvider().DefaultSpellCritMultiplier(),
 			ThreatMultiplier: 1,
 
 			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/common/tbc/enchant_effects.go
+++ b/sim/common/tbc/enchant_effects.go
@@ -249,7 +249,7 @@ func init() {
 			ProcMask:    core.ProcMaskEmpty,
 
 			DamageMultiplier: 1,
-			CritMultiplier:   character.DefaultSpellCritMultiplier(),
+			CritMultiplier:   agent.GetDefaultSpellValueProvider().DefaultSpellCritMultiplier(),
 			ThreatMultiplier: 1,
 
 			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/common/tbc/melee_items.go
+++ b/sim/common/tbc/melee_items.go
@@ -33,7 +33,7 @@ func init() {
 			ProcMask:    core.ProcMaskEmpty,
 
 			DamageMultiplier: 1,
-			CritMultiplier:   character.DefaultSpellCritMultiplier(),
+			CritMultiplier:   agent.GetDefaultSpellValueProvider().DefaultSpellCritMultiplier(),
 			ThreatMultiplier: 0.5,
 
 			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
@@ -222,7 +222,7 @@ func init() {
 			ProcMask:    core.ProcMaskEmpty,
 
 			DamageMultiplier: 1,
-			CritMultiplier:   character.DefaultSpellCritMultiplier(),
+			CritMultiplier:   agent.GetDefaultSpellValueProvider().DefaultSpellCritMultiplier(),
 			ThreatMultiplier: 1,
 
 			BonusCoefficient: 1,
@@ -258,7 +258,7 @@ func init() {
 			ProcMask:    core.ProcMaskEmpty,
 
 			DamageMultiplier: 1,
-			CritMultiplier:   character.DefaultSpellCritMultiplier(),
+			CritMultiplier:   agent.GetDefaultSpellValueProvider().DefaultSpellCritMultiplier(),
 			ThreatMultiplier: 1,
 
 			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/common/tbc/melee_sets.go
+++ b/sim/common/tbc/melee_sets.go
@@ -22,7 +22,7 @@ var ItemSetFistsOfFury = core.NewItemSet(core.ItemSet{
 				ProcMask:    core.ProcMaskEmpty,
 
 				DamageMultiplier: 1,
-				CritMultiplier:   character.DefaultSpellCritMultiplier(),
+				CritMultiplier:   agent.GetDefaultSpellValueProvider().DefaultSpellCritMultiplier(),
 				ThreatMultiplier: 1,
 
 				ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
@@ -63,7 +63,7 @@ var ItemSetStormshroud = core.NewItemSet(core.ItemSet{
 				ProcMask:    core.ProcMaskEmpty,
 
 				DamageMultiplier: 1,
-				CritMultiplier:   char.DefaultSpellCritMultiplier(),
+				CritMultiplier:   a.GetDefaultSpellValueProvider().DefaultSpellCritMultiplier(),
 				ThreatMultiplier: 1,
 
 				ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/common/wotlk/_damage_procs.go
+++ b/sim/common/wotlk/_damage_procs.go
@@ -27,7 +27,7 @@ func newProcDamageEffect(config ProcDamageEffect) {
 			ProcMask:    core.ProcMaskEmpty,
 
 			DamageMultiplier: 1,
-			CritMultiplier:   character.DefaultSpellCritMultiplier(),
+			CritMultiplier:   agent.GetDefaultSpellValueProvider().DefaultSpellCritMultiplier(),
 			ThreatMultiplier: 1,
 
 			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/common/wotlk/capacitors.go
+++ b/sim/common/wotlk/capacitors.go
@@ -46,7 +46,7 @@ func newCapacitorDamageEffect(config CapacitorDamageEffect) {
 			ProcMask:    core.ProcMaskEmpty,
 
 			DamageMultiplier: 1,
-			CritMultiplier:   character.DefaultSpellCritMultiplier(),
+			CritMultiplier:   agent.GetDefaultSpellValueProvider().DefaultSpellCritMultiplier(),
 			ThreatMultiplier: 1,
 
 			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/common/wotlk/enchant_effects.go
+++ b/sim/common/wotlk/enchant_effects.go
@@ -27,7 +27,7 @@ func init() {
 			ProcMask:    core.ProcMaskEmpty,
 
 			DamageMultiplier: 1,
-			CritMultiplier:   character.DefaultSpellCritMultiplier(),
+			CritMultiplier:   agent.GetDefaultSpellValueProvider().DefaultSpellCritMultiplier(),
 			ThreatMultiplier: 1,
 
 			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
@@ -71,7 +71,7 @@ func init() {
 			ProcMask:    core.ProcMaskSpellDamage,
 
 			DamageMultiplier: 1,
-			CritMultiplier:   character.DefaultSpellCritMultiplier(),
+			CritMultiplier:   agent.GetDefaultSpellValueProvider().DefaultSpellCritMultiplier(),
 			ThreatMultiplier: 1,
 
 			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/core/agent.go
+++ b/sim/core/agent.go
@@ -14,6 +14,8 @@ type Agent interface {
 	// The Character controlled by this Agent.
 	GetCharacter() *Character
 
+	GetDefaultSpellValueProvider() DefaultSpellValueProvider
+
 	// Called once after all Players/Pets/Targets have finished the construction phase.
 	// Use this to register spells and any initialization steps that require
 	// other raid members or auras.

--- a/sim/core/character.go
+++ b/sim/core/character.go
@@ -30,6 +30,12 @@ const (
 
 const CharacterBuildPhaseAll = CharacterBuildPhaseBase | CharacterBuildPhaseGear | CharacterBuildPhaseTalents | CharacterBuildPhaseBuffs | CharacterBuildPhaseConsumes
 
+type DefaultSpellValueProvider interface {
+	DefaultSpellCritMultiplier() float64
+	DefaultMeleeCritMultiplier() float64
+	DefaultHealingCritMultiplier() float64
+}
+
 // Character is a data structure to hold all the shared values that all
 // class logic shares.
 // All players have stats, equipment, auras, etc

--- a/sim/core/consumes.go
+++ b/sim/core/consumes.go
@@ -679,7 +679,7 @@ func makePotionActivationInternal(potionType proto.Potions, character *Character
 			SpellSchool: SpellSchoolFire,
 
 			DamageMultiplier: 1,
-			CritMultiplier:   character.DefaultSpellCritMultiplier(),
+			CritMultiplier:   character.Env.GetAgentFromUnit(&character.Unit).GetDefaultSpellValueProvider().DefaultSpellCritMultiplier(),
 			ThreatMultiplier: 1,
 
 			ApplyEffects: func(sim *Simulation, target *Unit, spell *Spell) {
@@ -1020,7 +1020,7 @@ func registerTinkerHandsCD(agent Agent, consumes *proto.Consumes) {
 			},
 
 			DamageMultiplier: 1,
-			CritMultiplier:   character.DefaultSpellCritMultiplier(),
+			CritMultiplier:   character.Env.GetAgentFromUnit(&character.Unit).GetDefaultSpellValueProvider().DefaultSpellCritMultiplier(),
 			ThreatMultiplier: 1,
 
 			ApplyEffects: func(sim *Simulation, unit *Unit, spell *Spell) {

--- a/sim/core/dot_test.go
+++ b/sim/core/dot_test.go
@@ -35,6 +35,8 @@ func (fa *FakeAgent) GetCharacter() *Character {
 	return &fa.Character
 }
 
+func (fa *FakeAgent) GetDefaultSpellValueProvider() DefaultSpellValueProvider { return fa.character }
+
 func (fa *FakeAgent) Initialize() {
 	if fa.Init != nil {
 		fa.Init()

--- a/sim/core/pet.go
+++ b/sim/core/pet.go
@@ -289,7 +289,8 @@ func (pet *Pet) Disable(sim *Simulation) {
 func (pet *Pet) GetCharacter() *Character {
 	return &pet.Character
 }
-func (pet *Pet) AddRaidBuffs(_ *proto.RaidBuffs)   {}
-func (pet *Pet) AddPartyBuffs(_ *proto.PartyBuffs) {}
-func (pet *Pet) ApplyTalents()                     {}
-func (pet *Pet) OnGCDReady(_ *Simulation)          {}
+func (pet *Pet) AddRaidBuffs(_ *proto.RaidBuffs)                         {}
+func (pet *Pet) AddPartyBuffs(_ *proto.PartyBuffs)                       {}
+func (pet *Pet) ApplyTalents()                                           {}
+func (pet *Pet) OnGCDReady(_ *Simulation)                                {}
+func (pet *Pet) GetDefaultSpellValueProvider() DefaultSpellValueProvider { return pet.character }

--- a/sim/core/target_ai.go
+++ b/sim/core/target_ai.go
@@ -49,11 +49,12 @@ func (target *Target) initialize(config *proto.Target) {
 }
 
 // Empty Agent interface functions.
-func (target *Target) AddRaidBuffs(_ *proto.RaidBuffs)   {}
-func (target *Target) AddPartyBuffs(_ *proto.PartyBuffs) {}
-func (target *Target) ApplyTalents()                     {}
-func (target *Target) GetCharacter() *Character          { return nil }
-func (target *Target) Initialize()                       {}
+func (target *Target) AddRaidBuffs(_ *proto.RaidBuffs)                         {}
+func (target *Target) AddPartyBuffs(_ *proto.PartyBuffs)                       {}
+func (target *Target) ApplyTalents()                                           {}
+func (target *Target) GetCharacter() *Character                                { return nil }
+func (target *Target) Initialize()                                             {}
+func (target *Target) GetDefaultSpellValueProvider() DefaultSpellValueProvider { return nil }
 
 func (target *Target) ExecuteCustomRotation(sim *Simulation) {
 	if target.AI != nil {

--- a/sim/core/target_dummy.go
+++ b/sim/core/target_dummy.go
@@ -43,9 +43,10 @@ func NewTargetDummy(dummyIndex int, party *Party, partyIndex int) *TargetDummy {
 func (td *TargetDummy) GetCharacter() *Character {
 	return &td.Character
 }
-func (td *TargetDummy) AddRaidBuffs(raidBuffs *proto.RaidBuffs)    {}
-func (td *TargetDummy) AddPartyBuffs(partyBuffs *proto.PartyBuffs) {}
-func (td *TargetDummy) ApplyTalents()                              {}
-func (td *TargetDummy) Initialize()                                {}
-func (td *TargetDummy) Reset(sim *Simulation)                      {}
-func (td *TargetDummy) ExecuteCustomRotation(sim *Simulation)      {}
+func (td *TargetDummy) AddRaidBuffs(raidBuffs *proto.RaidBuffs)                 {}
+func (td *TargetDummy) AddPartyBuffs(partyBuffs *proto.PartyBuffs)              {}
+func (td *TargetDummy) ApplyTalents()                                           {}
+func (td *TargetDummy) Initialize()                                             {}
+func (td *TargetDummy) Reset(sim *Simulation)                                   {}
+func (td *TargetDummy) ExecuteCustomRotation(sim *Simulation)                   {}
+func (td *TargetDummy) GetDefaultSpellValueProvider() DefaultSpellValueProvider { return td.character }

--- a/sim/death_knight/death_knight.go
+++ b/sim/death_knight/death_knight.go
@@ -230,6 +230,8 @@ type DeathKnightAgent interface {
 	GetDeathKnight() *DeathKnight
 }
 
+func (dk *DeathKnight) GetDefaultSpellValueProvider() core.DefaultSpellValueProvider { return dk }
+
 const (
 	DeathKnightSpellFlagNone int64 = 0
 	DeathKnightSpellIcyTouch int64 = 1 << iota

--- a/sim/death_knight/frost/TestFrost.results
+++ b/sim/death_knight/frost/TestFrost.results
@@ -320,7 +320,7 @@ dps_results: {
  value: {
   dps: 21998.53427
   tps: 19961.6477
-  hps: 245.25882
+  hps: 245.25883
  }
 }
 dps_results: {
@@ -336,7 +336,7 @@ dps_results: {
  value: {
   dps: 21944.09428
   tps: 20055.84482
-  hps: 245.25882
+  hps: 245.25883
  }
 }
 dps_results: {
@@ -344,7 +344,7 @@ dps_results: {
  value: {
   dps: 21351.64308
   tps: 19499.4618
-  hps: 245.25882
+  hps: 245.25883
  }
 }
 dps_results: {
@@ -368,7 +368,7 @@ dps_results: {
  value: {
   dps: 21150.92099
   tps: 19199.08409
-  hps: 245.25882
+  hps: 245.25883
  }
 }
 dps_results: {
@@ -1040,7 +1040,7 @@ dps_results: {
  value: {
   dps: 20899.85176
   tps: 19038.60319
-  hps: 245.25882
+  hps: 245.25883
  }
 }
 dps_results: {

--- a/sim/druid/druid.go
+++ b/sim/druid/druid.go
@@ -432,3 +432,5 @@ func (druid *Druid) UpdateBleedPower(bleedSpell *DruidSpell, sim *core.Simulatio
 type DruidAgent interface {
 	GetDruid() *Druid
 }
+
+func (druid *Druid) GetDefaultSpellValueProvider() core.DefaultSpellValueProvider { return druid }

--- a/sim/hunter/hunter.go
+++ b/sim/hunter/hunter.go
@@ -256,3 +256,5 @@ const (
 type HunterAgent interface {
 	GetHunter() *Hunter
 }
+
+func (hunter *Hunter) GetDefaultSpellValueProvider() core.DefaultSpellValueProvider { return hunter }

--- a/sim/mage/arcane/TestArcane.results
+++ b/sim/mage/arcane/TestArcane.results
@@ -305,8 +305,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 29174.60313
-  tps: 29332.853
+  dps: 29181.40498
+  tps: 29339.65485
  }
 }
 dps_results: {
@@ -536,8 +536,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-HarmlightToken-63839"
  value: {
-  dps: 28468.61709
-  tps: 28645.33026
+  dps: 28481.62314
+  tps: 28658.3363
  }
 }
 dps_results: {
@@ -1222,8 +1222,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 28525.05283
-  tps: 28743.29115
+  dps: 28536.09397
+  tps: 28754.33228
  }
 }
 dps_results: {
@@ -1264,15 +1264,15 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 29130.74985
-  tps: 29310.71037
+  dps: 29161.04171
+  tps: 29341.00223
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 30077.99079
-  tps: 30251.69274
+  dps: 30154.98801
+  tps: 30328.68996
  }
 }
 dps_results: {

--- a/sim/mage/arcane/arcane_barrage.go
+++ b/sim/mage/arcane/arcane_barrage.go
@@ -32,7 +32,7 @@ func (arcane *ArcaneMage) registerArcaneBarrageSpell() {
 		},
 
 		DamageMultiplier: 1,
-		CritMultiplier:   arcane.DefaultMageCritMultiplier(),
+		CritMultiplier:   arcane.DefaultSpellCritMultiplier(),
 		BonusCoefficient: 0.907,
 		ThreatMultiplier: 1,
 

--- a/sim/mage/arcane_blast.go
+++ b/sim/mage/arcane_blast.go
@@ -76,7 +76,7 @@ func (mage *Mage) registerArcaneBlastSpell() {
 		},
 
 		DamageMultiplier: 1,
-		CritMultiplier:   mage.DefaultMageCritMultiplier(),
+		CritMultiplier:   mage.DefaultSpellCritMultiplier(),
 		BonusCoefficient: 1.0,
 		ThreatMultiplier: 1,
 

--- a/sim/mage/arcane_explosion.go
+++ b/sim/mage/arcane_explosion.go
@@ -23,7 +23,7 @@ func (mage *Mage) registerArcaneExplosionSpell() {
 		},
 
 		DamageMultiplier: 1,
-		CritMultiplier:   mage.DefaultMageCritMultiplier(),
+		CritMultiplier:   mage.DefaultSpellCritMultiplier(),
 		BonusCoefficient: 0.186,
 		ThreatMultiplier: 1 - 0.4*float64(mage.Talents.ImprovedArcaneExplosion),
 

--- a/sim/mage/arcane_missiles.go
+++ b/sim/mage/arcane_missiles.go
@@ -33,7 +33,7 @@ func (mage *Mage) registerArcaneMissilesSpell() {
 		MissileSpeed:   20,
 
 		DamageMultiplier: 1,
-		CritMultiplier:   mage.DefaultMageCritMultiplier(),
+		CritMultiplier:   mage.DefaultSpellCritMultiplier(),
 		ThreatMultiplier: 1,
 		BonusCoefficient: 0.278,
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/mage/blast_wave.go
+++ b/sim/mage/blast_wave.go
@@ -32,7 +32,7 @@ func (mage *Mage) registerBlastWaveSpell() {
 			},
 		},
 		DamageMultiplierAdditive: 1,
-		CritMultiplier:           mage.DefaultMageCritMultiplier(),
+		CritMultiplier:           mage.DefaultSpellCritMultiplier(),
 		BonusCoefficient:         0.193,
 		ThreatMultiplier:         1,
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
@@ -65,7 +65,7 @@ func (mage *Mage) registerBlastWaveSpell() {
 		},
 
 		DamageMultiplierAdditive: 1,
-		CritMultiplier:           mage.DefaultMageCritMultiplier(),
+		CritMultiplier:           mage.DefaultSpellCritMultiplier(),
 		BonusCoefficient:         0.146,
 		ThreatMultiplier:         1,
 

--- a/sim/mage/blizzard.go
+++ b/sim/mage/blizzard.go
@@ -34,7 +34,7 @@ func (mage *Mage) registerBlizzardSpell() {
 		ClassSpellMask: MageSpellBlizzard,
 
 		DamageMultiplier: 1,
-		CritMultiplier:   mage.DefaultMageCritMultiplier(),
+		CritMultiplier:   mage.DefaultSpellCritMultiplier(),
 		BonusCoefficient: 0.162,
 		ThreatMultiplier: 1,
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/mage/combustion.go
+++ b/sim/mage/combustion.go
@@ -25,7 +25,7 @@ func (mage *Mage) registerCombustionSpell() {
 			},
 		},
 		DamageMultiplierAdditive: 1,
-		CritMultiplier:           mage.DefaultMageCritMultiplier(),
+		CritMultiplier:           mage.DefaultSpellCritMultiplier(),
 		BonusCoefficient:         1.113,
 		ThreatMultiplier:         1,
 
@@ -52,7 +52,7 @@ func (mage *Mage) registerCombustionSpell() {
 		Flags:          core.SpellFlagIgnoreModifiers | core.SpellFlagNoSpellMods | core.SpellFlagNoOnCastComplete | core.SpellFlagPassiveSpell,
 
 		DamageMultiplier: 1,
-		CritMultiplier:   mage.DefaultMageCritMultiplier(),
+		CritMultiplier:   mage.DefaultSpellCritMultiplier(),
 		ThreatMultiplier: 1,
 
 		Dot: core.DotConfig{

--- a/sim/mage/deep_freeze.go
+++ b/sim/mage/deep_freeze.go
@@ -32,7 +32,7 @@ func (mage *Mage) registerDeepFreezeSpell() {
 		},
 
 		DamageMultiplier: 1,
-		CritMultiplier:   mage.DefaultMageCritMultiplier(),
+		CritMultiplier:   mage.DefaultSpellCritMultiplier(),
 		BonusCoefficient: 2.058,
 		ThreatMultiplier: 1,
 

--- a/sim/mage/dragons_breath.go
+++ b/sim/mage/dragons_breath.go
@@ -30,7 +30,7 @@ func (mage *Mage) registerDragonsBreathSpell() {
 			},
 		},
 		DamageMultiplierAdditive: 1,
-		CritMultiplier:           mage.DefaultMageCritMultiplier(),
+		CritMultiplier:           mage.DefaultSpellCritMultiplier(),
 		BonusCoefficient:         0.193,
 		ThreatMultiplier:         1,
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/mage/fire/TestFire.results
+++ b/sim/mage/fire/TestFire.results
@@ -38,8 +38,8 @@ character_stats_results: {
 dps_results: {
  key: "TestFire-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 30647.01355
-  tps: 30116.29024
+  dps: 30658.82088
+  tps: 30128.09757
  }
 }
 dps_results: {
@@ -87,8 +87,8 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 30035.04441
-  tps: 29512.92948
+  dps: 30046.08825
+  tps: 29523.97332
  }
 }
 dps_results: {
@@ -221,8 +221,8 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 30403.13328
-  tps: 29271.28425
+  dps: 30413.9663
+  tps: 29281.90061
  }
 }
 dps_results: {
@@ -235,15 +235,15 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 30918.93247
-  tps: 30372.46888
+  dps: 30929.70841
+  tps: 30383.24483
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 30765.34213
-  tps: 30231.09489
+  dps: 30776.7054
+  tps: 30242.45815
  }
 }
 dps_results: {
@@ -319,8 +319,8 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 30215.94541
-  tps: 29685.2027
+  dps: 30226.50083
+  tps: 29695.75812
  }
 }
 dps_results: {
@@ -340,8 +340,8 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 30035.04441
-  tps: 29512.92948
+  dps: 30046.08825
+  tps: 29523.97332
  }
 }
 dps_results: {
@@ -354,15 +354,15 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 30233.90811
-  tps: 29702.2531
+  dps: 30245.54094
+  tps: 29713.88593
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 30215.94541
-  tps: 29685.2027
+  dps: 30226.50083
+  tps: 29695.75812
  }
 }
 dps_results: {
@@ -389,8 +389,8 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 30035.04441
-  tps: 29512.92948
+  dps: 30046.08825
+  tps: 29523.97332
  }
 }
 dps_results: {
@@ -452,22 +452,22 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-FirehawkRobesofConflagration"
  value: {
-  dps: 28232.35925
-  tps: 26992.46641
+  dps: 28241.05495
+  tps: 27001.16211
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Firelord'sVestments"
  value: {
-  dps: 26698.95212
-  tps: 26283.06874
+  dps: 26707.85764
+  tps: 26291.97425
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 30135.54235
-  tps: 29613.42743
+  dps: 30146.5862
+  tps: 29624.47127
  }
 }
 dps_results: {
@@ -480,8 +480,8 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 30403.13328
-  tps: 29864.45345
+  dps: 30413.9663
+  tps: 29875.28647
  }
 }
 dps_results: {
@@ -536,8 +536,8 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-HarmlightToken-63839"
  value: {
-  dps: 29023.23049
-  tps: 28518.19336
+  dps: 29041.37671
+  tps: 28536.33958
  }
 }
 dps_results: {
@@ -613,15 +613,15 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-Heartpierce-50641"
  value: {
-  dps: 30918.93247
-  tps: 30372.46888
+  dps: 30929.70841
+  tps: 30383.24483
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 30215.94541
-  tps: 29685.2027
+  dps: 30226.50083
+  tps: 29695.75812
  }
 }
 dps_results: {
@@ -921,8 +921,8 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 30035.04441
-  tps: 29512.92948
+  dps: 30046.08825
+  tps: 29523.97332
  }
 }
 dps_results: {
@@ -956,15 +956,15 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 30647.01355
-  tps: 30116.29024
+  dps: 30658.82088
+  tps: 30128.09757
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 30648.95544
-  tps: 30118.2207
+  dps: 30660.76278
+  tps: 30130.02803
  }
 }
 dps_results: {
@@ -1208,8 +1208,8 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-TimeLord'sRegalia"
  value: {
-  dps: 25687.67409
-  tps: 25264.37315
+  dps: 25696.78104
+  tps: 25273.4801
  }
 }
 dps_results: {
@@ -1222,8 +1222,8 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 29610.1466
-  tps: 29063.87456
+  dps: 29620.80216
+  tps: 29074.53012
  }
 }
 dps_results: {
@@ -1264,15 +1264,15 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 29689.89951
-  tps: 29181.93389
+  dps: 29728.15677
+  tps: 29220.19115
  }
 }
 dps_results: {
  key: "TestFire-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 30932.74388
-  tps: 30415.36489
+  dps: 31045.63578
+  tps: 30528.25679
  }
 }
 dps_results: {
@@ -1425,56 +1425,56 @@ dps_results: {
 dps_results: {
  key: "TestFire-Average-Default"
  value: {
-  dps: 31269.57088
-  tps: 30740.06791
+  dps: 31282.001
+  tps: 30752.49802
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-p1_fire-Fire-fire-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 49311.43593
-  tps: 52733.08974
+  dps: 49322.98105
+  tps: 52744.63486
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-p1_fire-Fire-fire-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 30918.93247
-  tps: 30372.46888
+  dps: 30929.70841
+  tps: 30383.24483
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-p1_fire-Fire-fire-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 41333.00318
-  tps: 40420.5279
+  dps: 41349.63471
+  tps: 40437.15943
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-p1_fire-Fire-fire-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 34624.57996
-  tps: 38227.3132
+  dps: 34632.29467
+  tps: 38235.02791
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-p1_fire-Fire-fire-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 20804.20825
-  tps: 20508.30689
+  dps: 20813.78635
+  tps: 20517.88498
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-p1_fire-Fire-fire-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 23389.61713
-  tps: 22761.83105
+  dps: 23400.99394
+  tps: 22773.20786
  }
 }
 dps_results: {
  key: "TestFire-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 30918.93247
-  tps: 30372.46888
+  dps: 30929.70841
+  tps: 30383.24483
  }
 }

--- a/sim/mage/fire/pyroblast.go
+++ b/sim/mage/fire/pyroblast.go
@@ -28,7 +28,7 @@ func (fire *FireMage) registerPyroblastSpell() {
 
 		DamageMultiplier:         1,
 		DamageMultiplierAdditive: 1,
-		CritMultiplier:           fire.DefaultMageCritMultiplier(),
+		CritMultiplier:           fire.DefaultSpellCritMultiplier(),
 		BonusCoefficient:         1.545,
 		ThreatMultiplier:         1,
 
@@ -52,7 +52,7 @@ func (fire *FireMage) registerPyroblastSpell() {
 		Flags:          core.SpellFlagNoOnCastComplete | core.SpellFlagPassiveSpell,
 
 		DamageMultiplier: 1,
-		CritMultiplier:   fire.DefaultMageCritMultiplier(),
+		CritMultiplier:   fire.DefaultSpellCritMultiplier(),
 		ThreatMultiplier: 1,
 
 		Dot: core.DotConfig{

--- a/sim/mage/fire_blast.go
+++ b/sim/mage/fire_blast.go
@@ -28,7 +28,7 @@ func (mage *Mage) registerFireBlastSpell() {
 		},
 
 		DamageMultiplierAdditive: 1,
-		CritMultiplier:           mage.DefaultMageCritMultiplier(),
+		CritMultiplier:           mage.DefaultSpellCritMultiplier(),
 		BonusCoefficient:         0.429,
 		ThreatMultiplier:         1,
 

--- a/sim/mage/fireball.go
+++ b/sim/mage/fireball.go
@@ -28,7 +28,7 @@ func (mage *Mage) registerFireballSpell() {
 		},
 
 		DamageMultiplierAdditive: 1,
-		CritMultiplier:           mage.DefaultMageCritMultiplier(),
+		CritMultiplier:           mage.DefaultSpellCritMultiplier(),
 		BonusCoefficient:         1.236,
 		ThreatMultiplier:         1,
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/mage/flame_orb.go
+++ b/sim/mage/flame_orb.go
@@ -55,7 +55,7 @@ func (mage *Mage) registerFlameOrbExplodeSpell() {
 		ClassSpellMask: MageSpellFlameOrb,
 
 		DamageMultiplier: 1,
-		CritMultiplier:   mage.DefaultMageCritMultiplier(),
+		CritMultiplier:   mage.DefaultSpellCritMultiplier(),
 		BonusCoefficient: 0.193,
 		ThreatMultiplier: 1,
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
@@ -136,7 +136,7 @@ func (fo *FlameOrb) registerFlameOrbTickSpell() {
 		},
 
 		DamageMultiplier: 1,
-		CritMultiplier:   fo.mageOwner.DefaultMageCritMultiplier(),
+		CritMultiplier:   fo.mageOwner.DefaultSpellCritMultiplier(),
 		BonusCoefficient: 0.134,
 		ThreatMultiplier: 1,
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/mage/flamestrike.go
+++ b/sim/mage/flamestrike.go
@@ -26,7 +26,7 @@ func (mage *Mage) registerFlamestrikeSpell() {
 		},
 
 		DamageMultiplierAdditive: 1,
-		CritMultiplier:           mage.DefaultMageCritMultiplier(),
+		CritMultiplier:           mage.DefaultSpellCritMultiplier(),
 		BonusCoefficient:         0.146,
 		ThreatMultiplier:         1,
 

--- a/sim/mage/freeze.go
+++ b/sim/mage/freeze.go
@@ -26,7 +26,7 @@ func (mage *Mage) registerFreezeSpell() {
 		},
 
 		DamageMultiplierAdditive: 1,
-		CritMultiplier:           mage.DefaultMageCritMultiplier(),
+		CritMultiplier:           mage.DefaultSpellCritMultiplier(),
 		BonusCoefficient:         0.029,
 		ThreatMultiplier:         1,
 

--- a/sim/mage/frost/water_elemental.go
+++ b/sim/mage/frost/water_elemental.go
@@ -130,7 +130,7 @@ func (we *WaterElemental) registerWaterboltSpell() {
 		},
 
 		DamageMultiplier: 1,
-		CritMultiplier:   we.mageOwner.DefaultMageCritMultiplier(),
+		CritMultiplier:   we.mageOwner.DefaultSpellCritMultiplier(),
 		ThreatMultiplier: 1,
 		BonusCoefficient: 0.833,
 

--- a/sim/mage/frostbolt.go
+++ b/sim/mage/frostbolt.go
@@ -33,7 +33,7 @@ func (mage *Mage) registerFrostboltSpell() {
 		},
 
 		DamageMultiplierAdditive: 1,
-		CritMultiplier:           mage.DefaultMageCritMultiplier(),
+		CritMultiplier:           mage.DefaultSpellCritMultiplier(),
 		BonusCoefficient:         0.943,
 		ThreatMultiplier:         1,
 

--- a/sim/mage/frostfire_bolt.go
+++ b/sim/mage/frostfire_bolt.go
@@ -31,7 +31,7 @@ func (mage *Mage) registerFrostfireBoltSpell() {
 		},
 
 		DamageMultiplier: 1,
-		CritMultiplier:   mage.DefaultMageCritMultiplier(),
+		CritMultiplier:   mage.DefaultSpellCritMultiplier(),
 		BonusCoefficient: 0.977,
 		ThreatMultiplier: 1,
 

--- a/sim/mage/frostfire_orb.go
+++ b/sim/mage/frostfire_orb.go
@@ -115,7 +115,9 @@ func (ffo *FrostfireOrb) registerFrostfireOrbTickSpell() {
 		},
 
 		DamageMultiplier: 1,
-		CritMultiplier:   ffo.mageOwner.DefaultSpellCritMultiplier(),
+
+		// should FFO benefit from meta gem?
+		CritMultiplier:   ffo.DefaultSpellCritMultiplier(),
 		BonusCoefficient: 0.134,
 		ThreatMultiplier: 1,
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {

--- a/sim/mage/ice_lance.go
+++ b/sim/mage/ice_lance.go
@@ -23,7 +23,7 @@ func (mage *Mage) registerIceLanceSpell() {
 		},
 
 		DamageMultiplierAdditive: 1,
-		CritMultiplier:           mage.DefaultMageCritMultiplier(),
+		CritMultiplier:           mage.DefaultSpellCritMultiplier(),
 		BonusCoefficient:         0.378,
 		ThreatMultiplier:         1,
 

--- a/sim/mage/living_bomb.go
+++ b/sim/mage/living_bomb.go
@@ -32,7 +32,7 @@ func (mage *Mage) registerLivingBombSpell() {
 		Flags:          core.SpellFlagNoOnCastComplete | core.SpellFlagPassiveSpell,
 
 		DamageMultiplierAdditive: 1,
-		CritMultiplier:           mage.DefaultMageCritMultiplier(),
+		CritMultiplier:           mage.DefaultSpellCritMultiplier(),
 		BonusCoefficient:         0.516,
 		ThreatMultiplier:         1,
 
@@ -64,7 +64,7 @@ func (mage *Mage) registerLivingBombSpell() {
 		},
 
 		DamageMultiplierAdditive: 1,
-		CritMultiplier:           mage.DefaultMageCritMultiplier(),
+		CritMultiplier:           mage.DefaultSpellCritMultiplier(),
 		ThreatMultiplier:         1,
 
 		Dot: core.DotConfig{

--- a/sim/mage/mage.go
+++ b/sim/mage/mage.go
@@ -280,11 +280,13 @@ type MageAgent interface {
 	GetMage() *Mage
 }
 
+func (mage *Mage) GetDefaultSpellValueProvider() core.DefaultSpellValueProvider { return mage }
+
 func (mage *Mage) hasChillEffect(spell *core.Spell) bool {
 	return spell.ClassSpellMask&MageSpellChill > 0 || (spell.ClassSpellMask == MageSpellBlizzard && mage.Talents.IceShards > 0)
 }
 
-func (mage *Mage) DefaultMageCritMultiplier() float64 {
+func (mage *Mage) DefaultSpellCritMultiplier() float64 {
 	return mage.SpellCritMultiplier(1.33, 0)
 }
 

--- a/sim/mage/scorch.go
+++ b/sim/mage/scorch.go
@@ -28,7 +28,7 @@ func (mage *Mage) registerScorchSpell() {
 
 		DamageMultiplierAdditive: 1,
 
-		CritMultiplier:   mage.DefaultMageCritMultiplier(),
+		CritMultiplier:   mage.DefaultSpellCritMultiplier(),
 		BonusCoefficient: 0.512,
 		ThreatMultiplier: 1,
 

--- a/sim/paladin/paladin.go
+++ b/sim/paladin/paladin.go
@@ -302,3 +302,5 @@ func NewPaladin(character *core.Character, talentsStr string, options *proto.Pal
 func (paladin *Paladin) BuilderCooldown() *core.Timer {
 	return paladin.Character.GetOrInitTimer(&paladin.sharedBuilderTimer)
 }
+
+func (paladin *Paladin) GetDefaultSpellValueProvider() core.DefaultSpellValueProvider { return paladin }

--- a/sim/priest/priest.go
+++ b/sim/priest/priest.go
@@ -159,6 +159,8 @@ type PriestAgent interface {
 	GetPriest() *Priest
 }
 
+func (priest *Priest) GetDefaultSpellValueProvider() core.DefaultSpellValueProvider { return priest }
+
 func (hunter *Priest) HasPrimeGlyph(glyph proto.PriestPrimeGlyph) bool {
 	return hunter.HasGlyph(int32(glyph))
 }

--- a/sim/rogue/rogue.go
+++ b/sim/rogue/rogue.go
@@ -322,6 +322,8 @@ type RogueAgent interface {
 	GetRogue() *Rogue
 }
 
+func (rogue *Rogue) GetDefaultSpellValueProvider() core.DefaultSpellValueProvider { return rogue }
+
 const (
 	RogueSpellFlagNone int64 = 0
 	RogueSpellAmbush   int64 = 1 << iota

--- a/sim/shaman/shaman.go
+++ b/sim/shaman/shaman.go
@@ -302,6 +302,8 @@ func (shaman *Shaman) Reset(sim *core.Simulation) {
 
 }
 
+func (shaman *Shaman) GetDefaultSpellValueProvider() core.DefaultSpellValueProvider { return shaman }
+
 func (shaman *Shaman) GetOverloadChance() float64 {
 	overloadChance := 0.0
 

--- a/sim/warlock/affliction/TestAffliction.results
+++ b/sim/warlock/affliction/TestAffliction.results
@@ -38,8 +38,8 @@ character_stats_results: {
 dps_results: {
  key: "TestAffliction-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 28431.53506
-  tps: 20689.87416
+  dps: 28439.17184
+  tps: 20697.51094
  }
 }
 dps_results: {
@@ -87,15 +87,15 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 28097.71094
-  tps: 20360.85654
+  dps: 28106.00317
+  tps: 20369.14877
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Balespider'sBurningVestments"
  value: {
-  dps: 28399.11308
-  tps: 20422.79393
+  dps: 28406.96593
+  tps: 20430.64678
  }
 }
 dps_results: {
@@ -221,8 +221,8 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 28294.87158
-  tps: 20119.60443
+  dps: 28302.79172
+  tps: 20127.36617
  }
 }
 dps_results: {
@@ -235,15 +235,15 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 28585.84371
-  tps: 20804.39172
+  dps: 28594.00145
+  tps: 20812.54946
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 28521.24178
-  tps: 20749.7843
+  dps: 28528.87856
+  tps: 20757.42108
  }
 }
 dps_results: {
@@ -319,8 +319,8 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 28228.07103
-  tps: 20465.58018
+  dps: 28235.48538
+  tps: 20472.99453
  }
 }
 dps_results: {
@@ -340,8 +340,8 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 28097.71094
-  tps: 20360.85654
+  dps: 28106.00317
+  tps: 20369.14877
  }
 }
 dps_results: {
@@ -354,15 +354,15 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 28272.56825
-  tps: 20533.00261
+  dps: 28280.36381
+  tps: 20540.79816
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 28228.07103
-  tps: 20465.58018
+  dps: 28235.48538
+  tps: 20472.99453
  }
 }
 dps_results: {
@@ -389,8 +389,8 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 28097.71094
-  tps: 20360.85654
+  dps: 28106.00317
+  tps: 20369.14877
  }
 }
 dps_results: {
@@ -452,8 +452,8 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 28244.13765
-  tps: 20511.28753
+  dps: 28251.552
+  tps: 20518.70188
  }
 }
 dps_results: {
@@ -466,8 +466,8 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 28294.87158
-  tps: 20522.47401
+  dps: 28302.79172
+  tps: 20530.39414
  }
 }
 dps_results: {
@@ -501,8 +501,8 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 23432.46907
-  tps: 16973.6794
+  dps: 23441.06483
+  tps: 16982.27515
  }
 }
 dps_results: {
@@ -529,8 +529,8 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-HarmlightToken-63839"
  value: {
-  dps: 27721.55191
-  tps: 20094.45548
+  dps: 27732.89052
+  tps: 20105.79409
  }
 }
 dps_results: {
@@ -606,8 +606,8 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 28228.07103
-  tps: 20465.58018
+  dps: 28235.48538
+  tps: 20472.99453
  }
 }
 dps_results: {
@@ -907,8 +907,8 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 28097.71094
-  tps: 20360.85654
+  dps: 28106.00317
+  tps: 20369.14877
  }
 }
 dps_results: {
@@ -942,15 +942,15 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 28431.53506
-  tps: 20689.87416
+  dps: 28439.17184
+  tps: 20697.51094
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 28431.53506
-  tps: 20689.87416
+  dps: 28439.17184
+  tps: 20697.51094
  }
 }
 dps_results: {
@@ -1005,8 +1005,8 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-ShadowflameRegalia"
  value: {
-  dps: 25938.474
-  tps: 18954.54693
+  dps: 25946.47428
+  tps: 18962.54722
  }
 }
 dps_results: {
@@ -1215,8 +1215,8 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 27462.47571
-  tps: 20089.10678
+  dps: 27472.20524
+  tps: 20098.83631
  }
 }
 dps_results: {
@@ -1257,15 +1257,15 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 28224.11236
-  tps: 20616.2025
+  dps: 28259.23143
+  tps: 20651.32157
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 28955.09941
-  tps: 21363.131
+  dps: 29065.94318
+  tps: 21473.97478
  }
 }
 dps_results: {
@@ -1418,182 +1418,182 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-Average-Default"
  value: {
-  dps: 28860.66401
-  tps: 21111.63823
+  dps: 28869.55198
+  tps: 21120.5262
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 29105.30892
-  tps: 29211.11679
+  dps: 29113.17302
+  tps: 29218.98089
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28146.09638
-  tps: 20811.32111
+  dps: 28155.00762
+  tps: 20820.23236
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p1-Affliction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 36194.71613
-  tps: 24021.16869
+  dps: 36203.89684
+  tps: 24030.34939
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p1-Affliction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 18751.78555
-  tps: 21425.57542
+  dps: 18756.75236
+  tps: 21430.54223
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p1-Affliction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 18751.78555
-  tps: 13629.67037
+  dps: 18756.75236
+  tps: 13634.63719
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p1-Affliction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 21443.40293
-  tps: 13091.70371
+  dps: 21454.50588
+  tps: 13102.80665
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 28848.65541
-  tps: 28813.57574
+  dps: 28857.22827
+  tps: 28822.1486
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 27979.74751
-  tps: 20623.82545
+  dps: 27987.8943
+  tps: 20631.97224
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p1-Affliction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 36331.3681
-  tps: 24273.98329
+  dps: 36336.994
+  tps: 24279.60919
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p1-Affliction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 18573.82727
-  tps: 21257.48303
+  dps: 18578.75999
+  tps: 21262.41576
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p1-Affliction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 18573.82727
-  tps: 13461.57799
+  dps: 18578.75999
+  tps: 13466.51071
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p1-Affliction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 21339.60642
-  tps: 12973.61424
+  dps: 21349.6781
+  tps: 12983.68593
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 29453.88984
-  tps: 28992.93466
+  dps: 29462.49181
+  tps: 29001.53663
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28585.84371
-  tps: 20804.39172
+  dps: 28594.00145
+  tps: 20812.54946
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p1-Affliction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 35870.13023
-  tps: 24295.65662
+  dps: 35879.16502
+  tps: 24304.69141
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p1-Affliction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 19007.61533
-  tps: 21378.72221
+  dps: 19012.56226
+  tps: 21383.66914
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p1-Affliction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 19007.61533
-  tps: 13581.9266
+  dps: 19012.56226
+  tps: 13586.87353
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p1-Affliction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 21133.89438
-  tps: 13181.82292
+  dps: 21139.88727
+  tps: 13187.81581
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 29165.10489
-  tps: 29188.79265
+  dps: 29174.24651
+  tps: 29197.93427
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p1-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28239.14249
-  tps: 20906.8622
+  dps: 28249.11976
+  tps: 20916.83947
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p1-Affliction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 36872.27252
-  tps: 24689.1798
+  dps: 36884.08018
+  tps: 24700.98745
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p1-Affliction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 18839.53613
-  tps: 21513.59137
+  dps: 18844.16514
+  tps: 21518.22038
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p1-Affliction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 18839.53613
-  tps: 13675.77285
+  dps: 18844.16514
+  tps: 13680.40186
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p1-Affliction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 22026.0208
-  tps: 13686.48677
+  dps: 22034.09878
+  tps: 13694.56474
  }
 }
 dps_results: {
  key: "TestAffliction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 28472.78643
-  tps: 20804.39172
+  dps: 28480.94417
+  tps: 20812.54946
  }
 }

--- a/sim/warlock/demonology/TestDemonology.results
+++ b/sim/warlock/demonology/TestDemonology.results
@@ -38,8 +38,8 @@ character_stats_results: {
 dps_results: {
  key: "TestDemonology-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 30479.102
-  tps: 15371.13584
+  dps: 30489.77521
+  tps: 15381.80905
  }
 }
 dps_results: {
@@ -87,15 +87,15 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 30278.54005
-  tps: 15219.08305
+  dps: 30288.90239
+  tps: 15229.4454
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Balespider'sBurningVestments"
  value: {
-  dps: 30407.13834
-  tps: 15031.32467
+  dps: 30419.12072
+  tps: 15043.30705
  }
 }
 dps_results: {
@@ -221,8 +221,8 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 30447.72432
-  tps: 15008.9693
+  dps: 30458.11473
+  tps: 15019.1519
  }
 }
 dps_results: {
@@ -235,15 +235,15 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 30650.00265
-  tps: 15456.64507
+  dps: 30660.70476
+  tps: 15467.34719
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 30550.7437
-  tps: 15403.7026
+  dps: 30561.41692
+  tps: 15414.37581
  }
 }
 dps_results: {
@@ -319,8 +319,8 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 30347.56104
-  tps: 15250.08015
+  dps: 30357.92339
+  tps: 15260.4425
  }
 }
 dps_results: {
@@ -340,8 +340,8 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 30278.54005
-  tps: 15219.08305
+  dps: 30288.90239
+  tps: 15229.4454
  }
 }
 dps_results: {
@@ -354,15 +354,15 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 30447.72432
-  tps: 15309.24009
+  dps: 30458.11473
+  tps: 15319.63049
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 30347.56104
-  tps: 15250.08015
+  dps: 30357.92339
+  tps: 15260.4425
  }
 }
 dps_results: {
@@ -389,8 +389,8 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 30278.54005
-  tps: 15219.08305
+  dps: 30288.90239
+  tps: 15229.4454
  }
 }
 dps_results: {
@@ -452,8 +452,8 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 30278.54005
-  tps: 15219.06341
+  dps: 30288.90239
+  tps: 15229.42575
  }
 }
 dps_results: {
@@ -466,8 +466,8 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 30447.72432
-  tps: 15303.35228
+  dps: 30458.11473
+  tps: 15313.74269
  }
 }
 dps_results: {
@@ -501,8 +501,8 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 24752.21356
-  tps: 12365.30029
+  dps: 24760.90595
+  tps: 12373.99268
  }
 }
 dps_results: {
@@ -529,8 +529,8 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-HarmlightToken-63839"
  value: {
-  dps: 29061.2286
-  tps: 14751.03094
+  dps: 29079.36814
+  tps: 14769.17049
  }
 }
 dps_results: {
@@ -606,8 +606,8 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 30347.56104
-  tps: 15250.08015
+  dps: 30357.92339
+  tps: 15260.4425
  }
 }
 dps_results: {
@@ -907,8 +907,8 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 30278.54005
-  tps: 15219.08305
+  dps: 30288.90239
+  tps: 15229.4454
  }
 }
 dps_results: {
@@ -942,15 +942,15 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 30479.102
-  tps: 15371.13584
+  dps: 30489.77521
+  tps: 15381.80905
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 30479.102
-  tps: 15371.05335
+  dps: 30489.77521
+  tps: 15381.72657
  }
 }
 dps_results: {
@@ -1005,8 +1005,8 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-ShadowflameRegalia"
  value: {
-  dps: 27745.3042
-  tps: 14001.00412
+  dps: 27755.58853
+  tps: 14011.28846
  }
 }
 dps_results: {
@@ -1215,8 +1215,8 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 27215.08257
-  tps: 14820.41373
+  dps: 27226.02019
+  tps: 14831.35136
  }
 }
 dps_results: {
@@ -1257,15 +1257,15 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 29513.96717
-  tps: 15236.93695
+  dps: 29549.71205
+  tps: 15272.68183
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 30433.64871
-  tps: 15953.81254
+  dps: 30543.11822
+  tps: 16063.28205
  }
 }
 dps_results: {
@@ -1418,182 +1418,182 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Average-Default"
  value: {
-  dps: 30784.1056
-  tps: 15616.42303
+  dps: 30795.87059
+  tps: 15628.18803
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p1-Demonology Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 45325.03428
-  tps: 41392.84133
+  dps: 45340.25643
+  tps: 41408.06347
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p1-Demonology Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29846.47308
-  tps: 15404.63179
+  dps: 29861.59026
+  tps: 15419.74897
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p1-Demonology Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 47636.66714
-  tps: 22964.67148
+  dps: 47659.09751
+  tps: 22987.10184
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p1-Demonology Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 30536.26253
-  tps: 30130.4028
+  dps: 30542.37808
+  tps: 30136.51835
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p1-Demonology Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 21186.64187
-  tps: 10754.09497
+  dps: 21192.75742
+  tps: 10760.21052
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p1-Demonology Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 29174.37624
-  tps: 12921.25662
+  dps: 29181.26077
+  tps: 12928.14114
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p1-Demonology Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 44804.08173
-  tps: 40803.88636
+  dps: 44816.99412
+  tps: 40816.79874
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p1-Demonology Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29693.31568
-  tps: 15246.06692
+  dps: 29704.95269
+  tps: 15257.70393
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p1-Demonology Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 47129.53804
-  tps: 22755.90509
+  dps: 47145.77666
+  tps: 22772.14371
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p1-Demonology Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 30248.91805
-  tps: 29839.25601
+  dps: 30254.46746
+  tps: 29844.80542
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p1-Demonology Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20992.05993
-  tps: 10638.09738
+  dps: 20997.60934
+  tps: 10643.64679
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p1-Demonology Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 28826.33592
-  tps: 12652.39482
+  dps: 28837.54465
+  tps: 12663.60355
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p1-Demonology Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 46197.32962
-  tps: 41381.19729
+  dps: 46209.93205
+  tps: 41393.79972
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p1-Demonology Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 30650.00265
-  tps: 15456.64507
+  dps: 30660.70476
+  tps: 15467.34719
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p1-Demonology Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 48912.76682
-  tps: 23093.8644
+  dps: 48929.00306
+  tps: 23110.10063
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p1-Demonology Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 31311.24577
-  tps: 30371.24285
+  dps: 31317.7704
+  tps: 30377.76748
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p1-Demonology Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 21690.81423
-  tps: 10765.83878
+  dps: 21697.33886
+  tps: 10772.36341
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p1-Demonology Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 30093.22634
-  tps: 12861.09506
+  dps: 30104.43343
+  tps: 12872.30214
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p1-Demonology Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 46773.7499
-  tps: 42658.48401
+  dps: 46786.8964
+  tps: 42671.63051
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p1-Demonology Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 30038.1814
-  tps: 15616.24449
+  dps: 30051.61476
+  tps: 15629.67784
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p1-Demonology Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 48734.30621
-  tps: 23917.78639
+  dps: 48753.06695
+  tps: 23936.54713
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p1-Demonology Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 31517.51802
-  tps: 30923.19751
+  dps: 31524.20207
+  tps: 30929.88156
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p1-Demonology Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 21377.79822
-  tps: 10859.51354
+  dps: 21384.48227
+  tps: 10866.19759
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p1-Demonology Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 30486.63239
-  tps: 13774.83395
+  dps: 30496.52683
+  tps: 13784.72839
  }
 }
 dps_results: {
  key: "TestDemonology-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 30500.73363
-  tps: 15456.64507
+  dps: 30511.43575
+  tps: 15467.34719
  }
 }

--- a/sim/warlock/destruction/TestDestruction.results
+++ b/sim/warlock/destruction/TestDestruction.results
@@ -38,8 +38,8 @@ character_stats_results: {
 dps_results: {
  key: "TestDestruction-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 29420.75624
-  tps: 19058.80791
+  dps: 29432.34848
+  tps: 19070.40015
  }
 }
 dps_results: {
@@ -87,15 +87,15 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 29136.56103
-  tps: 18850.14413
+  dps: 29147.43659
+  tps: 18861.01969
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Balespider'sBurningVestments"
  value: {
-  dps: 25337.2033
-  tps: 15526.13359
+  dps: 25350.89583
+  tps: 15539.82612
  }
 }
 dps_results: {
@@ -221,8 +221,8 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 29291.45282
-  tps: 18585.99131
+  dps: 29303.12994
+  tps: 18597.43489
  }
 }
 dps_results: {
@@ -235,15 +235,15 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 29577.5445
-  tps: 19163.02943
+  dps: 29589.57194
+  tps: 19175.05687
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 29478.98445
-  tps: 19100.85647
+  dps: 29491.33634
+  tps: 19113.20836
  }
 }
 dps_results: {
@@ -319,8 +319,8 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 29191.63627
-  tps: 18886.51958
+  dps: 29203.62839
+  tps: 18898.5117
  }
 }
 dps_results: {
@@ -340,8 +340,8 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 29136.56103
-  tps: 18850.14413
+  dps: 29147.43659
+  tps: 18861.01969
  }
 }
 dps_results: {
@@ -354,15 +354,15 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 29316.10612
-  tps: 18984.77923
+  dps: 29327.73364
+  tps: 18996.40675
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 29191.63627
-  tps: 18886.51958
+  dps: 29203.62839
+  tps: 18898.5117
  }
 }
 dps_results: {
@@ -389,8 +389,8 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 29136.56103
-  tps: 18850.14413
+  dps: 29147.43659
+  tps: 18861.01969
  }
 }
 dps_results: {
@@ -452,8 +452,8 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 29199.83993
-  tps: 18891.85831
+  dps: 29211.1331
+  tps: 18903.15148
  }
 }
 dps_results: {
@@ -466,8 +466,8 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 29291.45282
-  tps: 18949.65206
+  dps: 29303.12994
+  tps: 18961.32918
  }
 }
 dps_results: {
@@ -501,8 +501,8 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 21439.26119
-  tps: 13524.54725
+  dps: 21450.06553
+  tps: 13535.35159
  }
 }
 dps_results: {
@@ -529,8 +529,8 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-HarmlightToken-63839"
  value: {
-  dps: 28193.2409
-  tps: 18350.28365
+  dps: 28206.46928
+  tps: 18363.51203
  }
 }
 dps_results: {
@@ -606,8 +606,8 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 29191.63627
-  tps: 18886.51958
+  dps: 29203.62839
+  tps: 18898.5117
  }
 }
 dps_results: {
@@ -907,8 +907,8 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 29136.56103
-  tps: 18850.14413
+  dps: 29147.43659
+  tps: 18861.01969
  }
 }
 dps_results: {
@@ -942,15 +942,15 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 29420.75624
-  tps: 19058.80791
+  dps: 29432.34848
+  tps: 19070.40015
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 29420.75624
-  tps: 19058.79898
+  dps: 29432.34848
+  tps: 19070.39122
  }
 }
 dps_results: {
@@ -1005,8 +1005,8 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-ShadowflameRegalia"
  value: {
-  dps: 26741.45353
-  tps: 17338.00731
+  dps: 26754.26642
+  tps: 17350.8202
  }
 }
 dps_results: {
@@ -1215,8 +1215,8 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 28235.28801
-  tps: 18396.93239
+  dps: 28242.0869
+  tps: 18403.73128
  }
 }
 dps_results: {
@@ -1257,15 +1257,15 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 29014.1718
-  tps: 18960.26042
+  dps: 29048.64625
+  tps: 18994.73487
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 29730.91062
-  tps: 19565.41333
+  dps: 29824.60529
+  tps: 19659.108
  }
 }
 dps_results: {
@@ -1418,182 +1418,182 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-Average-Default"
  value: {
-  dps: 29975.72287
-  tps: 19514.5603
+  dps: 29988.9574
+  tps: 19527.79483
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Goblin-p1-Destruction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 30932.13499
-  tps: 35541.53281
+  dps: 30944.55015
+  tps: 35553.94797
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Goblin-p1-Destruction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29232.03221
-  tps: 19116.66568
+  dps: 29243.24577
+  tps: 19127.87924
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Goblin-p1-Destruction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 39606.59339
-  tps: 23811.61334
+  dps: 39628.43095
+  tps: 23833.4509
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Goblin-p1-Destruction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 18871.38948
-  tps: 26030.27767
+  dps: 18878.3363
+  tps: 26037.2245
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Goblin-p1-Destruction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 18871.38948
-  tps: 12414.26859
+  dps: 18878.3363
+  tps: 12421.21542
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Goblin-p1-Destruction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 22010.13303
-  tps: 13069.64738
+  dps: 22023.66669
+  tps: 13083.18104
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p1-Destruction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 30774.66502
-  tps: 35336.65379
+  dps: 30788.26856
+  tps: 35350.25733
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p1-Destruction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29037.21811
-  tps: 19007.92888
+  dps: 29049.20842
+  tps: 19019.91918
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p1-Destruction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 39626.13596
-  tps: 23787.44984
+  dps: 39644.20571
+  tps: 23805.5196
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p1-Destruction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 18803.87743
-  tps: 25773.68552
+  dps: 18811.39643
+  tps: 25781.20452
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p1-Destruction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 18803.87743
-  tps: 12454.59356
+  dps: 18811.39643
+  tps: 12462.11256
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p1-Destruction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 21866.92854
-  tps: 13037.37585
+  dps: 21879.11477
+  tps: 13049.56207
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p1-Destruction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 31317.48938
-  tps: 35487.62972
+  dps: 31331.13957
+  tps: 35501.27991
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p1-Destruction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29577.5445
-  tps: 19163.02943
+  dps: 29589.57194
+  tps: 19175.05687
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p1-Destruction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 40726.16363
-  tps: 24089.32292
+  dps: 40744.3767
+  tps: 24107.53598
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p1-Destruction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 19179.57248
-  tps: 25799.13976
+  dps: 19187.0579
+  tps: 25806.62518
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p1-Destruction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 19179.57248
-  tps: 12549.00792
+  dps: 19187.0579
+  tps: 12556.49334
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p1-Destruction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 22577.43887
-  tps: 13212.5835
+  dps: 22589.74275
+  tps: 13224.88738
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p1-Destruction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 31071.36748
-  tps: 35900.62111
+  dps: 31084.99479
+  tps: 35914.24842
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p1-Destruction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29388.11391
-  tps: 19261.43189
+  dps: 29399.58917
+  tps: 19272.90715
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p1-Destruction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 40315.17852
-  tps: 24200.93926
+  dps: 40336.6087
+  tps: 24222.36944
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p1-Destruction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 19040.28597
-  tps: 26183.56555
+  dps: 19049.27039
+  tps: 26192.54997
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p1-Destruction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 19040.28597
-  tps: 12567.60874
+  dps: 19049.27039
+  tps: 12576.59316
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p1-Destruction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 22810.04684
-  tps: 13647.78941
+  dps: 22824.72289
+  tps: 13662.46545
  }
 }
 dps_results: {
  key: "TestDestruction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 29570.38563
-  tps: 19163.02943
+  dps: 29582.41307
+  tps: 19175.05687
  }
 }

--- a/sim/warlock/warlock.go
+++ b/sim/warlock/warlock.go
@@ -237,6 +237,7 @@ const (
 	PetExpertiseScale = 1.53 * core.ExpertisePerQuarterPercentReduction
 )
 
+func (warlock *Warlock) GetDefaultSpellValueProvider() core.DefaultSpellValueProvider { return warlock }
 func (warlock *Warlock) DefaultSpellCritMultiplier() float64 {
 	return warlock.SpellCritMultiplier(1.33, 0.0)
 }

--- a/sim/warrior/warrior.go
+++ b/sim/warrior/warrior.go
@@ -236,3 +236,5 @@ func (warrior *Warrior) GetCriticalBlockChance() float64 {
 type WarriorAgent interface {
 	GetWarrior() *Warrior
 }
+
+func (warrior *Warrior) GetDefaultSpellValueProvider() core.DefaultSpellValueProvider { return warrior }


### PR DESCRIPTION
During some PTR data evaluation it became apparant that the class specific default multiplier were not used correctly for spells defined outside the actual class folders. This is due to the non-oop nature of go.

I tried to define a proper interface and use it where necessary. Feel free to propose a different aproach. This is fairly new terretory for me in go ;).