### PR TITLE
Add Gurthalak, Voice of the Deeps

### DIFF
--- a/sim/common/cata/gurthalak.go
+++ b/sim/common/cata/gurthalak.go
@@ -1,0 +1,238 @@
+package cata
+
+import (
+	"time"
+
+	"github.com/wowsims/cata/sim/core"
+	"github.com/wowsims/cata/sim/core/stats"
+)
+
+// Gurthalak, Voice of the Deeps
+// Equip: Your melee attacks have a chance to cause you to summon a Tentacle of the Old Ones to fight by your side for 12 sec.
+// (Proc chance: 2%)
+func init() {
+	// These spells ignore the slot the weapon is in.
+	// Any other ability should only trigger the proc if the weapon is in the right slot.
+	ignoresSlot := map[int32]bool{
+		23881: true, // Bloodthirst
+		6544:  true, // Heroic Leap
+		6343:  true, // Thunder Clap
+	}
+
+	// TODO: Check if there's any restrictions on certain off-hand attacks like there are for Apparatus and Vessel.
+
+	for _, v := range []ItemVersion{ItemVersionLFR, ItemVersionNormal, ItemVersionHeroic} {
+		version := v // Gotta scope this for the closure
+		labelSuffix := []string{" (LFR)", "", " (Heroic)"}[version]
+
+		gurthalakItemID := []int32{78487, 77191, 78478}[version]
+		core.NewItemEffect(gurthalakItemID, func(agent core.Agent) {
+			var gurthalak GurthalakAgent
+			if gurth, canEquip := agent.(GurthalakAgent); canEquip {
+				gurthalak = gurth
+			} else {
+				return
+			}
+
+			character := agent.GetCharacter()
+			procMask := character.GetProcMaskForItem(gurthalakItemID)
+
+			core.MakeProcTriggerAura(&character.Unit, core.ProcTrigger{
+				Name:     "Gurthalak Trigger" + labelSuffix,
+				ActionID: core.ActionID{ItemID: gurthalakItemID},
+				Callback: core.CallbackOnSpellHitDealt,
+				ProcMask: core.ProcMaskMelee, // TODO: Verify correct proc masks on the PTR
+				Outcome:  core.OutcomeLanded,
+				Harmful:  true,
+				Handler: func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
+					tentacles := gurthalak.GetTentacles()
+
+					if _, ignore := ignoresSlot[spell.ActionID.SpellID]; !spell.ProcMask.Matches(procMask) && !ignore {
+						return
+					}
+
+					if !sim.Proc(0.02, "Gurthalak, Voice of the Deeps"+labelSuffix) {
+						return
+					}
+
+					if sim.Log != nil {
+						character.Log(sim, "Gurthalak procced by %s", spell.ActionID)
+					}
+
+					for _, tentacle := range tentacles {
+						if tentacle.IsActive() {
+							continue
+						}
+
+						tentacle.ProccedItemVersion = version
+						tentacle.EnableWithTimeout(sim, tentacle, time.Second*12)
+
+						return
+					}
+
+					if sim.Log != nil {
+						character.Log(sim, "No tentacles available for Gurthalak to proc, this is unreasonable.")
+					}
+				},
+			})
+		})
+	}
+}
+
+type TentacleOfTheOldOnesPet struct {
+	core.Pet
+	mindFlay           map[ItemVersion]*core.Spell
+	castsLeft          int32
+	castDelay          time.Duration
+	ProccedItemVersion ItemVersion
+}
+
+type GurthalakAgent interface {
+	GetTentacles() []*TentacleOfTheOldOnesPet
+}
+
+func NewTentacleOfTheOldOnesPet(character *core.Character) *TentacleOfTheOldOnesPet {
+	pet := &TentacleOfTheOldOnesPet{
+		Pet: core.NewPet("Tentacle of the Old Ones", character, stats.Stats{
+			stats.Stamina: 100,
+		}, func(ownerStats stats.Stats) stats.Stats {
+			return stats.Stats{
+				stats.SpellHitPercent:  ownerStats[stats.SpellHitPercent],
+				stats.SpellCritPercent: ownerStats[stats.SpellCritPercent],
+			}
+		}, false, true),
+	}
+
+	pet.Pet.OnPetEnable = pet.enable
+	pet.PseudoStats.DamageTakenMultiplier = 0
+
+	return pet
+}
+
+func (pet *TentacleOfTheOldOnesPet) enable(sim *core.Simulation) {
+	pet.castDelay = sim.CurrentTime + time.Second
+	pet.castsLeft = 3
+
+	// The tentacles inherit the owner's damage dealt multipliers (Avenging Wrath, Berserker Stance, Communion etc.)
+	// as well as Shadow School damage multipliers like Unholy DKs Dreadblade mastery.
+	// TODO: Verify this on the PTR
+	pet.PseudoStats.DamageDealtMultiplier = pet.Owner.PseudoStats.DamageDealtMultiplier
+	pet.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexShadow] = pet.Owner.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexShadow]
+
+	// It also inherits the owner's spell hit and crit, on each cast of Mind Flay.
+	// TODO: Verify this on the PTR
+	pet.EnableDynamicStats(func(ownerStats stats.Stats) stats.Stats {
+		return stats.Stats{
+			stats.SpellHitPercent:  ownerStats[stats.SpellHitPercent],
+			stats.SpellCritPercent: ownerStats[stats.SpellCritPercent],
+		}
+	})
+}
+
+func (pet *TentacleOfTheOldOnesPet) GetPet() *core.Pet {
+	return &pet.Pet
+}
+
+func (pet *TentacleOfTheOldOnesPet) Initialize() {
+	pet.registerMindFlay()
+}
+
+func (pet *TentacleOfTheOldOnesPet) registerMindFlay() {
+	actionID := core.ActionID{SpellID: 52586}
+
+	pet.mindFlay = make(map[ItemVersion]*core.Spell)
+	for _, v := range []ItemVersion{ItemVersionLFR, ItemVersionNormal, ItemVersionHeroic} {
+		version := v // Gotta scope this for the closure
+		labelSuffix := []string{" (LFR)", "", " (Heroic)"}[version]
+
+		// TODO: Verify these damage numbers on the PTR, they do match all of the videos on YouTube at least.
+		baseTickDamage := []float64{9881, 11155, 12591}[version]
+
+		pet.mindFlay[version] = pet.RegisterSpell(core.SpellConfig{
+			ActionID:    actionID.WithTag(int32(version)),
+			SpellSchool: core.SpellSchoolShadow,
+			ProcMask:    core.ProcMaskSpellDamage,
+			Flags:       core.SpellFlagNoOnCastComplete | core.SpellFlagChanneled,
+
+			Cast: core.CastConfig{
+				DefaultCast: core.Cast{
+					GCD: core.GCDDefault,
+				},
+			},
+
+			Dot: core.DotConfig{
+				Aura: core.Aura{
+					Label: "Mind Flay " + labelSuffix,
+				},
+				NumberOfTicks:       3,
+				TickLength:          time.Second,
+				AffectedByCastSpeed: false,
+
+				OnSnapshot: func(sim *core.Simulation, target *core.Unit, dot *core.Dot, isRollover bool) {
+					dot.Snapshot(target, baseTickDamage)
+				},
+				OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
+					dot.CalcAndDealPeriodicSnapshotDamage(sim, target, dot.OutcomeSnapshotCrit)
+				},
+			},
+
+			DamageMultiplier:         1,
+			DamageMultiplierAdditive: 1,
+			ThreatMultiplier:         1,
+			CritMultiplier:           pet.DefaultSpellCritMultiplier(),
+
+			ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
+				pet.castsLeft--
+
+				result := spell.CalcOutcome(sim, target, spell.OutcomeMagicHitNoHitCounter)
+				dot := spell.Dot(target)
+				// The last cast had a 50/50 chance of only getting 2 ticks back in the day.
+				// This could've been because of aura delays or something not present in Classic.
+				// TODO: Verify this on the PTR
+				if pet.castsLeft == 0 {
+					dot.BaseTickCount = []int32{2, 3}[int(sim.RollWithLabel(0, 2, "Tentacle of the Old Ones"+labelSuffix))]
+				} else {
+					dot.BaseTickCount = 3
+				}
+
+				if result.Landed() {
+					dot.Apply(sim)
+					// In old videos there seems to be a delay between each cast, we simulate this by setting an explicit wait time.
+					// TODO: Verify this on the PTR
+					pet.castDelay = sim.CurrentTime + time.Second*4
+				}
+			},
+		})
+	}
+}
+
+func (pet *TentacleOfTheOldOnesPet) Reset(sim *core.Simulation) {
+	pet.castDelay = sim.CurrentTime
+	pet.castsLeft = 3
+}
+
+func (pet *TentacleOfTheOldOnesPet) ExecuteCustomRotation(sim *core.Simulation) {
+	if sim.CurrentTime < pet.castDelay {
+		pet.WaitUntil(sim, pet.castDelay)
+		return
+	}
+
+	mindFlay := pet.mindFlay[pet.ProccedItemVersion]
+	if !pet.GCD.IsReady(sim) || pet.Unit.ChanneledDot != nil && pet.Unit.ChanneledDot.Spell == mindFlay {
+		return
+	}
+
+	if pet.castsLeft <= 0 {
+		if pet.IsEnabled() {
+			pet.Disable(sim)
+		}
+		return
+	}
+
+	// These should update at the time of cast. Popping wings mid spawn should apply on the next cast for example.
+	// TODO: Verify this on the PTR
+	pet.PseudoStats.DamageDealtMultiplier = pet.Owner.PseudoStats.DamageDealtMultiplier
+	pet.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexShadow] = pet.Owner.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexShadow]
+
+	mindFlay.Cast(sim, pet.CurrentTarget)
+}

--- a/sim/death_knight/blood/TestBlood.results
+++ b/sim/death_knight/blood/TestBlood.results
@@ -780,6 +780,30 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestBlood-AllItems-Gurthalak,VoiceoftheDeeps-77191"
+ value: {
+  dps: 23636.0766
+  tps: 118220.30064
+  hps: 6340.27181
+ }
+}
+dps_results: {
+ key: "TestBlood-AllItems-Gurthalak,VoiceoftheDeeps-78478"
+ value: {
+  dps: 23818.43258
+  tps: 119197.74564
+  hps: 6386.79742
+ }
+}
+dps_results: {
+ key: "TestBlood-AllItems-Gurthalak,VoiceoftheDeeps-78487"
+ value: {
+  dps: 23475.3602
+  tps: 117358.84325
+  hps: 6298.44576
+ }
+}
+dps_results: {
  key: "TestBlood-AllItems-HarmlightToken-63839"
  value: {
   dps: 21848.77386

--- a/sim/death_knight/death_knight.go
+++ b/sim/death_knight/death_knight.go
@@ -4,6 +4,7 @@ import (
 	"math"
 	"time"
 
+	"github.com/wowsims/cata/sim/common/cata"
 	"github.com/wowsims/cata/sim/core"
 	"github.com/wowsims/cata/sim/core/proto"
 	"github.com/wowsims/cata/sim/core/stats"
@@ -69,6 +70,19 @@ type DeathKnight struct {
 
 	// Runic power decay, used during pre pull
 	RunicPowerDecayAura *core.Aura
+
+	// Cached Gurthalak tentacles
+	gurthalakTentacles []*cata.TentacleOfTheOldOnesPet
+}
+
+func (deathKnight *DeathKnight) GetTentacles() []*cata.TentacleOfTheOldOnesPet {
+	return deathKnight.gurthalakTentacles
+}
+
+func (dk *DeathKnight) NewTentacleOfTheOldOnesPet() *cata.TentacleOfTheOldOnesPet {
+	pet := cata.NewTentacleOfTheOldOnesPet(&dk.Character)
+	dk.AddPet(pet)
+	return pet
 }
 
 func (dk *DeathKnight) GetCharacter() *core.Character {
@@ -229,6 +243,14 @@ func NewDeathKnight(character *core.Character, inputs DeathKnightInputs, talents
 		AutoSwingMelee: true,
 	})
 
+	if mh := dk.MainHand(); mh.Name == "Gurthalak, Voice of the Deeps" {
+		dk.gurthalakTentacles = make([]*cata.TentacleOfTheOldOnesPet, 10)
+
+		for i := 0; i < 10; i++ {
+			dk.gurthalakTentacles[i] = dk.NewTentacleOfTheOldOnesPet()
+		}
+	}
+
 	return dk
 }
 
@@ -327,6 +349,7 @@ const (
 	DeathKnightSpellBoneShield
 	DeathKnightSpellDancingRuneWeapon
 	DeathKnightSpellDeathPact
+	DeathKnightSpellUnholyBlight
 
 	DeathKnightSpellKillingMachine     // Used to react to km procs
 	DeathKnightSpellConvertToDeathRune // Used to react to death rune gains

--- a/sim/death_knight/frost/TestFrost.results
+++ b/sim/death_knight/frost/TestFrost.results
@@ -772,6 +772,30 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFrost-AllItems-Gurthalak,VoiceoftheDeeps-77191"
+ value: {
+  dps: 40280.33101
+  tps: 37567.63192
+  hps: 516.16093
+ }
+}
+dps_results: {
+ key: "TestFrost-AllItems-Gurthalak,VoiceoftheDeeps-78478"
+ value: {
+  dps: 40280.33101
+  tps: 37567.63192
+  hps: 516.16093
+ }
+}
+dps_results: {
+ key: "TestFrost-AllItems-Gurthalak,VoiceoftheDeeps-78487"
+ value: {
+  dps: 40280.33101
+  tps: 37567.63192
+  hps: 516.16093
+ }
+}
+dps_results: {
  key: "TestFrost-AllItems-HarmlightToken-63839"
  value: {
   dps: 37634.65227

--- a/sim/death_knight/talents_unholy.go
+++ b/sim/death_knight/talents_unholy.go
@@ -178,10 +178,11 @@ func (dk *DeathKnight) applyUnholyBlight() {
 	}
 
 	unholyBlight := dk.Unit.RegisterSpell(core.SpellConfig{
-		ActionID:    core.ActionID{SpellID: 49194},
-		SpellSchool: core.SpellSchoolShadow,
-		ProcMask:    core.ProcMaskEmpty,
-		Flags:       core.SpellFlagNoOnCastComplete | core.SpellFlagIgnoreModifiers | core.SpellFlagNoOnDamageDealt | core.SpellFlagPassiveSpell,
+		ActionID:       core.ActionID{SpellID: 49194},
+		SpellSchool:    core.SpellSchoolShadow,
+		ProcMask:       core.ProcMaskEmpty,
+		Flags:          core.SpellFlagNoOnCastComplete | core.SpellFlagIgnoreModifiers | core.SpellFlagNoOnDamageDealt | core.SpellFlagPassiveSpell,
+		ClassSpellMask: DeathKnightSpellUnholyBlight,
 
 		DamageMultiplier: 1,
 		ThreatMultiplier: 1,

--- a/sim/death_knight/unholy/TestUnholy.results
+++ b/sim/death_knight/unholy/TestUnholy.results
@@ -780,6 +780,30 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestUnholy-AllItems-Gurthalak,VoiceoftheDeeps-77191"
+ value: {
+  dps: 44041.15678
+  tps: 32881.9536
+  hps: 639.53641
+ }
+}
+dps_results: {
+ key: "TestUnholy-AllItems-Gurthalak,VoiceoftheDeeps-78478"
+ value: {
+  dps: 44376.72271
+  tps: 33143.17469
+  hps: 645.07383
+ }
+}
+dps_results: {
+ key: "TestUnholy-AllItems-Gurthalak,VoiceoftheDeeps-78487"
+ value: {
+  dps: 43745.4969
+  tps: 32651.76157
+  hps: 634.55833
+ }
+}
+dps_results: {
  key: "TestUnholy-AllItems-HarmlightToken-63839"
  value: {
   dps: 38792.83815

--- a/sim/death_knight/unholy/unholy.go
+++ b/sim/death_knight/unholy/unholy.go
@@ -72,11 +72,14 @@ func (uhdk *UnholyDeathKnight) ApplyTalents() {
 
 	// Mastery: Dreadblade
 	masteryMod := uhdk.AddDynamicMod(core.SpellModConfig{
-		Kind:   core.SpellMod_DamageDone_Pct,
-		School: core.SpellSchoolShadow,
+		Kind:      core.SpellMod_DamageDone_Pct,
+		School:    core.SpellSchoolShadow,
+		ClassMask: death_knight.DeathKnightSpellScourgeStrikeShadow | death_knight.DeathKnightSpellUnholyBlight,
 	})
 
 	uhdk.AddOnMasteryStatChanged(func(sim *core.Simulation, oldMastery float64, newMastery float64) {
+		uhdk.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexShadow] *=
+			(1.2 + 0.025*core.MasteryRatingToMasteryPoints(newMastery)) / (1.2 + 0.025*core.MasteryRatingToMasteryPoints(oldMastery))
 		masteryMod.UpdateFloatValue(uhdk.getMasteryShadowBonus())
 	})
 
@@ -84,6 +87,7 @@ func (uhdk *UnholyDeathKnight) ApplyTalents() {
 		Label:    "Dreadblade",
 		ActionID: core.ActionID{SpellID: 77515},
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
+			uhdk.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexShadow] *= 1.2 + 0.025*uhdk.GetMasteryPoints()
 			masteryMod.UpdateFloatValue(uhdk.getMasteryShadowBonus())
 			masteryMod.Activate()
 		},

--- a/sim/hunter/beast_mastery/TestBM.results
+++ b/sim/hunter/beast_mastery/TestBM.results
@@ -716,6 +716,27 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestBM-AllItems-Gurthalak,VoiceoftheDeeps-77191"
+ value: {
+  dps: 22279.4006
+  tps: 18781.13274
+ }
+}
+dps_results: {
+ key: "TestBM-AllItems-Gurthalak,VoiceoftheDeeps-78478"
+ value: {
+  dps: 22279.4006
+  tps: 18781.13274
+ }
+}
+dps_results: {
+ key: "TestBM-AllItems-Gurthalak,VoiceoftheDeeps-78487"
+ value: {
+  dps: 22279.4006
+  tps: 18781.13274
+ }
+}
+dps_results: {
  key: "TestBM-AllItems-HarmlightToken-63839"
  value: {
   dps: 20882.39663

--- a/sim/hunter/marksmanship/TestMM.results
+++ b/sim/hunter/marksmanship/TestMM.results
@@ -716,6 +716,27 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestMM-AllItems-Gurthalak,VoiceoftheDeeps-77191"
+ value: {
+  dps: 22137.58222
+  tps: 19812.38772
+ }
+}
+dps_results: {
+ key: "TestMM-AllItems-Gurthalak,VoiceoftheDeeps-78478"
+ value: {
+  dps: 22137.58222
+  tps: 19812.38772
+ }
+}
+dps_results: {
+ key: "TestMM-AllItems-Gurthalak,VoiceoftheDeeps-78487"
+ value: {
+  dps: 22137.58222
+  tps: 19812.38772
+ }
+}
+dps_results: {
  key: "TestMM-AllItems-HarmlightToken-63839"
  value: {
   dps: 20810.34439

--- a/sim/hunter/survival/TestSV.results
+++ b/sim/hunter/survival/TestSV.results
@@ -716,6 +716,27 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestSV-AllItems-Gurthalak,VoiceoftheDeeps-77191"
+ value: {
+  dps: 25695.89141
+  tps: 23152.73683
+ }
+}
+dps_results: {
+ key: "TestSV-AllItems-Gurthalak,VoiceoftheDeeps-78478"
+ value: {
+  dps: 25695.89141
+  tps: 23152.73683
+ }
+}
+dps_results: {
+ key: "TestSV-AllItems-Gurthalak,VoiceoftheDeeps-78487"
+ value: {
+  dps: 25695.89141
+  tps: 23152.73683
+ }
+}
+dps_results: {
  key: "TestSV-AllItems-HarmlightToken-63839"
  value: {
   dps: 23984.92967

--- a/sim/mage/arcane/TestArcane.results
+++ b/sim/mage/arcane/TestArcane.results
@@ -681,6 +681,27 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestArcane-AllItems-Gurthalak,VoiceoftheDeeps-77191"
+ value: {
+  dps: 36834.19841
+  tps: 35946.64969
+ }
+}
+dps_results: {
+ key: "TestArcane-AllItems-Gurthalak,VoiceoftheDeeps-78478"
+ value: {
+  dps: 36834.19841
+  tps: 35946.64969
+ }
+}
+dps_results: {
+ key: "TestArcane-AllItems-Gurthalak,VoiceoftheDeeps-78487"
+ value: {
+  dps: 36834.19841
+  tps: 35946.64969
+ }
+}
+dps_results: {
  key: "TestArcane-AllItems-HarmlightToken-63839"
  value: {
   dps: 34885.88562

--- a/sim/mage/fire/TestFire.results
+++ b/sim/mage/fire/TestFire.results
@@ -674,6 +674,27 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFire-AllItems-Gurthalak,VoiceoftheDeeps-77191"
+ value: {
+  dps: 39487.8086
+  tps: 35194.95554
+ }
+}
+dps_results: {
+ key: "TestFire-AllItems-Gurthalak,VoiceoftheDeeps-78478"
+ value: {
+  dps: 39487.8086
+  tps: 35194.95554
+ }
+}
+dps_results: {
+ key: "TestFire-AllItems-Gurthalak,VoiceoftheDeeps-78487"
+ value: {
+  dps: 39487.8086
+  tps: 35194.95554
+ }
+}
+dps_results: {
  key: "TestFire-AllItems-HarmlightToken-63839"
  value: {
   dps: 37155.01731

--- a/sim/paladin/paladin.go
+++ b/sim/paladin/paladin.go
@@ -3,6 +3,7 @@ package paladin
 import (
 	"time"
 
+	"github.com/wowsims/cata/sim/common/cata"
 	"github.com/wowsims/cata/sim/core"
 	"github.com/wowsims/cata/sim/core/proto"
 	"github.com/wowsims/cata/sim/core/stats"
@@ -182,6 +183,19 @@ type Paladin struct {
 	JudgementsOfThePureAura *core.Aura
 	GrandCrusaderAura       *core.Aura
 	SacredDutyAura          *core.Aura
+
+	// Cached Gurthalak tentacles
+	gurthalakTentacles []*cata.TentacleOfTheOldOnesPet
+}
+
+func (paladin *Paladin) GetTentacles() []*cata.TentacleOfTheOldOnesPet {
+	return paladin.gurthalakTentacles
+}
+
+func (paladin *Paladin) NewTentacleOfTheOldOnesPet() *cata.TentacleOfTheOldOnesPet {
+	pet := cata.NewTentacleOfTheOldOnesPet(&paladin.Character)
+	paladin.AddPet(pet)
+	return pet
 }
 
 // Implemented by each Paladin spec.
@@ -310,6 +324,14 @@ func NewPaladin(character *core.Character, talentsStr string, options *proto.Pal
 
 	// Bonus Armor and Armor are treated identically for Paladins
 	paladin.AddStatDependency(stats.BonusArmor, stats.Armor, 1)
+
+	if mh := paladin.MainHand(); mh.Name == "Gurthalak, Voice of the Deeps" {
+		paladin.gurthalakTentacles = make([]*cata.TentacleOfTheOldOnesPet, 10)
+
+		for i := 0; i < 10; i++ {
+			paladin.gurthalakTentacles[i] = paladin.NewTentacleOfTheOldOnesPet()
+		}
+	}
 
 	return paladin
 }

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -702,6 +702,27 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestRetribution-AllItems-Gurthalak,VoiceoftheDeeps-77191"
+ value: {
+  dps: 39479.56516
+  tps: 39353.96306
+ }
+}
+dps_results: {
+ key: "TestRetribution-AllItems-Gurthalak,VoiceoftheDeeps-78478"
+ value: {
+  dps: 39696.8897
+  tps: 39571.2876
+ }
+}
+dps_results: {
+ key: "TestRetribution-AllItems-Gurthalak,VoiceoftheDeeps-78487"
+ value: {
+  dps: 39288.18981
+  tps: 39162.58772
+ }
+}
+dps_results: {
  key: "TestRetribution-AllItems-HarmlightToken-63839"
  value: {
   dps: 36086.28618

--- a/sim/rogue/combat/TestCombat.results
+++ b/sim/rogue/combat/TestCombat.results
@@ -296,13 +296,6 @@ dps_results: {
  }
 }
 dps_results: {
- key: "TestCombat-AllItems-Bryntroll,theBoneArbiter-50709"
- value: {
-  dps: 29966.48987
-  tps: 21276.20781
- }
-}
-dps_results: {
  key: "TestCombat-AllItems-BurningShadowspiritDiamond"
  value: {
   dps: 29756.19126
@@ -1373,13 +1366,6 @@ dps_results: {
  value: {
   dps: 27844.47743
   tps: 19769.57898
- }
-}
-dps_results: {
- key: "TestCombat-AllItems-Shadowmourne-49623"
- value: {
-  dps: 29966.48987
-  tps: 21276.20781
  }
 }
 dps_results: {

--- a/sim/rogue/combat/combat_test.go
+++ b/sim/rogue/combat/combat_test.go
@@ -48,6 +48,11 @@ func TestCombat(t *testing.T) {
 				proto.WeaponType_WeaponTypeMace,
 				proto.WeaponType_WeaponTypeSword,
 			},
+			HandTypes: []proto.HandType{
+				proto.HandType_HandTypeMainHand,
+				proto.HandType_HandTypeOffHand,
+				proto.HandType_HandTypeOneHand,
+			},
 		},
 	}))
 }

--- a/sim/warrior/arms/TestArms.results
+++ b/sim/warrior/arms/TestArms.results
@@ -702,6 +702,27 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestArms-AllItems-Gurthalak,VoiceoftheDeeps-77191"
+ value: {
+  dps: 35978.8597
+  tps: 22746.71029
+ }
+}
+dps_results: {
+ key: "TestArms-AllItems-Gurthalak,VoiceoftheDeeps-78478"
+ value: {
+  dps: 36228.85822
+  tps: 22917.45826
+ }
+}
+dps_results: {
+ key: "TestArms-AllItems-Gurthalak,VoiceoftheDeeps-78487"
+ value: {
+  dps: 35513.8859
+  tps: 22684.60531
+ }
+}
+dps_results: {
  key: "TestArms-AllItems-HarmlightToken-63839"
  value: {
   dps: 31488.55325

--- a/sim/warrior/fury/TestFury.results
+++ b/sim/warrior/fury/TestFury.results
@@ -716,6 +716,27 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestFury-AllItems-Gurthalak,VoiceoftheDeeps-77191"
+ value: {
+  dps: 31382.1484
+  tps: 26206.495
+ }
+}
+dps_results: {
+ key: "TestFury-AllItems-Gurthalak,VoiceoftheDeeps-78478"
+ value: {
+  dps: 31382.1484
+  tps: 26206.495
+ }
+}
+dps_results: {
+ key: "TestFury-AllItems-Gurthalak,VoiceoftheDeeps-78487"
+ value: {
+  dps: 31382.1484
+  tps: 26206.495
+ }
+}
+dps_results: {
  key: "TestFury-AllItems-HarmlightToken-63839"
  value: {
   dps: 28663.09175
@@ -1117,8 +1138,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-MoltenGiantWarplate"
  value: {
-  dps: 29920.25909
-  tps: 25024.7138
+  dps: 29902.20637
+  tps: 25006.66108
  }
 }
 dps_results: {
@@ -2372,15 +2393,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-smf-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 37403.70051
-  tps: 31552.0675
+  dps: 37385.16086
+  tps: 31533.52785
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-smf-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 44835.44846
-  tps: 36518.40984
+  dps: 44742.91365
+  tps: 36425.87503
  }
 }
 dps_results: {
@@ -2393,15 +2414,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-smf-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 23412.96871
-  tps: 19333.63376
+  dps: 23401.00062
+  tps: 19321.66567
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-smf-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 24745.10417
-  tps: 19239.03987
+  dps: 24682.55422
+  tps: 19176.48991
  }
 }
 dps_results: {
@@ -2414,15 +2435,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-tg-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 36833.54023
-  tps: 30559.09198
+  dps: 36805.00728
+  tps: 30530.55904
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-tg-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 43825.63304
-  tps: 35644.57706
+  dps: 43722.09469
+  tps: 35541.03871
  }
 }
 dps_results: {
@@ -2435,15 +2456,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-tg-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 23060.54391
-  tps: 18690.57124
+  dps: 23037.6971
+  tps: 18667.72443
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-tg-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 24835.50163
-  tps: 19085.13087
+  dps: 24761.88077
+  tps: 19011.51001
  }
 }
 dps_results: {
@@ -2456,15 +2477,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-smf-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 29999.75112
-  tps: 25922.75821
+  dps: 29985.50917
+  tps: 25908.51627
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-smf-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 36329.14116
-  tps: 30454.11756
+  dps: 36260.10168
+  tps: 30385.07808
  }
 }
 dps_results: {
@@ -2477,15 +2498,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-smf-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 18733.86313
-  tps: 15963.21968
+  dps: 18724.11089
+  tps: 15953.46744
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-smf-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 20015.92253
-  tps: 15855.91443
+  dps: 19969.65004
+  tps: 15809.64194
  }
 }
 dps_results: {
@@ -2498,15 +2519,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-tg-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 29867.81528
-  tps: 25174.46305
+  dps: 29843.41539
+  tps: 25150.06317
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-tg-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 35919.16167
-  tps: 29656.65
+  dps: 35837.76254
+  tps: 29575.25087
  }
 }
 dps_results: {
@@ -2519,15 +2540,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-tg-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 18731.22584
-  tps: 15534.20653
+  dps: 18710.81967
+  tps: 15513.80037
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-tg-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 19928.25909
-  tps: 15570.45209
+  dps: 19871.86914
+  tps: 15514.06214
  }
 }
 dps_results: {
@@ -2540,15 +2561,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-smf-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 47948.34663
-  tps: 39380.31752
+  dps: 47913.81717
+  tps: 39345.78806
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-smf-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 57447.77044
-  tps: 45786.45367
+  dps: 57280.10668
+  tps: 45618.78991
  }
 }
 dps_results: {
@@ -2561,15 +2582,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-smf-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 31059.60756
-  tps: 24786.60759
+  dps: 31035.75009
+  tps: 24762.75012
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-smf-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 32882.47284
-  tps: 24780.84717
+  dps: 32763.62585
+  tps: 24662.00018
  }
 }
 dps_results: {
@@ -2582,15 +2603,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-tg-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 48129.65802
-  tps: 38508.69881
+  dps: 48075.98111
+  tps: 38455.02189
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-tg-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 57124.45076
-  tps: 44993.00902
+  dps: 56932.00391
+  tps: 44800.56217
  }
 }
 dps_results: {
@@ -2603,15 +2624,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-tg-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 31118.44219
-  tps: 24304.70316
+  dps: 31075.05411
+  tps: 24261.31508
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-tg-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 32782.80175
-  tps: 24132.09112
+  dps: 32648.52758
+  tps: 23997.81696
  }
 }
 dps_results: {
@@ -2624,15 +2645,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-smf-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 38570.86797
-  tps: 32646.64393
+  dps: 38541.78619
+  tps: 32617.56216
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-smf-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 46118.82862
-  tps: 38083.27304
+  dps: 45973.46851
+  tps: 37937.91293
  }
 }
 dps_results: {
@@ -2645,15 +2666,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-smf-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 24554.40653
-  tps: 20375.29367
+  dps: 24534.3689
+  tps: 20355.25604
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-smf-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 26469.62936
-  tps: 20862.67961
+  dps: 26371.34116
+  tps: 20764.39141
  }
 }
 dps_results: {
@@ -2666,15 +2687,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-tg-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 38963.76335
-  tps: 31793.79961
+  dps: 38909.4808
+  tps: 31739.51706
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-tg-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 46333.08376
-  tps: 37019.55178
+  dps: 46178.39208
+  tps: 36864.8601
  }
 }
 dps_results: {
@@ -2687,15 +2708,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-tg-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 24799.83357
-  tps: 19883.47595
+  dps: 24760.06194
+  tps: 19843.70432
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-tg-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 26803.66054
-  tps: 20376.9239
+  dps: 26685.15236
+  tps: 20258.41572
  }
 }
 dps_results: {
@@ -3044,15 +3065,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-smf-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 37415.15234
-  tps: 31344.99973
+  dps: 37396.44621
+  tps: 31326.29359
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-smf-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 44135.6771
-  tps: 35819.4541
+  dps: 44040.91871
+  tps: 35724.6957
  }
 }
 dps_results: {
@@ -3065,15 +3086,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-smf-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 23458.87908
-  tps: 19359.74368
+  dps: 23446.06074
+  tps: 19346.92534
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-smf-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 24631.4433
-  tps: 19127.12667
+  dps: 24568.97817
+  tps: 19064.66154
  }
 }
 dps_results: {
@@ -3086,15 +3107,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-tg-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 36721.51166
-  tps: 30291.2772
+  dps: 36692.16459
+  tps: 30261.93013
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-tg-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 43535.90696
-  tps: 35253.89071
+  dps: 43430.09905
+  tps: 35148.0828
  }
 }
 dps_results: {
@@ -3107,15 +3128,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-tg-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 23277.83731
-  tps: 18877.81112
+  dps: 23257.10907
+  tps: 18857.08288
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-tg-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 24018.72573
-  tps: 18284.55406
+  dps: 23948.17732
+  tps: 18214.00564
  }
 }
 dps_results: {
@@ -3128,15 +3149,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-smf-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 29975.75011
-  tps: 25756.92415
+  dps: 29960.48075
+  tps: 25741.65479
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-smf-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 35709.08424
-  tps: 29796.49423
+  dps: 35630.67879
+  tps: 29718.08878
  }
 }
 dps_results: {
@@ -3149,15 +3170,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-smf-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 18961.32663
-  tps: 16169.1352
+  dps: 18951.2184
+  tps: 16159.02697
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-smf-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 19987.23039
-  tps: 15802.17805
+  dps: 19940.71546
+  tps: 15755.66312
  }
 }
 dps_results: {
@@ -3170,15 +3191,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-tg-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 29729.45909
-  tps: 24985.33456
+  dps: 29703.76762
+  tps: 24959.64309
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-tg-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 35834.96283
-  tps: 29654.77386
+  dps: 35749.24422
+  tps: 29569.05526
  }
 }
 dps_results: {
@@ -3191,15 +3212,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-tg-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 18901.88795
-  tps: 15592.75435
+  dps: 18881.05633
+  tps: 15571.92273
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-tg-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 19784.42543
-  tps: 15334.365
+  dps: 19729.76621
+  tps: 15279.70578
  }
 }
 dps_results: {
@@ -3212,15 +3233,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-smf-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 47619.21189
-  tps: 38901.40546
+  dps: 47584.82833
+  tps: 38867.02191
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-smf-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 56769.10893
-  tps: 45075.16292
+  dps: 56604.9483
+  tps: 44911.0023
  }
 }
 dps_results: {
@@ -3233,15 +3254,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-smf-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 31079.91642
-  tps: 24843.2554
+  dps: 31054.77387
+  tps: 24818.11285
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-smf-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 32477.87128
-  tps: 24616.36168
+  dps: 32365.89616
+  tps: 24504.38656
  }
 }
 dps_results: {
@@ -3254,15 +3275,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-tg-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 48052.82114
-  tps: 38313.41967
+  dps: 47991.67729
+  tps: 38252.27582
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-tg-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 56217.68709
-  tps: 43711.0935
+  dps: 56029.86679
+  tps: 43523.2732
  }
 }
 dps_results: {
@@ -3275,15 +3296,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-tg-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 31243.02842
-  tps: 24254.797
+  dps: 31194.86664
+  tps: 24206.63522
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-tg-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 32494.2566
-  tps: 23998.54142
+  dps: 32360.34668
+  tps: 23864.6315
  }
 }
 dps_results: {
@@ -3296,15 +3317,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-smf-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 38129.96189
-  tps: 32128.93855
+  dps: 38101.17878
+  tps: 32100.15544
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-smf-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 45896.82359
-  tps: 37785.25608
+  dps: 45758.75239
+  tps: 37647.18487
  }
 }
 dps_results: {
@@ -3317,15 +3338,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-smf-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 24363.62326
-  tps: 20126.19229
+  dps: 24344.92236
+  tps: 20107.49139
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-smf-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 25915.14341
-  tps: 19885.87687
+  dps: 25824.4521
+  tps: 19795.18556
  }
 }
 dps_results: {
@@ -3338,15 +3359,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-tg-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 38689.71705
-  tps: 31665.13586
+  dps: 38642.57657
+  tps: 31617.99539
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-tg-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 45457.0454
-  tps: 36409.36979
+  dps: 45298.15467
+  tps: 36250.47905
  }
 }
 dps_results: {
@@ -3359,15 +3380,15 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-tg-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 25125.48039
-  tps: 20026.65383
+  dps: 25087.39343
+  tps: 19988.56688
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-tg-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 25908.73269
-  tps: 19351.00914
+  dps: 25796.92352
+  tps: 19239.19996
  }
 }
 dps_results: {

--- a/sim/warrior/fury/death_wish.go
+++ b/sim/warrior/fury/death_wish.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/wowsims/cata/sim/core"
 	"github.com/wowsims/cata/sim/core/proto"
+	"github.com/wowsims/cata/sim/core/stats"
 	"github.com/wowsims/cata/sim/warrior"
 )
 
@@ -25,13 +26,13 @@ func (war *FuryWarrior) RegisterDeathWish() {
 				bonusSnapshot = 1.0 + (0.2 * war.EnrageEffectMultiplier)
 			}
 
-			war.PseudoStats.DamageDealtMultiplier *= bonusSnapshot
+			war.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexPhysical] *= bonusSnapshot
 			if !hasGlyph {
 				war.PseudoStats.DamageTakenMultiplier *= bonusSnapshot
 			}
 		},
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
-			war.PseudoStats.DamageDealtMultiplier /= bonusSnapshot
+			war.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexPhysical] /= bonusSnapshot
 			if !hasGlyph {
 				war.PseudoStats.DamageTakenMultiplier /= bonusSnapshot
 			}

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -295,13 +295,6 @@ dps_results: {
  }
 }
 dps_results: {
- key: "TestProtectionWarrior-AllItems-Bryntroll,theBoneArbiter-50709"
- value: {
-  dps: 4659.08749
-  tps: 28426.12721
- }
-}
-dps_results: {
  key: "TestProtectionWarrior-AllItems-BurningShadowspiritDiamond"
  value: {
   dps: 4682.21129
@@ -1423,13 +1416,6 @@ dps_results: {
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SeaStar-56290"
- value: {
-  dps: 4659.08749
-  tps: 28426.12721
- }
-}
-dps_results: {
- key: "TestProtectionWarrior-AllItems-Shadowmourne-49623"
  value: {
   dps: 4659.08749
   tps: 28426.12721

--- a/sim/warrior/protection/protection_test.go
+++ b/sim/warrior/protection/protection_test.go
@@ -39,6 +39,11 @@ func TestProtectionWarrior(t *testing.T) {
 var ItemFilter = core.ItemFilter{
 	ArmorType: proto.ArmorType_ArmorTypePlate,
 
+	HandTypes: []proto.HandType{
+		proto.HandType_HandTypeMainHand,
+		proto.HandType_HandTypeOneHand,
+	},
+
 	WeaponTypes: []proto.WeaponType{
 		proto.WeaponType_WeaponTypeAxe,
 		proto.WeaponType_WeaponTypeSword,

--- a/sim/warrior/warrior.go
+++ b/sim/warrior/warrior.go
@@ -3,6 +3,7 @@ package warrior
 import (
 	"time"
 
+	"github.com/wowsims/cata/sim/common/cata"
 	"github.com/wowsims/cata/sim/core"
 	"github.com/wowsims/cata/sim/core/proto"
 	"github.com/wowsims/cata/sim/core/stats"
@@ -131,6 +132,19 @@ type Warrior struct {
 	SunderArmorAuras       core.AuraArray
 	ThunderClapAuras       core.AuraArray
 	ColossusSmashAuras     core.AuraArray
+
+	// Cached Gurthalak tentacles
+	gurthalakTentacles []*cata.TentacleOfTheOldOnesPet
+}
+
+func (warrior *Warrior) GetTentacles() []*cata.TentacleOfTheOldOnesPet {
+	return warrior.gurthalakTentacles
+}
+
+func (warrior *Warrior) NewTentacleOfTheOldOnesPet() *cata.TentacleOfTheOldOnesPet {
+	pet := cata.NewTentacleOfTheOldOnesPet(&warrior.Character)
+	warrior.AddPet(pet)
+	return pet
 }
 
 func (warrior *Warrior) GetCharacter() *core.Character {
@@ -203,6 +217,15 @@ func NewWarrior(character *core.Character, talents string, inputs WarriorInputs)
 	warrior.PseudoStats.BaseDodgeChance += 0.03664
 	warrior.PseudoStats.BaseParryChance += 0.05
 	warrior.CriticalBlockChance = append(warrior.CriticalBlockChance, 0.0, 0.0)
+
+	if mh, oh := warrior.MainHand(), warrior.OffHand(); mh.Name == "Gurthalak, Voice of the Deeps" || oh.Name == "Gurthalak, Voice of the Deeps" {
+		warrior.gurthalakTentacles = make([]*cata.TentacleOfTheOldOnesPet, 10)
+
+		for i := 0; i < 10; i++ {
+			warrior.gurthalakTentacles[i] = warrior.NewTentacleOfTheOldOnesPet()
+		}
+	}
+
 	return warrior
 }
 

--- a/ui/core/constants/item_notices.tsx
+++ b/ui/core/constants/item_notices.tsx
@@ -187,6 +187,8 @@ const TENTATIVE_IMPLEMENTATION_ITEMS = [
 	78484, 77195, 78475,
 	// Vishanka, Jaws of the Earth - LFR, Normal, Heroic
 	78480, 78359, 78471,
+	// Gurthalak, Voice of the Deeps - LFR, Normal, Heroic
+	78487, 77191, 78478,
 
 	// Veil of Lies
 	72900,
@@ -303,27 +305,6 @@ export const ITEM_NOTICES = new Map<number, ItemNoticeData>([
 			[Spec.SpecDestructionWarlock]: false,
 			[Spec.SpecShadowPriest]: false,
 		},
-	],
-	[
-		// Gurthalak, Voice of the Deeps - LFR
-		78487,
-		{
-			[Spec.SpecUnknown]: MISSING_IMPLEMENTATION_WARNING,
-		}
-	],
-	[
-		// Gurthalak, Voice of the Deeps - Normal
-		77191,
-		{
-			[Spec.SpecUnknown]: MISSING_IMPLEMENTATION_WARNING,
-		}
-	],
-	[
-		// Gurthalak, Voice of the Deeps - Heroic
-		78478,
-		{
-			[Spec.SpecUnknown]: MISSING_IMPLEMENTATION_WARNING,
-		}
 	],
 ]);
 

--- a/ui/core/proto_utils/action_id.ts
+++ b/ui/core/proto_utils/action_id.ts
@@ -313,12 +313,23 @@ export class ActionId {
 				}
 				break;
 			case 'Mind Flay':
-				if (tag == 1) {
-					name += ' (1 Tick)';
-				} else if (tag == 2) {
-					name += ' (2 Tick)';
-				} else if (tag == 3) {
-					name += ' (3 Tick)';
+				if (this.spellId === 15407) {
+					if (tag == 1) {
+						name += ' (1 Tick)';
+					} else if (tag == 2) {
+						name += ' (2 Tick)';
+					} else if (tag == 3) {
+						name += ' (3 Tick)';
+					}
+				} else {
+					// Gurthalak, Voice of the Deeps
+					if (tag === 0) {
+						name += ' (LFR)';
+					} else if (tag === 1) {
+						name += ' (Normal)';
+					} else if (tag === 2) {
+						name += ' (Heroic)';
+					}
 				}
 				break;
 			case 'Mind Sear':
@@ -605,11 +616,11 @@ export class ActionId {
 			// Souldrinker - Drain Life
 			case 'Drain Life':
 				if (this.spellId === 109828) {
-					name += ' 1.3%'
+					name += ' 1.3%';
 				} else if (this.spellId === 108022) {
-					name += ' 1.5%'
+					name += ' 1.5%';
 				} else if (this.spellId === 109831) {
-					name += ' 1.7%'
+					name += ' 1.7%';
 				}
 
 				if (this.tag === 2) {
@@ -860,6 +871,7 @@ const petNameToActionId: Record<string, ActionId> = {
 	'Spirit Wolf 1': ActionId.fromSpellId(51533),
 	'Spirit Wolf 2': ActionId.fromSpellId(51533),
 	Valkyr: ActionId.fromSpellId(71844),
+	'Tentacle of the Old Ones': ActionId.fromSpellId(107818),
 	Treant: ActionId.fromSpellId(33831),
 	'Water Elemental': ActionId.fromSpellId(31687),
 };


### PR DESCRIPTION
Tried to replicate all the EJ-, Wowhead- and Simc-comments I could gather.
Damage matches all the videos of the different versions of the sword on YouTube, including which buffs increase the proc damage.

Had to modify Unholy mastery to apply to all shadow damage and move the SpellMod to only modify Unholy Blight and Scourge Strike off-hand since they had IgnoreAllModifiers.

Also made a change to Death Wish for Fury Warriors since it's only supposed to increase physical damage, changes most tests a big seeing as it appeared to modify the T12 fire-proc.

I've been restrictive with the proc mask for now and skipped the `Can Proc From Procs` flag, it's there in the db but it already pretty much matches the expected numbers.
The rest has to be tested on the PTR :)
Left lot's of TODOs for future testing!

The cap for amount of simultaneous spawns is 10. I tested with 500k 15min Fury TG sims with added haste and white hit cap and still couldn't get more than 9 to spawn so it should be safe.