### PR TITLE
[Paladin] Move all item procs to items.go and fix ret T13 4pc modifier

### DIFF
--- a/sim/paladin/divine_protection.go
+++ b/sim/paladin/divine_protection.go
@@ -40,10 +40,6 @@ func (paladin *Paladin) registerDivineProtectionSpell() {
 			} else {
 				paladin.PseudoStats.DamageTakenMultiplier /= 0.8
 			}
-
-			if paladin.FlamingAegis != nil {
-				paladin.FlamingAegis.Activate(sim)
-			}
 		},
 	})
 
@@ -70,11 +66,10 @@ func (paladin *Paladin) registerDivineProtectionSpell() {
 		},
 	})
 
-	paladin.AddMajorCooldown(core.MajorCooldown{
-		Spell: paladin.DivineProtection,
-		Type:  core.CooldownTypeSurvival,
-		ShouldActivate: func(sim *core.Simulation, character *core.Character) bool {
-			return character.Spec == proto.Spec_SpecProtectionPaladin
-		},
-	})
+	if paladin.Spec == proto.Spec_SpecProtectionPaladin {
+		paladin.AddMajorCooldown(core.MajorCooldown{
+			Spell: paladin.DivineProtection,
+			Type:  core.CooldownTypeSurvival,
+		})
+	}
 }

--- a/sim/paladin/judgement.go
+++ b/sim/paladin/judgement.go
@@ -7,9 +7,6 @@ import (
 )
 
 func (paladin *Paladin) registerJudgement() {
-	hpMetrics := paladin.NewHolyPowerMetrics(core.ActionID{SpellID: 105767})
-	hasT132pc := paladin.HasSetBonus(ItemSetBattleplateOfRadiantGlory, 2)
-
 	paladin.RegisterSpell(core.SpellConfig{
 		ActionID:    core.ActionID{SpellID: 20271},
 		SpellSchool: core.SpellSchoolHoly,
@@ -39,18 +36,6 @@ func (paladin *Paladin) registerJudgement() {
 
 			if result.Landed() {
 				paladin.CurrentJudgement.Cast(sim, target)
-				if hasT132pc {
-					// TODO: Measure the aura update delay distribution on PTR.
-					waitTime := time.Millisecond * time.Duration(sim.RollWithLabel(150, 750, "T13 2pc"))
-					core.StartDelayedAction(sim, core.DelayedActionOptions{
-						DoAt:     sim.CurrentTime + waitTime,
-						Priority: core.ActionPriorityRegen,
-
-						OnAction: func(_ *core.Simulation) {
-							paladin.GainHolyPower(sim, 1, hpMetrics)
-						},
-					})
-				}
 			}
 		},
 	})

--- a/sim/paladin/paladin.go
+++ b/sim/paladin/paladin.go
@@ -29,7 +29,6 @@ const (
 	SpellMaskConsecration
 	SpellMaskHammerOfTheRighteousMelee
 	SpellMaskHammerOfTheRighteousAoe
-	SpellMaskHandOfReckoning
 	SpellMaskAvengersShield
 	SpellMaskDivinePlea
 	SpellMaskDivineProtection
@@ -102,6 +101,26 @@ const SpellMaskModifiedByTwoHandedSpec = SpellMaskJudgement |
 	SpellMaskSealsOfCommand |
 	SpellMaskHammerOfWrath
 
+const SpellMaskModifiedByZealOfTheCrusader = SpellMaskTemplarsVerdict |
+	SpellMaskCrusaderStrike |
+	SpellMaskDivineStorm |
+	SpellMaskExorcism |
+	SpellMaskGlyphOfExorcism |
+	SpellMaskHammerOfWrath |
+	SpellMaskJudgementOfTruth |
+	SpellMaskJudgementOfRighteousness |
+	SpellMaskHolyWrath |
+	SpellMaskConsecration |
+	SpellMaskHammerOfTheRighteousMelee |
+	SpellMaskHammerOfTheRighteousAoe |
+	SpellMaskAvengersShield |
+	SpellMaskCensure |
+	SpellMaskSealsOfCommand |
+	SpellMaskHolyShock |
+	SpellMaskSealOfTruth |
+	SpellMaskSealOfRighteousness |
+	SpellMaskSealOfJustice
+
 var TalentTreeSizes = [3]int{20, 20, 20}
 
 type Paladin struct {
@@ -163,9 +182,6 @@ type Paladin struct {
 	JudgementsOfThePureAura *core.Aura
 	GrandCrusaderAura       *core.Aura
 	SacredDutyAura          *core.Aura
-
-	// Prot T12 4pc
-	FlamingAegis *core.Aura
 }
 
 // Implemented by each Paladin spec.

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -115,8 +115,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-BattleplateofRadiantGlory"
  value: {
-  dps: 34371.07031
-  tps: 34285.33165
+  dps: 34215.93731
+  tps: 34130.19865
  }
 }
 dps_results: {

--- a/sim/paladin/talents_retribution.go
+++ b/sim/paladin/talents_retribution.go
@@ -332,23 +332,11 @@ func (paladin *Paladin) applyZealotry() {
 		duration += time.Second * 15
 	}
 
-	hasT134pc := paladin.HasSetBonus(ItemSetBattleplateOfRadiantGlory, 4)
-
 	paladin.ZealotryAura = paladin.RegisterAura(core.Aura{
 		Label:    "Zealotry",
 		ActionID: actionId,
 		Duration: duration,
-
-		OnGain: func(aura *core.Aura, sim *core.Simulation) {
-			if hasT134pc {
-				aura.Unit.PseudoStats.DamageDealtMultiplier *= 1.18
-			}
-		},
-		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
-			if hasT134pc {
-				aura.Unit.PseudoStats.DamageDealtMultiplier /= 1.18
-			}
-		},
+		// Holy Power logic is handled for each ability
 	})
 
 	paladin.Zealotry = paladin.RegisterSpell(core.SpellConfig{


### PR DESCRIPTION
Many set bonuses were handled in the spell code, now moving them all to proc triggers within items.go.
Ret T13 4pc actually explicitly state which spells are affected by it, most notably not including auto attacks, which is now fixed.