### PR TITLE
Allow specs to selectively hide MCDs from the Simple Cooldowns UI

### DIFF
--- a/ui/core/components/individual_sim_ui/cooldowns_picker.ts
+++ b/ui/core/components/individual_sim_ui/cooldowns_picker.ts
@@ -87,7 +87,8 @@ export class CooldownsPicker extends Component {
 			.getMetadata()
 			.getSpells()
 			.filter(spell => spell.data.isMajorCooldown)
-			.map(spell => spell.id);
+			.map(spell => spell.id)
+			.filter(actionId => !this.player.hiddenMCDs.includes(actionId.spellId));
 
 		const actionPicker = new IconEnumPicker<Player<any>, ActionIdProto>(parentElem, this.player, {
 			extraCssClasses: ['cooldown-action-picker'],

--- a/ui/core/player.ts
+++ b/ui/core/player.ts
@@ -204,6 +204,7 @@ export type SimpleRotationGenerator<SpecType extends Spec> = (
 export interface PlayerConfig<SpecType extends Spec> {
 	autoRotation: AutoRotationGenerator<SpecType>;
 	simpleRotation?: SimpleRotationGenerator<SpecType>;
+	hiddenMCDs?: Array<number>; // spell IDs for any MCDs that should be omitted from the Simple Cooldowns UI
 }
 
 const SPEC_CONFIGS: Partial<Record<Spec, PlayerConfig<any>>> = {};
@@ -254,6 +255,7 @@ export class Player<SpecType extends Spec> {
 
 	private readonly autoRotationGenerator: AutoRotationGenerator<SpecType> | null = null;
 	private readonly simpleRotationGenerator: SimpleRotationGenerator<SpecType> | null = null;
+	readonly hiddenMCDs: Array<number>;
 
 	private itemEPCache = new Array<Map<number, number>>();
 	private gemEPCache = new Map<number, number>();
@@ -321,6 +323,7 @@ export class Player<SpecType extends Spec> {
 		} else {
 			this.simpleRotationGenerator = null;
 		}
+		this.hiddenMCDs = specConfig.hiddenMCDs || new Array<number>();
 
 		for (let i = 0; i < ItemSlot.ItemSlotRanged + 1; ++i) {
 			this.itemEPCache[i] = new Map();

--- a/ui/druid/feral/sim.ts
+++ b/ui/druid/feral/sim.ts
@@ -155,6 +155,8 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFeralDruid, {
 		});
 	},
 
+	hiddenMCDs: [50334],
+
 	raidSimPresets: [
 		{
 			spec: Spec.SpecFeralDruid,


### PR DESCRIPTION
 On branch hide-mcds
 Changes to be committed:
	modified:   ui/core/components/individual_sim_ui/cooldowns_picker.ts
	modified:   ui/core/player.ts
	modified:   ui/druid/feral/sim.ts