### PR TITLE
Fix block scoping for item version variable

### DIFF
--- a/sim/common/cata/other_effects.go
+++ b/sim/common/cata/other_effects.go
@@ -787,7 +787,8 @@ func init() {
 		})
 	}
 
-	for _, version := range []ItemVersion{ItemVersionLFR, ItemVersionNormal, ItemVersionHeroic} {
+	for _, v := range []ItemVersion{ItemVersionLFR, ItemVersionNormal, ItemVersionHeroic} {
+		version := v // Gotta scope this for the closure
 		labelSuffix := []string{" (LFR)", "", " (Heroic)"}[version]
 
 		vialItemID := []int32{77979, 77207, 77999}[version]

--- a/sim/death_knight/blood/TestBlood.results
+++ b/sim/death_knight/blood/TestBlood.results
@@ -246,16 +246,16 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 14875.16264
-  tps: 72825.57421
+  dps: 14807.38889
+  tps: 72463.03183
   hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 14803.45203
-  tps: 72443.56311
+  dps: 14672.50601
+  tps: 71722.91824
   hps: 3614.08661
  }
 }
@@ -406,16 +406,16 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 14091.9106
-  tps: 68359.48266
+  dps: 14038.02105
+  tps: 68069.36641
   hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 14077.2182
-  tps: 68280.50825
+  dps: 13977.21837
+  tps: 67742.63664
   hps: 3614.08661
  }
 }
@@ -1942,16 +1942,16 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-VialofShadows-77207"
  value: {
-  dps: 14263.69015
-  tps: 69591.74484
+  dps: 14214.46851
+  tps: 69325.83438
   hps: 3614.08661
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-VialofShadows-77979"
  value: {
-  dps: 14282.212
-  tps: 69581.04965
+  dps: 14189.98117
+  tps: 69084.02585
   hps: 3614.08661
  }
 }

--- a/sim/death_knight/frost/TestFrost.results
+++ b/sim/death_knight/frost/TestFrost.results
@@ -238,16 +238,16 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 40124.47609
-  tps: 37917.02514
+  dps: 40021.81348
+  tps: 37814.36252
   hps: 506.11588
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 39952.81756
-  tps: 37757.20893
+  dps: 39755.3019
+  tps: 37559.69327
   hps: 506.88858
  }
 }
@@ -398,16 +398,16 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 38017.28694
-  tps: 35888.20402
+  dps: 37964.91383
+  tps: 35835.8309
   hps: 506.11588
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 37942.18621
-  tps: 35813.10328
+  dps: 37844.36212
+  tps: 35715.27919
   hps: 506.11588
  }
 }
@@ -1942,16 +1942,16 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-VialofShadows-77207"
  value: {
-  dps: 38252.19824
-  tps: 36080.74432
+  dps: 38197.01157
+  tps: 36025.55765
   hps: 506.11588
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-VialofShadows-77979"
  value: {
-  dps: 38224.63628
-  tps: 36061.37321
+  dps: 38120.22082
+  tps: 35956.95775
   hps: 507.66127
  }
 }

--- a/sim/death_knight/unholy/TestUnholy.results
+++ b/sim/death_knight/unholy/TestUnholy.results
@@ -246,16 +246,16 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 39628.93605
-  tps: 29827.33837
+  dps: 39517.34096
+  tps: 29715.74329
   hps: 628.42635
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 39429.86268
-  tps: 29684.65295
+  dps: 39206.15106
+  tps: 29460.94133
   hps: 628.42635
  }
 }
@@ -406,16 +406,16 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 37600.37561
-  tps: 28287.75024
+  dps: 37526.96589
+  tps: 28214.34053
   hps: 628.42635
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 37547.44988
-  tps: 28230.80932
+  dps: 37411.33942
+  tps: 28094.69885
   hps: 628.42635
  }
 }
@@ -1941,16 +1941,16 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-VialofShadows-77207"
  value: {
-  dps: 37938.28976
-  tps: 28436.98777
+  dps: 37882.04528
+  tps: 28380.74329
   hps: 628.42635
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-VialofShadows-77979"
  value: {
-  dps: 37831.32101
-  tps: 28392.04085
+  dps: 37722.2398
+  tps: 28282.95964
   hps: 628.42635
  }
 }

--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -354,15 +354,15 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 28342.24591
-  tps: 28340.09751
+  dps: 28305.58988
+  tps: 28303.44148
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 27959.27818
-  tps: 27958.35825
+  dps: 27895.3433
+  tps: 27894.42337
  }
 }
 dps_results: {

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -221,15 +221,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 27245.33216
-  tps: 38845.54284
+  dps: 27120.02454
+  tps: 38689.58284
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 27135.7745
-  tps: 38441.44383
+  dps: 26898.80709
+  tps: 38123.71123
  }
 }
 dps_results: {
@@ -354,15 +354,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 25485.51678
-  tps: 36406.02053
+  dps: 25480.35072
+  tps: 36380.19023
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 25480.64776
-  tps: 36385.70227
+  dps: 25472.08793
+  tps: 36342.90314
  }
 }
 dps_results: {
@@ -1707,15 +1707,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77207"
  value: {
-  dps: 27849.93311
-  tps: 39229.18821
+  dps: 27779.8327
+  tps: 39127.99166
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77979"
  value: {
-  dps: 27616.26549
-  tps: 39384.92951
+  dps: 27481.69067
+  tps: 39185.27416
  }
 }
 dps_results: {

--- a/sim/druid/guardian/TestGuardian.results
+++ b/sim/druid/guardian/TestGuardian.results
@@ -214,15 +214,15 @@ dps_results: {
 dps_results: {
  key: "TestGuardian-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 8727.71952
-  tps: 43700.73761
+  dps: 8630.69473
+  tps: 43215.61363
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 8724.83687
-  tps: 43686.65103
+  dps: 8543.01354
+  tps: 42777.53435
  }
 }
 dps_results: {
@@ -347,15 +347,15 @@ dps_results: {
 dps_results: {
  key: "TestGuardian-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 8031.38578
-  tps: 40219.64246
+  dps: 8005.95564
+  tps: 40092.49176
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 7970.28548
-  tps: 39914.32534
+  dps: 7922.27042
+  tps: 39674.25002
  }
 }
 dps_results: {
@@ -1707,15 +1707,15 @@ dps_results: {
 dps_results: {
  key: "TestGuardian-AllItems-VialofShadows-77207"
  value: {
-  dps: 8729.23207
-  tps: 43710.05848
+  dps: 8667.6242
+  tps: 43402.01912
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-VialofShadows-77979"
  value: {
-  dps: 8674.52025
-  tps: 43436.16148
+  dps: 8558.46296
+  tps: 42855.87501
  }
 }
 dps_results: {

--- a/sim/hunter/beast_mastery/TestBM.results
+++ b/sim/hunter/beast_mastery/TestBM.results
@@ -242,15 +242,15 @@ dps_results: {
 dps_results: {
  key: "TestBM-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 21615.22872
-  tps: 18395.87466
+  dps: 21533.27613
+  tps: 18313.92206
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 21541.91451
-  tps: 18303.74242
+  dps: 21387.59006
+  tps: 18149.41797
  }
 }
 dps_results: {
@@ -382,15 +382,15 @@ dps_results: {
 dps_results: {
  key: "TestBM-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 21099.01866
-  tps: 17849.05422
+  dps: 21074.31734
+  tps: 17824.3529
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 21085.69866
-  tps: 17835.6508
+  dps: 21041.95694
+  tps: 17791.90909
  }
 }
 dps_results: {
@@ -1721,15 +1721,15 @@ dps_results: {
 dps_results: {
  key: "TestBM-AllItems-VialofShadows-77207"
  value: {
-  dps: 22515.93058
-  tps: 19084.65771
+  dps: 22468.44859
+  tps: 19037.17573
  }
 }
 dps_results: {
  key: "TestBM-AllItems-VialofShadows-77979"
  value: {
-  dps: 22395.92376
-  tps: 18973.32924
+  dps: 22306.26164
+  tps: 18883.66712
  }
 }
 dps_results: {

--- a/sim/hunter/marksmanship/TestMM.results
+++ b/sim/hunter/marksmanship/TestMM.results
@@ -242,15 +242,15 @@ dps_results: {
 dps_results: {
  key: "TestMM-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 21379.00652
-  tps: 19218.00925
+  dps: 21326.60421
+  tps: 19165.60694
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 21295.62836
-  tps: 19128.94068
+  dps: 21193.8746
+  tps: 19027.18692
  }
 }
 dps_results: {
@@ -382,15 +382,15 @@ dps_results: {
 dps_results: {
  key: "TestMM-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 20955.4829
-  tps: 18781.88595
+  dps: 20938.26545
+  tps: 18764.66851
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 20946.74573
-  tps: 18773.23211
+  dps: 20916.09652
+  tps: 18742.5829
  }
 }
 dps_results: {
@@ -1721,15 +1721,15 @@ dps_results: {
 dps_results: {
  key: "TestMM-AllItems-VialofShadows-77207"
  value: {
-  dps: 22396.53089
-  tps: 20101.12074
+  dps: 22365.59854
+  tps: 20070.18838
  }
 }
 dps_results: {
  key: "TestMM-AllItems-VialofShadows-77979"
  value: {
-  dps: 22132.09102
-  tps: 19840.74988
+  dps: 22067.4359
+  tps: 19776.09476
  }
 }
 dps_results: {

--- a/sim/hunter/survival/TestSV.results
+++ b/sim/hunter/survival/TestSV.results
@@ -242,15 +242,15 @@ dps_results: {
 dps_results: {
  key: "TestSV-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 23980.239
-  tps: 21634.37927
+  dps: 23933.28311
+  tps: 21587.42339
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 23968.46583
-  tps: 21627.64712
+  dps: 23873.64871
+  tps: 21532.83
  }
 }
 dps_results: {
@@ -382,15 +382,15 @@ dps_results: {
 dps_results: {
  key: "TestSV-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 23642.37557
-  tps: 21287.87082
+  dps: 23619.90877
+  tps: 21265.40403
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 23640.27202
-  tps: 21285.85167
+  dps: 23598.24523
+  tps: 21243.82488
  }
 }
 dps_results: {
@@ -1721,15 +1721,15 @@ dps_results: {
 dps_results: {
  key: "TestSV-AllItems-VialofShadows-77207"
  value: {
-  dps: 25208.92744
-  tps: 22702.60109
+  dps: 25177.17106
+  tps: 22670.8447
  }
 }
 dps_results: {
  key: "TestSV-AllItems-VialofShadows-77979"
  value: {
-  dps: 25161.88322
-  tps: 22674.78443
+  dps: 25099.21579
+  tps: 22612.11701
  }
 }
 dps_results: {

--- a/sim/mage/arcane/TestArcane.results
+++ b/sim/mage/arcane/TestArcane.results
@@ -354,15 +354,15 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 37385.64225
-  tps: 36516.75816
+  dps: 37233.0357
+  tps: 36364.15161
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 37101.59487
-  tps: 36270.27196
+  dps: 36818.1011
+  tps: 35986.77819
  }
 }
 dps_results: {

--- a/sim/mage/fire/TestFire.results
+++ b/sim/mage/fire/TestFire.results
@@ -354,15 +354,15 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 37271.92024
-  tps: 35694.22825
+  dps: 37227.3588
+  tps: 35649.66681
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 37646.63522
-  tps: 36043.95195
+  dps: 37572.42487
+  tps: 35969.7416
  }
 }
 dps_results: {

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -249,15 +249,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 31625.67763
-  tps: 31641.02088
+  dps: 31503.90503
+  tps: 31519.24828
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 31490.91036
-  tps: 31506.25361
+  dps: 31269.71574
+  tps: 31285.059
  }
 }
 dps_results: {
@@ -389,15 +389,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 29957.21805
-  tps: 29976.43303
+  dps: 29860.67743
+  tps: 29879.89241
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 29867.96137
-  tps: 29885.17708
+  dps: 29689.15969
+  tps: 29706.3754
  }
 }
 dps_results: {
@@ -1707,15 +1707,15 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-VialofShadows-77207"
  value: {
-  dps: 30374.36808
-  tps: 30389.71133
+  dps: 30295.42253
+  tps: 30310.76578
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-VialofShadows-77979"
  value: {
-  dps: 30211.35888
-  tps: 30226.70213
+  dps: 30063.92195
+  tps: 30079.2652
  }
 }
 dps_results: {

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -221,15 +221,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 35059.54756
-  tps: 31856.51676
+  dps: 35050.99343
+  tps: 31847.96263
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 35046.54013
-  tps: 31843.50933
+  dps: 35032.66248
+  tps: 31829.63168
  }
 }
 dps_results: {
@@ -368,15 +368,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 38186.00546
-  tps: 34689.90217
+  dps: 38039.06205
+  tps: 34542.95877
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 38075.77971
-  tps: 34547.20256
+  dps: 37808.73654
+  tps: 34280.15939
  }
 }
 dps_results: {
@@ -1707,15 +1707,15 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-VialofShadows-77207"
  value: {
-  dps: 35099.9883
-  tps: 31896.9575
+  dps: 35087.1446
+  tps: 31884.1138
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-VialofShadows-77979"
  value: {
-  dps: 35096.70872
-  tps: 31893.67792
+  dps: 35071.73971
+  tps: 31868.70891
  }
 }
 dps_results: {

--- a/sim/rogue/assassination/TestAssassination.results
+++ b/sim/rogue/assassination/TestAssassination.results
@@ -258,15 +258,15 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 29112.27663
-  tps: 20669.71641
+  dps: 28988.55009
+  tps: 20581.87057
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 28992.63055
-  tps: 20584.76769
+  dps: 28746.5186
+  tps: 20410.0282
  }
 }
 dps_results: {
@@ -391,15 +391,15 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 27521.73657
-  tps: 19540.43297
+  dps: 27483.15357
+  tps: 19513.03903
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 27520.81683
-  tps: 19539.77995
+  dps: 27450.54924
+  tps: 19489.88996
  }
 }
 dps_results: {
@@ -1702,15 +1702,15 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-VialofShadows-77207"
  value: {
-  dps: 29783.17659
-  tps: 21146.05538
+  dps: 29700.98
+  tps: 21087.6958
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VialofShadows-77979"
  value: {
-  dps: 29583.46216
-  tps: 21004.25813
+  dps: 29429.28669
+  tps: 20894.79355
  }
 }
 dps_results: {

--- a/sim/rogue/combat/TestCombat.results
+++ b/sim/rogue/combat/TestCombat.results
@@ -235,15 +235,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 29879.80146
-  tps: 21214.65904
+  dps: 29722.53252
+  tps: 21102.99809
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 29789.59736
-  tps: 21150.61412
+  dps: 29506.6792
+  tps: 20949.74223
  }
 }
 dps_results: {
@@ -1707,15 +1707,15 @@ dps_results: {
 dps_results: {
  key: "TestCombat-AllItems-VialofShadows-77207"
  value: {
-  dps: 30381.67051
-  tps: 21570.98606
+  dps: 30301.61527
+  tps: 21514.14684
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-VialofShadows-77979"
  value: {
-  dps: 30189.03724
-  tps: 21434.21644
+  dps: 30042.27123
+  tps: 21330.01258
  }
 }
 dps_results: {

--- a/sim/rogue/subtlety/TestSubtlety.results
+++ b/sim/rogue/subtlety/TestSubtlety.results
@@ -221,15 +221,15 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 23911.004
-  tps: 16976.81284
+  dps: 23751.34352
+  tps: 16863.4539
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 23811.30793
-  tps: 16906.02863
+  dps: 23516.06256
+  tps: 16696.40442
  }
 }
 dps_results: {
@@ -1665,15 +1665,15 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-VialofShadows-77207"
  value: {
-  dps: 24455.01996
-  tps: 17363.06417
+  dps: 24369.4009
+  tps: 17302.27464
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-VialofShadows-77979"
  value: {
-  dps: 24254.73338
-  tps: 17220.8607
+  dps: 24096.88604
+  tps: 17108.78909
  }
 }
 dps_results: {

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -242,15 +242,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 34428.28387
-  tps: 740.8579
+  dps: 34412.4623
+  tps: 725.03633
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 34438.35302
-  tps: 751.00003
+  dps: 34406.10064
+  tps: 718.74766
  }
 }
 dps_results: {
@@ -382,15 +382,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 36296.14276
-  tps: 976.5966
+  dps: 36256.09299
+  tps: 936.54683
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 36174.75072
-  tps: 1029.27794
+  dps: 36087.26224
+  tps: 941.78946
  }
 }
 dps_results: {
@@ -1721,15 +1721,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-VialofShadows-77207"
  value: {
-  dps: 34469.89679
-  tps: 782.44528
+  dps: 34449.26039
+  tps: 761.80888
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-VialofShadows-77979"
  value: {
-  dps: 34469.34102
-  tps: 782.10851
+  dps: 34430.58789
+  tps: 743.35538
  }
 }
 dps_results: {

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -235,15 +235,15 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 36363.11292
-  tps: 23855.00735
+  dps: 36242.8812
+  tps: 23734.77562
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 36311.65611
-  tps: 23847.12171
+  dps: 36082.81992
+  tps: 23618.28552
  }
 }
 dps_results: {
@@ -375,15 +375,15 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 35344.03216
-  tps: 23071.16429
+  dps: 35255.81506
+  tps: 22982.94719
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 35341.52063
-  tps: 23047.8914
+  dps: 35174.06791
+  tps: 22880.43868
  }
 }
 dps_results: {
@@ -1721,15 +1721,15 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-VialofShadows-77207"
  value: {
-  dps: 36947.34765
-  tps: 24022.21334
+  dps: 36877.00833
+  tps: 23951.87402
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-VialofShadows-77979"
  value: {
-  dps: 36737.02832
-  tps: 23917.82961
+  dps: 36603.16342
+  tps: 23783.96471
  }
 }
 dps_results: {

--- a/sim/warlock/affliction/TestAffliction.results
+++ b/sim/warlock/affliction/TestAffliction.results
@@ -361,15 +361,15 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 36256.63939
-  tps: 26681.02671
+  dps: 36187.24412
+  tps: 26611.63144
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 36039.40629
-  tps: 26460.11716
+  dps: 35910.63849
+  tps: 26331.34936
  }
 }
 dps_results: {

--- a/sim/warlock/demonology/TestDemonology.results
+++ b/sim/warlock/demonology/TestDemonology.results
@@ -361,15 +361,15 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 37125.36621
-  tps: 19422.87669
+  dps: 37067.80475
+  tps: 19365.31523
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 36877.64349
-  tps: 19241.69201
+  dps: 36766.41278
+  tps: 19130.4613
  }
 }
 dps_results: {

--- a/sim/warlock/destruction/TestDestruction.results
+++ b/sim/warlock/destruction/TestDestruction.results
@@ -361,15 +361,15 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 37289.04198
-  tps: 23995.5962
+  dps: 37228.48587
+  tps: 23935.04008
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 37045.51125
-  tps: 23805.34628
+  dps: 36928.43666
+  tps: 23688.27169
  }
 }
 dps_results: {

--- a/sim/warrior/arms/TestArms.results
+++ b/sim/warrior/arms/TestArms.results
@@ -221,15 +221,15 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 33907.49693
-  tps: 22429.78187
+  dps: 33760.91585
+  tps: 22283.20079
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 33867.38785
-  tps: 22390.18092
+  dps: 33594.84139
+  tps: 22117.63446
  }
 }
 dps_results: {
@@ -1721,15 +1721,15 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-VialofShadows-77207"
  value: {
-  dps: 32722.91642
-  tps: 21611.35538
+  dps: 32632.65802
+  tps: 21521.09699
  }
 }
 dps_results: {
  key: "TestArms-AllItems-VialofShadows-77979"
  value: {
-  dps: 32833.81075
-  tps: 21586.74473
+  dps: 32668.45824
+  tps: 21421.39223
  }
 }
 dps_results: {

--- a/sim/warrior/fury/TestFury.results
+++ b/sim/warrior/fury/TestFury.results
@@ -235,15 +235,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 32043.57731
-  tps: 26737.58683
+  dps: 31874.98893
+  tps: 26568.99845
  }
 }
 dps_results: {
  key: "TestFury-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 31803.82663
-  tps: 26655.76508
+  dps: 31502.80243
+  tps: 26354.74088
  }
 }
 dps_results: {
@@ -1742,15 +1742,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-VialofShadows-77207"
  value: {
-  dps: 30591.29375
-  tps: 25357.71642
+  dps: 30489.78779
+  tps: 25256.21046
  }
 }
 dps_results: {
  key: "TestFury-AllItems-VialofShadows-77979"
  value: {
-  dps: 30422.03777
-  tps: 25264.23795
+  dps: 30230.90279
+  tps: 25073.10297
  }
 }
 dps_results: {

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -234,15 +234,15 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 5516.78208
-  tps: 33079.66553
+  dps: 5454.33939
+  tps: 32767.45212
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 5436.56288
-  tps: 32610.43233
+  dps: 5327.50586
+  tps: 32065.14721
  }
 }
 dps_results: {
@@ -1746,15 +1746,15 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-VialofShadows-77207"
  value: {
-  dps: 5187.73859
-  tps: 31129.84349
+  dps: 5137.96363
+  tps: 30880.96866
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-VialofShadows-77979"
  value: {
-  dps: 5196.21315
-  tps: 31198.56987
+  dps: 5103.66606
+  tps: 30735.83445
  }
 }
 dps_results: {


### PR DESCRIPTION
Every trinket was using the highest rank (the last value in the loop) for all aura ids, stat values etc 🤦 thanks to some fun scoping issues