### PR TITLE
[WARRIOR][UI] Fix Prot block percent & add toughness to UI stats

### DIFF
--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -32,7 +32,7 @@ character_stats_results: {
   final_stats: 0.84923
   final_stats: 9.05356
   final_stats: 5.65261
-  final_stats: 40.74737
+  final_stats: 51.08467
  }
 }
 dps_results: {
@@ -1494,9 +1494,9 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-Average-Default"
  value: {
-  dps: 14534.94697
-  tps: 83733.08016
-  dtps: 16484.81524
+  dps: 14602.09556
+  tps: 84072.35717
+  dtps: 15380.8344
  }
 }
 dps_results: {
@@ -1586,8 +1586,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 16804.34167
-  tps: 96746.89516
-  dtps: 16435.41698
+  dps: 17016.52071
+  tps: 97797.75866
+  dtps: 15374.71046
  }
 }

--- a/sim/warrior/protection/protection.go
+++ b/sim/warrior/protection/protection.go
@@ -80,7 +80,7 @@ func (war *ProtectionWarrior) RegisterSpecializationEffects() {
 
 	// Sentinel stat buffs
 	war.MultiplyStat(stats.Stamina, 1.15)
-	war.MultiplyStat(stats.BlockPercent, 1.15)
+	war.AddStat(stats.BlockPercent, 15)
 
 	// Vengeance
 	core.ApplyVengeanceEffect(war.GetCharacter(), &war.VengeanceTracker, 93098)

--- a/ui/warrior/protection/sim.ts
+++ b/ui/warrior/protection/sim.ts
@@ -6,7 +6,7 @@ import { Player } from '../../core/player.js';
 import { PlayerClasses } from '../../core/player_classes';
 import { APLRotation } from '../../core/proto/apl.js';
 import { Debuffs, Faction, IndividualBuffs, PartyBuffs, PseudoStat, Race, RaidBuffs, Spec, Stat } from '../../core/proto/common.js';
-import { UnitStat } from '../../core/proto_utils/stats.js';
+import { Stats, UnitStat } from '../../core/proto_utils/stats.js';
 import * as ProtectionWarriorInputs from '../inputs.js';
 import * as Presets from './presets.js';
 
@@ -65,6 +65,20 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecProtectionWarrior, {
 			PseudoStat.PseudoStatParryPercent,
 		],
 	),
+
+	modifyDisplayStats: (player: Player<Spec.SpecProtectionWarrior>) => {
+		const playerStats = player.getCurrentStats();
+		const gearStats = Stats.fromProto(playerStats.gearStats);
+		const gearArmor = gearStats.getStat(Stat.StatArmor);
+		const gearBonusArmor = gearStats.getStat(Stat.StatBonusArmor);
+
+		const toughnessValues = [0, 0.03, 0.06, 0.1];
+		const talentsMod = new Stats().addStat(Stat.StatArmor, (gearArmor - gearBonusArmor) * toughnessValues[player.getTalents().toughness]);
+
+		return {
+			talents: talentsMod,
+		};
+	},
 
 	defaults: {
 		// Default equipped gear.


### PR DESCRIPTION
- Sentinel has a fixed 15% block, not multiplicative
- Added Toughness to be included in the UI's Armor values