### PR TITLE
Feral Rotation Updates

### DIFF
--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -34,7 +34,7 @@ func (cat *FeralDruid) OnGCDReady(sim *core.Simulation) {
 	}
 
 	// Check for an opportunity to cancel Primal Madness if we just casted a spell.
-	if !cat.GCD.IsReady(sim) && cat.PrimalMadnessAura.IsActive() && !cat.BerserkAura.IsActive() && cat.Rotation.CancelPrimalMadness {
+	if !cat.GCD.IsReady(sim) && cat.PrimalMadnessAura.IsActive() && cat.Rotation.CancelPrimalMadness {
 		// Determine cancellation threshold based on the expected Energy
 		// loss when Primal Madness will naturally expire.
 		energyThresh := 10.0 * float64(cat.Talents.PrimalMadness)

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -33,9 +33,22 @@ func (cat *FeralDruid) OnGCDReady(sim *core.Simulation) {
 		}
 	}
 
-	// Check for an opportunity to cancel Primal Madness if we just casted a spell
-	if !cat.GCD.IsReady(sim) && cat.PrimalMadnessAura.IsActive() && !cat.BerserkAura.IsActive() && (cat.CurrentEnergy() < 10.0*float64(cat.Talents.PrimalMadness)) && cat.Rotation.CancelPrimalMadness {
-		cat.PrimalMadnessAura.Deactivate(sim)
+	// Check for an opportunity to cancel Primal Madness if we just casted a spell.
+	if !cat.GCD.IsReady(sim) && cat.PrimalMadnessAura.IsActive() && !cat.BerserkAura.IsActive() && cat.Rotation.CancelPrimalMadness {
+		// Determine cancellation threshold based on the expected Energy
+		// loss when Primal Madness will naturally expire.
+		energyThresh := 10.0 * float64(cat.Talents.PrimalMadness)
+
+		// Apply a conservative correction to account for the cost of losing one final buffed Shred at the very
+		// end of the TF or Zerk window due to an early cancellation.
+		energyThresh -= core.TernaryFloat64(cat.BerserkAura.IsActive(), 0.5, 0.15) * cat.Shred.DefaultCast.Cost
+
+		// Apply input delay realism to Energy measurement for a real player.
+		energyThresh += cat.EnergyRegenPerSecond() * cat.ReactionTime.Seconds()
+
+		if cat.CurrentEnergy() < energyThresh {
+			cat.PrimalMadnessAura.Deactivate(sim)
+		}
 	}
 }
 


### PR DESCRIPTION
- Lowered Primal Madness cancellation threshold for normal TF windows from 20e to 14e to account for the effective Energy cost of losing a final TF-buffed Shred at the very end of the window due to an early cancellation.
- Re-enabled Primal Madness cancellation during Berserk with a 0 Energy threshold, matching the same logic for the correction term applied to cancellations during TF windows.
- Net DPS impacts of this PR under default settings: P1 BiS = +115 DPS, P3 loot priority reference = +129 DPS, P3 BiS = +73 DPS