### PR TITLE
Add missing trinket implementations

### DIFF
--- a/sim/common/cata/other_effects.go
+++ b/sim/common/cata/other_effects.go
@@ -691,7 +691,7 @@ func registerApparatusOfKhazGoroth(config apparatusConfig) {
 			Cast: core.CastConfig{
 				SharedCD: core.Cooldown{
 					Timer:    character.GetOffensiveTrinketCD(),
-					Duration: time.Second * 15,
+					Duration: time.Second * 20,
 				},
 				CD: core.Cooldown{
 					Timer:    character.NewTimer(),
@@ -816,7 +816,7 @@ func RegisterIgniteEffect(unit *core.Unit, config IgniteConfig) *core.Spell {
 			applyDotAt := sim.CurrentTime + waitTime
 
 			// Check for max duration munching
-			if dot.RemainingDuration(sim) > time.Second*4 + waitTime {
+			if dot.RemainingDuration(sim) > time.Second*4+waitTime {
 				if sim.Log != nil {
 					unit.Log(sim, "New %s proc was munched due to max %s duration", config.DotAuraLabel, config.DotAuraLabel)
 				}

--- a/sim/common/cata/other_effects.go
+++ b/sim/common/cata/other_effects.go
@@ -9,60 +9,6 @@ import (
 )
 
 func init() {
-	core.NewItemEffect(55816, func(agent core.Agent) {
-		character := agent.GetCharacter()
-		actionID := core.ActionID{SpellID: 92179}
-
-		procAura := character.NewTemporaryStatsAura("Leaden Despair Proc", actionID, stats.Stats{stats.Armor: 2580}, time.Second*10)
-
-		icd := core.Cooldown{
-			Timer:    character.NewTimer(),
-			Duration: time.Second * 30,
-		}
-		procAura.Icd = &icd
-
-		core.MakeProcTriggerAura(&character.Unit, core.ProcTrigger{
-			Name:     "Leaden Despair Trigger",
-			Callback: core.CallbackOnSpellHitTaken,
-			ProcMask: core.ProcMaskDirect,
-			ActionID: core.ActionID{ItemID: 55816},
-			Harmful:  true,
-			Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellResult) {
-				if icd.IsReady(sim) && character.CurrentHealthPercent() < 0.35 {
-					icd.Use(sim)
-					procAura.Activate(sim)
-				}
-			},
-		})
-	})
-
-	core.NewItemEffect(56347, func(agent core.Agent) {
-		character := agent.GetCharacter()
-		actionID := core.ActionID{SpellID: 92184}
-
-		procAura := character.NewTemporaryStatsAura("Leaden Despair (Heroic) Proc", actionID, stats.Stats{stats.Armor: 3420}, time.Second*10)
-
-		icd := core.Cooldown{
-			Timer:    character.NewTimer(),
-			Duration: time.Second * 30,
-		}
-		procAura.Icd = &icd
-
-		core.MakeProcTriggerAura(&character.Unit, core.ProcTrigger{
-			Name:     "Leaden Despair (Heroic) Trigger",
-			Callback: core.CallbackOnSpellHitTaken,
-			ProcMask: core.ProcMaskDirect,
-			ActionID: core.ActionID{ItemID: 56347},
-			Harmful:  true,
-			Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellResult) {
-				if icd.IsReady(sim) && character.CurrentHealthPercent() < 0.35 {
-					icd.Use(sim)
-					procAura.Activate(sim)
-				}
-			},
-		})
-	})
-
 	core.NewItemEffect(63839, func(agent core.Agent) {
 		character := agent.GetCharacter()
 		spreadDot := character.RegisterSpell(core.SpellConfig{
@@ -262,475 +208,333 @@ func init() {
 		})
 	})
 
-	core.NewItemEffect(59514, func(agent core.Agent) {
-		character := agent.GetCharacter()
+	for _, hc := range []bool{false, true} {
+		heroic := hc // Need to copy value because iterator variables are not captured by closure
+		labelSuffix := core.Ternary(heroic, " (Heroic)", "")
 
-		procAura := core.MakeStackingAura(character, core.StackingStatAura{
-			Aura: core.Aura{
-				Label:     "Heart's Revelation",
-				ActionID:  core.ActionID{SpellID: 91027},
-				Duration:  time.Second * 15,
-				MaxStacks: 5,
-			},
-			BonusPerStack: stats.Stats{stats.SpellPower: 77},
-		})
+		leadenItemID := core.TernaryInt32(heroic, 56347, 55816)
+		core.NewItemEffect(leadenItemID, func(agent core.Agent) {
+			character := agent.GetCharacter()
+			actionID := core.ActionID{SpellID: core.TernaryInt32(heroic, 92184, 92179)}
+			armorBonus := core.TernaryFloat64(heroic, 3420, 2580)
 
-		core.MakePermanent(core.MakeProcTriggerAura(&character.Unit, core.ProcTrigger{
-			Name:       "Heart of Ignacious Aura",
-			ActionID:   core.ActionID{ItemID: 59514},
-			Callback:   core.CallbackOnSpellHitDealt,
-			ProcMask:   core.ProcMaskSpellDamage,
-			ProcChance: 1,
-			Outcome:    core.OutcomeLanded,
-			ICD:        time.Second * 2,
-			Handler: func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-				procAura.Activate(sim)
-				procAura.AddStack(sim)
-			},
-		}))
+			procAura := character.NewTemporaryStatsAura("Leaden Despair Proc"+labelSuffix, actionID, stats.Stats{stats.Armor: armorBonus}, time.Second*10)
 
-		buffAura := character.RegisterAura(core.Aura{
-			Label:     "Heart's Judgement",
-			ActionID:  core.ActionID{SpellID: 91041},
-			Duration:  time.Second * 20,
-			MaxStacks: 5,
-			OnStacksChange: func(aura *core.Aura, sim *core.Simulation, oldStacks, newStacks int32) {
-				deltaHasteRating := float64(321) * float64(newStacks-oldStacks)
-				character.AddStatDynamic(sim, stats.HasteRating, deltaHasteRating)
-			},
-		})
+			icd := core.Cooldown{
+				Timer:    character.NewTimer(),
+				Duration: time.Second * 30,
+			}
+			procAura.Icd = &icd
 
-		sharedCD := character.GetOffensiveTrinketCD()
-		trinketSpell := character.RegisterSpell(core.SpellConfig{
-			ActionID:    core.ActionID{ItemID: 59514},
-			SpellSchool: core.SpellSchoolPhysical,
-			ProcMask:    core.ProcMaskEmpty,
-			Flags:       core.SpellFlagNoOnCastComplete,
-			Cast: core.CastConfig{
-				SharedCD: core.Cooldown{
-					Timer:    sharedCD,
-					Duration: time.Second * 20,
+			core.MakeProcTriggerAura(&character.Unit, core.ProcTrigger{
+				Name:     "Leaden Despair Trigger" + labelSuffix,
+				Callback: core.CallbackOnSpellHitTaken,
+				ProcMask: core.ProcMaskDirect,
+				ActionID: core.ActionID{ItemID: leadenItemID},
+				Harmful:  true,
+				Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellResult) {
+					if icd.IsReady(sim) && character.CurrentHealthPercent() < 0.35 {
+						icd.Use(sim)
+						procAura.Activate(sim)
+					}
 				},
-				CD: core.Cooldown{
-					Timer:    character.NewTimer(),
-					Duration: time.Minute * 2,
+			})
+		})
+
+		heartItemID := core.TernaryInt32(heroic, 65110, 59514)
+		core.NewItemEffect(heartItemID, func(agent core.Agent) {
+			character := agent.GetCharacter()
+
+			procAura := core.MakeStackingAura(character, core.StackingStatAura{
+				Aura: core.Aura{
+					Label:     "Heart's Revelation" + labelSuffix,
+					ActionID:  core.ActionID{SpellID: core.TernaryInt32(heroic, 92325, 91027)},
+					Duration:  time.Second * 15,
+					MaxStacks: 5,
 				},
-			},
-			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-				buffAura.Activate(sim)
-				buffAura.SetStacks(sim, procAura.GetStacks())
-				procAura.Deactivate(sim)
-			},
-		})
+				BonusPerStack: stats.Stats{stats.SpellPower: core.TernaryFloat64(heroic, 87, 77)},
+			})
 
-		character.AddMajorCooldown(core.MajorCooldown{
-			Spell:    trinketSpell,
-			Priority: core.CooldownPriorityDefault,
-			Type:     core.CooldownTypeDPS,
-			ShouldActivate: func(s *core.Simulation, c *core.Character) bool {
-				return procAura.GetStacks() == 5
-			},
-		})
-	})
-
-	core.NewItemEffect(65110, func(agent core.Agent) {
-		character := agent.GetCharacter()
-
-		procAura := core.MakeStackingAura(character, core.StackingStatAura{
-			Aura: core.Aura{
-				Label:     "Heart's Revelation (Heroic)",
-				ActionID:  core.ActionID{SpellID: 92325},
-				Duration:  time.Second * 15,
-				MaxStacks: 5,
-			},
-			BonusPerStack: stats.Stats{stats.SpellPower: 87},
-		})
-
-		core.MakePermanent(core.MakeProcTriggerAura(&character.Unit, core.ProcTrigger{
-			Name:       "Heart of Ignacious (Heroic) Aura",
-			ActionID:   core.ActionID{ItemID: 65110},
-			Callback:   core.CallbackOnSpellHitDealt,
-			ProcMask:   core.ProcMaskSpellDamage,
-			ProcChance: 1,
-			Outcome:    core.OutcomeLanded,
-			ICD:        time.Second * 2,
-			Handler: func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-				procAura.Activate(sim)
-				procAura.AddStack(sim)
-			},
-		}))
-
-		buffAura := character.RegisterAura(core.Aura{
-			Label:     "Heart's Judgement (Heroic)",
-			ActionID:  core.ActionID{SpellID: 92328},
-			Duration:  time.Second * 20,
-			MaxStacks: 5,
-			OnStacksChange: func(aura *core.Aura, sim *core.Simulation, oldStacks, newStacks int32) {
-				deltaHasteRating := float64(363) * float64(newStacks-oldStacks)
-				character.AddStatDynamic(sim, stats.HasteRating, deltaHasteRating)
-			},
-		})
-
-		sharedCD := character.GetOffensiveTrinketCD()
-		trinketSpell := character.RegisterSpell(core.SpellConfig{
-			ActionID:    core.ActionID{ItemID: 65110},
-			SpellSchool: core.SpellSchoolPhysical,
-			ProcMask:    core.ProcMaskEmpty,
-			Flags:       core.SpellFlagNoOnCastComplete,
-			Cast: core.CastConfig{
-				SharedCD: core.Cooldown{
-					Timer:    sharedCD,
-					Duration: time.Second * 20,
-				},
-				CD: core.Cooldown{
-					Timer:    character.NewTimer(),
-					Duration: time.Minute * 2,
-				},
-			},
-			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-				buffAura.Activate(sim)
-				buffAura.SetStacks(sim, procAura.GetStacks())
-				procAura.Deactivate(sim)
-			},
-		})
-
-		character.AddMajorCooldown(core.MajorCooldown{
-			Spell:    trinketSpell,
-			Priority: core.CooldownPriorityDefault,
-			Type:     core.CooldownTypeDPS,
-			ShouldActivate: func(s *core.Simulation, c *core.Character) bool {
-				return procAura.GetStacks() == 5
-			},
-		})
-	})
-
-	core.NewItemEffect(59354, func(agent core.Agent) {
-		character := agent.GetCharacter()
-
-		procAura := core.MakeStackingAura(character, core.StackingStatAura{
-			Aura: core.Aura{
-				Label:     "Inner Eye",
-				ActionID:  core.ActionID{SpellID: 91320},
-				Duration:  time.Second * 15,
-				MaxStacks: 5,
-				Icd: &core.Cooldown{
-					Timer:    character.NewTimer(),
-					Duration: time.Second * 30,
-				},
-			},
-			BonusPerStack: stats.Stats{stats.Spirit: 103},
-		})
-
-		core.MakePermanent(core.MakeProcTriggerAura(&character.Unit, core.ProcTrigger{
-			Name:       "Jar of Ancient Remedies Aura",
-			ActionID:   core.ActionID{ItemID: 59354},
-			Callback:   core.CallbackOnHealDealt,
-			ProcMask:   core.ProcMaskSpellHealing,
-			ProcChance: 1,
-			Outcome:    core.OutcomeLanded,
-			ICD:        time.Second * 2,
-			Handler: func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-				if procAura.Icd.IsReady(sim) {
+			core.MakePermanent(core.MakeProcTriggerAura(&character.Unit, core.ProcTrigger{
+				Name:       "Heart of Ignacious Aura" + labelSuffix,
+				ActionID:   core.ActionID{ItemID: heartItemID},
+				Callback:   core.CallbackOnSpellHitDealt,
+				ProcMask:   core.ProcMaskSpellDamage,
+				ProcChance: 1,
+				Outcome:    core.OutcomeLanded,
+				ICD:        time.Second * 2,
+				Handler: func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 					procAura.Activate(sim)
 					procAura.AddStack(sim)
-				}
-			},
-		}))
-
-		manaMetric := character.NewManaMetrics(core.ActionID{SpellID: 91322})
-		trinketSpell := character.RegisterSpell(core.SpellConfig{
-			ActionID:    core.ActionID{ItemID: 59461},
-			SpellSchool: core.SpellSchoolPhysical,
-			ProcMask:    core.ProcMaskEmpty,
-			Flags:       core.SpellFlagNoOnCastComplete,
-			Cast: core.CastConfig{
-				CD: core.Cooldown{
-					Timer:    character.NewTimer(),
-					Duration: time.Minute * 2,
 				},
-			},
-			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-				procAura.Deactivate(sim)
+			}))
 
-				// can not regain stacks for 30 seconds
-				procAura.Icd.Use(sim)
-				character.AddMana(sim, 6420, manaMetric)
-			},
-		})
-
-		character.AddMajorCooldown(core.MajorCooldown{
-			Spell:    trinketSpell,
-			Priority: core.CooldownPriorityDefault,
-			Type:     core.CooldownTypeMana,
-		})
-	})
-
-	core.NewItemEffect(65029, func(agent core.Agent) {
-		character := agent.GetCharacter()
-
-		procAura := core.MakeStackingAura(character, core.StackingStatAura{
-			Aura: core.Aura{
-				Label:     "Inner Eye (Heroic)",
-				ActionID:  core.ActionID{SpellID: 92329},
-				Duration:  time.Second * 15,
+			hastePerStack := core.TernaryFloat64(heroic, 363, 321)
+			buffAura := character.RegisterAura(core.Aura{
+				Label:     "Heart's Judgement" + labelSuffix,
+				ActionID:  core.ActionID{SpellID: core.TernaryInt32(heroic, 92328, 91041)},
+				Duration:  time.Second * 20,
 				MaxStacks: 5,
-				Icd: &core.Cooldown{
-					Timer:    character.NewTimer(),
-					Duration: time.Second * 30,
+				OnStacksChange: func(aura *core.Aura, sim *core.Simulation, oldStacks, newStacks int32) {
+					deltaHasteRating := hastePerStack * float64(newStacks-oldStacks)
+					character.AddStatDynamic(sim, stats.HasteRating, deltaHasteRating)
 				},
-			},
-			BonusPerStack: stats.Stats{stats.Spirit: 116},
-		})
+			})
 
-		core.MakePermanent(core.MakeProcTriggerAura(&character.Unit, core.ProcTrigger{
-			Name:       "Jar of Ancient Remedies (Heroic) Aura",
-			ActionID:   core.ActionID{ItemID: 65029},
-			Callback:   core.CallbackOnHealDealt,
-			ProcMask:   core.ProcMaskSpellHealing,
-			ProcChance: 1,
-			Outcome:    core.OutcomeLanded,
-			ICD:        time.Second * 2,
-			Handler: func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-				if procAura.Icd.IsReady(sim) {
-					procAura.Activate(sim)
-					procAura.AddStack(sim)
-				}
-			},
-		}))
-
-		manaMetric := character.NewManaMetrics(core.ActionID{SpellID: 92331})
-		trinketSpell := character.RegisterSpell(core.SpellConfig{
-			ActionID:    core.ActionID{ItemID: 65029},
-			SpellSchool: core.SpellSchoolPhysical,
-			ProcMask:    core.ProcMaskEmpty,
-			Flags:       core.SpellFlagNoOnCastComplete,
-			Cast: core.CastConfig{
-				CD: core.Cooldown{
-					Timer:    character.NewTimer(),
-					Duration: time.Minute * 2,
+			sharedCD := character.GetOffensiveTrinketCD()
+			trinketSpell := character.RegisterSpell(core.SpellConfig{
+				ActionID:    core.ActionID{ItemID: heartItemID},
+				SpellSchool: core.SpellSchoolPhysical,
+				ProcMask:    core.ProcMaskEmpty,
+				Flags:       core.SpellFlagNoOnCastComplete,
+				Cast: core.CastConfig{
+					SharedCD: core.Cooldown{
+						Timer:    sharedCD,
+						Duration: time.Second * 20,
+					},
+					CD: core.Cooldown{
+						Timer:    character.NewTimer(),
+						Duration: time.Minute * 2,
+					},
 				},
-			},
-			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-				procAura.Deactivate(sim)
-				// can not regain stacks for 30 seconds
-				procAura.Icd.Use(sim)
-				character.AddMana(sim, 7260, manaMetric)
-			},
+				ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
+					buffAura.Activate(sim)
+					buffAura.SetStacks(sim, procAura.GetStacks())
+					procAura.Deactivate(sim)
+				},
+			})
+
+			character.AddMajorCooldown(core.MajorCooldown{
+				Spell:    trinketSpell,
+				Priority: core.CooldownPriorityDefault,
+				Type:     core.CooldownTypeDPS,
+				ShouldActivate: func(s *core.Simulation, c *core.Character) bool {
+					return procAura.GetStacks() == 5
+				},
+			})
 		})
 
-		character.AddMajorCooldown(core.MajorCooldown{
-			Spell:    trinketSpell,
-			Priority: core.CooldownPriorityDefault,
-			Type:     core.CooldownTypeMana,
+		jarItemID := core.TernaryInt32(heroic, 65029, 59354)
+		core.NewItemEffect(jarItemID, func(agent core.Agent) {
+			character := agent.GetCharacter()
+
+			manaReturn := core.TernaryFloat64(heroic, 7260, 6420)
+
+			procAura := core.MakeStackingAura(character, core.StackingStatAura{
+				Aura: core.Aura{
+					Label:     "Inner Eye" + labelSuffix,
+					ActionID:  core.ActionID{SpellID: core.TernaryInt32(heroic, 91320, 92329)},
+					Duration:  time.Second * 15,
+					MaxStacks: 5,
+					Icd: &core.Cooldown{
+						Timer:    character.NewTimer(),
+						Duration: time.Second * 30,
+					},
+				},
+				BonusPerStack: stats.Stats{stats.Spirit: core.TernaryFloat64(heroic, 116, 103)},
+			})
+
+			core.MakePermanent(core.MakeProcTriggerAura(&character.Unit, core.ProcTrigger{
+				Name:       "Jar of Ancient Remedies Aura" + labelSuffix,
+				ActionID:   core.ActionID{ItemID: jarItemID},
+				Callback:   core.CallbackOnHealDealt,
+				ProcMask:   core.ProcMaskSpellHealing,
+				ProcChance: 1,
+				Outcome:    core.OutcomeLanded,
+				ICD:        time.Second * 2,
+				Handler: func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+					if procAura.Icd.IsReady(sim) {
+						procAura.Activate(sim)
+						procAura.AddStack(sim)
+					}
+				},
+			}))
+
+			manaMetric := character.NewManaMetrics(core.ActionID{SpellID: core.TernaryInt32(heroic, 92331, 91322)})
+			trinketSpell := character.RegisterSpell(core.SpellConfig{
+				ActionID:    core.ActionID{ItemID: jarItemID},
+				SpellSchool: core.SpellSchoolPhysical,
+				ProcMask:    core.ProcMaskEmpty,
+				Flags:       core.SpellFlagNoOnCastComplete,
+				Cast: core.CastConfig{
+					CD: core.Cooldown{
+						Timer:    character.NewTimer(),
+						Duration: time.Minute * 2,
+					},
+				},
+				ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
+					procAura.Deactivate(sim)
+					// can not regain stacks for 30 seconds
+					procAura.Icd.Use(sim)
+					character.AddMana(sim, manaReturn, manaMetric)
+				},
+			})
+
+			character.AddMajorCooldown(core.MajorCooldown{
+				Spell:    trinketSpell,
+				Priority: core.CooldownPriorityDefault,
+				Type:     core.CooldownTypeMana,
+			})
 		})
-	})
 
-	// Normal
-	registerApparatusOfKhazGoroth(apparatusConfig{
-		ItemID:        68972,
-		BonusPerStack: 508,
-	})
+		matrixItemID := core.TernaryInt32(heroic, 69150, 68994)
+		core.NewItemEffect(matrixItemID, func(agent core.Agent) {
+			character := agent.GetCharacter()
 
-	// Heroic
-	registerApparatusOfKhazGoroth(apparatusConfig{
-		ItemID:        69113,
-		BonusPerStack: 575,
-		Heroic:        true,
-	})
+			bonusStats := core.TernaryFloat64(heroic, 1834, 1624)
 
-	core.NewItemEffect(68994, func(agent core.Agent) {
-		character := agent.GetCharacter()
+			procAuraCrit := character.NewTemporaryStatsAura(
+				"Matrix Restabilizer Crit Proc"+labelSuffix,
+				core.ActionID{SpellID: core.TernaryInt32(heroic, 97140, 96978)},
+				stats.Stats{stats.CritRating: bonusStats},
+				time.Second*30)
+			procAuraHaste := character.NewTemporaryStatsAura(
+				"Matrix Restabilizer Haste Proc"+labelSuffix,
+				core.ActionID{SpellID: core.TernaryInt32(heroic, 97139, 96977)},
+				stats.Stats{stats.HasteRating: bonusStats},
+				time.Second*30)
+			procAuraMastery := character.NewTemporaryStatsAura(
+				"Matrix Restabilizer Mastery Proc"+labelSuffix,
+				core.ActionID{SpellID: core.TernaryInt32(heroic, 97141, 96979)},
+				stats.Stats{stats.MasteryRating: bonusStats},
+				time.Second*30)
 
-		bonusStats := 1624.0
-		procAuraCrit := character.NewTemporaryStatsAura("Matrix Restabilizer Crit Proc", core.ActionID{SpellID: 96978}, stats.Stats{stats.CritRating: bonusStats}, time.Second*30)
-		procAuraHaste := character.NewTemporaryStatsAura("Matrix Restabilizer Haste Proc", core.ActionID{SpellID: 96977}, stats.Stats{stats.HasteRating: bonusStats}, time.Second*30)
-		procAuraMastery := character.NewTemporaryStatsAura("Matrix Restabilizer Mastery Proc", core.ActionID{SpellID: 96979}, stats.Stats{stats.MasteryRating: bonusStats}, time.Second*30)
+			icd := core.Cooldown{
+				Timer:    character.NewTimer(),
+				Duration: time.Second * 105,
+			}
 
-		icd := core.Cooldown{
-			Timer:    character.NewTimer(),
-			Duration: time.Second * 105,
-		}
+			procAuraCrit.Icd = &icd
+			procAuraHaste.Icd = &icd
+			procAuraMastery.Icd = &icd
 
-		procAuraCrit.Icd = &icd
-		procAuraHaste.Icd = &icd
-		procAuraMastery.Icd = &icd
+			core.MakeProcTriggerAura(&character.Unit, core.ProcTrigger{
+				Name:       "Matrix Restabilizer Trigger" + labelSuffix,
+				Callback:   core.CallbackOnSpellHitDealt,
+				ProcMask:   core.ProcMaskMeleeOrRanged,
+				ProcChance: 0.2,
+				ActionID:   core.ActionID{ItemID: matrixItemID},
+				Harmful:    true,
+				Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellResult) {
+					if icd.IsReady(sim) {
+						statType := character.GetHighestStatType([]stats.Stat{stats.CritRating, stats.HasteRating, stats.MasteryRating})
+						switch statType {
+						case stats.CritRating:
+							procAuraCrit.Activate(sim)
+						case stats.HasteRating:
+							procAuraHaste.Activate(sim)
+						case stats.MasteryRating:
+							procAuraMastery.Activate(sim)
+						default:
+							panic("unexpected statType")
+						}
+						icd.Use(sim)
+					}
+				},
+			})
+		})
 
-		core.MakeProcTriggerAura(&character.Unit, core.ProcTrigger{
-			Name:       "Matrix Restabilizer Trigger",
-			Callback:   core.CallbackOnSpellHitDealt,
-			ProcMask:   core.ProcMaskMeleeOrRanged,
-			ProcChance: 0.2,
-			ActionID:   core.ActionID{ItemID: 68994},
-			Harmful:    true,
-			Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellResult) {
-				if icd.IsReady(sim) {
+		apparatusItemID := core.TernaryInt32(heroic, 69113, 68972)
+		core.NewItemEffect(apparatusItemID, func(agent core.Agent) {
+			character := agent.GetCharacter()
+
+			bonusPerStack := core.TernaryFloat64(heroic, 575, 508)
+			buffDuration := time.Second * 15
+
+			buffAuraCrit := character.NewTemporaryStatBuffWithStacks(
+				"Blessing of the Shaper Crit"+labelSuffix,
+				core.ActionID{SpellID: 96928},
+				stats.Stats{stats.CritRating: bonusPerStack},
+				5,
+				buffDuration)
+
+			buffAuraHaste := character.NewTemporaryStatBuffWithStacks(
+				"Blessing of the Shaper Haste"+labelSuffix,
+				core.ActionID{SpellID: 96927},
+				stats.Stats{stats.HasteRating: bonusPerStack},
+				5,
+				buffDuration)
+
+			buffAuraMastery := character.NewTemporaryStatBuffWithStacks(
+				"Blessing of the Shaper Mastery"+labelSuffix,
+				core.ActionID{SpellID: 96929},
+				stats.Stats{stats.MasteryRating: bonusPerStack},
+				5,
+				buffDuration)
+
+			titanicPower := character.RegisterAura(core.Aura{
+				Label:     "Titanic Power" + labelSuffix,
+				ActionID:  core.ActionID{SpellID: 96923},
+				Duration:  time.Second * 30,
+				MaxStacks: 5,
+			})
+
+			core.MakePermanent(core.MakeProcTriggerAura(&character.Unit, core.ProcTrigger{
+				Name:       "Titanic Power Aura" + labelSuffix,
+				ActionID:   core.ActionID{SpellID: 96924},
+				Callback:   core.CallbackOnSpellHitDealt,
+				ProcMask:   core.ProcMaskMelee,
+				ProcChance: 1,
+				Outcome:    core.OutcomeCrit,
+				Handler: func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+					if buffAuraCrit.IsActive() || buffAuraHaste.IsActive() || buffAuraMastery.IsActive() {
+						return
+					}
+
+					titanicPower.Activate(sim)
+					titanicPower.AddStack(sim)
+				},
+			}))
+
+			trinketSpell := character.RegisterSpell(core.SpellConfig{
+				ActionID:    core.ActionID{ItemID: apparatusItemID},
+				SpellSchool: core.SpellSchoolPhysical,
+				ProcMask:    core.ProcMaskEmpty,
+				Flags:       core.SpellFlagNoOnCastComplete,
+				Cast: core.CastConfig{
+					SharedCD: core.Cooldown{
+						Timer:    character.GetOffensiveTrinketCD(),
+						Duration: time.Second * 20,
+					},
+					CD: core.Cooldown{
+						Timer:    character.NewTimer(),
+						Duration: time.Minute * 2,
+					},
+				},
+				ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
 					statType := character.GetHighestStatType([]stats.Stat{stats.CritRating, stats.HasteRating, stats.MasteryRating})
+
 					switch statType {
 					case stats.CritRating:
-						procAuraCrit.Activate(sim)
+						buffAuraCrit.Activate(sim)
+						buffAuraCrit.SetStacks(sim, titanicPower.GetStacks())
 					case stats.HasteRating:
-						procAuraHaste.Activate(sim)
+						buffAuraHaste.Activate(sim)
+						buffAuraHaste.SetStacks(sim, titanicPower.GetStacks())
 					case stats.MasteryRating:
-						procAuraMastery.Activate(sim)
+						buffAuraMastery.Activate(sim)
+						buffAuraMastery.SetStacks(sim, titanicPower.GetStacks())
 					default:
 						panic("unexpected statType")
 					}
-					icd.Use(sim)
-				}
-			},
-		})
-	})
 
-	core.NewItemEffect(69150, func(agent core.Agent) {
-		character := agent.GetCharacter()
-
-		bonusStats := 1834.0
-		procAuraCrit := character.NewTemporaryStatsAura("Matrix Restabilizer Crit Proc (Heroic)", core.ActionID{SpellID: 97140}, stats.Stats{stats.CritRating: bonusStats}, time.Second*30)
-		procAuraHaste := character.NewTemporaryStatsAura("Matrix Restabilizer Haste Proc (Heroic)", core.ActionID{SpellID: 97139}, stats.Stats{stats.HasteRating: bonusStats}, time.Second*30)
-		procAuraMastery := character.NewTemporaryStatsAura("Matrix Restabilizer Mastery Proc (Heroic)", core.ActionID{SpellID: 97141}, stats.Stats{stats.MasteryRating: bonusStats}, time.Second*30)
-
-		icd := core.Cooldown{
-			Timer:    character.NewTimer(),
-			Duration: time.Second * 105,
-		}
-
-		procAuraCrit.Icd = &icd
-		procAuraHaste.Icd = &icd
-		procAuraMastery.Icd = &icd
-
-		core.MakeProcTriggerAura(&character.Unit, core.ProcTrigger{
-			Name:       "Matrix Restabilizer Trigger (Heroic)",
-			Callback:   core.CallbackOnSpellHitDealt,
-			ProcMask:   core.ProcMaskMeleeOrRanged,
-			ProcChance: 0.2,
-			ActionID:   core.ActionID{ItemID: 69150},
-			Harmful:    true,
-			Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellResult) {
-				if icd.IsReady(sim) {
-					statType := character.GetHighestStatType([]stats.Stat{stats.CritRating, stats.HasteRating, stats.MasteryRating})
-					switch statType {
-					case stats.CritRating:
-						procAuraCrit.Activate(sim)
-					case stats.HasteRating:
-						procAuraHaste.Activate(sim)
-					case stats.MasteryRating:
-						procAuraMastery.Activate(sim)
-					default:
-						panic("unexpected statType")
-					}
-					icd.Use(sim)
-				}
-			},
-		})
-	})
-}
-
-type apparatusConfig struct {
-	ItemID        int32
-	BonusPerStack float64
-	Heroic        bool
-}
-
-func registerApparatusOfKhazGoroth(config apparatusConfig) {
-	core.NewItemEffect(config.ItemID, func(agent core.Agent) {
-		character := agent.GetCharacter()
-
-		labelSuffix := core.Ternary(config.Heroic, " (Heroic)", "")
-		buffDuration := time.Second * 15
-
-		buffAuraCrit := character.NewTemporaryStatBuffWithStacks(
-			"Blessing of the Shaper Crit"+labelSuffix,
-			core.ActionID{SpellID: 96928},
-			stats.Stats{stats.CritRating: config.BonusPerStack},
-			5,
-			buffDuration)
-
-		buffAuraHaste := character.NewTemporaryStatBuffWithStacks(
-			"Blessing of the Shaper Haste"+labelSuffix,
-			core.ActionID{SpellID: 96927},
-			stats.Stats{stats.HasteRating: config.BonusPerStack},
-			5,
-			buffDuration)
-
-		buffAuraMastery := character.NewTemporaryStatBuffWithStacks(
-			"Blessing of the Shaper Mastery"+labelSuffix,
-			core.ActionID{SpellID: 96929},
-			stats.Stats{stats.MasteryRating: config.BonusPerStack},
-			5,
-			buffDuration)
-
-		titanicPower := character.RegisterAura(core.Aura{
-			Label:     "Titanic Power" + labelSuffix,
-			ActionID:  core.ActionID{SpellID: 96923},
-			Duration:  time.Second * 30,
-			MaxStacks: 5,
-		})
-
-		core.MakePermanent(core.MakeProcTriggerAura(&character.Unit, core.ProcTrigger{
-			Name:       "Titanic Power Aura" + labelSuffix,
-			ActionID:   core.ActionID{SpellID: 96924},
-			Callback:   core.CallbackOnSpellHitDealt,
-			ProcMask:   core.ProcMaskMelee,
-			ProcChance: 1,
-			Outcome:    core.OutcomeCrit,
-			Handler: func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
-				if buffAuraCrit.IsActive() || buffAuraHaste.IsActive() || buffAuraMastery.IsActive() {
-					return
-				}
-
-				titanicPower.Activate(sim)
-				titanicPower.AddStack(sim)
-			},
-		}))
-
-		trinketSpell := character.RegisterSpell(core.SpellConfig{
-			ActionID:    core.ActionID{ItemID: config.ItemID},
-			SpellSchool: core.SpellSchoolPhysical,
-			ProcMask:    core.ProcMaskEmpty,
-			Flags:       core.SpellFlagNoOnCastComplete,
-			Cast: core.CastConfig{
-				SharedCD: core.Cooldown{
-					Timer:    character.GetOffensiveTrinketCD(),
-					Duration: time.Second * 20,
+					titanicPower.Deactivate(sim)
 				},
-				CD: core.Cooldown{
-					Timer:    character.NewTimer(),
-					Duration: time.Minute * 2,
+				ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
+					return titanicPower.IsActive()
 				},
-			},
-			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-				statType := character.GetHighestStatType([]stats.Stat{stats.CritRating, stats.HasteRating, stats.MasteryRating})
+			})
 
-				switch statType {
-				case stats.CritRating:
-					buffAuraCrit.Activate(sim)
-					buffAuraCrit.SetStacks(sim, titanicPower.GetStacks())
-				case stats.HasteRating:
-					buffAuraHaste.Activate(sim)
-					buffAuraHaste.SetStacks(sim, titanicPower.GetStacks())
-				case stats.MasteryRating:
-					buffAuraMastery.Activate(sim)
-					buffAuraMastery.SetStacks(sim, titanicPower.GetStacks())
-				default:
-					panic("unexpected statType")
-				}
-
-				titanicPower.Deactivate(sim)
-			},
-			ExtraCastCondition: func(sim *core.Simulation, target *core.Unit) bool {
-				return titanicPower.IsActive()
-			},
+			character.AddMajorCooldown(core.MajorCooldown{
+				Spell:    trinketSpell,
+				Priority: core.CooldownPriorityDefault,
+				Type:     core.CooldownTypeDPS,
+				ShouldActivate: func(sim *core.Simulation, character *core.Character) bool {
+					return titanicPower.IsActive()
+				},
+			})
 		})
-
-		character.AddMajorCooldown(core.MajorCooldown{
-			Spell:    trinketSpell,
-			Priority: core.CooldownPriorityDefault,
-			Type:     core.CooldownTypeDPS,
-			ShouldActivate: func(sim *core.Simulation, character *core.Character) bool {
-				return titanicPower.IsActive()
-			},
-		})
-	})
+	}
 }
 
 // Takes in the SpellResult for the triggering spell, and returns the damage per

--- a/sim/death_knight/blood/TestBlood.results
+++ b/sim/death_knight/blood/TestBlood.results
@@ -1172,6 +1172,22 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestBlood-AllItems-ScalesofLife-68915"
+ value: {
+  dps: 13803.93262
+  tps: 66990.06155
+  hps: 4078.69022
+ }
+}
+dps_results: {
+ key: "TestBlood-AllItems-ScalesofLife-69109"
+ value: {
+  dps: 13803.93262
+  tps: 66990.06155
+  hps: 4140.70429
+ }
+}
+dps_results: {
  key: "TestBlood-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
   dps: 13976.3816

--- a/sim/death_knight/blood/TestBlood.results
+++ b/sim/death_knight/blood/TestBlood.results
@@ -780,6 +780,22 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestBlood-AllItems-JawsofDefeat-68926"
+ value: {
+  dps: 13803.93262
+  tps: 66990.06155
+  hps: 3597.80333
+ }
+}
+dps_results: {
+ key: "TestBlood-AllItems-JawsofDefeat-69111"
+ value: {
+  dps: 13803.93262
+  tps: 66990.06155
+  hps: 3597.80333
+ }
+}
+dps_results: {
  key: "TestBlood-AllItems-JujuofNimbleness-63840"
  value: {
   dps: 13934.12024

--- a/sim/death_knight/blood/TestBlood.results
+++ b/sim/death_knight/blood/TestBlood.results
@@ -1276,6 +1276,22 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestBlood-AllItems-SpidersilkSpindle-68981"
+ value: {
+  dps: 13803.93262
+  tps: 66990.06155
+  hps: 3597.80333
+ }
+}
+dps_results: {
+ key: "TestBlood-AllItems-SpidersilkSpindle-69138"
+ value: {
+  dps: 13803.93262
+  tps: 66990.06155
+  hps: 3597.80333
+ }
+}
+dps_results: {
  key: "TestBlood-AllItems-StayofExecution-68996"
  value: {
   dps: 13803.93262

--- a/sim/death_knight/blood/TestBlood.results
+++ b/sim/death_knight/blood/TestBlood.results
@@ -1276,6 +1276,14 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestBlood-AllItems-StayofExecution-68996"
+ value: {
+  dps: 13803.93262
+  tps: 66990.06155
+  hps: 3597.80333
+ }
+}
+dps_results: {
  key: "TestBlood-AllItems-Stonemother'sKiss-61411"
  value: {
   dps: 13937.50878

--- a/sim/death_knight/frost/TestFrost.results
+++ b/sim/death_knight/frost/TestFrost.results
@@ -1268,6 +1268,14 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFrost-AllItems-StayofExecution-68996"
+ value: {
+  dps: 20745.1798
+  tps: 18901.58265
+  hps: 242.45587
+ }
+}
+dps_results: {
  key: "TestFrost-AllItems-Stonemother'sKiss-61411"
  value: {
   dps: 20878.61931

--- a/sim/death_knight/frost/TestFrost.results
+++ b/sim/death_knight/frost/TestFrost.results
@@ -772,6 +772,22 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFrost-AllItems-JawsofDefeat-68926"
+ value: {
+  dps: 20745.1798
+  tps: 18901.58265
+  hps: 242.45587
+ }
+}
+dps_results: {
+ key: "TestFrost-AllItems-JawsofDefeat-69111"
+ value: {
+  dps: 20745.1798
+  tps: 18901.58265
+  hps: 242.45587
+ }
+}
+dps_results: {
  key: "TestFrost-AllItems-JujuofNimbleness-63840"
  value: {
   dps: 21012.60482

--- a/sim/death_knight/frost/TestFrost.results
+++ b/sim/death_knight/frost/TestFrost.results
@@ -1268,6 +1268,22 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFrost-AllItems-SpidersilkSpindle-68981"
+ value: {
+  dps: 21046.64751
+  tps: 19203.05037
+  hps: 242.45587
+ }
+}
+dps_results: {
+ key: "TestFrost-AllItems-SpidersilkSpindle-69138"
+ value: {
+  dps: 21086.00361
+  tps: 19242.40647
+  hps: 242.45587
+ }
+}
+dps_results: {
  key: "TestFrost-AllItems-StayofExecution-68996"
  value: {
   dps: 20745.1798

--- a/sim/death_knight/frost/TestFrost.results
+++ b/sim/death_knight/frost/TestFrost.results
@@ -1164,6 +1164,22 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFrost-AllItems-ScalesofLife-68915"
+ value: {
+  dps: 20745.1798
+  tps: 18901.58265
+  hps: 531.88082
+ }
+}
+dps_results: {
+ key: "TestFrost-AllItems-ScalesofLife-69109"
+ value: {
+  dps: 20745.1798
+  tps: 18901.58265
+  hps: 568.96024
+ }
+}
+dps_results: {
  key: "TestFrost-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
   dps: 21015.29714

--- a/sim/death_knight/unholy/TestUnholy.results
+++ b/sim/death_knight/unholy/TestUnholy.results
@@ -1268,6 +1268,22 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestUnholy-AllItems-SpidersilkSpindle-68981"
+ value: {
+  dps: 31071.47193
+  tps: 23176.55359
+  hps: 546.10701
+ }
+}
+dps_results: {
+ key: "TestUnholy-AllItems-SpidersilkSpindle-69138"
+ value: {
+  dps: 31136.47029
+  tps: 23247.96017
+  hps: 546.10701
+ }
+}
+dps_results: {
  key: "TestUnholy-AllItems-StayofExecution-68996"
  value: {
   dps: 30574.59353

--- a/sim/death_knight/unholy/TestUnholy.results
+++ b/sim/death_knight/unholy/TestUnholy.results
@@ -1164,6 +1164,22 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestUnholy-AllItems-ScalesofLife-68915"
+ value: {
+  dps: 30574.59353
+  tps: 22630.58823
+  hps: 879.08437
+ }
+}
+dps_results: {
+ key: "TestUnholy-AllItems-ScalesofLife-69109"
+ value: {
+  dps: 30574.59353
+  tps: 22630.58823
+  hps: 921.60089
+ }
+}
+dps_results: {
  key: "TestUnholy-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
   dps: 31051.98354

--- a/sim/death_knight/unholy/TestUnholy.results
+++ b/sim/death_knight/unholy/TestUnholy.results
@@ -764,6 +764,22 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestUnholy-AllItems-JawsofDefeat-68926"
+ value: {
+  dps: 30574.59353
+  tps: 22630.58823
+  hps: 546.10701
+ }
+}
+dps_results: {
+ key: "TestUnholy-AllItems-JawsofDefeat-69111"
+ value: {
+  dps: 30574.59353
+  tps: 22630.58823
+  hps: 546.10701
+ }
+}
+dps_results: {
  key: "TestUnholy-AllItems-JujuofNimbleness-63840"
  value: {
   dps: 31016.77288

--- a/sim/death_knight/unholy/TestUnholy.results
+++ b/sim/death_knight/unholy/TestUnholy.results
@@ -1268,6 +1268,14 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestUnholy-AllItems-StayofExecution-68996"
+ value: {
+  dps: 30574.59353
+  tps: 22630.58823
+  hps: 546.10701
+ }
+}
+dps_results: {
  key: "TestUnholy-AllItems-Stonemother'sKiss-61411"
  value: {
   dps: 30994.55983

--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -1115,6 +1115,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestBalance-AllItems-StayofExecution-68996"
+ value: {
+  dps: 26258.64645
+  tps: 26265.2223
+ }
+}
+dps_results: {
  key: "TestBalance-AllItems-Stonemother'sKiss-61411"
  value: {
   dps: 27220.9425

--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -681,6 +681,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestBalance-AllItems-JawsofDefeat-68926"
+ value: {
+  dps: 27583.60578
+  tps: 27559.75754
+ }
+}
+dps_results: {
+ key: "TestBalance-AllItems-JawsofDefeat-69111"
+ value: {
+  dps: 27762.73948
+  tps: 27736.76907
+ }
+}
+dps_results: {
  key: "TestBalance-AllItems-JujuofNimbleness-63840"
  value: {
   dps: 26558.1322

--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -1115,6 +1115,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestBalance-AllItems-SpidersilkSpindle-68981"
+ value: {
+  dps: 26782.40463
+  tps: 26788.98048
+ }
+}
+dps_results: {
+ key: "TestBalance-AllItems-SpidersilkSpindle-69138"
+ value: {
+  dps: 26850.78037
+  tps: 26857.35622
+ }
+}
+dps_results: {
  key: "TestBalance-AllItems-StayofExecution-68996"
  value: {
   dps: 26258.64645

--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -1031,6 +1031,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestBalance-AllItems-ScalesofLife-68915"
+ value: {
+  dps: 26258.64645
+  tps: 26265.2223
+ }
+}
+dps_results: {
+ key: "TestBalance-AllItems-ScalesofLife-69109"
+ value: {
+  dps: 26258.64645
+  tps: 26265.2223
+ }
+}
+dps_results: {
  key: "TestBalance-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
   dps: 26258.64645

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -1024,6 +1024,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFeral-AllItems-ScalesofLife-68915"
+ value: {
+  dps: 25439.58027
+  tps: 36362.5747
+ }
+}
+dps_results: {
+ key: "TestFeral-AllItems-ScalesofLife-69109"
+ value: {
+  dps: 25439.58027
+  tps: 36362.5747
+ }
+}
+dps_results: {
  key: "TestFeral-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
   dps: 26587.05699

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -1108,6 +1108,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFeral-AllItems-StayofExecution-68996"
+ value: {
+  dps: 25439.58027
+  tps: 36362.5747
+ }
+}
+dps_results: {
  key: "TestFeral-AllItems-Stonemother'sKiss-61411"
  value: {
   dps: 25477.60379

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -1108,6 +1108,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFeral-AllItems-SpidersilkSpindle-68981"
+ value: {
+  dps: 25878.17637
+  tps: 37076.63242
+ }
+}
+dps_results: {
+ key: "TestFeral-AllItems-SpidersilkSpindle-69138"
+ value: {
+  dps: 25935.43434
+  tps: 37169.85145
+ }
+}
+dps_results: {
  key: "TestFeral-AllItems-StayofExecution-68996"
  value: {
   dps: 25439.58027

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -681,6 +681,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFeral-AllItems-JawsofDefeat-68926"
+ value: {
+  dps: 25439.58027
+  tps: 36362.26815
+ }
+}
+dps_results: {
+ key: "TestFeral-AllItems-JawsofDefeat-69111"
+ value: {
+  dps: 25439.58027
+  tps: 36362.22816
+ }
+}
+dps_results: {
  key: "TestFeral-AllItems-JujuofNimbleness-63840"
  value: {
   dps: 26867.90737

--- a/sim/druid/guardian/TestGuardian.results
+++ b/sim/druid/guardian/TestGuardian.results
@@ -681,6 +681,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestGuardian-AllItems-JawsofDefeat-68926"
+ value: {
+  dps: 7790.0918
+  tps: 39013.00627
+ }
+}
+dps_results: {
+ key: "TestGuardian-AllItems-JawsofDefeat-69111"
+ value: {
+  dps: 7790.0918
+  tps: 39013.00627
+ }
+}
+dps_results: {
  key: "TestGuardian-AllItems-JujuofNimbleness-63840"
  value: {
   dps: 8040.21465

--- a/sim/druid/guardian/TestGuardian.results
+++ b/sim/druid/guardian/TestGuardian.results
@@ -1024,6 +1024,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestGuardian-AllItems-ScalesofLife-68915"
+ value: {
+  dps: 7800.93141
+  tps: 39067.10435
+ }
+}
+dps_results: {
+ key: "TestGuardian-AllItems-ScalesofLife-69109"
+ value: {
+  dps: 7800.93141
+  tps: 39067.10435
+ }
+}
+dps_results: {
  key: "TestGuardian-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
   dps: 8074.79408

--- a/sim/druid/guardian/TestGuardian.results
+++ b/sim/druid/guardian/TestGuardian.results
@@ -1108,6 +1108,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestGuardian-AllItems-SpidersilkSpindle-68981"
+ value: {
+  dps: 7800.93141
+  tps: 39067.10435
+ }
+}
+dps_results: {
+ key: "TestGuardian-AllItems-SpidersilkSpindle-69138"
+ value: {
+  dps: 7800.93141
+  tps: 39067.10435
+ }
+}
+dps_results: {
  key: "TestGuardian-AllItems-StayofExecution-68996"
  value: {
   dps: 7800.93141

--- a/sim/druid/guardian/TestGuardian.results
+++ b/sim/druid/guardian/TestGuardian.results
@@ -1108,6 +1108,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestGuardian-AllItems-StayofExecution-68996"
+ value: {
+  dps: 7800.93141
+  tps: 39067.10435
+ }
+}
+dps_results: {
  key: "TestGuardian-AllItems-Stonemother'sKiss-61411"
  value: {
   dps: 7843.2887

--- a/sim/hunter/beast_mastery/TestBM.results
+++ b/sim/hunter/beast_mastery/TestBM.results
@@ -1143,6 +1143,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestBM-AllItems-StayofExecution-68996"
+ value: {
+  dps: 20882.39663
+  tps: 17632.35153
+ }
+}
+dps_results: {
  key: "TestBM-AllItems-Stonemother'sKiss-61411"
  value: {
   dps: 20882.39663

--- a/sim/hunter/beast_mastery/TestBM.results
+++ b/sim/hunter/beast_mastery/TestBM.results
@@ -1143,6 +1143,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestBM-AllItems-SpidersilkSpindle-68981"
+ value: {
+  dps: 21060.22343
+  tps: 17714.58044
+ }
+}
+dps_results: {
+ key: "TestBM-AllItems-SpidersilkSpindle-69138"
+ value: {
+  dps: 21083.43842
+  tps: 17725.31529
+ }
+}
+dps_results: {
  key: "TestBM-AllItems-StayofExecution-68996"
  value: {
   dps: 20882.39663

--- a/sim/hunter/beast_mastery/TestBM.results
+++ b/sim/hunter/beast_mastery/TestBM.results
@@ -1052,6 +1052,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestBM-AllItems-ScalesofLife-68915"
+ value: {
+  dps: 20882.39663
+  tps: 17632.35153
+ }
+}
+dps_results: {
+ key: "TestBM-AllItems-ScalesofLife-69109"
+ value: {
+  dps: 20882.39663
+  tps: 17632.35153
+ }
+}
+dps_results: {
  key: "TestBM-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
   dps: 21567.03803

--- a/sim/hunter/beast_mastery/TestBM.results
+++ b/sim/hunter/beast_mastery/TestBM.results
@@ -716,6 +716,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestBM-AllItems-JawsofDefeat-68926"
+ value: {
+  dps: 20882.39663
+  tps: 17632.35153
+ }
+}
+dps_results: {
+ key: "TestBM-AllItems-JawsofDefeat-69111"
+ value: {
+  dps: 20882.39663
+  tps: 17632.35153
+ }
+}
+dps_results: {
  key: "TestBM-AllItems-JujuofNimbleness-63840"
  value: {
   dps: 21594.99132

--- a/sim/hunter/marksmanship/TestMM.results
+++ b/sim/hunter/marksmanship/TestMM.results
@@ -1143,6 +1143,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestMM-AllItems-StayofExecution-68996"
+ value: {
+  dps: 20804.36191
+  tps: 18630.89211
+ }
+}
+dps_results: {
  key: "TestMM-AllItems-Stonemother'sKiss-61411"
  value: {
   dps: 20817.48847

--- a/sim/hunter/marksmanship/TestMM.results
+++ b/sim/hunter/marksmanship/TestMM.results
@@ -1052,6 +1052,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestMM-AllItems-ScalesofLife-68915"
+ value: {
+  dps: 20804.36191
+  tps: 18630.89211
+ }
+}
+dps_results: {
+ key: "TestMM-AllItems-ScalesofLife-69109"
+ value: {
+  dps: 20804.36191
+  tps: 18630.89211
+ }
+}
+dps_results: {
  key: "TestMM-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
   dps: 21420.1186

--- a/sim/hunter/marksmanship/TestMM.results
+++ b/sim/hunter/marksmanship/TestMM.results
@@ -716,6 +716,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestMM-AllItems-JawsofDefeat-68926"
+ value: {
+  dps: 20804.36191
+  tps: 18630.89211
+ }
+}
+dps_results: {
+ key: "TestMM-AllItems-JawsofDefeat-69111"
+ value: {
+  dps: 20804.36191
+  tps: 18630.89211
+ }
+}
+dps_results: {
  key: "TestMM-AllItems-JujuofNimbleness-63840"
  value: {
   dps: 21461.55365

--- a/sim/hunter/marksmanship/TestMM.results
+++ b/sim/hunter/marksmanship/TestMM.results
@@ -1143,6 +1143,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestMM-AllItems-SpidersilkSpindle-68981"
+ value: {
+  dps: 21211.72465
+  tps: 19028.51013
+ }
+}
+dps_results: {
+ key: "TestMM-AllItems-SpidersilkSpindle-69138"
+ value: {
+  dps: 21251.98386
+  tps: 19085.24799
+ }
+}
+dps_results: {
  key: "TestMM-AllItems-StayofExecution-68996"
  value: {
   dps: 20804.36191

--- a/sim/hunter/survival/TestSV.results
+++ b/sim/hunter/survival/TestSV.results
@@ -1052,6 +1052,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestSV-AllItems-ScalesofLife-68915"
+ value: {
+  dps: 24461.81628
+  tps: 22098.30071
+ }
+}
+dps_results: {
+ key: "TestSV-AllItems-ScalesofLife-69109"
+ value: {
+  dps: 24461.81628
+  tps: 22098.30071
+ }
+}
+dps_results: {
  key: "TestSV-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
   dps: 25262.26776

--- a/sim/hunter/survival/TestSV.results
+++ b/sim/hunter/survival/TestSV.results
@@ -716,6 +716,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestSV-AllItems-JawsofDefeat-68926"
+ value: {
+  dps: 24461.81628
+  tps: 22098.30071
+ }
+}
+dps_results: {
+ key: "TestSV-AllItems-JawsofDefeat-69111"
+ value: {
+  dps: 24461.81628
+  tps: 22098.30071
+ }
+}
+dps_results: {
  key: "TestSV-AllItems-JujuofNimbleness-63840"
  value: {
   dps: 25280.63561

--- a/sim/hunter/survival/TestSV.results
+++ b/sim/hunter/survival/TestSV.results
@@ -1143,6 +1143,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestSV-AllItems-StayofExecution-68996"
+ value: {
+  dps: 24461.81628
+  tps: 22098.30071
+ }
+}
+dps_results: {
  key: "TestSV-AllItems-Stonemother'sKiss-61411"
  value: {
   dps: 24474.26667

--- a/sim/hunter/survival/TestSV.results
+++ b/sim/hunter/survival/TestSV.results
@@ -1143,6 +1143,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestSV-AllItems-SpidersilkSpindle-68981"
+ value: {
+  dps: 24800.08856
+  tps: 22436.01372
+ }
+}
+dps_results: {
+ key: "TestSV-AllItems-SpidersilkSpindle-69138"
+ value: {
+  dps: 24844.24943
+  tps: 22480.10158
+ }
+}
+dps_results: {
  key: "TestSV-AllItems-StayofExecution-68996"
  value: {
   dps: 24461.81628

--- a/sim/mage/arcane/TestArcane.results
+++ b/sim/mage/arcane/TestArcane.results
@@ -1094,6 +1094,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestArcane-AllItems-SpidersilkSpindle-68981"
+ value: {
+  dps: 28088.73162
+  tps: 28223.44576
+ }
+}
+dps_results: {
+ key: "TestArcane-AllItems-SpidersilkSpindle-69138"
+ value: {
+  dps: 28154.61227
+  tps: 28289.3264
+ }
+}
+dps_results: {
  key: "TestArcane-AllItems-StayofExecution-68996"
  value: {
   dps: 27381.61965

--- a/sim/mage/arcane/TestArcane.results
+++ b/sim/mage/arcane/TestArcane.results
@@ -1094,6 +1094,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestArcane-AllItems-StayofExecution-68996"
+ value: {
+  dps: 27381.61965
+  tps: 27507.52299
+ }
+}
+dps_results: {
  key: "TestArcane-AllItems-Stonemother'sKiss-61411"
  value: {
   dps: 28592.03804

--- a/sim/mage/arcane/TestArcane.results
+++ b/sim/mage/arcane/TestArcane.results
@@ -1010,6 +1010,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestArcane-AllItems-ScalesofLife-68915"
+ value: {
+  dps: 27584.0859
+  tps: 27718.80004
+ }
+}
+dps_results: {
+ key: "TestArcane-AllItems-ScalesofLife-69109"
+ value: {
+  dps: 27584.0859
+  tps: 27718.80004
+ }
+}
+dps_results: {
  key: "TestArcane-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
   dps: 27584.0859

--- a/sim/mage/arcane/TestArcane.results
+++ b/sim/mage/arcane/TestArcane.results
@@ -681,6 +681,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestArcane-AllItems-JawsofDefeat-68926"
+ value: {
+  dps: 28903.78531
+  tps: 29092.92309
+ }
+}
+dps_results: {
+ key: "TestArcane-AllItems-JawsofDefeat-69111"
+ value: {
+  dps: 29095.66398
+  tps: 29292.88951
+ }
+}
+dps_results: {
  key: "TestArcane-AllItems-JujuofNimbleness-63840"
  value: {
   dps: 27931.53727

--- a/sim/mage/fire/TestFire.results
+++ b/sim/mage/fire/TestFire.results
@@ -1094,6 +1094,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFire-AllItems-StayofExecution-68996"
+ value: {
+  dps: 27980.06567
+  tps: 27497.51044
+ }
+}
+dps_results: {
  key: "TestFire-AllItems-Stonemother'sKiss-61411"
  value: {
   dps: 29327.63305

--- a/sim/mage/fire/TestFire.results
+++ b/sim/mage/fire/TestFire.results
@@ -1010,6 +1010,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFire-AllItems-ScalesofLife-68915"
+ value: {
+  dps: 27980.06567
+  tps: 27497.51044
+ }
+}
+dps_results: {
+ key: "TestFire-AllItems-ScalesofLife-69109"
+ value: {
+  dps: 27980.06567
+  tps: 27497.51044
+ }
+}
+dps_results: {
  key: "TestFire-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
   dps: 27980.06567

--- a/sim/mage/fire/TestFire.results
+++ b/sim/mage/fire/TestFire.results
@@ -681,6 +681,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFire-AllItems-JawsofDefeat-68926"
+ value: {
+  dps: 29470.54367
+  tps: 28944.10443
+ }
+}
+dps_results: {
+ key: "TestFire-AllItems-JawsofDefeat-69111"
+ value: {
+  dps: 29865.91355
+  tps: 29338.98345
+ }
+}
+dps_results: {
  key: "TestFire-AllItems-JujuofNimbleness-63840"
  value: {
   dps: 28267.77906

--- a/sim/mage/fire/TestFire.results
+++ b/sim/mage/fire/TestFire.results
@@ -1094,6 +1094,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFire-AllItems-SpidersilkSpindle-68981"
+ value: {
+  dps: 28470.37881
+  tps: 27980.93614
+ }
+}
+dps_results: {
+ key: "TestFire-AllItems-SpidersilkSpindle-69138"
+ value: {
+  dps: 28553.97096
+  tps: 28064.52829
+ }
+}
+dps_results: {
  key: "TestFire-AllItems-StayofExecution-68996"
  value: {
   dps: 27980.06567

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -1122,6 +1122,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestRetribution-AllItems-SpidersilkSpindle-68981"
+ value: {
+  dps: 29648.87565
+  tps: 29664.2189
+ }
+}
+dps_results: {
+ key: "TestRetribution-AllItems-SpidersilkSpindle-69138"
+ value: {
+  dps: 29726.23866
+  tps: 29741.58191
+ }
+}
+dps_results: {
  key: "TestRetribution-AllItems-StayofExecution-68996"
  value: {
   dps: 29056.39382

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -1031,6 +1031,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestRetribution-AllItems-ScalesofLife-68915"
+ value: {
+  dps: 29056.27505
+  tps: 29071.6183
+ }
+}
+dps_results: {
+ key: "TestRetribution-AllItems-ScalesofLife-69109"
+ value: {
+  dps: 29056.27505
+  tps: 29071.6183
+ }
+}
+dps_results: {
  key: "TestRetribution-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
   dps: 29735.39546

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -688,6 +688,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestRetribution-AllItems-JawsofDefeat-68926"
+ value: {
+  dps: 29084.03281
+  tps: 29102.7746
+ }
+}
+dps_results: {
+ key: "TestRetribution-AllItems-JawsofDefeat-69111"
+ value: {
+  dps: 29066.14065
+  tps: 29086.80611
+ }
+}
+dps_results: {
  key: "TestRetribution-AllItems-JujuofNimbleness-63840"
  value: {
   dps: 29760.50253

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -1122,6 +1122,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestRetribution-AllItems-StayofExecution-68996"
+ value: {
+  dps: 29056.39382
+  tps: 29071.73707
+ }
+}
+dps_results: {
  key: "TestRetribution-AllItems-Stonemother'sKiss-61411"
  value: {
   dps: 29207.78062

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -688,6 +688,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestShadow-AllItems-JawsofDefeat-68926"
+ value: {
+  dps: 29157.83634
+  tps: 27088.16104
+ }
+}
+dps_results: {
+ key: "TestShadow-AllItems-JawsofDefeat-69111"
+ value: {
+  dps: 29336.09335
+  tps: 27239.11062
+ }
+}
+dps_results: {
  key: "TestShadow-AllItems-JujuofNimbleness-63840"
  value: {
   dps: 28047.43367

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -1038,6 +1038,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestShadow-AllItems-ScalesofLife-68915"
+ value: {
+  dps: 27699.74157
+  tps: 25794.72689
+ }
+}
+dps_results: {
+ key: "TestShadow-AllItems-ScalesofLife-69109"
+ value: {
+  dps: 27699.74157
+  tps: 25794.72689
+ }
+}
+dps_results: {
  key: "TestShadow-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
   dps: 27699.74157

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -1122,6 +1122,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestShadow-AllItems-SpidersilkSpindle-68981"
+ value: {
+  dps: 28418.57353
+  tps: 26513.55885
+ }
+}
+dps_results: {
+ key: "TestShadow-AllItems-SpidersilkSpindle-69138"
+ value: {
+  dps: 28427.52924
+  tps: 26522.51457
+ }
+}
+dps_results: {
  key: "TestShadow-AllItems-StayofExecution-68996"
  value: {
   dps: 27663.56689

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -1122,6 +1122,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestShadow-AllItems-StayofExecution-68996"
+ value: {
+  dps: 27663.56689
+  tps: 25754.98178
+ }
+}
+dps_results: {
  key: "TestShadow-AllItems-Stonemother'sKiss-61411"
  value: {
   dps: 28688.10326

--- a/sim/rogue/assassination/TestAssassination.results
+++ b/sim/rogue/assassination/TestAssassination.results
@@ -711,6 +711,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestAssassination-AllItems-JawsofDefeat-68926"
+ value: {
+  dps: 27441.96409
+  tps: 19483.7945
+ }
+}
+dps_results: {
+ key: "TestAssassination-AllItems-JawsofDefeat-69111"
+ value: {
+  dps: 27441.96409
+  tps: 19483.7945
+ }
+}
+dps_results: {
  key: "TestAssassination-AllItems-JujuofNimbleness-63840"
  value: {
   dps: 28617.42272

--- a/sim/rogue/assassination/TestAssassination.results
+++ b/sim/rogue/assassination/TestAssassination.results
@@ -1117,6 +1117,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestAssassination-AllItems-StayofExecution-68996"
+ value: {
+  dps: 27441.96409
+  tps: 19483.7945
+ }
+}
+dps_results: {
  key: "TestAssassination-AllItems-Stonemother'sKiss-61411"
  value: {
   dps: 27680.42918

--- a/sim/rogue/assassination/TestAssassination.results
+++ b/sim/rogue/assassination/TestAssassination.results
@@ -1033,6 +1033,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestAssassination-AllItems-ScalesofLife-68915"
+ value: {
+  dps: 27441.96409
+  tps: 19483.7945
+ }
+}
+dps_results: {
+ key: "TestAssassination-AllItems-ScalesofLife-69109"
+ value: {
+  dps: 27441.96409
+  tps: 19483.7945
+ }
+}
+dps_results: {
  key: "TestAssassination-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
   dps: 28667.06727

--- a/sim/rogue/assassination/TestAssassination.results
+++ b/sim/rogue/assassination/TestAssassination.results
@@ -1117,6 +1117,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestAssassination-AllItems-SpidersilkSpindle-68981"
+ value: {
+  dps: 28043.15231
+  tps: 19910.63814
+ }
+}
+dps_results: {
+ key: "TestAssassination-AllItems-SpidersilkSpindle-69138"
+ value: {
+  dps: 28121.63641
+  tps: 19966.36185
+ }
+}
+dps_results: {
  key: "TestAssassination-AllItems-StayofExecution-68996"
  value: {
   dps: 27441.96409

--- a/sim/rogue/combat/TestCombat.results
+++ b/sim/rogue/combat/TestCombat.results
@@ -1024,6 +1024,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestCombat-AllItems-ScalesofLife-68915"
+ value: {
+  dps: 27704.91629
+  tps: 19670.49057
+ }
+}
+dps_results: {
+ key: "TestCombat-AllItems-ScalesofLife-69109"
+ value: {
+  dps: 27704.91629
+  tps: 19670.49057
+ }
+}
+dps_results: {
  key: "TestCombat-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
   dps: 28992.49129

--- a/sim/rogue/combat/TestCombat.results
+++ b/sim/rogue/combat/TestCombat.results
@@ -1115,6 +1115,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestCombat-AllItems-StayofExecution-68996"
+ value: {
+  dps: 27704.91629
+  tps: 19670.49057
+ }
+}
+dps_results: {
  key: "TestCombat-AllItems-Stonemother'sKiss-61411"
  value: {
   dps: 27704.91629

--- a/sim/rogue/combat/TestCombat.results
+++ b/sim/rogue/combat/TestCombat.results
@@ -695,6 +695,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestCombat-AllItems-JawsofDefeat-68926"
+ value: {
+  dps: 27704.91629
+  tps: 19670.49057
+ }
+}
+dps_results: {
+ key: "TestCombat-AllItems-JawsofDefeat-69111"
+ value: {
+  dps: 27704.91629
+  tps: 19670.49057
+ }
+}
+dps_results: {
  key: "TestCombat-AllItems-JujuofNimbleness-63840"
  value: {
   dps: 29076.89314

--- a/sim/rogue/combat/TestCombat.results
+++ b/sim/rogue/combat/TestCombat.results
@@ -1115,6 +1115,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestCombat-AllItems-SpidersilkSpindle-68981"
+ value: {
+  dps: 28334.7659
+  tps: 20117.68379
+ }
+}
+dps_results: {
+ key: "TestCombat-AllItems-SpidersilkSpindle-69138"
+ value: {
+  dps: 28546.97442
+  tps: 20268.35184
+ }
+}
+dps_results: {
  key: "TestCombat-AllItems-StayofExecution-68996"
  value: {
   dps: 27704.91629

--- a/sim/rogue/subtlety/TestSubtlety.results
+++ b/sim/rogue/subtlety/TestSubtlety.results
@@ -1080,6 +1080,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestSubtlety-AllItems-SpidersilkSpindle-68981"
+ value: {
+  dps: 21829.92243
+  tps: 15499.24493
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-SpidersilkSpindle-69138"
+ value: {
+  dps: 21852.57497
+  tps: 15515.32823
+ }
+}
+dps_results: {
  key: "TestSubtlety-AllItems-StayofExecution-68996"
  value: {
   dps: 21639.32405

--- a/sim/rogue/subtlety/TestSubtlety.results
+++ b/sim/rogue/subtlety/TestSubtlety.results
@@ -1080,6 +1080,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestSubtlety-AllItems-StayofExecution-68996"
+ value: {
+  dps: 21639.32405
+  tps: 15363.92008
+ }
+}
+dps_results: {
  key: "TestSubtlety-AllItems-Stonemother'sKiss-61411"
  value: {
   dps: 21639.32405

--- a/sim/rogue/subtlety/TestSubtlety.results
+++ b/sim/rogue/subtlety/TestSubtlety.results
@@ -996,6 +996,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestSubtlety-AllItems-ScalesofLife-68915"
+ value: {
+  dps: 21639.32405
+  tps: 15363.92008
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-ScalesofLife-69109"
+ value: {
+  dps: 21639.32405
+  tps: 15363.92008
+ }
+}
+dps_results: {
  key: "TestSubtlety-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
   dps: 22716.20002

--- a/sim/rogue/subtlety/TestSubtlety.results
+++ b/sim/rogue/subtlety/TestSubtlety.results
@@ -674,6 +674,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestSubtlety-AllItems-JawsofDefeat-68926"
+ value: {
+  dps: 21639.32405
+  tps: 15363.92008
+ }
+}
+dps_results: {
+ key: "TestSubtlety-AllItems-JawsofDefeat-69111"
+ value: {
+  dps: 21639.32405
+  tps: 15363.92008
+ }
+}
+dps_results: {
  key: "TestSubtlety-AllItems-JujuofNimbleness-63840"
  value: {
   dps: 22909.13088

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -1122,6 +1122,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestElemental-AllItems-SpidersilkSpindle-68981"
+ value: {
+  dps: 30428.14406
+  tps: 592.31769
+ }
+}
+dps_results: {
+ key: "TestElemental-AllItems-SpidersilkSpindle-69138"
+ value: {
+  dps: 30608.8098
+  tps: 595.21472
+ }
+}
+dps_results: {
  key: "TestElemental-AllItems-Spiritwalker'sRegalia"
  value: {
   dps: 29413.12564

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -1129,6 +1129,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestElemental-AllItems-StayofExecution-68996"
+ value: {
+  dps: 30105.59576
+  tps: 581.33731
+ }
+}
+dps_results: {
  key: "TestElemental-AllItems-Stonemother'sKiss-61411"
  value: {
   dps: 31053.04638

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -688,6 +688,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestElemental-AllItems-JawsofDefeat-68926"
+ value: {
+  dps: 31526.73717
+  tps: 591.40147
+ }
+}
+dps_results: {
+ key: "TestElemental-AllItems-JawsofDefeat-69111"
+ value: {
+  dps: 31704.49071
+  tps: 593.19706
+ }
+}
+dps_results: {
  key: "TestElemental-AllItems-JujuofNimbleness-63840"
  value: {
   dps: 30328.71314

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -1031,6 +1031,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestElemental-AllItems-ScalesofLife-68915"
+ value: {
+  dps: 30105.59576
+  tps: 581.33731
+ }
+}
+dps_results: {
+ key: "TestElemental-AllItems-ScalesofLife-69109"
+ value: {
+  dps: 30105.59576
+  tps: 581.33731
+ }
+}
+dps_results: {
  key: "TestElemental-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
   dps: 30105.59576

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -1122,6 +1122,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestEnhancement-AllItems-SpidersilkSpindle-68981"
+ value: {
+  dps: 28522.50042
+  tps: 18862.85609
+ }
+}
+dps_results: {
+ key: "TestEnhancement-AllItems-SpidersilkSpindle-69138"
+ value: {
+  dps: 28602.37264
+  tps: 18901.47631
+ }
+}
+dps_results: {
  key: "TestEnhancement-AllItems-Spiritwalker'sRegalia"
  value: {
   dps: 20599.32485

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -1129,6 +1129,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestEnhancement-AllItems-StayofExecution-68996"
+ value: {
+  dps: 27910.67917
+  tps: 18567.02518
+ }
+}
+dps_results: {
  key: "TestEnhancement-AllItems-Stonemother'sKiss-61411"
  value: {
   dps: 28199.81651

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -688,6 +688,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestEnhancement-AllItems-JawsofDefeat-68926"
+ value: {
+  dps: 27955.43636
+  tps: 18584.33601
+ }
+}
+dps_results: {
+ key: "TestEnhancement-AllItems-JawsofDefeat-69111"
+ value: {
+  dps: 27961.31232
+  tps: 18585.34984
+ }
+}
+dps_results: {
  key: "TestEnhancement-AllItems-JujuofNimbleness-63840"
  value: {
   dps: 29092.60549

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -1031,6 +1031,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestEnhancement-AllItems-ScalesofLife-68915"
+ value: {
+  dps: 27910.67917
+  tps: 18567.02518
+ }
+}
+dps_results: {
+ key: "TestEnhancement-AllItems-ScalesofLife-69109"
+ value: {
+  dps: 27910.67917
+  tps: 18567.02518
+ }
+}
+dps_results: {
  key: "TestEnhancement-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
   dps: 29085.53877

--- a/sim/warlock/affliction/TestAffliction.results
+++ b/sim/warlock/affliction/TestAffliction.results
@@ -1087,6 +1087,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestAffliction-AllItems-SpidersilkSpindle-68981"
+ value: {
+  dps: 27038.56737
+  tps: 19823.42335
+ }
+}
+dps_results: {
+ key: "TestAffliction-AllItems-SpidersilkSpindle-69138"
+ value: {
+  dps: 27137.41802
+  tps: 19922.274
+ }
+}
+dps_results: {
  key: "TestAffliction-AllItems-StayofExecution-68996"
  value: {
   dps: 26632.48919

--- a/sim/warlock/affliction/TestAffliction.results
+++ b/sim/warlock/affliction/TestAffliction.results
@@ -996,6 +996,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestAffliction-AllItems-ScalesofLife-68915"
+ value: {
+  dps: 26625.26751
+  tps: 19448.52951
+ }
+}
+dps_results: {
+ key: "TestAffliction-AllItems-ScalesofLife-69109"
+ value: {
+  dps: 26639.05967
+  tps: 19476.99847
+ }
+}
+dps_results: {
  key: "TestAffliction-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
   dps: 26742.01542

--- a/sim/warlock/affliction/TestAffliction.results
+++ b/sim/warlock/affliction/TestAffliction.results
@@ -667,6 +667,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestAffliction-AllItems-JawsofDefeat-68926"
+ value: {
+  dps: 27832.64175
+  tps: 20284.68809
+ }
+}
+dps_results: {
+ key: "TestAffliction-AllItems-JawsofDefeat-69111"
+ value: {
+  dps: 27940.09765
+  tps: 20379.69507
+ }
+}
+dps_results: {
  key: "TestAffliction-AllItems-JujuofNimbleness-63840"
  value: {
   dps: 26799.45893

--- a/sim/warlock/affliction/TestAffliction.results
+++ b/sim/warlock/affliction/TestAffliction.results
@@ -1087,6 +1087,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestAffliction-AllItems-StayofExecution-68996"
+ value: {
+  dps: 26632.48919
+  tps: 19449.56118
+ }
+}
+dps_results: {
  key: "TestAffliction-AllItems-Stonemother'sKiss-61411"
  value: {
   dps: 27476.49322

--- a/sim/warlock/demonology/TestDemonology.results
+++ b/sim/warlock/demonology/TestDemonology.results
@@ -1087,6 +1087,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestDemonology-AllItems-SpidersilkSpindle-68981"
+ value: {
+  dps: 28609.66893
+  tps: 14482.80385
+ }
+}
+dps_results: {
+ key: "TestDemonology-AllItems-SpidersilkSpindle-69138"
+ value: {
+  dps: 28748.39123
+  tps: 14534.08606
+ }
+}
+dps_results: {
  key: "TestDemonology-AllItems-StayofExecution-68996"
  value: {
   dps: 26255.46545

--- a/sim/warlock/demonology/TestDemonology.results
+++ b/sim/warlock/demonology/TestDemonology.results
@@ -667,6 +667,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestDemonology-AllItems-JawsofDefeat-68926"
+ value: {
+  dps: 27430.49636
+  tps: 14874.07642
+ }
+}
+dps_results: {
+ key: "TestDemonology-AllItems-JawsofDefeat-69111"
+ value: {
+  dps: 27556.51612
+  tps: 14944.56798
+ }
+}
+dps_results: {
  key: "TestDemonology-AllItems-JujuofNimbleness-63840"
  value: {
   dps: 26642.93221

--- a/sim/warlock/demonology/TestDemonology.results
+++ b/sim/warlock/demonology/TestDemonology.results
@@ -1087,6 +1087,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestDemonology-AllItems-StayofExecution-68996"
+ value: {
+  dps: 26255.46545
+  tps: 14252.99982
+ }
+}
+dps_results: {
  key: "TestDemonology-AllItems-Stonemother'sKiss-61411"
  value: {
   dps: 28907.54744

--- a/sim/warlock/demonology/TestDemonology.results
+++ b/sim/warlock/demonology/TestDemonology.results
@@ -996,6 +996,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestDemonology-AllItems-ScalesofLife-68915"
+ value: {
+  dps: 27925.65786
+  tps: 14230.85394
+ }
+}
+dps_results: {
+ key: "TestDemonology-AllItems-ScalesofLife-69109"
+ value: {
+  dps: 27925.93816
+  tps: 14231.32287
+ }
+}
+dps_results: {
  key: "TestDemonology-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
   dps: 27916.05747

--- a/sim/warlock/destruction/TestDestruction.results
+++ b/sim/warlock/destruction/TestDestruction.results
@@ -667,6 +667,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestDestruction-AllItems-JawsofDefeat-68926"
+ value: {
+  dps: 28549.4818
+  tps: 18551.73159
+ }
+}
+dps_results: {
+ key: "TestDestruction-AllItems-JawsofDefeat-69111"
+ value: {
+  dps: 28724.12617
+  tps: 18669.45348
+ }
+}
+dps_results: {
  key: "TestDestruction-AllItems-JujuofNimbleness-63840"
  value: {
   dps: 27571.10045

--- a/sim/warlock/destruction/TestDestruction.results
+++ b/sim/warlock/destruction/TestDestruction.results
@@ -1087,6 +1087,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestDestruction-AllItems-StayofExecution-68996"
+ value: {
+  dps: 27307.11696
+  tps: 17730.66788
+ }
+}
+dps_results: {
  key: "TestDestruction-AllItems-Stonemother'sKiss-61411"
  value: {
   dps: 28304.47635

--- a/sim/warlock/destruction/TestDestruction.results
+++ b/sim/warlock/destruction/TestDestruction.results
@@ -996,6 +996,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestDestruction-AllItems-ScalesofLife-68915"
+ value: {
+  dps: 27353.05069
+  tps: 17742.37066
+ }
+}
+dps_results: {
+ key: "TestDestruction-AllItems-ScalesofLife-69109"
+ value: {
+  dps: 27353.05069
+  tps: 17742.58565
+ }
+}
+dps_results: {
  key: "TestDestruction-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
   dps: 27354.947

--- a/sim/warlock/destruction/TestDestruction.results
+++ b/sim/warlock/destruction/TestDestruction.results
@@ -1087,6 +1087,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestDestruction-AllItems-SpidersilkSpindle-68981"
+ value: {
+  dps: 27782.73908
+  tps: 18046.51689
+ }
+}
+dps_results: {
+ key: "TestDestruction-AllItems-SpidersilkSpindle-69138"
+ value: {
+  dps: 27838.58661
+  tps: 18086.01475
+ }
+}
+dps_results: {
  key: "TestDestruction-AllItems-StayofExecution-68996"
  value: {
   dps: 27307.11696

--- a/sim/warrior/arms/TestArms.results
+++ b/sim/warrior/arms/TestArms.results
@@ -695,6 +695,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestArms-AllItems-JawsofDefeat-68926"
+ value: {
+  dps: 31488.55325
+  tps: 20471.84565
+ }
+}
+dps_results: {
+ key: "TestArms-AllItems-JawsofDefeat-69111"
+ value: {
+  dps: 31488.55325
+  tps: 20471.84565
+ }
+}
+dps_results: {
  key: "TestArms-AllItems-JujuofNimbleness-63840"
  value: {
   dps: 32105.66145

--- a/sim/warrior/arms/TestArms.results
+++ b/sim/warrior/arms/TestArms.results
@@ -1136,6 +1136,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestArms-AllItems-StayofExecution-68996"
+ value: {
+  dps: 31507.77555
+  tps: 20491.39159
+ }
+}
+dps_results: {
  key: "TestArms-AllItems-Stonemother'sKiss-61411"
  value: {
   dps: 31488.55325

--- a/sim/warrior/arms/TestArms.results
+++ b/sim/warrior/arms/TestArms.results
@@ -80,8 +80,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 33942.40247
-  tps: 22143.24753
+  dps: 33942.6615
+  tps: 22143.50333
  }
 }
 dps_results: {
@@ -1530,8 +1530,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-Settings-Orc-p3_arms_bis-Basic-arms-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 41483.8493
-  tps: 27564.34681
+  dps: 41483.39564
+  tps: 27564.11385
  }
 }
 dps_results: {

--- a/sim/warrior/arms/TestArms.results
+++ b/sim/warrior/arms/TestArms.results
@@ -1045,6 +1045,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestArms-AllItems-ScalesofLife-68915"
+ value: {
+  dps: 31488.55325
+  tps: 20471.84565
+ }
+}
+dps_results: {
+ key: "TestArms-AllItems-ScalesofLife-69109"
+ value: {
+  dps: 31488.55325
+  tps: 20471.84565
+ }
+}
+dps_results: {
  key: "TestArms-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
   dps: 32015.47399

--- a/sim/warrior/arms/TestArms.results
+++ b/sim/warrior/arms/TestArms.results
@@ -1136,6 +1136,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestArms-AllItems-SpidersilkSpindle-68981"
+ value: {
+  dps: 32077.49846
+  tps: 21071.54983
+ }
+}
+dps_results: {
+ key: "TestArms-AllItems-SpidersilkSpindle-69138"
+ value: {
+  dps: 32053.97389
+  tps: 21193.61065
+ }
+}
+dps_results: {
  key: "TestArms-AllItems-StayofExecution-68996"
  value: {
   dps: 31507.77555

--- a/sim/warrior/fury/TestFury.results
+++ b/sim/warrior/fury/TestFury.results
@@ -1157,6 +1157,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFury-AllItems-StayofExecution-68996"
+ value: {
+  dps: 28613.10708
+  tps: 23785.19572
+ }
+}
+dps_results: {
  key: "TestFury-AllItems-Stonemother'sKiss-61411"
  value: {
   dps: 28663.09175

--- a/sim/warrior/fury/TestFury.results
+++ b/sim/warrior/fury/TestFury.results
@@ -1157,6 +1157,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFury-AllItems-SpidersilkSpindle-68981"
+ value: {
+  dps: 29547.92044
+  tps: 24259.89393
+ }
+}
+dps_results: {
+ key: "TestFury-AllItems-SpidersilkSpindle-69138"
+ value: {
+  dps: 29438.25767
+  tps: 24148.0935
+ }
+}
+dps_results: {
  key: "TestFury-AllItems-StayofExecution-68996"
  value: {
   dps: 28613.10708

--- a/sim/warrior/fury/TestFury.results
+++ b/sim/warrior/fury/TestFury.results
@@ -716,6 +716,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFury-AllItems-JawsofDefeat-68926"
+ value: {
+  dps: 28663.09175
+  tps: 23757.76147
+ }
+}
+dps_results: {
+ key: "TestFury-AllItems-JawsofDefeat-69111"
+ value: {
+  dps: 28663.09175
+  tps: 23757.76147
+ }
+}
+dps_results: {
  key: "TestFury-AllItems-JujuofNimbleness-63840"
  value: {
   dps: 29576.94297

--- a/sim/warrior/fury/TestFury.results
+++ b/sim/warrior/fury/TestFury.results
@@ -1066,6 +1066,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFury-AllItems-ScalesofLife-68915"
+ value: {
+  dps: 28663.09175
+  tps: 23757.76147
+ }
+}
+dps_results: {
+ key: "TestFury-AllItems-ScalesofLife-69109"
+ value: {
+  dps: 28663.09175
+  tps: 23757.76147
+ }
+}
+dps_results: {
  key: "TestFury-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
   dps: 29582.34405

--- a/sim/warrior/fury/TestFury.results
+++ b/sim/warrior/fury/TestFury.results
@@ -80,15 +80,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 31145.43495
-  tps: 25959.5066
+  dps: 31114.55069
+  tps: 25928.37532
  }
 }
 dps_results: {
  key: "TestFury-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 31702.89146
-  tps: 26360.31922
+  dps: 31671.135
+  tps: 26332.48921
  }
 }
 dps_results: {

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -1079,6 +1079,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestProtectionWarrior-AllItems-ScalesofLife-68915"
+ value: {
+  dps: 4659.08749
+  tps: 28426.12721
+ }
+}
+dps_results: {
+ key: "TestProtectionWarrior-AllItems-ScalesofLife-69109"
+ value: {
+  dps: 4659.08749
+  tps: 28426.12721
+ }
+}
+dps_results: {
  key: "TestProtectionWarrior-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
   dps: 4714.685

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -1170,6 +1170,13 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestProtectionWarrior-AllItems-StayofExecution-68996"
+ value: {
+  dps: 4659.08749
+  tps: 28426.12721
+ }
+}
+dps_results: {
  key: "TestProtectionWarrior-AllItems-Stonemother'sKiss-61411"
  value: {
   dps: 4659.08749

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -1170,6 +1170,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestProtectionWarrior-AllItems-SpidersilkSpindle-68981"
+ value: {
+  dps: 4659.08749
+  tps: 28426.12721
+ }
+}
+dps_results: {
+ key: "TestProtectionWarrior-AllItems-SpidersilkSpindle-69138"
+ value: {
+  dps: 4659.08749
+  tps: 28426.12721
+ }
+}
+dps_results: {
  key: "TestProtectionWarrior-AllItems-StayofExecution-68996"
  value: {
   dps: 4659.08749

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -729,6 +729,20 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestProtectionWarrior-AllItems-JawsofDefeat-68926"
+ value: {
+  dps: 4659.08749
+  tps: 28426.12721
+ }
+}
+dps_results: {
+ key: "TestProtectionWarrior-AllItems-JawsofDefeat-69111"
+ value: {
+  dps: 4659.08749
+  tps: 28426.12721
+ }
+}
+dps_results: {
  key: "TestProtectionWarrior-AllItems-JujuofNimbleness-63840"
  value: {
   dps: 4659.08749

--- a/ui/core/constants/item_notices.tsx
+++ b/ui/core/constants/item_notices.tsx
@@ -115,8 +115,6 @@ const NOT_YET_IMPLEMENTED_ITEMS = [
 	68915,
 	// Scales of Life - 391
 	69109,
-	// Stay of Execution - 378
-	68996,
 ];
 
 export const ITEM_NOTICES = new Map<number, ItemNoticeData>([

--- a/ui/core/constants/item_notices.tsx
+++ b/ui/core/constants/item_notices.tsx
@@ -103,10 +103,6 @@ const NON_EXISTING_ITEMS = [
 const NOT_YET_IMPLEMENTED_WARNING = <>The equip/use effect on this item is not yet implemented!</>;
 
 const NOT_YET_IMPLEMENTED_ITEMS = [
-	// Jaws of Defeat - 378
-	68926,
-	// Jaws of Defeat - 391
-	69111,
 	// Spidersilk Spindle- 378
 	68981,
 	// Spidersilk Spindle- 391

--- a/ui/core/constants/item_notices.tsx
+++ b/ui/core/constants/item_notices.tsx
@@ -100,18 +100,7 @@ const NON_EXISTING_ITEMS = [
 	71576,
 ];
 
-const NOT_YET_IMPLEMENTED_WARNING = <>The equip/use effect on this item is not yet implemented!</>;
-
-const NOT_YET_IMPLEMENTED_ITEMS = [
-	// Eye of Blazing Power - 378
-	68983,
-	// Eye of Blazing Power - 391
-	69149,
-	// Scales of Life - 378
-	68915,
-	// Scales of Life - 391
-	69109,
-];
+const WILL_NOT_BE_IMPLEMENTED_WARNING = <>The equip/use effect on this item is will not be implemented!</>;
 
 export const ITEM_NOTICES = new Map<number, ItemNoticeData>([
 	...NON_EXISTING_ITEMS.map((itemID): [number, ItemNoticeData] => [
@@ -120,12 +109,20 @@ export const ITEM_NOTICES = new Map<number, ItemNoticeData>([
 			[Spec.SpecUnknown]: ITEM_DOESNT_EXIST_WARNING,
 		},
 	]),
-	...NOT_YET_IMPLEMENTED_ITEMS.map((itemID): [number, ItemNoticeData] => [
-		itemID,
+	[
+		// Eye of Blazing Power - 378
+		68983,
 		{
-			[Spec.SpecUnknown]: NOT_YET_IMPLEMENTED_WARNING,
+			[Spec.SpecUnknown]: WILL_NOT_BE_IMPLEMENTED_WARNING,
 		},
-	]),
+	],
+	[
+		// Eye of Blazing Power - 391
+		69149,
+		{
+			[Spec.SpecUnknown]: WILL_NOT_BE_IMPLEMENTED_WARNING,
+		},
+	],
 	// Dragonwrath, Tarecgosa's Rest
 	[
 		71086,

--- a/ui/core/constants/item_notices.tsx
+++ b/ui/core/constants/item_notices.tsx
@@ -103,10 +103,6 @@ const NON_EXISTING_ITEMS = [
 const NOT_YET_IMPLEMENTED_WARNING = <>The equip/use effect on this item is not yet implemented!</>;
 
 const NOT_YET_IMPLEMENTED_ITEMS = [
-	// Spidersilk Spindle- 378
-	68981,
-	// Spidersilk Spindle- 391
-	69138,
 	// Eye of Blazing Power - 378
 	68983,
 	// Eye of Blazing Power - 391


### PR DESCRIPTION
Adds the following trinkets from #902:
- [Jaws of Defeat](https://www.wowhead.com/cata/item=68926/jaws-of-defeat)
- [Jaws of Defeat Heroic](https://www.wowhead.com/cata/item=69111/jaws-of-defeat)
- [Spidersilk Spindle](https://www.wowhead.com/cata/item=68981/spidersilk-spindle)
- [Spidersilk Spindle Heroic](https://www.wowhead.com/cata/item=69138/spidersilk-spindle)
- [Scales of Life](https://www.wowhead.com/cata/item=68915/scales-of-life)
- [Scales of Life Heroic](https://www.wowhead.com/cata/item=69109/scales-of-life) 
- [Stay of Execution](https://www.wowhead.com/cata/item=68996/stay-of-execution)

[Eye of Blazing Power](https://www.wowhead.com/cata/item=68983/eye-of-blazing-power) and [Eye of Blazing Power Heroic](https://www.wowhead.com/cata/item=69149/eye-of-blazing-power) marked with a notice as "will not be implemented".