### PR TITLE
[Blood] Convert death runes for DS

### DIFF
--- a/sim/core/runic_power.go
+++ b/sim/core/runic_power.go
@@ -1061,12 +1061,12 @@ func (spell *Spell) SpendRefundableCostAndConvertBloodRune(sim *Simulation, resu
 	spell.Cost.(*RuneCostImpl).spendRefundableCostAndConvertBloodRune(sim, spell, result, convertChance)
 }
 
-func (rc *RuneCostImpl) spendRefundableCostAndConvertFrostOrUnholyRune(sim *Simulation, spell *Spell, result *SpellResult, convertChance float64) {
+func (rc *RuneCostImpl) spendCostAndConvertFrostOrUnholyRune(sim *Simulation, spell *Spell, result *SpellResult, convertChance float64, refundable bool) {
 	cost := RuneCost(spell.CurCast.Cost) // cost was already optimized in RuneSpell.Cast
 	if cost == 0 {
 		return // it was free this time. we don't care
 	}
-	if !result.Landed() {
+	if refundable && !result.Landed() {
 		// misses just don't get spent as a way to avoid having to cancel regeneration PAs
 		// only spend RP
 		if rc.RefundCost > 0 {
@@ -1096,7 +1096,11 @@ func (rc *RuneCostImpl) spendRefundableCostAndConvertFrostOrUnholyRune(sim *Simu
 }
 
 func (spell *Spell) SpendRefundableCostAndConvertFrostOrUnholyRune(sim *Simulation, result *SpellResult, convertChance float64) {
-	spell.Cost.(*RuneCostImpl).spendRefundableCostAndConvertFrostOrUnholyRune(sim, spell, result, convertChance)
+	spell.Cost.(*RuneCostImpl).spendCostAndConvertFrostOrUnholyRune(sim, spell, result, convertChance, true)
+}
+
+func (spell *Spell) SpendCostAndConvertFrostOrUnholyRune(sim *Simulation, result *SpellResult, convertChance float64) {
+	spell.Cost.(*RuneCostImpl).spendCostAndConvertFrostOrUnholyRune(sim, spell, result, convertChance, false)
 }
 
 func (rc *RuneCostImpl) spendRefundableCostAndConvertBloodOrFrostRune(sim *Simulation, spell *Spell, result *SpellResult, convertChance float64) {

--- a/sim/death_knight/blood/TestBlood.results
+++ b/sim/death_knight/blood/TestBlood.results
@@ -38,2232 +38,2232 @@ character_stats_results: {
 dps_results: {
  key: "TestBlood-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 13943.68877
-  tps: 67590.77835
-  hps: 3554.58578
+  dps: 13743.56088
+  tps: 66479.43257
+  hps: 3587.14839
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3703.36553
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3738.4675
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 14003.20038
-  tps: 67690.9645
-  hps: 3581.26571
+  dps: 13794.23768
+  tps: 66542.31587
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 14332.76785
-  tps: 69537.75742
-  hps: 3581.26571
+  dps: 14125.67438
+  tps: 68388.14525
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 14400.70603
-  tps: 69883.91977
-  hps: 3581.26571
+  dps: 14192.67808
+  tps: 68729.24529
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ArrowofTime-72897"
  value: {
-  dps: 14562.34353
-  tps: 70973.37178
-  hps: 3741.60298
+  dps: 14263.98267
+  tps: 69334.66154
+  hps: 3747.17275
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3665.0139
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3697.83479
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 13838.60129
-  tps: 67030.13492
-  hps: 3581.26571
+  dps: 13638.27148
+  tps: 65917.19442
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 14013.46659
-  tps: 67908.88258
-  hps: 3581.26571
+  dps: 13849.15703
+  tps: 67024.23698
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 14037.40658
-  tps: 68025.43487
-  hps: 3581.26571
+  dps: 13866.16987
+  tps: 67096.07631
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BindingPromise-67037"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 13936.64674
-  tps: 67292.55145
-  hps: 3581.26571
+  dps: 13738.06446
+  tps: 66248.55446
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 14049.59432
-  tps: 67977.45049
-  hps: 3581.26571
+  dps: 13845.87661
+  tps: 66879.78833
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 14280.88925
-  tps: 69005.28763
-  hps: 3581.26571
+  dps: 14081.45616
+  tps: 67894.77603
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 14001.31646
-  tps: 67842.58809
-  hps: 3662.86914
+  dps: 13836.47567
+  tps: 66956.73127
+  hps: 3696.58341
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3662.86914
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3696.58341
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3662.86914
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3696.58341
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 13927.93675
-  tps: 67430.24878
-  hps: 3581.26571
+  dps: 13742.85083
+  tps: 66382.39938
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 14247.00435
-  tps: 68991.08908
-  hps: 3581.26571
+  dps: 14037.94206
+  tps: 67836.76176
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 15090.58645
-  tps: 73879.10255
-  hps: 3581.26571
+  dps: 14875.16264
+  tps: 72825.57421
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 14986.47734
-  tps: 73297.31676
-  hps: 3581.26571
+  dps: 14803.45203
+  tps: 72443.56311
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 15158.7732
-  tps: 74302.50232
-  hps: 3581.26571
+  dps: 14934.99564
+  tps: 73123.30365
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BottledLightning-66879"
  value: {
-  dps: 13889.72307
-  tps: 67218.65902
-  hps: 3581.26571
+  dps: 13673.40748
+  tps: 66012.83478
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BottledWishes-77114"
  value: {
-  dps: 14105.30243
-  tps: 68470.53685
-  hps: 3697.76022
+  dps: 13825.22597
+  tps: 67210.15399
+  hps: 3701.33354
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BottledWishes-77985"
  value: {
-  dps: 14180.42137
-  tps: 69129.49731
-  hps: 3716.857
+  dps: 13808.70208
+  tps: 67177.67316
+  hps: 3696.32646
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BottledWishes-78005"
  value: {
-  dps: 14269.88
-  tps: 69433.06381
-  hps: 3736.26214
+  dps: 13903.04541
+  tps: 67523.67599
+  hps: 3744.69944
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 13797.58675
-  tps: 65468.98191
-  hps: 3554.58578
+  dps: 13597.87347
+  tps: 64381.52557
+  hps: 3587.14839
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 14563.23102
-  tps: 70341.91545
-  hps: 3793.87387
+  dps: 14284.95559
+  tps: 69077.61257
+  hps: 3795.36259
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 13915.81307
-  tps: 67430.64593
-  hps: 3554.58578
+  dps: 13712.6358
+  tps: 66298.96116
+  hps: 3587.14839
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 13953.59515
-  tps: 67630.87378
-  hps: 3554.58578
+  dps: 13752.71142
+  tps: 66517.33204
+  hps: 3587.14839
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 14150.76659
-  tps: 68645.92196
-  hps: 3581.26571
+  dps: 13986.6179
+  tps: 67778.75328
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 14819.83805
-  tps: 71946.63585
-  hps: 3581.26571
+  dps: 14607.45432
+  tps: 70761.02569
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 14716.29109
-  tps: 71366.99883
-  hps: 3581.26571
+  dps: 14489.90648
+  tps: 70124.22913
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 14978.28505
-  tps: 72743.89864
-  hps: 3581.26571
+  dps: 14748.9483
+  tps: 71496.24441
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CrushingWeight-59506"
  value: {
-  dps: 14632.7598
-  tps: 71199.08689
-  hps: 3708.38787
+  dps: 14295.24147
+  tps: 69443.77624
+  hps: 3703.41263
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CrushingWeight-65118"
  value: {
-  dps: 14854.8691
-  tps: 72289.05892
-  hps: 3751.13706
+  dps: 14450.45385
+  tps: 70408.79556
+  hps: 3761.79654
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 14291.85916
-  tps: 69469.42319
-  hps: 3581.26571
+  dps: 14091.9106
+  tps: 68359.48266
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 14279.88973
-  tps: 69412.45543
-  hps: 3581.26571
+  dps: 14077.2182
+  tps: 68280.50825
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CunningoftheCruel-78000"
  value: {
-  dps: 14284.29576
-  tps: 69437.57919
-  hps: 3581.26571
+  dps: 14083.37309
+  tps: 68313.23131
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3663.85488
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3697.57994
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 14634.67895
-  tps: 71207.86271
-  hps: 3582.89658
+  dps: 14304.51087
+  tps: 69384.9623
+  hps: 3603.09015
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 14379.91764
-  tps: 69922.06346
-  hps: 3582.89658
+  dps: 14034.06168
+  tps: 68016.78576
+  hps: 3603.09015
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 13846.53479
-  tps: 67092.97482
-  hps: 3581.26571
+  dps: 13645.26818
+  tps: 65975.23171
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 14136.56374
-  tps: 68624.75603
-  hps: 3629.89303
+  dps: 13932.81272
+  tps: 67616.32915
+  hps: 3666.98981
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 13833.52356
-  tps: 66993.97777
-  hps: 3554.58578
+  dps: 13635.93988
+  tps: 65901.44452
+  hps: 3587.14839
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 13955.40639
-  tps: 67541.7424
-  hps: 3663.64222
+  dps: 13693.53353
+  tps: 66505.75317
+  hps: 3682.5419
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 14541.53201
-  tps: 70580.25806
-  hps: 3581.26571
+  dps: 14323.20831
+  tps: 69322.37807
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 13797.58675
-  tps: 66805.08358
-  hps: 3581.26571
+  dps: 13597.87347
+  tps: 65695.43426
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ElementiumDeathplateBattlearmor"
  value: {
-  dps: 13973.41464
-  tps: 68148.74245
-  hps: 3435.07122
+  dps: 13780.35142
+  tps: 67289.53149
+  hps: 3471.65227
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ElementiumDeathplateBattlegear"
  value: {
-  dps: 15358.54891
-  tps: 74757.30218
-  hps: 3631.91602
+  dps: 15020.59668
+  tps: 73109.02084
+  hps: 3644.34255
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 13797.58675
-  tps: 66805.08358
-  hps: 3554.58578
+  dps: 13597.87347
+  tps: 65695.43426
+  hps: 3587.14839
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 13833.52356
-  tps: 66993.97777
-  hps: 3554.58578
+  dps: 13635.93988
+  tps: 65901.44452
+  hps: 3587.14839
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 14183.1265
-  tps: 68685.95847
-  hps: 3581.26571
+  dps: 13998.1304
+  tps: 67688.39229
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 14197.06409
-  tps: 68752.72757
-  hps: 3581.26571
+  dps: 13999.03055
+  tps: 67714.13744
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 14354.64588
-  tps: 69112.28929
-  hps: 3581.26571
+  dps: 14154.49551
+  tps: 67984.88666
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 13797.58675
-  tps: 66805.08358
-  hps: 3581.26571
+  dps: 13597.87347
+  tps: 65695.43426
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 14947.96464
-  tps: 72789.3189
-  hps: 3581.26571
+  dps: 14732.80957
+  tps: 71594.83508
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 14818.91882
-  tps: 72118.50468
-  hps: 3581.26571
+  dps: 14605.49326
+  tps: 70933.52642
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 15089.91504
-  tps: 73527.21454
-  hps: 3581.26571
+  dps: 14872.85751
+  tps: 72322.2746
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FallofMortality-59500"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FallofMortality-65124"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 13973.85703
-  tps: 67641.00029
-  hps: 3581.26571
+  dps: 13761.20847
+  tps: 66457.37764
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3721.91177
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3756.09423
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 14251.60626
-  tps: 68872.84177
-  hps: 3581.26571
+  dps: 14052.14178
+  tps: 67762.30996
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FireoftheDeep-77988"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FireoftheDeep-78008"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 13797.58675
-  tps: 66805.08358
-  hps: 3554.58578
+  dps: 13597.87347
+  tps: 65695.43426
+  hps: 3587.14839
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FluidDeath-58181"
  value: {
-  dps: 13970.23321
-  tps: 67740.18615
-  hps: 3581.26571
+  dps: 13802.76986
+  tps: 66841.06151
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 13797.58675
-  tps: 66805.08358
-  hps: 3554.58578
+  dps: 13597.87347
+  tps: 65695.43426
+  hps: 3587.14839
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 14525.74587
-  tps: 70724.47233
-  hps: 3581.26571
+  dps: 14362.89043
+  tps: 69862.74548
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GaleofShadows-56138"
  value: {
-  dps: 13940.5629
-  tps: 67533.91885
-  hps: 3681.69945
+  dps: 13633.24269
+  tps: 65877.62553
+  hps: 3696.85733
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GaleofShadows-56462"
  value: {
-  dps: 14028.79017
-  tps: 67911.45781
-  hps: 3684.82132
+  dps: 13668.38029
+  tps: 66160.40525
+  hps: 3658.35541
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GearDetector-61462"
  value: {
-  dps: 14069.97198
-  tps: 68127.07981
-  hps: 3665.97566
+  dps: 13796.77528
+  tps: 66851.21149
+  hps: 3687.4345
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3639.55571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3673.78361
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 14001.87222
-  tps: 67817.56775
-  hps: 3581.26571
+  dps: 13806.40238
+  tps: 66752.47765
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 14098.47051
-  tps: 68266.14914
-  hps: 3581.26571
+  dps: 13925.42598
+  tps: 67339.62855
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HarmlightToken-63839"
  value: {
-  dps: 13888.48316
-  tps: 67297.20252
-  hps: 3581.26571
+  dps: 13689.30456
+  tps: 66188.64575
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 14130.31208
-  tps: 68506.19361
-  hps: 3581.26571
+  dps: 13926.00336
+  tps: 67371.66711
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 14020.59094
-  tps: 67746.62576
-  hps: 3652.84287
+  dps: 13737.24961
+  tps: 66328.13274
+  hps: 3664.15091
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 13966.43417
-  tps: 67543.57544
-  hps: 3659.25509
+  dps: 13708.74127
+  tps: 66248.99028
+  hps: 3665.55605
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HeartofRage-59224"
  value: {
-  dps: 14488.62951
-  tps: 70371.95007
-  hps: 3617.79657
+  dps: 14221.78808
+  tps: 69095.18042
+  hps: 3602.2731
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HeartofRage-65072"
  value: {
-  dps: 14569.82762
-  tps: 70786.18485
-  hps: 3617.79657
+  dps: 14298.66439
+  tps: 69482.03255
+  hps: 3602.2731
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HeartofSolace-55868"
  value: {
-  dps: 13940.5629
-  tps: 67533.91885
-  hps: 3681.69945
+  dps: 13633.24269
+  tps: 65877.62553
+  hps: 3696.85733
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HeartofSolace-56393"
  value: {
-  dps: 14513.01083
-  tps: 70182.49178
-  hps: 3684.82132
+  dps: 14142.43596
+  tps: 68387.29088
+  hps: 3658.35541
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HeartofThunder-55845"
  value: {
-  dps: 13829.94315
-  tps: 66982.62675
-  hps: 3617.63081
+  dps: 13629.74349
+  tps: 65870.38101
+  hps: 3650.27111
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HeartofThunder-56370"
  value: {
-  dps: 13835.61995
-  tps: 67013.77597
-  hps: 3629.47061
+  dps: 13635.33495
+  tps: 65901.07471
+  hps: 3662.05211
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 13981.00193
-  tps: 67745.50336
-  hps: 3581.26571
+  dps: 13798.2913
+  tps: 66753.14156
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 13833.52356
-  tps: 66993.97777
-  hps: 3554.58578
+  dps: 13635.93988
+  tps: 65901.44452
+  hps: 3587.14839
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 14307.08982
-  tps: 69123.79183
-  hps: 3581.26571
+  dps: 14107.68482
+  tps: 68013.2983
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 14307.08982
-  tps: 69123.79183
-  hps: 3581.26571
+  dps: 14107.68482
+  tps: 68013.2983
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IndomitablePride-77211"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3807.55105
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3842.56257
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IndomitablePride-77983"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3781.85927
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3816.62207
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IndomitablePride-78003"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3836.53666
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3871.82878
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3614.08357
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3646.74148
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 14394.33355
-  tps: 69707.21355
-  hps: 3752.12259
+  dps: 14168.05773
+  tps: 68659.74487
+  hps: 3772.25892
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 14263.82409
-  tps: 69392.95157
-  hps: 3722.56343
+  dps: 13995.6911
+  tps: 68004.85805
+  hps: 3748.63513
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 14497.97706
-  tps: 70237.32758
-  hps: 3756.50973
+  dps: 14270.60329
+  tps: 69208.63859
+  hps: 3773.41294
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 13936.64674
-  tps: 67292.55145
-  hps: 3581.26571
+  dps: 13738.06446
+  tps: 66248.55446
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 13915.47889
-  tps: 67443.4223
-  hps: 3581.26571
+  dps: 13723.01522
+  tps: 66370.73126
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 13981.08527
-  tps: 67718.97684
-  hps: 3581.26571
+  dps: 13779.88521
+  tps: 66614.46833
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 14402.25004
-  tps: 69619.83707
-  hps: 3697.76022
+  dps: 14120.61562
+  tps: 68355.09499
+  hps: 3701.33354
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-KiroptyricSigil-77984"
  value: {
-  dps: 14449.58129
-  tps: 70236.31283
-  hps: 3716.857
+  dps: 14058.11266
+  tps: 68185.6112
+  hps: 3696.32646
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-KiroptyricSigil-78004"
  value: {
-  dps: 14618.3725
-  tps: 70835.24732
-  hps: 3736.26214
+  dps: 14238.54322
+  tps: 68825.81689
+  hps: 3744.69944
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 14207.16983
-  tps: 68428.98797
-  hps: 3672.19077
+  dps: 13910.31588
+  tps: 67205.69468
+  hps: 3677.16923
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 14207.16983
-  tps: 68428.98797
-  hps: 3672.19077
+  dps: 13910.31588
+  tps: 67205.69468
+  hps: 3677.16923
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 14056.90877
-  tps: 68157.91803
-  hps: 3666.87534
+  dps: 13843.85527
+  tps: 67063.97633
+  hps: 3677.25508
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LastWord-50708"
  value: {
-  dps: 14589.28477
-  tps: 69800.7979
-  hps: 3812.88473
+  dps: 14377.20099
+  tps: 69002.63228
+  hps: 3839.68392
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LeadenDespair-55816"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3687.65605
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3721.50689
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LeadenDespair-56347"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3721.91177
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3756.09423
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 14030.99
-  tps: 68148.44148
-  hps: 3621.67824
+  dps: 13819.04363
+  tps: 67033.82042
+  hps: 3590.71394
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 14062.51949
-  tps: 68279.4635
-  hps: 3617.79657
+  dps: 13801.84715
+  tps: 67035.28949
+  hps: 3602.2731
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 14307.53954
-  tps: 69444.86641
-  hps: 3581.26571
+  dps: 14100.95798
+  tps: 68297.61393
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MagmaPlatedBattlearmor"
  value: {
-  dps: 13401.37803
-  tps: 64865.72797
-  hps: 3259.12654
+  dps: 13081.99253
+  tps: 63414.88371
+  hps: 3275.32247
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MagmaPlatedBattlegear"
  value: {
-  dps: 14684.50447
-  tps: 71404.11398
-  hps: 3483.50993
+  dps: 14560.02468
+  tps: 70940.01962
+  hps: 3487.47219
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 14369.32161
-  tps: 69161.95725
-  hps: 3599.01137
+  dps: 14105.2462
+  tps: 67773.12482
+  hps: 3626.82519
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 14508.25375
-  tps: 69698.35306
-  hps: 3617.79657
+  dps: 14240.07766
+  tps: 68428.89078
+  hps: 3602.2731
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 14154.76983
-  tps: 68630.81205
-  hps: 3581.26571
+  dps: 13950.12469
+  tps: 67494.46312
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 14199.60903
-  tps: 68859.27921
-  hps: 3581.26571
+  dps: 13994.34713
+  tps: 67719.58915
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 13991.94126
-  tps: 67802.2682
-  hps: 3581.26571
+  dps: 13826.41307
+  tps: 66907.14532
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 14016.34348
-  tps: 67920.27279
-  hps: 3581.26571
+  dps: 13846.08776
+  tps: 66996.26013
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 14102.90057
-  tps: 67915.90725
-  hps: 3581.26571
+  dps: 13900.64578
+  tps: 66788.53448
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 14353.5618
-  tps: 68804.322
-  hps: 3581.26571
+  dps: 14149.30595
+  tps: 67662.68127
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 14002.43743
-  tps: 67848.19294
-  hps: 3581.26571
+  dps: 13836.82982
+  tps: 66958.50204
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3749.25046
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3783.69758
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 14221.83857
-  tps: 68886.53033
-  hps: 3581.26571
+  dps: 14006.6511
+  tps: 67690.34881
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 14061.0789
-  tps: 68209.69703
-  hps: 3652.84287
+  dps: 13811.30753
+  tps: 67073.83086
+  hps: 3670.28016
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 13827.39063
-  tps: 66968.6208
-  hps: 3581.26571
+  dps: 13627.22934
+  tps: 65856.57989
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 13933.10942
-  tps: 67488.10129
-  hps: 3581.26571
+  dps: 13747.60446
+  tps: 66473.34004
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 13797.58675
-  tps: 66805.08358
-  hps: 3581.26571
+  dps: 13597.87347
+  tps: 65695.43426
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 14441.37692
-  tps: 70325.29351
-  hps: 3713.76054
+  dps: 14082.29084
+  tps: 68471.79694
+  hps: 3709.62774
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 14500.1793
-  tps: 70437.22109
-  hps: 3668.19785
+  dps: 14299.74734
+  tps: 69543.6102
+  hps: 3688.81424
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Rainsong-55854"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Rainsong-56377"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReflectionoftheLight-77986"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReflectionoftheLight-78006"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 13989.82235
-  tps: 67807.89821
-  hps: 3554.58578
+  dps: 13785.61959
+  tps: 66670.63985
+  hps: 3587.14839
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 13915.81307
-  tps: 67430.64593
-  hps: 3554.58578
+  dps: 13712.6358
+  tps: 66298.96116
+  hps: 3587.14839
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 14251.14462
-  tps: 69069.18307
-  hps: 3581.26571
+  dps: 14067.15422
+  tps: 68068.12278
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 14106.12257
-  tps: 68360.55512
-  hps: 3581.26571
+  dps: 13901.26598
+  tps: 67194.83786
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 14118.73076
-  tps: 68454.12691
-  hps: 3581.26571
+  dps: 13911.80381
+  tps: 67285.77471
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RosaryofLight-72901"
  value: {
-  dps: 14610.97354
-  tps: 70946.21048
-  hps: 3581.26571
+  dps: 14396.57527
+  tps: 69754.99505
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RottingSkull-77116"
  value: {
-  dps: 14984.13886
-  tps: 71472.08066
-  hps: 3581.26571
+  dps: 14799.46351
+  tps: 70460.06748
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RottingSkull-77987"
  value: {
-  dps: 14846.54115
-  tps: 70931.47984
-  hps: 3581.26571
+  dps: 14666.33216
+  tps: 69935.67566
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RottingSkull-78007"
  value: {
-  dps: 15128.15915
-  tps: 72032.03428
-  hps: 3581.26571
+  dps: 14952.55354
+  tps: 71069.362
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuneofZeth-68998"
  value: {
-  dps: 14047.661
-  tps: 68081.87296
-  hps: 3581.26571
+  dps: 13876.72784
+  tps: 67143.59708
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScalesofLife-68915"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 4061.27528
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 4095.92967
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScalesofLife-69109"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 4123.17492
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 4158.06846
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 13935.11499
-  tps: 67524.15901
-  hps: 3581.26571
+  dps: 13752.74806
+  tps: 66526.87364
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SeaStar-55256"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SeaStar-56290"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Shadowmourne-49623"
  value: {
-  dps: 15107.87189
-  tps: 73061.77453
-  hps: 3817.82195
+  dps: 14833.55815
+  tps: 71764.08658
+  hps: 3852.03142
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ShardofWoe-60233"
  value: {
-  dps: 14237.72935
-  tps: 69072.79503
-  hps: 3706.44864
+  dps: 13960.23215
+  tps: 67567.72792
+  hps: 3735.02227
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 14247.10998
-  tps: 69029.89104
-  hps: 3673.14769
+  dps: 13937.98655
+  tps: 67495.58341
+  hps: 3696.54897
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3666.24623
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3699.88981
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 13938.72464
-  tps: 67543.46445
-  hps: 3581.26571
+  dps: 13761.40667
+  tps: 66578.11303
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 13954.55837
-  tps: 67607.29914
-  hps: 3581.26571
+  dps: 13781.60521
+  tps: 66676.80048
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Sorrowsong-55879"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Sorrowsong-56400"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 14102.90057
-  tps: 67915.90725
-  hps: 3581.26571
+  dps: 13900.64578
+  tps: 66788.53448
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SoulCasket-58183"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3807.55105
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3842.56257
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3781.85927
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3816.62207
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3836.53666
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3871.82878
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 14621.37287
-  tps: 70935.75025
-  hps: 3736.76761
+  dps: 14283.92804
+  tps: 69302.55986
+  hps: 3747.2586
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 14546.09411
-  tps: 70799.4354
-  hps: 3728.30169
+  dps: 14285.12494
+  tps: 69444.81219
+  hps: 3757.26953
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 14829.87978
-  tps: 72063.66408
-  hps: 3772.71037
+  dps: 14463.10701
+  tps: 70297.91026
+  hps: 3771.05088
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StayofExecution-68996"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 13930.15228
-  tps: 67535.89316
-  hps: 3581.26571
+  dps: 13729.58287
+  tps: 66422.17734
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StumpofTime-62465"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StumpofTime-62470"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3740.02777
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3774.38561
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 14276.74502
-  tps: 69278.24051
-  hps: 3637.23355
+  dps: 13981.58918
+  tps: 67774.91177
+  hps: 3677.73193
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TearofBlood-55819"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TearofBlood-56351"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheHungerer-68927"
  value: {
-  dps: 14517.53249
-  tps: 70512.53804
-  hps: 3712.27276
+  dps: 14231.44697
+  tps: 69132.69177
+  hps: 3747.03288
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheHungerer-69112"
  value: {
-  dps: 14566.99771
-  tps: 70854.76688
-  hps: 3724.89687
+  dps: 14271.87787
+  tps: 69396.14454
+  hps: 3750.99719
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 13942.04055
-  tps: 67604.76169
-  hps: 3581.26571
+  dps: 13770.77335
+  tps: 66680.85514
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 13965.0961
-  tps: 67731.00716
-  hps: 3581.26571
+  dps: 13791.66069
+  tps: 66792.11456
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 13951.47186
-  tps: 67561.79628
-  hps: 3634.81104
+  dps: 13736.84428
+  tps: 66447.28298
+  hps: 3654.55637
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 13816.47436
-  tps: 66912.94123
-  hps: 3581.26571
+  dps: 13614.88856
+  tps: 65788.02614
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-UnheededWarning-59520"
  value: {
-  dps: 14157.61767
-  tps: 68728.27743
-  hps: 3581.26571
+  dps: 13983.7011
+  tps: 67798.3775
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 13998.37581
-  tps: 67771.33055
-  hps: 3581.26571
+  dps: 13787.98783
+  tps: 66603.79486
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 13998.37581
-  tps: 67771.33055
-  hps: 3581.26571
+  dps: 13787.98783
+  tps: 66603.79486
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 13998.37581
-  tps: 67771.33055
-  hps: 3581.26571
+  dps: 13787.98783
+  tps: 66603.79486
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 8039.64866
-  tps: 37174.72007
-  hps: 3595.86797
+  dps: 7971.68506
+  tps: 37035.78535
+  hps: 3631.77852
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 14048.59172
-  tps: 68147.2523
-  hps: 3581.26571
+  dps: 13848.79009
+  tps: 67035.88105
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 14078.16509
-  tps: 68329.75428
-  hps: 3581.26571
+  dps: 13876.81261
+  tps: 67203.1727
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 14332.76785
-  tps: 69537.75742
-  hps: 3581.26571
+  dps: 14125.67438
+  tps: 68388.14525
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-VeilofLies-72900"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3770.66028
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3805.31467
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 14549.08674
-  tps: 70730.60303
-  hps: 3581.26571
+  dps: 14361.49364
+  tps: 69696.3793
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 14639.62204
-  tps: 71211.84527
-  hps: 3581.26571
+  dps: 14454.99741
+  tps: 70197.36301
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-VialofShadows-77207"
  value: {
-  dps: 14529.58749
-  tps: 70794.14526
-  hps: 3581.26571
+  dps: 14263.69015
+  tps: 69591.74484
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-VialofShadows-77979"
  value: {
-  dps: 14486.4904
-  tps: 70625.61573
-  hps: 3581.26571
+  dps: 14282.212
+  tps: 69581.04965
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-VialofShadows-77999"
  value: {
-  dps: 14427.77921
-  tps: 70252.82232
-  hps: 3581.26571
+  dps: 14212.77032
+  tps: 69168.89376
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3740.02777
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3774.38561
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3760.44945
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3795.00498
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 13998.37581
-  tps: 67771.33055
-  hps: 3581.26571
+  dps: 13787.98783
+  tps: 66603.79486
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 14307.08982
-  tps: 69123.79183
-  hps: 3581.26571
+  dps: 14107.68482
+  tps: 68013.2983
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3667.5634
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3701.32906
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 14150.77872
-  tps: 68624.05957
-  hps: 3767.3726
+  dps: 13853.93329
+  tps: 67201.34359
+  hps: 3779.42491
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 14023.59996
-  tps: 67962.49137
-  hps: 3667.5634
+  dps: 13855.35454
+  tps: 67048.08924
+  hps: 3701.32906
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 13960.30601
-  tps: 67740.72835
-  hps: 3703.71635
+  dps: 13703.3962
+  tps: 66500.87353
+  hps: 3689.13765
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3667.5634
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3701.32906
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3667.5634
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3701.32906
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 13915.65632
-  tps: 67375.97884
-  hps: 3581.26571
+  dps: 13744.38463
+  tps: 66451.35554
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 14246.37925
-  tps: 69004.48818
-  hps: 3581.26571
+  dps: 14043.99444
+  tps: 67876.41715
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WillofUnbinding-77995"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 13896.19211
-  tps: 67365.17066
-  hps: 3616.19754
+  dps: 13576.2162
+  tps: 65753.94986
+  hps: 3651.7747
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 13844.48418
-  tps: 67054.7786
-  hps: 3645.05091
+  dps: 13637.30269
+  tps: 66042.09073
+  hps: 3668.8464
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 14146.97122
-  tps: 68670.43102
-  hps: 3581.26571
+  dps: 13975.7687
+  tps: 67754.09101
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 14105.14094
-  tps: 68442.56648
-  hps: 3581.26571
+  dps: 13935.56437
+  tps: 67529.20106
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 14178.46904
-  tps: 68852.60563
-  hps: 3581.26571
+  dps: 14002.40346
+  tps: 67901.84134
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3689.63235
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3723.50232
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3689.63235
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3723.50232
  }
 }
 dps_results: {
  key: "TestBlood-Average-Default"
  value: {
-  dps: 13749.78674
-  tps: 66920.41806
-  hps: 3598.07778
+  dps: 13470.70748
+  tps: 65565.9636
+  hps: 3614.87661
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Goblin-p1-Basic-simple-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17347.90667
-  tps: 84066.64727
-  hps: 3716.9586
+  dps: 17101.23403
+  tps: 82900.11618
+  hps: 3753.74702
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Goblin-p1-Basic-simple-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 13737.46638
-  tps: 66602.16034
-  hps: 3627.67085
+  dps: 13476.90849
+  tps: 65388.47547
+  hps: 3649.91811
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Goblin-p1-Basic-simple-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 18678.35705
-  tps: 77916.32905
+  dps: 18331.58727
+  tps: 76193.77561
   hps: 7034.09514
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Goblin-p1-Basic-simple-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 13122.33215
-  tps: 63359.69644
-  hps: 3162.03641
+  dps: 12932.9996
+  tps: 62493.04509
+  hps: 3173.56993
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Goblin-p1-Basic-simple-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 10206.5051
-  tps: 49464.3278
-  hps: 3105.62636
+  dps: 10008.1905
+  tps: 48415.91512
+  hps: 3107.53708
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Goblin-p1-Basic-simple-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 12675.41056
-  tps: 52277.04275
+  dps: 12451.53314
+  tps: 51163.50036
   hps: 5816.60575
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Worgen-p1-Basic-simple-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17546.25697
-  tps: 84907.40625
-  hps: 3703.71134
+  dps: 17118.91807
+  tps: 82808.03834
+  hps: 3713.95121
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Worgen-p1-Basic-simple-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 13812.36141
-  tps: 66886.15379
-  hps: 3581.26571
+  dps: 13612.42604
+  tps: 65775.31888
+  hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Worgen-p1-Basic-simple-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 19037.88681
-  tps: 79778.13248
-  hps: 6992.19483
+  dps: 18704.56881
+  tps: 78102.90127
+  hps: 7020.59997
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Worgen-p1-Basic-simple-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 13271.78045
-  tps: 64070.29202
-  hps: 3180.48289
+  dps: 12894.29752
+  tps: 62204.34302
+  hps: 3187.46242
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Worgen-p1-Basic-simple-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 10255.18059
-  tps: 49625.63081
-  hps: 3087.20038
+  dps: 10035.51674
+  tps: 48618.44075
+  hps: 3103.5184
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Worgen-p1-Basic-simple-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 12518.45532
-  tps: 51570.16522
+  dps: 12294.88924
+  tps: 50458.64717
   hps: 5712.56303
  }
 }
 dps_results: {
  key: "TestBlood-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 12572.54111
-  tps: 61580.9196
-  hps: 3464.58697
+  dps: 12240.83093
+  tps: 59906.8798
+  hps: 3467.14614
  }
 }


### PR DESCRIPTION
[Blood Rites](https://www.wowhead.com/cata/spell=50034/blood-rites) was not added to Death Strike, only Obliterate. Seeing as DS isn't refunded on miss/dodge/parry it has to be handled a little differently!