### PR TITLE
Fix potential DR-ed Parry issue

### DIFF
--- a/sim/death_knight/dancing_rune_weapon.go
+++ b/sim/death_knight/dancing_rune_weapon.go
@@ -35,12 +35,17 @@ func (dk *DeathKnight) registerDancingRuneWeaponSpell() {
 	hasGlyph := dk.HasMajorGlyph(proto.DeathKnightMajorGlyph_GlyphOfDancingRuneWeapon)
 
 	hasT12Set := dk.HasSetBonus(ItemSetElementiumDeathplateBattlearmor, 4)
-	t124PAura := dk.NewTemporaryStatsAura(
-		"Flaming Rune Weapon",
-		core.ActionID{SpellID: 101162},
-		stats.Stats{stats.ParryRating: 15 * core.ParryRatingPerParryPercent},
-		time.Second*12,
-	)
+	t124PAura := dk.RegisterAura(core.Aura{
+		Label:    "Flaming Rune Weapon",
+		ActionID: core.ActionID{SpellID: 101162},
+		Duration: time.Second * 12,
+		OnGain: func(aura *core.Aura, sim *core.Simulation) {
+			dk.PseudoStats.BaseParryChance += 0.15
+		},
+		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
+			dk.PseudoStats.BaseParryChance -= 0.15
+		},
+	})
 
 	dancingRuneWeaponAura := dk.RegisterAura(core.Aura{
 		Label:    "Dancing Rune Weapon",
@@ -58,13 +63,13 @@ func (dk *DeathKnight) registerDancingRuneWeaponSpell() {
 			copySpell.Cast(sim, dk.CurrentTarget)
 		},
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
-			dk.AddStatDynamic(sim, stats.ParryRating, 20*core.ParryRatingPerParryPercent)
+			dk.PseudoStats.BaseParryChance += 0.20
 			if hasGlyph {
 				dk.PseudoStats.ThreatMultiplier *= 1.5
 			}
 		},
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
-			dk.AddStatDynamic(sim, stats.ParryRating, -20*core.ParryRatingPerParryPercent)
+			dk.PseudoStats.BaseParryChance -= 0.20
 			if hasGlyph {
 				dk.PseudoStats.ThreatMultiplier /= 1.5
 			}

--- a/sim/paladin/items.go
+++ b/sim/paladin/items.go
@@ -174,10 +174,10 @@ var ItemSetBattlearmorOfImmolation = core.NewItemSet(core.ItemSet{
 				Duration: time.Second * 10,
 
 				OnGain: func(aura *core.Aura, sim *core.Simulation) {
-					paladin.AddStatDynamic(sim, stats.ParryRating, 12*core.ParryRatingPerParryPercent)
+					paladin.PseudoStats.BaseParryChance += 0.12
 				},
 				OnExpire: func(aura *core.Aura, sim *core.Simulation) {
-					paladin.AddStatDynamic(sim, stats.ParryRating, -12*core.ParryRatingPerParryPercent)
+					paladin.PseudoStats.BaseParryChance -= 0.12
 				},
 			})
 

--- a/sim/warrior/items.go
+++ b/sim/warrior/items.go
@@ -228,10 +228,10 @@ var ItemSetMoltenGiantBattleplate = core.NewItemSet(core.ItemSet{
 				ActionID: core.ActionID{SpellID: 99242},
 				Duration: 10 * time.Second,
 				OnGain: func(aura *core.Aura, sim *core.Simulation) {
-					character.AddStatDynamic(sim, stats.ParryRating, 6*core.ParryRatingPerParryPercent)
+					character.PseudoStats.BaseParryChance += 0.6
 				},
 				OnExpire: func(aura *core.Aura, sim *core.Simulation) {
-					character.AddStatDynamic(sim, stats.ParryRating, -6*core.ParryRatingPerParryPercent)
+					character.PseudoStats.BaseParryChance -= 0.6
 				},
 			})
 

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -23,7 +23,7 @@ character_stats_results: {
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 33491
+  final_stats: 36815.1
   final_stats: 250
   final_stats: 212806.14125
   final_stats: 0
@@ -1494,9 +1494,9 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-Average-Default"
  value: {
-  dps: 14602.09556
-  tps: 84072.35717
-  dtps: 15380.8344
+  dps: 14601.31684
+  tps: 84069.77166
+  dtps: 15399.9476
  }
 }
 dps_results: {
@@ -1586,8 +1586,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 17016.52071
-  tps: 97797.75866
-  dtps: 15374.71046
+  dps: 16995.35369
+  tps: 97732.05209
+  dtps: 15407.7729
  }
 }

--- a/sim/warrior/talents.go
+++ b/sim/warrior/talents.go
@@ -227,7 +227,7 @@ func (warrior *Warrior) applyToughness() {
 	if warrior.Talents.Toughness == 0 {
 		return
 	}
-	warrior.PseudoStats.ArmorMultiplier *= 1.0 + []float64{0.0, 0.03, 0.06, 0.1}[warrior.Talents.Toughness]
+	warrior.ApplyEquipScaling(stats.Armor, []float64{1.0, 1.03, 1.06, 1.1}[warrior.Talents.Toughness])
 }
 
 func (warrior *Warrior) applyBloodAndThunder() {

--- a/ui/warrior/protection/sim.ts
+++ b/ui/warrior/protection/sim.ts
@@ -6,7 +6,7 @@ import { Player } from '../../core/player.js';
 import { PlayerClasses } from '../../core/player_classes';
 import { APLRotation } from '../../core/proto/apl.js';
 import { Debuffs, Faction, IndividualBuffs, PartyBuffs, PseudoStat, Race, RaidBuffs, Spec, Stat } from '../../core/proto/common.js';
-import { Stats, UnitStat } from '../../core/proto_utils/stats.js';
+import { UnitStat } from '../../core/proto_utils/stats.js';
 import * as ProtectionWarriorInputs from '../inputs.js';
 import * as Presets from './presets.js';
 
@@ -65,20 +65,6 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecProtectionWarrior, {
 			PseudoStat.PseudoStatParryPercent,
 		],
 	),
-
-	modifyDisplayStats: (player: Player<Spec.SpecProtectionWarrior>) => {
-		const playerStats = player.getCurrentStats();
-		const gearStats = Stats.fromProto(playerStats.gearStats);
-		const gearArmor = gearStats.getStat(Stat.StatArmor);
-		const gearBonusArmor = gearStats.getStat(Stat.StatBonusArmor);
-
-		const toughnessValues = [0, 0.03, 0.06, 0.1];
-		const talentsMod = new Stats().addStat(Stat.StatArmor, (gearArmor - gearBonusArmor) * toughnessValues[player.getTalents().toughness]);
-
-		return {
-			talents: talentsMod,
-		};
-	},
 
 	defaults: {
 		// Default equipped gear.


### PR DESCRIPTION
According to the tooltips of the following abilities they scale % wise. Most of these according to @NerdEgghead should scale with the Base parry chance which is non-DR.

- Warrior: https://www.wowhead.com/cata/spell=99242/item-warrior-t12-protection-4p-bonus
- Paladin: https://www.wowhead.com/cata/spell=99090/flaming-aegis
- DK: https://www.wowhead.com/cata/spell=49028/dancing-rune-weapon
- DK: https://www.wowhead.com/cata/spell=101162/flaming-rune-weapon