### PR TITLE
Add ability to limit breakpoint capping

### DIFF
--- a/proto/ui.proto
+++ b/proto/ui.proto
@@ -318,6 +318,7 @@ message IndividualSimSettings {
 	Stat heal_ref_stat = 13;
 	Stat tank_ref_stat = 14;
 	UnitStats stat_caps = 15;
+	UnitStats breakpoint_limits = 16;
 }
 
 message StatCapConfig {

--- a/ui/core/components/suggest_reforges_action.tsx
+++ b/ui/core/components/suggest_reforges_action.tsx
@@ -629,7 +629,7 @@ export class ReforgeOptimizer {
 	}
 
 	buildSoftCapBreakpointsLimiter({ useSoftCapBreakpointsInput }: { useSoftCapBreakpointsInput: BooleanPicker<Player<any>> | null }) {
-		if (!useSoftCapBreakpointsInput) return null;
+		if (!this.enableBreakpointLimits || !useSoftCapBreakpointsInput) return null;
 
 		const tableRef = ref<HTMLTableElement>();
 		const breakpointsLimitTooltipRef = ref<HTMLButtonElement>();

--- a/ui/core/individual_sim_ui.tsx
+++ b/ui/core/individual_sim_ui.tsx
@@ -58,6 +58,8 @@ const SAVED_EP_WEIGHTS_STORAGE_KEY = '__savedEPWeights__';
 const SAVED_ROTATION_STORAGE_KEY = '__savedRotation__';
 const SAVED_SETTINGS_STORAGE_KEY = '__savedSettings__';
 const SAVED_TALENTS_STORAGE_KEY = '__savedTalents__';
+const SAVED_BREAKPOINTS_LIMIT_STORAGE_KEY = '__breakpointsLimit__';
+
 
 export type InputConfig<ModObject> =
 	| InputHelpers.TypedBooleanPickerConfig<ModObject>
@@ -578,6 +580,10 @@ export abstract class IndividualSimUI<SpecType extends Spec> extends SimUI {
 
 	getSavedTalentsStorageKey(): string {
 		return this.getStorageKey(SAVED_TALENTS_STORAGE_KEY);
+	}
+
+	getSavedBreakpointsLimitStorageKey(): string {
+		return this.getStorageKey(SAVED_BREAKPOINTS_LIMIT_STORAGE_KEY);
 	}
 
 	// Returns the actual key to use for local storage, based on the given key part and the site context.

--- a/ui/core/individual_sim_ui.tsx
+++ b/ui/core/individual_sim_ui.tsx
@@ -530,6 +530,7 @@ export abstract class IndividualSimUI<SpecType extends Spec> extends SimUI {
 			if (this.individualConfig.defaults.statCaps) this.player.setStatCaps(eventID, this.individualConfig.defaults.statCaps);
 			if (this.individualConfig.defaults.softCapBreakpoints)
 				this.player.setSoftCapBreakpoints(eventID, this.individualConfig.defaults.softCapBreakpoints);
+			this.player.setBreakpointLimits(eventID, new Stats());
 			this.player.setProfession1(eventID, this.individualConfig.defaults.other?.profession1 || Profession.Engineering);
 			this.player.setProfession2(eventID, this.individualConfig.defaults.other?.profession2 || Profession.Jewelcrafting);
 			this.player.setDistanceFromTarget(eventID, this.individualConfig.defaults.other?.distanceFromTarget || 0);

--- a/ui/core/individual_sim_ui.tsx
+++ b/ui/core/individual_sim_ui.tsx
@@ -58,8 +58,6 @@ const SAVED_EP_WEIGHTS_STORAGE_KEY = '__savedEPWeights__';
 const SAVED_ROTATION_STORAGE_KEY = '__savedRotation__';
 const SAVED_SETTINGS_STORAGE_KEY = '__savedSettings__';
 const SAVED_TALENTS_STORAGE_KEY = '__savedTalents__';
-const SAVED_BREAKPOINTS_LIMIT_STORAGE_KEY = '__breakpointsLimit__';
-
 
 export type InputConfig<ModObject> =
 	| InputHelpers.TypedBooleanPickerConfig<ModObject>
@@ -582,10 +580,6 @@ export abstract class IndividualSimUI<SpecType extends Spec> extends SimUI {
 		return this.getStorageKey(SAVED_TALENTS_STORAGE_KEY);
 	}
 
-	getSavedBreakpointsLimitStorageKey(): string {
-		return this.getStorageKey(SAVED_BREAKPOINTS_LIMIT_STORAGE_KEY);
-	}
-
 	// Returns the actual key to use for local storage, based on the given key part and the site context.
 	getStorageKey(keyPart: string): string {
 		// Local storage is shared by all sites under the same domain, so we need to use
@@ -624,6 +618,7 @@ export abstract class IndividualSimUI<SpecType extends Spec> extends SimUI {
 				epWeightsStats: this.player.getEpWeights().toProto(),
 				epRatios: this.player.getEpRatios(),
 				statCaps: this.player.getStatCaps().toProto(),
+				breakpointLimits: this.player.getBreakpointLimits().toProto(),
 				dpsRefStat: this.dpsRefStat,
 				healRefStat: this.healRefStat,
 				tankRefStat: this.tankRefStat,
@@ -682,6 +677,10 @@ export abstract class IndividualSimUI<SpecType extends Spec> extends SimUI {
 
 				if (settings.statCaps) {
 					this.player.setStatCaps(eventID, Stats.fromProto(settings.statCaps));
+				}
+
+				if (settings.breakpointLimits) {
+					this.player.setBreakpointLimits(eventID, Stats.fromProto(settings.breakpointLimits));
 				}
 
 				if (settings.dpsRefStat) {

--- a/ui/core/player.ts
+++ b/ui/core/player.ts
@@ -270,6 +270,7 @@ export class Player<SpecType extends Spec> {
 	private epWeights: Stats = new Stats();
 	private statCaps: Stats = new Stats();
 	private softCapBreakpoints: StatCap[] = [];
+	private breakpointLimits: Stats = new Stats();
 	private currentStats: PlayerStats = PlayerStats.create();
 	private metadata: UnitMetadata = new UnitMetadata();
 	private petMetadatas: UnitMetadataList = new UnitMetadataList();
@@ -292,6 +293,7 @@ export class Player<SpecType extends Spec> {
 	readonly epWeightsChangeEmitter = new TypedEvent<void>('PlayerEpWeights');
 	readonly statCapsChangeEmitter = new TypedEvent<void>('StatCaps');
 	readonly softCapBreakpointsChangeEmitter = new TypedEvent<void>('SoftCapBreakpoints');
+	readonly breakpointLimitsChangeEmitter = new TypedEvent<void>('BreakpointLimits');
 	readonly miscOptionsChangeEmitter = new TypedEvent<void>('PlayerMiscOptions');
 
 	readonly currentStatsEmitter = new TypedEvent<void>('PlayerCurrentStats');
@@ -351,6 +353,7 @@ export class Player<SpecType extends Spec> {
 				this.epRatiosChangeEmitter,
 				this.epRefStatChangeEmitter,
 				this.statCapsChangeEmitter,
+				this.breakpointLimitsChangeEmitter,
 			],
 			'PlayerChange',
 		);
@@ -498,6 +501,14 @@ export class Player<SpecType extends Spec> {
 	setSoftCapBreakpoints(eventID: EventID, newSoftCapBreakpoints: StatCap[]) {
 		this.softCapBreakpoints = newSoftCapBreakpoints;
 		this.softCapBreakpointsChangeEmitter.emit(eventID);
+	}
+	getBreakpointLimits(): Stats {
+		return this.breakpointLimits;
+	}
+
+	setBreakpointLimits(eventID: EventID, newLimits: Stats) {
+		this.breakpointLimits = newLimits;
+		this.breakpointLimitsChangeEmitter.emit(eventID);
 	}
 
 	getDefaultEpRatios(isTankSpec: boolean, isHealingSpec: boolean): Array<number> {

--- a/ui/core/proto_utils/stats.ts
+++ b/ui/core/proto_utils/stats.ts
@@ -210,6 +210,14 @@ export class UnitStat {
 		}
 	}
 
+	toJson(): object {
+		return UnitStatProto.toJson(this.toProto()) as object;
+	}
+
+	static fromJson(obj: any): UnitStat {
+		return UnitStat.fromProto(UnitStatProto.fromJson(obj));
+	}
+
 	toProto(): UnitStatProto {
 		const protoMessage = UnitStatProto.create({});
 

--- a/ui/mage/fire/sim.tsx
+++ b/ui/mage/fire/sim.tsx
@@ -239,6 +239,7 @@ export class FireMageSimUI extends IndividualSimUI<Spec.SpecFireMage> {
 		player.sim.waitForInit().then(() => {
 			new ReforgeOptimizer(this, {
 				statSelectionPresets: Presets.FIRE_BREAKPOINTS,
+				enableBreakpointLimits: true,
 				updateSoftCaps: softCaps => {
 					const raidBuffs = player.getRaid()?.getBuffs();
 					const hasBL = !!(raidBuffs?.bloodlust || raidBuffs?.timeWarp || raidBuffs?.heroism);

--- a/ui/mage/fire/sim.tsx
+++ b/ui/mage/fire/sim.tsx
@@ -271,7 +271,7 @@ export class FireMageSimUI extends IndividualSimUI<Spec.SpecFireMage> {
 										if (!hasCloseMatchingValue(blBreakpoint)) adjustedHastedBreakpoints.add(blBreakpoint);
 										if (hasBerserking) {
 											const berserkingBreakpoint = modifyHaste(blBreakpoint, 1.2);
-											if (berserkingBreakpoint > 0 && !hasCloseMatchingValue(blBreakpoint)) {
+											if (berserkingBreakpoint > 0 && !hasCloseMatchingValue(berserkingBreakpoint)) {
 												adjustedHastedBreakpoints.add(berserkingBreakpoint);
 											}
 										}
@@ -283,7 +283,7 @@ export class FireMageSimUI extends IndividualSimUI<Spec.SpecFireMage> {
 										if (!hasCloseMatchingValue(piBreakpoint)) adjustedHastedBreakpoints.add(piBreakpoint);
 										if (hasBerserking) {
 											const berserkingBreakpoint = modifyHaste(piBreakpoint, 1.2);
-											if (berserkingBreakpoint > 0 && !hasCloseMatchingValue(piBreakpoint)) {
+											if (berserkingBreakpoint > 0 && !hasCloseMatchingValue(berserkingBreakpoint)) {
 												adjustedHastedBreakpoints.add(berserkingBreakpoint);
 											}
 										}


### PR DESCRIPTION
- Add the ability to let the user choose to override to a max breakpoint limit
  - Example: A Mage would like to have more control over which breakpoint should be the cap (15%, 20% etc), to go a bit more Crit heavy. The stat cap flow doesn't work for that due to 0-ing the EP after reaching a cap.
- Dropdown is based on the available options defined by the Sim

![image](https://github.com/user-attachments/assets/a014072a-ddd4-4756-839a-969104391446)
