### PR TITLE
[Mage] Adjust T12 MI crit chance

### DIFF
--- a/sim/mage/arcane/TestArcane.results
+++ b/sim/mage/arcane/TestArcane.results
@@ -38,70 +38,70 @@ character_stats_results: {
 dps_results: {
  key: "TestArcane-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 39384.13047
+  dps: 39253.40552
   tps: 35850.70426
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 37121.80745
+  dps: 36980.41861
   tps: 33439.39665
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 37015.04833
+  dps: 36889.10503
   tps: 33426.01799
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 36970.04529
+  dps: 36837.15876
   tps: 33354.74541
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 37024.96158
+  dps: 36892.07506
   tps: 33395.9485
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ArrowofTime-72897"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 38807.71717
+  dps: 38676.99221
   tps: 35322.81012
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 36178.8687
+  dps: 36045.96507
   tps: 32616.22418
   hps: 137.18816
  }
@@ -109,469 +109,469 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 38184.62791
+  dps: 38042.866
   tps: 34390.01267
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 38373.79922
+  dps: 38230.19187
   tps: 34538.81378
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BindingPromise-67037"
  value: {
-  dps: 36199.43328
+  dps: 36066.54676
   tps: 32668.24355
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 36831.37011
+  dps: 36703.60319
   tps: 33236.77351
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 36638.9605
+  dps: 36506.07397
   tps: 33074.09627
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 36696.49423
+  dps: 36563.6077
   tps: 33127.22025
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 36141.35552
+  dps: 36009.10068
   tps: 32577.34277
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 37411.66939
+  dps: 37276.87255
   tps: 33711.99636
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 36184.18055
+  dps: 36049.38371
   tps: 32619.59037
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 36831.46318
+  dps: 36687.80469
   tps: 33211.55445
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 36242.50222
+  dps: 36109.4918
   tps: 32694.53766
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 36199.43328
+  dps: 36066.54676
   tps: 32668.24355
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 37107.83623
+  dps: 36974.94971
   tps: 33490.13722
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BottledLightning-66879"
  value: {
-  dps: 36886.75711
+  dps: 36737.13845
   tps: 33406.17875
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BottledWishes-77114"
  value: {
-  dps: 38338.08658
+  dps: 38200.0182
   tps: 34731.82146
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BottledWishes-77985"
  value: {
-  dps: 37932.89576
+  dps: 37796.3639
   tps: 34365.73695
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BottledWishes-78005"
  value: {
-  dps: 38399.88434
+  dps: 38264.11346
   tps: 34853.54093
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 39178.73556
+  dps: 39044.34196
   tps: 34992.62152
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 36199.43328
+  dps: 36066.54676
   tps: 32668.24355
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 39762.95796
+  dps: 39628.56436
   tps: 36225.71744
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 39458.80835
+  dps: 39325.1521
   tps: 35887.4681
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 36837.08594
+  dps: 36693.42745
   tps: 33217.16398
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 37627.02936
+  dps: 37492.64985
   tps: 33998.65861
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CrushingWeight-59506"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CrushingWeight-65118"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 39886.60226
+  dps: 39751.63632
   tps: 36311.04465
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 39273.26021
+  dps: 39125.04953
   tps: 35676.26644
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-CunningoftheCruel-78000"
  value: {
-  dps: 40195.66821
+  dps: 40051.07724
   tps: 36720.23621
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 37722.60524
+  dps: 37586.05445
   tps: 34036.98086
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 38624.64473
+  dps: 38488.12457
   tps: 35009.91931
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 36540.84124
+  dps: 36400.42688
   tps: 32953.86978
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 38879.33386
+  dps: 38745.67761
   tps: 35357.79071
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 37461.69085
+  dps: 37329.00489
   tps: 33903.53085
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 36901.84202
+  dps: 36758.95414
   tps: 33263.31835
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 38807.71717
+  dps: 38676.99221
   tps: 35322.81012
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 36597.33621
+  dps: 36459.6455
   tps: 33063.36224
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 39248.91724
+  dps: 39118.90158
   tps: 35715.25786
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 38879.33386
+  dps: 38745.67761
   tps: 35357.79071
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 37015.04833
+  dps: 36889.10503
   tps: 33426.01799
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 38807.71717
+  dps: 38676.99221
   tps: 35322.81012
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FallofMortality-59500"
  value: {
-  dps: 37722.60524
+  dps: 37586.05445
   tps: 34036.98086
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FallofMortality-65124"
  value: {
-  dps: 37749.44146
+  dps: 37610.7253
   tps: 34098.54975
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 37342.77255
+  dps: 37205.37465
   tps: 33802.42263
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 36184.18055
+  dps: 36049.38371
   tps: 32619.59037
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 37628.84726
+  dps: 37494.81097
   tps: 34075.7895
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 36199.43328
+  dps: 36066.54676
   tps: 32668.24355
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 38792.04444
+  dps: 38658.00815
   tps: 35121.88625
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 36679.95982
+  dps: 36545.16298
   tps: 33076.79384
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FirehawkRobesofConflagration"
  value: {
-  dps: 34990.53172
+  dps: 34859.82927
   tps: 31945.62149
  }
 }
@@ -585,756 +585,756 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 36998.11046
+  dps: 36865.22393
   tps: 33405.71868
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FireoftheDeep-77988"
  value: {
-  dps: 36907.45125
+  dps: 36774.56472
   tps: 33322.00817
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FireoftheDeep-78008"
  value: {
-  dps: 37100.9738
+  dps: 36968.08727
   tps: 33500.69791
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 38908.93449
+  dps: 38778.20953
   tps: 35416.96867
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FluidDeath-58181"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 39178.73556
+  dps: 39044.34196
   tps: 35689.17731
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 38888.69931
+  dps: 38755.93023
   tps: 35192.08097
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 36872.70496
+  dps: 36730.94306
   tps: 33219.30524
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-GaleofShadows-56138"
  value: {
-  dps: 36898.7534
+  dps: 36758.55964
   tps: 33328.75833
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-GaleofShadows-56462"
  value: {
-  dps: 36806.38021
+  dps: 36670.91026
   tps: 33295.43566
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-GearDetector-61462"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 36944.57151
+  dps: 36805.21553
   tps: 33313.68927
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Gurthalak,VoiceoftheDeeps-77191"
  value: {
-  dps: 39762.95796
+  dps: 39628.56436
   tps: 36225.71744
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Gurthalak,VoiceoftheDeeps-78478"
  value: {
-  dps: 39762.95796
+  dps: 39628.56436
   tps: 36225.71744
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Gurthalak,VoiceoftheDeeps-78487"
  value: {
-  dps: 39762.95796
+  dps: 39628.56436
   tps: 36225.71744
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-HarmlightToken-63839"
  value: {
-  dps: 37362.37126
+  dps: 37218.44696
   tps: 33862.88773
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 37914.40631
+  dps: 37769.3542
   tps: 34305.85445
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 38057.6651
+  dps: 37918.06449
   tps: 34313.93236
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-HeartofRage-59224"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-HeartofRage-65072"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-HeartofSolace-55868"
  value: {
-  dps: 36898.7534
+  dps: 36758.55964
   tps: 33328.75833
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-HeartofSolace-56393"
  value: {
-  dps: 36806.38021
+  dps: 36670.91026
   tps: 33295.43566
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-HeartofThunder-55845"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-HeartofThunder-56370"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Heartpierce-50641"
  value: {
-  dps: 39762.95796
+  dps: 39628.56436
   tps: 36225.71744
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 38879.33386
+  dps: 38745.67761
   tps: 35357.79071
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 36742.58457
+  dps: 36607.78773
   tps: 33134.54586
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 36742.58457
+  dps: 36607.78773
   tps: 33134.54586
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 36638.9605
+  dps: 36506.07397
   tps: 33074.09627
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 36696.49423
+  dps: 36563.6077
   tps: 33127.22025
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-IndomitablePride-77211"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-IndomitablePride-77983"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-IndomitablePride-78003"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 39295.74373
+  dps: 39150.10416
   tps: 35604.66621
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 38866.87009
+  dps: 38719.19505
   tps: 35200.7175
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 39406.55813
+  dps: 39264.81842
   tps: 35856.42312
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 37363.78977
+  dps: 37236.02285
   tps: 33705.25152
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 36611.7161
+  dps: 36475.06996
   tps: 33104.31816
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 36487.05275
+  dps: 36354.7702
   tps: 33042.8731
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 37829.90855
+  dps: 37694.98102
   tps: 34222.28563
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 38083.58652
+  dps: 37960.38216
   tps: 34530.23579
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 36831.37011
+  dps: 36703.60319
   tps: 33236.77351
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 36985.31398
+  dps: 36847.2456
   tps: 33543.42162
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-KiroptyricSigil-77984"
  value: {
-  dps: 36740.46944
+  dps: 36603.93759
   tps: 33314.37045
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-KiroptyricSigil-78004"
  value: {
-  dps: 36876.94725
+  dps: 36741.17637
   tps: 33505.49953
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 36528.1666
+  dps: 36388.31173
   tps: 32947.0418
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 36528.1666
+  dps: 36388.31173
   tps: 32947.0418
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 36423.68816
+  dps: 36292.71351
   tps: 33007.48906
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-LeadenDespair-55816"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-LeadenDespair-56347"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 36444.41476
+  dps: 36316.64784
   tps: 32880.00668
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 36444.41476
+  dps: 36316.64784
   tps: 32880.00668
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 36245.72636
+  dps: 36113.32587
   tps: 32706.12316
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 36245.72636
+  dps: 36113.32587
   tps: 32706.12316
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 36928.68133
+  dps: 36800.91441
   tps: 33325.39549
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 36991.59952
+  dps: 36863.8326
   tps: 33383.22254
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 36444.41476
+  dps: 36316.64784
   tps: 32880.00668
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 36444.41476
+  dps: 36316.64784
   tps: 32880.00668
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 36759.2583
+  dps: 36626.37177
   tps: 33185.17368
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 36759.2583
+  dps: 36626.37177
   tps: 33185.17368
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 37858.73893
+  dps: 37715.08044
   tps: 34134.10179
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 38813.97171
+  dps: 38683.57211
   tps: 35075.56867
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 36199.43328
+  dps: 36066.54676
   tps: 32668.24355
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 37995.20374
+  dps: 37862.43467
   tps: 34379.77869
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 38263.61244
+  dps: 38121.31919
   tps: 34671.03916
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 36789.9922
+  dps: 36648.25768
   tps: 33195.5564
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 37670.56272
+  dps: 37533.39891
   tps: 34052.95048
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 36559.40329
+  dps: 36418.98892
   tps: 32972.10983
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 38807.71717
+  dps: 38676.99221
   tps: 35322.81012
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Rainsong-55854"
  value: {
-  dps: 36202.94848
+  dps: 36070.06196
   tps: 32671.39771
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Rainsong-56377"
  value: {
-  dps: 36242.25686
+  dps: 36109.24644
   tps: 32694.31926
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Rathrak,thePoisonousMind-77195"
  value: {
-  dps: 34100.76125
+  dps: 33981.3711
   tps: 33273.57347
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Rathrak,thePoisonousMind-78475"
  value: {
-  dps: 35142.85425
+  dps: 34997.85159
   tps: 34251.11424
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Rathrak,thePoisonousMind-78484"
  value: {
-  dps: 33040.18049
+  dps: 32893.00022
   tps: 32234.59447
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 37673.43941
+  dps: 37542.99585
   tps: 33929.89453
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ReflectionoftheLight-77986"
  value: {
-  dps: 37519.42916
+  dps: 37388.9856
   tps: 33794.19394
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ReflectionoftheLight-78006"
  value: {
-  dps: 37843.42081
+  dps: 37712.97725
   tps: 34079.06197
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 39384.13047
+  dps: 39253.40552
   tps: 35850.70426
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 39405.96796
+  dps: 39274.63579
   tps: 35845.65326
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 37279.14482
+  dps: 37134.67755
   tps: 33573.38582
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RosaryofLight-72901"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RottingSkull-77116"
  value: {
-  dps: 36961.95734
+  dps: 36820.76256
   tps: 33343.68386
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RottingSkull-77987"
  value: {
-  dps: 36941.10453
+  dps: 36801.79954
   tps: 33315.68289
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RottingSkull-78007"
  value: {
-  dps: 37127.69995
+  dps: 36988.25019
   tps: 33496.48376
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-RuneofZeth-68998"
  value: {
-  dps: 38158.28994
+  dps: 38012.73943
   tps: 34420.51362
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ScalesofLife-68915"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
   hps: 470.89972
  }
@@ -1342,7 +1342,7 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-ScalesofLife-69109"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
   hps: 531.17048
  }
@@ -1350,91 +1350,91 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SeaStar-55256"
  value: {
-  dps: 36737.61112
+  dps: 36603.55644
   tps: 33124.85184
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SeaStar-56290"
  value: {
-  dps: 37271.94862
+  dps: 37137.89394
   tps: 33600.22499
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ShardofWoe-60233"
  value: {
-  dps: 39164.54361
+  dps: 39026.61022
   tps: 35518.81236
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 36920.58022
+  dps: 36785.78338
   tps: 33294.63469
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 37016.5864
+  dps: 36881.78956
   tps: 33382.60624
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Sorrowsong-55879"
  value: {
-  dps: 37302.26482
+  dps: 37169.3783
   tps: 33652.2921
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Sorrowsong-56400"
  value: {
-  dps: 37447.85615
+  dps: 37314.96963
   tps: 33782.20043
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 36444.41476
+  dps: 36316.64784
   tps: 32880.00668
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SoulCasket-58183"
  value: {
-  dps: 38322.94661
+  dps: 38188.14977
   tps: 34541.61913
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Souldrinker-77193"
  value: {
-  dps: 39818.68043
+  dps: 39684.28683
   tps: 36281.43992
   hps: 135.83703
  }
@@ -1442,7 +1442,7 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-Souldrinker-78479"
  value: {
-  dps: 39826.36653
+  dps: 39691.97293
   tps: 36289.12601
   hps: 154.55179
  }
@@ -1450,7 +1450,7 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-Souldrinker-78488"
  value: {
-  dps: 39811.07067
+  dps: 39676.67707
   tps: 36273.83015
   hps: 117.30812
  }
@@ -1458,210 +1458,210 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 37717.84473
+  dps: 37584.9582
   tps: 34060.94062
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 37475.31475
+  dps: 37342.42822
   tps: 33849.73411
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 37692.16264
+  dps: 37559.27611
   tps: 34057.61394
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 36867.35198
+  dps: 36734.46545
   tps: 33284.98236
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 36954.5243
+  dps: 36821.63777
   tps: 33365.47324
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 37160.12674
+  dps: 37026.86083
   tps: 33680.39408
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 36908.03624
+  dps: 36779.64142
   tps: 33515.61404
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 37383.43189
+  dps: 37242.51894
   tps: 33873.4683
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-StayofExecution-68996"
  value: {
-  dps: 36184.18055
+  dps: 36049.38371
   tps: 32619.59037
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 37627.2111
+  dps: 37485.05616
   tps: 33995.92241
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-StumpofTime-62465"
  value: {
-  dps: 37301.71959
+  dps: 37168.83307
   tps: 33657.96592
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-StumpofTime-62470"
  value: {
-  dps: 37377.67659
+  dps: 37244.79007
   tps: 33715.94896
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 37735.07548
+  dps: 37592.6893
   tps: 34158.27001
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TearofBlood-55819"
  value: {
-  dps: 37030.82754
+  dps: 36890.54439
   tps: 33477.05023
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TearofBlood-56351"
  value: {
-  dps: 37549.06354
+  dps: 37416.22946
   tps: 34008.21728
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 37291.70215
+  dps: 37158.81562
   tps: 33664.69635
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 37714.72398
+  dps: 37581.83745
   tps: 34043.26346
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TheHungerer-68927"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-TheHungerer-69112"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 38532.8196
+  dps: 38396.26881
   tps: 34778.72566
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Ti'tahk,theStepsofTime-77190"
  value: {
-  dps: 51713.16298
+  dps: 51577.71157
   tps: 47275.33301
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Ti'tahk,theStepsofTime-78477"
  value: {
-  dps: 53158.38316
+  dps: 53012.59325
   tps: 48466.147
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Ti'tahk,theStepsofTime-78486"
  value: {
-  dps: 49981.79577
+  dps: 49845.92228
   tps: 45685.91646
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 36638.9605
+  dps: 36506.07397
   tps: 33074.09627
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 36696.49423
+  dps: 36563.6077
   tps: 33127.22025
  }
 }
@@ -1675,336 +1675,336 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 37655.44159
+  dps: 37521.26353
   tps: 34361.46816
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-UnheededWarning-59520"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 36119.65874
+  dps: 35985.60407
   tps: 32575.21968
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 36742.58457
+  dps: 36607.78773
   tps: 33134.54586
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 36742.58457
+  dps: 36607.78773
   tps: 33134.54586
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 36742.58457
+  dps: 36607.78773
   tps: 33134.54586
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 39083.57683
+  dps: 38933.52602
   tps: 35629.9944
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-VeilofLies-72900"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-VialofShadows-77207"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-VialofShadows-77979"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-VialofShadows-77999"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 36199.43328
+  dps: 36066.54676
   tps: 32668.24355
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 36199.43328
+  dps: 36066.54676
   tps: 32668.24355
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 36184.18055
+  dps: 36049.38371
   tps: 32619.59037
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 37480.31186
+  dps: 37345.51502
   tps: 33773.08486
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 36184.18055
+  dps: 36049.38371
   tps: 32619.59037
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 36930.99138
+  dps: 36800.35339
   tps: 33438.91473
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 36892.4985
+  dps: 36750.7366
   tps: 33236.13779
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 36792.38378
+  dps: 36659.49726
   tps: 33215.76021
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 37235.16084
+  dps: 37102.27432
   tps: 33610.97174
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 36199.43328
+  dps: 36066.54676
   tps: 32668.24355
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 39992.71995
+  dps: 39857.25095
   tps: 36191.71755
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 39451.57385
+  dps: 39309.57036
   tps: 35723.49907
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-WillofUnbinding-77995"
  value: {
-  dps: 40476.72295
+  dps: 40336.47529
   tps: 36764.82562
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 37504.30413
+  dps: 37361.46433
   tps: 33877.81814
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 38094.29889
+  dps: 37958.0614
   tps: 34499.2736
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 36564.94423
+  dps: 36430.14739
   tps: 32970.71159
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 36199.612
+  dps: 36066.72547
   tps: 32668.42226
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 36865.76314
+  dps: 36737.99622
   tps: 33267.56844
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 36865.76314
+  dps: 36737.99622
   tps: 33267.56844
  }
 }
 dps_results: {
  key: "TestArcane-Average-Default"
  value: {
-  dps: 40388.12987
+  dps: 40245.73531
   tps: 36578.16367
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p3-Arcane-arcane-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 39741.0634
+  dps: 39606.6698
   tps: 52592.07793
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p3-Arcane-arcane-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 39762.95796
+  dps: 39628.56436
   tps: 36225.71744
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p3-Arcane-arcane-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 58558.61364
+  dps: 58373.84881
   tps: 53802.71999
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p3-Arcane-arcane-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 25420.98408
+  dps: 25334.7499
   tps: 38801.66744
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p3-Arcane-arcane-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 25420.98408
+  dps: 25334.7499
   tps: 23091.24594
  }
 }
 dps_results: {
  key: "TestArcane-Settings-Troll-p3-Arcane-arcane-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 32485.30213
+  dps: 32372.56126
   tps: 29731.37894
  }
 }
 dps_results: {
  key: "TestArcane-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 39762.95796
+  dps: 39628.56436
   tps: 36225.71744
  }
 }

--- a/sim/mage/fire/TestFire.results
+++ b/sim/mage/fire/TestFire.results
@@ -38,70 +38,70 @@ character_stats_results: {
 dps_results: {
  key: "TestFire-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 39006.92598
+  dps: 38872.37418
   tps: 34778.58082
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 36843.8424
+  dps: 36710.61401
   tps: 32863.65827
  }
 }
 dps_results: {
  key: "TestFire-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 37067.31637
+  dps: 36925.30646
   tps: 33068.3026
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 37267.87904
+  dps: 37128.01874
   tps: 33157.05614
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 37491.50935
+  dps: 37355.2063
   tps: 33350.26079
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ArrowofTime-72897"
  value: {
-  dps: 36053.56695
+  dps: 35917.49712
   tps: 32175.22552
  }
 }
 dps_results: {
  key: "TestFire-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 38223.05005
+  dps: 38089.86604
   tps: 34065.22121
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 36193.15398
+  dps: 36052.96215
   tps: 32263.14088
   hps: 109.88026
  }
@@ -109,462 +109,462 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 38538.35233
+  dps: 38395.31932
   tps: 34332.92456
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 38585.408
+  dps: 38437.09718
   tps: 34461.80878
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BindingPromise-67037"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 36751.25057
+  dps: 36610.54276
   tps: 32776.23035
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 36830.77747
+  dps: 36686.83633
   tps: 32849.04111
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 36830.77747
+  dps: 36686.83633
   tps: 32849.04111
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 37746.74748
+  dps: 37606.84593
   tps: 33647.12029
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 36942.84332
+  dps: 36789.31207
   tps: 32866.72109
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 36455.30614
+  dps: 36314.59834
   tps: 32495.70088
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 37404.94071
+  dps: 37265.53769
   tps: 33350.04024
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 36576.57469
+  dps: 36435.86688
   tps: 32616.99542
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 36565.8952
+  dps: 36425.1874
   tps: 32606.2831
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 36585.60909
+  dps: 36444.90129
   tps: 32625.92611
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BottledLightning-66879"
  value: {
-  dps: 37556.34942
+  dps: 37417.197
   tps: 33505.3492
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BottledWishes-77114"
  value: {
-  dps: 39012.33773
+  dps: 38870.9682
   tps: 34843.799
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BottledWishes-77985"
  value: {
-  dps: 38118.32817
+  dps: 37982.57644
   tps: 34133.34388
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BottledWishes-78005"
  value: {
-  dps: 38738.179
+  dps: 38601.88236
   tps: 34678.00093
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 38430.95314
+  dps: 38297.58604
   tps: 33595.30464
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 39523.62237
+  dps: 39393.44258
   tps: 35237.8112
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 39584.70052
+  dps: 39453.20741
   tps: 35296.05004
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 36963.5705
+  dps: 36810.0869
   tps: 32886.08714
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 37426.80405
+  dps: 37284.31459
   tps: 33384.9424
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 37409.44561
+  dps: 37262.52414
   tps: 33318.3373
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 37433.09709
+  dps: 37293.54204
   tps: 33368.55097
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 36887.66439
+  dps: 36746.73553
   tps: 32875.82669
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CrushingWeight-59506"
  value: {
-  dps: 36011.90417
+  dps: 35874.3715
   tps: 32266.23775
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CrushingWeight-65118"
  value: {
-  dps: 36461.45004
+  dps: 36328.33101
   tps: 32510.94655
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 38920.18525
+  dps: 38778.54507
   tps: 34851.03086
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 38645.90485
+  dps: 38506.79595
   tps: 34676.07475
  }
 }
 dps_results: {
  key: "TestFire-AllItems-CunningoftheCruel-78000"
  value: {
-  dps: 39889.12151
+  dps: 39742.41156
   tps: 35776.80477
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 37426.80405
+  dps: 37284.31459
   tps: 33384.9424
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 37103.14576
+  dps: 36965.55076
   tps: 33055.01529
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 38370.43274
+  dps: 38237.53055
   tps: 34250.83671
  }
 }
 dps_results: {
  key: "TestFire-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 37273.36723
+  dps: 37131.00557
   tps: 33294.39365
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 37109.5119
+  dps: 36958.75931
   tps: 33114.37441
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 38223.05005
+  dps: 38089.86604
   tps: 34065.22121
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 36764.61783
+  dps: 36617.96535
   tps: 32757.93676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 38463.40136
+  dps: 38329.38193
   tps: 34299.26251
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 38370.43274
+  dps: 38237.53055
   tps: 34250.83671
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 37067.31637
+  dps: 36925.30646
   tps: 33068.3026
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 38223.05005
+  dps: 38089.86604
   tps: 34065.22121
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FallofMortality-59500"
  value: {
-  dps: 37426.80405
+  dps: 37284.31459
   tps: 33384.9424
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FallofMortality-65124"
  value: {
-  dps: 37701.76125
+  dps: 37567.47396
   tps: 33655.49576
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 37901.10316
+  dps: 37757.20531
   tps: 33820.86272
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 36586.75379
+  dps: 36449.41263
   tps: 32575.32265
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 37153.48679
+  dps: 37004.9306
   tps: 33112.46256
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 38454.26933
+  dps: 38309.64948
   tps: 34276.5383
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 36830.77747
+  dps: 36686.83633
   tps: 32849.04111
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FirehawkRobesofConflagration"
  value: {
-  dps: 35257.22698
+  dps: 35138.33013
   tps: 31525.68625
  }
 }
@@ -578,756 +578,756 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 37174.80797
+  dps: 37032.79806
   tps: 33168.53116
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FireoftheDeep-77988"
  value: {
-  dps: 37067.31637
+  dps: 36925.30646
   tps: 33068.3026
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FireoftheDeep-78008"
  value: {
-  dps: 37282.29957
+  dps: 37140.28966
   tps: 33268.75972
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 38223.05005
+  dps: 38089.86604
   tps: 34065.22121
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FluidDeath-58181"
  value: {
-  dps: 36586.75379
+  dps: 36449.41263
   tps: 32575.32265
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 38430.95314
+  dps: 38297.58604
   tps: 34278.6531
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 38518.79803
+  dps: 38375.8278
   tps: 34363.06602
  }
 }
 dps_results: {
  key: "TestFire-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 36990.24948
+  dps: 36842.31069
   tps: 32942.51413
  }
 }
 dps_results: {
  key: "TestFire-AllItems-GaleofShadows-56138"
  value: {
-  dps: 37476.80019
+  dps: 37342.98002
   tps: 33427.65829
  }
 }
 dps_results: {
  key: "TestFire-AllItems-GaleofShadows-56462"
  value: {
-  dps: 37415.85454
+  dps: 37280.91645
   tps: 33532.50241
  }
 }
 dps_results: {
  key: "TestFire-AllItems-GearDetector-61462"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 36886.35473
+  dps: 36752.46482
   tps: 32901.70127
  }
 }
 dps_results: {
  key: "TestFire-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Gurthalak,VoiceoftheDeeps-77191"
  value: {
-  dps: 39523.62237
+  dps: 39393.44258
   tps: 35237.8112
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Gurthalak,VoiceoftheDeeps-78478"
  value: {
-  dps: 39523.62237
+  dps: 39393.44258
   tps: 35237.8112
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Gurthalak,VoiceoftheDeeps-78487"
  value: {
-  dps: 39523.62237
+  dps: 39393.44258
   tps: 35237.8112
  }
 }
 dps_results: {
  key: "TestFire-AllItems-HarmlightToken-63839"
  value: {
-  dps: 37254.35564
+  dps: 37119.13414
   tps: 33286.67253
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 37703.24681
+  dps: 37571.54476
   tps: 33678.65875
  }
 }
 dps_results: {
  key: "TestFire-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 38196.11302
+  dps: 38067.79144
   tps: 34199.92188
  }
 }
 dps_results: {
  key: "TestFire-AllItems-HeartofRage-59224"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-HeartofRage-65072"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-HeartofSolace-55868"
  value: {
-  dps: 36643.80611
+  dps: 36509.41346
   tps: 32662.09423
  }
 }
 dps_results: {
  key: "TestFire-AllItems-HeartofSolace-56393"
  value: {
-  dps: 36421.86387
+  dps: 36288.24449
   tps: 32623.13437
  }
 }
 dps_results: {
  key: "TestFire-AllItems-HeartofThunder-55845"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-HeartofThunder-56370"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Heartpierce-50641"
  value: {
-  dps: 39523.62237
+  dps: 39393.44258
   tps: 35237.8112
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 38370.43274
+  dps: 38237.53055
   tps: 34250.83671
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 36959.82477
+  dps: 36817.81486
   tps: 32968.07403
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 36959.82477
+  dps: 36817.81486
   tps: 32968.07403
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 36830.77747
+  dps: 36686.83633
   tps: 32849.04111
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 36830.77747
+  dps: 36686.83633
   tps: 32849.04111
  }
 }
 dps_results: {
  key: "TestFire-AllItems-IndomitablePride-77211"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-IndomitablePride-77983"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-IndomitablePride-78003"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 39473.61743
+  dps: 39324.22405
   tps: 35291.99377
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 39417.58515
+  dps: 39288.05959
   tps: 35287.98665
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 40595.86227
+  dps: 40463.36873
   tps: 36369.27548
  }
 }
 dps_results: {
  key: "TestFire-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 37475.69008
+  dps: 37336.89952
   tps: 33439.2738
  }
 }
 dps_results: {
  key: "TestFire-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 36497.44384
+  dps: 36355.99259
   tps: 32540.96871
  }
 }
 dps_results: {
  key: "TestFire-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 36497.44384
+  dps: 36355.99259
   tps: 32543.76871
  }
 }
 dps_results: {
  key: "TestFire-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 37913.51519
+  dps: 37775.72188
   tps: 33814.01168
  }
 }
 dps_results: {
  key: "TestFire-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 38116.84907
+  dps: 37982.15223
   tps: 34013.39744
  }
 }
 dps_results: {
  key: "TestFire-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 36751.25057
+  dps: 36610.54276
   tps: 32776.23035
  }
 }
 dps_results: {
  key: "TestFire-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 36586.75379
+  dps: 36449.41263
   tps: 32575.32265
  }
 }
 dps_results: {
  key: "TestFire-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 36586.75379
+  dps: 36449.41263
   tps: 32575.32265
  }
 }
 dps_results: {
  key: "TestFire-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 36951.96398
+  dps: 36809.42615
   tps: 32966.12418
  }
 }
 dps_results: {
  key: "TestFire-AllItems-KiroptyricSigil-77984"
  value: {
-  dps: 36501.23188
+  dps: 36362.7469
   tps: 32706.63397
  }
 }
 dps_results: {
  key: "TestFire-AllItems-KiroptyricSigil-78004"
  value: {
-  dps: 36425.17907
+  dps: 36286.77556
   tps: 32580.51391
  }
 }
 dps_results: {
  key: "TestFire-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 36691.03265
+  dps: 36565.01792
   tps: 32805.51205
  }
 }
 dps_results: {
  key: "TestFire-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 36691.03265
+  dps: 36565.01792
   tps: 32805.51205
  }
 }
 dps_results: {
  key: "TestFire-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 36595.67571
+  dps: 36470.62027
   tps: 32640.75138
  }
 }
 dps_results: {
  key: "TestFire-AllItems-LeadenDespair-55816"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-LeadenDespair-56347"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 36586.75379
+  dps: 36449.41263
   tps: 32575.32265
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 36455.30614
+  dps: 36314.59834
   tps: 32495.70088
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 36455.30614
+  dps: 36314.59834
   tps: 32495.70088
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 37030.06595
+  dps: 36891.82123
   tps: 33034.54357
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 37041.52373
+  dps: 36903.16777
   tps: 33075.51256
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 36586.75379
+  dps: 36449.41263
   tps: 32575.32265
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 36586.75379
+  dps: 36449.41263
   tps: 32575.32265
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 36959.82477
+  dps: 36817.81486
   tps: 32968.07403
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 36959.82477
+  dps: 36817.81486
   tps: 32968.07403
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 38405.37848
+  dps: 38252.72298
   tps: 34174.02997
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 38470.80435
+  dps: 38326.69647
   tps: 34299.28022
  }
 }
 dps_results: {
  key: "TestFire-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 38296.23975
+  dps: 38149.71836
   tps: 34175.50664
  }
 }
 dps_results: {
  key: "TestFire-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 38598.30196
+  dps: 38459.98091
   tps: 34475.28157
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 36922.77476
+  dps: 36771.82855
   tps: 32864.40256
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 37353.0681
+  dps: 37211.17826
   tps: 33317.98688
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 38019.56107
+  dps: 37881.27367
   tps: 33881.87365
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 38223.05005
+  dps: 38089.86604
   tps: 34065.22121
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Rainsong-55854"
  value: {
-  dps: 36455.30614
+  dps: 36314.59834
   tps: 32495.70088
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Rainsong-56377"
  value: {
-  dps: 36455.30614
+  dps: 36314.59834
   tps: 32495.70088
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Rathrak,thePoisonousMind-77195"
  value: {
-  dps: 33311.82598
+  dps: 33178.32806
   tps: 31850.46559
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Rathrak,thePoisonousMind-78475"
  value: {
-  dps: 35360.2425
+  dps: 35236.05103
   tps: 33842.19231
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Rathrak,thePoisonousMind-78484"
  value: {
-  dps: 32383.18272
+  dps: 32257.73056
   tps: 30987.05461
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 38072.19694
+  dps: 37933.84098
   tps: 34001.16139
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ReflectionoftheLight-77986"
  value: {
-  dps: 37888.44615
+  dps: 37750.09019
   tps: 33834.09013
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ReflectionoftheLight-78006"
  value: {
-  dps: 38291.14107
+  dps: 38152.78511
   tps: 34201.25316
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 39006.92598
+  dps: 38872.37418
   tps: 34778.58082
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 39029.62122
+  dps: 38895.07834
   tps: 34784.12136
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 36942.38536
+  dps: 36783.88344
   tps: 32932.72205
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 36586.75379
+  dps: 36449.41263
   tps: 32575.32265
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 36586.75379
+  dps: 36449.41263
   tps: 32575.32265
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RosaryofLight-72901"
  value: {
-  dps: 37362.15217
+  dps: 37230.50852
   tps: 33360.02598
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RottingSkull-77116"
  value: {
-  dps: 36845.54453
+  dps: 36693.74032
   tps: 32912.92599
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RottingSkull-77987"
  value: {
-  dps: 37022.38902
+  dps: 36869.11188
   tps: 32997.23101
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RottingSkull-78007"
  value: {
-  dps: 37217.81261
+  dps: 37065.9984
   tps: 33252.68155
  }
 }
 dps_results: {
  key: "TestFire-AllItems-RuneofZeth-68998"
  value: {
-  dps: 38451.37372
+  dps: 38307.25735
   tps: 34273.78696
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ScalesofLife-68915"
  value: {
-  dps: 36194.05075
+  dps: 36053.85892
   tps: 32263.84728
   hps: 387.10174
  }
@@ -1335,7 +1335,7 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-ScalesofLife-69109"
  value: {
-  dps: 36194.05075
+  dps: 36053.85892
   tps: 32263.84728
   hps: 436.64714
  }
@@ -1343,91 +1343,91 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SeaStar-55256"
  value: {
-  dps: 37070.52523
+  dps: 36931.77538
   tps: 33067.29499
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SeaStar-56290"
  value: {
-  dps: 37599.08272
+  dps: 37460.32865
   tps: 33542.57676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ShardofWoe-60233"
  value: {
-  dps: 36692.40286
+  dps: 36555.88997
   tps: 32769.63528
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 37183.29634
+  dps: 37043.39479
   tps: 33152.32597
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 37219.78153
+  dps: 37080.36187
   tps: 33216.30509
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Sorrowsong-55879"
  value: {
-  dps: 37682.339
+  dps: 37540.27987
   tps: 33599.97115
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Sorrowsong-56400"
  value: {
-  dps: 37820.2632
+  dps: 37676.35317
   tps: 33702.04303
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 36586.75379
+  dps: 36449.41263
   tps: 32575.32265
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SoulCasket-58183"
  value: {
-  dps: 38580.26092
+  dps: 38440.30911
   tps: 34412.04508
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Souldrinker-77193"
  value: {
-  dps: 39582.40432
+  dps: 39452.22453
   tps: 35296.59316
   hps: 117.56391
  }
@@ -1435,7 +1435,7 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-Souldrinker-78479"
  value: {
-  dps: 39590.50415
+  dps: 39460.32436
   tps: 35304.69298
   hps: 133.76356
  }
@@ -1443,7 +1443,7 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-Souldrinker-78488"
  value: {
-  dps: 39574.38529
+  dps: 39444.2055
   tps: 35288.57413
   hps: 101.52586
  }
@@ -1451,217 +1451,217 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 37942.88223
+  dps: 37804.75366
   tps: 33876.72179
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 37511.28215
+  dps: 37377.07241
   tps: 33488.71142
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 37981.69308
+  dps: 37850.65894
   tps: 33918.44925
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 37067.31637
+  dps: 36925.30646
   tps: 33068.3026
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 37067.31637
+  dps: 36925.30646
   tps: 33068.3026
  }
 }
 dps_results: {
  key: "TestFire-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 37409.63608
+  dps: 37262.77652
   tps: 33440.55026
  }
 }
 dps_results: {
  key: "TestFire-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 37361.87323
+  dps: 37226.44443
   tps: 33368.6307
  }
 }
 dps_results: {
  key: "TestFire-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 37617.58246
+  dps: 37495.54492
   tps: 33659.2499
  }
 }
 dps_results: {
  key: "TestFire-AllItems-StayofExecution-68996"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 37900.57616
+  dps: 37751.68803
   tps: 33783.83459
  }
 }
 dps_results: {
  key: "TestFire-AllItems-StumpofTime-62465"
  value: {
-  dps: 37935.79696
+  dps: 37797.45322
   tps: 33789.84254
  }
 }
 dps_results: {
  key: "TestFire-AllItems-StumpofTime-62470"
  value: {
-  dps: 37874.51985
+  dps: 37735.12954
   tps: 33771.121
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 37582.56507
+  dps: 37446.95639
   tps: 33572.65649
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TearofBlood-55819"
  value: {
-  dps: 37092.37394
+  dps: 36956.43679
   tps: 33083.79487
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TearofBlood-56351"
  value: {
-  dps: 37153.48679
+  dps: 37004.9306
   tps: 33112.46256
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 37662.60197
+  dps: 37527.04202
   tps: 33589.09843
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 37754.41697
+  dps: 37614.18677
   tps: 33710.94671
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TheHungerer-68927"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-TheHungerer-69112"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 38131.92997
+  dps: 37989.95036
   tps: 34040.79107
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 38473.6773
+  dps: 38346.54049
   tps: 34261.78745
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Ti'tahk,theStepsofTime-77190"
  value: {
-  dps: 52606.4858
+  dps: 52471.65822
   tps: 47162.61424
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Ti'tahk,theStepsofTime-78477"
  value: {
-  dps: 54294.39496
+  dps: 54147.64592
   tps: 48723.49315
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Ti'tahk,theStepsofTime-78486"
  value: {
-  dps: 51252.00693
+  dps: 51115.96105
   tps: 45889.88772
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 36830.77747
+  dps: 36686.83633
   tps: 32849.04111
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 36830.77747
+  dps: 36686.83633
   tps: 32849.04111
  }
 }
@@ -1675,378 +1675,378 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 36377.54906
+  dps: 36244.58378
   tps: 32410.95036
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 37487.52995
+  dps: 37353.93635
   tps: 33431.80612
  }
 }
 dps_results: {
  key: "TestFire-AllItems-UnheededWarning-59520"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 36455.30614
+  dps: 36314.59834
   tps: 32495.70088
  }
 }
 dps_results: {
  key: "TestFire-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 36959.82477
+  dps: 36817.81486
   tps: 32968.07403
  }
 }
 dps_results: {
  key: "TestFire-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 36959.82477
+  dps: 36817.81486
   tps: 32968.07403
  }
 }
 dps_results: {
  key: "TestFire-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 36959.82477
+  dps: 36817.81486
   tps: 32968.07403
  }
 }
 dps_results: {
  key: "TestFire-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 38259.36899
+  dps: 38138.54567
   tps: 34117.85233
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 36835.19841
+  dps: 36691.25727
   tps: 32840.7862
  }
 }
 dps_results: {
  key: "TestFire-AllItems-VeilofLies-72900"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 36240.52502
+  dps: 36100.60524
   tps: 32319.13506
  }
 }
 dps_results: {
  key: "TestFire-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 36359.56081
+  dps: 36220.99596
   tps: 32457.35944
  }
 }
 dps_results: {
  key: "TestFire-AllItems-VialofShadows-77207"
  value: {
-  dps: 36620.11095
+  dps: 36479.40315
   tps: 32660.15419
  }
 }
 dps_results: {
  key: "TestFire-AllItems-VialofShadows-77979"
  value: {
-  dps: 36599.2947
+  dps: 36458.58689
   tps: 32639.21329
  }
 }
 dps_results: {
  key: "TestFire-AllItems-VialofShadows-77999"
  value: {
-  dps: 36628.5292
+  dps: 36487.8214
   tps: 32668.97923
  }
 }
 dps_results: {
  key: "TestFire-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 37811.45114
+  dps: 37671.54959
   tps: 33705.98955
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 36586.75379
+  dps: 36449.41263
   tps: 32575.32265
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 36817.10466
+  dps: 36681.73263
   tps: 32849.66251
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 37021.36296
+  dps: 36869.07076
   tps: 32980.16799
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 36959.82477
+  dps: 36817.81486
   tps: 32968.07403
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 37583.572
+  dps: 37444.81794
   tps: 33518.58815
  }
 }
 dps_results: {
  key: "TestFire-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 40072.75056
+  dps: 39935.57918
   tps: 35671.81389
  }
 }
 dps_results: {
  key: "TestFire-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 39588.82027
+  dps: 39449.29711
   tps: 35260.44018
  }
 }
 dps_results: {
  key: "TestFire-AllItems-WillofUnbinding-77995"
  value: {
-  dps: 40627.95935
+  dps: 40484.82182
   tps: 36201.05569
  }
 }
 dps_results: {
  key: "TestFire-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 37570.49411
+  dps: 37434.49754
   tps: 33438.03659
  }
 }
 dps_results: {
  key: "TestFire-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 38441.55282
+  dps: 38300.16594
   tps: 34269.22128
  }
 }
 dps_results: {
  key: "TestFire-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 36751.25057
+  dps: 36610.54276
   tps: 32776.23035
  }
 }
 dps_results: {
  key: "TestFire-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 36447.32043
+  dps: 36306.61263
   tps: 32487.676
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 36981.20265
+  dps: 36842.95793
   tps: 32989.23198
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 36981.20265
+  dps: 36842.95793
   tps: 32989.23198
  }
 }
 dps_results: {
  key: "TestFire-Average-Default"
  value: {
-  dps: 40434.32826
+  dps: 40288.60342
   tps: 36008.6977
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-p3_fire-Fire-fire-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 95781.70485
+  dps: 95633.41904
   tps: 61633.71951
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-p3_fire-Fire-fire-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 39523.62237
+  dps: 39393.44258
   tps: 35237.8112
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-p3_fire-Fire-fire-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 51941.03576
+  dps: 51806.67836
   tps: 46372.55198
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-p3_fire-Fire-fire-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 68681.88785
+  dps: 68576.19323
   tps: 44890.40729
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-p3_fire-Fire-fire-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26592.73331
+  dps: 26479.04862
   tps: 23757.12988
  }
 }
 dps_results: {
  key: "TestFire-Settings-Troll-p3_fire-Fire-fire-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 27739.3099
+  dps: 27615.23568
   tps: 24673.399
  }
 }
 dps_results: {
  key: "TestFire-Settings-Worgen-p3_fire-Fire-fire-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 94799.69835
+  dps: 94653.0726
   tps: 59550.47035
  }
 }
 dps_results: {
  key: "TestFire-Settings-Worgen-p3_fire-Fire-fire-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 38001.61485
+  dps: 37860.71423
   tps: 34049.21018
  }
 }
 dps_results: {
  key: "TestFire-Settings-Worgen-p3_fire-Fire-fire-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 46528.13416
+  dps: 46380.47306
   tps: 41853.1456
  }
 }
 dps_results: {
  key: "TestFire-Settings-Worgen-p3_fire-Fire-fire-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 68438.31255
+  dps: 68325.31752
   tps: 44904.12217
  }
 }
 dps_results: {
  key: "TestFire-Settings-Worgen-p3_fire-Fire-fire-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26492.64557
+  dps: 26380.07175
   tps: 23654.59015
  }
 }
 dps_results: {
  key: "TestFire-Settings-Worgen-p3_fire-Fire-fire-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 28004.95369
+  dps: 27883.13733
   tps: 24955.12541
  }
 }
 dps_results: {
  key: "TestFire-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 39523.62237
+  dps: 39393.44258
   tps: 35237.8112
  }
 }

--- a/sim/mage/mirror_image_t12.go
+++ b/sim/mage/mirror_image_t12.go
@@ -58,18 +58,14 @@ func (mi *T12MirrorImage) ExecuteCustomRotation(sim *core.Simulation) {
 }
 
 var t12MirrorImageBaseStats = stats.Stats{
-	stats.Mana: 27020, // Confirmed via ingame bars at 80
-
-	// seems to be about 8% baseline in wotlk
-	stats.SpellCritPercent: 8,
+	stats.Mana:             27020, // Confirmed via ingame bars at 80
+	stats.SpellCritPercent: 0,
 }
 
 func createT12MirrorImageInheritance() func(stats.Stats) stats.Stats {
 	return func(ownerStats stats.Stats) stats.Stats {
 		return stats.Stats{
-			// According to the simcraft implementation, the T12 Mirror Images snapshot the owner's crit
-			stats.SpellCritPercent: ownerStats[stats.SpellCritPercent],
-			stats.SpellHitPercent:  ownerStats[stats.SpellHitPercent],
+			stats.SpellHitPercent: ownerStats[stats.SpellHitPercent],
 		}
 	}
 }

--- a/sim/warlock/affliction/TestAffliction.results
+++ b/sim/warlock/affliction/TestAffliction.results
@@ -38,77 +38,77 @@ character_stats_results: {
 dps_results: {
  key: "TestAffliction-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 38912.25836
+  dps: 38904.86169
   tps: 26502.89705
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 37124.38361
+  dps: 37118.7366
   tps: 25337.04131
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 37215.76306
+  dps: 37209.07312
   tps: 25431.70415
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 37449.66381
+  dps: 37442.84322
   tps: 25536.30792
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 37461.82535
+  dps: 37455.00477
   tps: 25544.43063
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ArrowofTime-72897"
  value: {
-  dps: 37022.28709
+  dps: 37016.19811
   tps: 25373.46498
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 38364.22574
+  dps: 38356.2138
   tps: 26072.58195
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Balespider'sBurningVestments"
  value: {
-  dps: 35771.87636
+  dps: 35765.96565
   tps: 24459.68614
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 36485.35339
+  dps: 36479.65077
   tps: 24896.06325
   hps: 102.469
  }
@@ -116,532 +116,532 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 38428.34461
+  dps: 38423.12971
   tps: 26095.0001
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 38639.77301
+  dps: 38634.30435
   tps: 26255.23571
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BindingPromise-67037"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 36817.80471
+  dps: 36810.0414
   tps: 25250.10853
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 36939.33979
+  dps: 36934.23188
   tps: 25272.64578
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 36939.33979
+  dps: 36934.23188
   tps: 25272.64578
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 36545.20384
+  dps: 36537.78142
   tps: 24927.49628
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 37575.10676
+  dps: 37567.68433
   tps: 25594.57373
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 36554.20466
+  dps: 36546.78223
   tps: 24921.17844
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 37006.9301
+  dps: 37001.26704
   tps: 25301.23132
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 36487.59059
+  dps: 36481.62446
   tps: 24932.69417
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 36455.24366
+  dps: 36449.56785
   tps: 24900.77528
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 37429.24997
+  dps: 37424.14206
   tps: 25501.19442
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 36662.68839
+  dps: 36657.75284
   tps: 25036.15668
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 36645.02703
+  dps: 36640.2777
   tps: 25014.30185
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 36687.94095
+  dps: 36683.12141
   tps: 25058.32615
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BottledLightning-66879"
  value: {
-  dps: 37297.05609
+  dps: 37291.19178
   tps: 25407.92171
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BottledWishes-77114"
  value: {
-  dps: 38543.8818
+  dps: 38540.05551
   tps: 26258.04664
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BottledWishes-77985"
  value: {
-  dps: 38562.0269
+  dps: 38556.50964
   tps: 26225.34856
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BottledWishes-78005"
  value: {
-  dps: 38916.28544
+  dps: 38911.54807
   tps: 26575.03459
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 38648.37372
+  dps: 38640.05519
   tps: 25626.00532
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 39078.94519
+  dps: 39070.62666
   tps: 26521.07496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 38973.7933
+  dps: 38966.06323
   tps: 26536.2697
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 37137.86135
+  dps: 37132.64646
   tps: 25278.97901
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 37488.41082
+  dps: 37482.18778
   tps: 25564.59059
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 37105.97198
+  dps: 37099.83501
   tps: 25337.51425
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 37198.0869
+  dps: 37192.11941
   tps: 25345.9893
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 37128.66489
+  dps: 37123.0311
   tps: 25277.42649
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CrushingWeight-59506"
  value: {
-  dps: 36834.33499
+  dps: 36829.16191
   tps: 25072.56502
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CrushingWeight-65118"
  value: {
-  dps: 36931.44299
+  dps: 36925.88589
   tps: 25160.47813
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 39465.46835
+  dps: 39457.71409
   tps: 27447.38913
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 39030.73866
+  dps: 39022.26176
   tps: 27145.40998
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CunningoftheCruel-78000"
  value: {
-  dps: 39816.37118
+  dps: 39808.34363
   tps: 27751.69018
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 36455.84594
+  dps: 36450.17013
   tps: 24902.0429
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 37573.34954
+  dps: 37567.93054
   tps: 25724.2486
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 36802.2916
+  dps: 36797.29349
   tps: 25078.9026
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 38533.85316
+  dps: 38526.12309
   tps: 26149.68182
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 37548.18041
+  dps: 37542.07516
   tps: 25574.05777
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 37072.05357
+  dps: 37066.43608
   tps: 25218.68402
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 38364.22574
+  dps: 38356.2138
   tps: 26072.58195
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 37090.92666
+  dps: 37083.4974
   tps: 25311.45268
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 38520.70788
+  dps: 38513.74908
   tps: 26164.4235
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 38533.85316
+  dps: 38526.12309
   tps: 26149.68182
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 37215.76306
+  dps: 37209.07312
   tps: 25431.70415
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 38364.22574
+  dps: 38356.2138
   tps: 26072.58195
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FallofMortality-59500"
  value: {
-  dps: 37573.34954
+  dps: 37567.93054
   tps: 25724.2486
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FallofMortality-65124"
  value: {
-  dps: 37802.06588
+  dps: 37797.2381
   tps: 25896.69985
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 37929.02017
+  dps: 37921.67913
   tps: 25802.38322
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 36944.57842
+  dps: 36938.96701
   tps: 25065.89326
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 37483.83754
+  dps: 37479.04695
   tps: 25592.82765
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 36578.42577
+  dps: 36571.82373
   tps: 24965.88931
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 38432.5425
+  dps: 38427.75192
   tps: 26219.30087
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 36960.59605
+  dps: 36953.17363
   tps: 25290.58862
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 37114.43995
+  dps: 37109.33203
   tps: 25422.9501
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FireoftheDeep-77988"
  value: {
-  dps: 37114.43995
+  dps: 37109.33203
   tps: 25422.9501
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FireoftheDeep-78008"
  value: {
-  dps: 37249.95892
+  dps: 37244.85101
   tps: 25546.02202
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 38474.08983
+  dps: 38466.69316
   tps: 26118.14751
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FluidDeath-58181"
  value: {
-  dps: 36822.60766
+  dps: 36815.78707
   tps: 25137.30542
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 38648.37372
+  dps: 38640.05519
   tps: 26142.1837
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 38507.87987
+  dps: 38502.46582
   tps: 26519.73646
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 37163.90852
+  dps: 37158.69362
   tps: 25298.78018
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GaleofShadows-56138"
  value: {
-  dps: 37692.85981
+  dps: 37686.23049
   tps: 25807.45644
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GaleofShadows-56462"
  value: {
-  dps: 38112.93278
+  dps: 38107.89558
   tps: 25943.36238
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GearDetector-61462"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
@@ -655,630 +655,630 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 37153.56306
+  dps: 37147.24706
   tps: 25359.72162
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HarmlightToken-63839"
  value: {
-  dps: 37930.92078
+  dps: 37923.64232
   tps: 25698.38153
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 38005.34155
+  dps: 38000.27608
   tps: 25905.61327
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 38167.52263
+  dps: 38161.28778
   tps: 26080.39667
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofRage-59224"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofRage-65072"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofSolace-55868"
  value: {
-  dps: 36907.21163
+  dps: 36900.58231
   tps: 25265.39373
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofSolace-56393"
  value: {
-  dps: 37212.25712
+  dps: 37207.21992
   tps: 25326.36613
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofThunder-55845"
  value: {
-  dps: 36544.17605
+  dps: 36538.96617
   tps: 24921.85435
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofThunder-56370"
  value: {
-  dps: 36544.17301
+  dps: 36538.96313
   tps: 24922.20411
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 38533.85316
+  dps: 38526.12309
   tps: 26149.68182
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 36960.59605
+  dps: 36953.17363
   tps: 25290.58862
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 36960.59605
+  dps: 36953.17363
   tps: 25290.58862
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 36947.12776
+  dps: 36942.01985
   tps: 25273.21413
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 36947.12776
+  dps: 36942.01985
   tps: 25273.21413
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-IndomitablePride-77211"
  value: {
-  dps: 36518.31532
+  dps: 36511.6216
   tps: 24940.66885
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-IndomitablePride-77983"
  value: {
-  dps: 36572.2785
+  dps: 36565.6904
   tps: 24943.14876
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-IndomitablePride-78003"
  value: {
-  dps: 36515.39009
+  dps: 36509.01002
   tps: 24984.25616
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 36544.17605
+  dps: 36538.96617
   tps: 24921.73204
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 39490.30198
+  dps: 39484.7814
   tps: 27003.28072
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 38830.78168
+  dps: 38824.85566
   tps: 26578.52795
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 40066.27159
+  dps: 40060.15387
   tps: 27372.03249
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 37425.19801
+  dps: 37417.4347
   tps: 25646.35715
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 36337.82164
+  dps: 36332.94037
   tps: 24739.4368
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 36575.28481
+  dps: 36569.7999
   tps: 24916.48502
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 37865.15764
+  dps: 37861.04267
   tps: 25729.13333
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 38124.55165
+  dps: 38119.97
   tps: 25933.05603
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 36817.80471
+  dps: 36810.0414
   tps: 25250.10853
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 36822.60766
+  dps: 36815.78707
   tps: 25137.30542
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 36822.60766
+  dps: 36815.78707
   tps: 25137.30542
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 37129.15243
+  dps: 37125.32613
   tps: 25340.41132
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KiroptyricSigil-77984"
  value: {
-  dps: 37288.70037
+  dps: 37283.18311
   tps: 25400.70707
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KiroptyricSigil-78004"
  value: {
-  dps: 37294.31652
+  dps: 37289.57915
   tps: 25509.01179
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 36863.58661
+  dps: 36858.28258
   tps: 25119.09936
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 36863.58661
+  dps: 36858.28258
   tps: 25119.09936
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 37114.75945
+  dps: 37110.50386
   tps: 25172.64384
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LeadenDespair-55816"
  value: {
-  dps: 36539.45502
+  dps: 36533.70875
   tps: 24943.26925
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LeadenDespair-56347"
  value: {
-  dps: 36578.42577
+  dps: 36571.82373
   tps: 24965.88931
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 36822.60766
+  dps: 36815.78707
   tps: 25137.30542
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 36546.67197
+  dps: 36538.90866
   tps: 25003.32182
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 36546.67197
+  dps: 36538.90866
   tps: 25003.32182
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 36538.10157
+  dps: 36532.60864
   tps: 24901.7607
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 36538.10157
+  dps: 36532.60864
   tps: 24901.7607
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 36896.57478
+  dps: 36888.81147
   tps: 25322.45591
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 36925.73334
+  dps: 36917.97004
   tps: 25349.05042
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 37067.20701
+  dps: 37060.79135
   tps: 25079.72888
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 37067.20701
+  dps: 37060.79135
   tps: 25079.72888
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 36947.12776
+  dps: 36942.01985
   tps: 25273.21413
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 36947.12776
+  dps: 36942.01985
   tps: 25273.21413
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 38261.15271
+  dps: 38255.93781
   tps: 26017.34368
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 38112.64506
+  dps: 38106.42203
   tps: 26110.27262
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 36495.11012
+  dps: 36488.56002
   tps: 24932.15997
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 38356.88369
+  dps: 38351.46964
   tps: 26379.17688
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 38731.97372
+  dps: 38726.76582
   tps: 26591.53436
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 36866.45687
+  dps: 36860.25035
   tps: 25158.73704
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 37562.72022
+  dps: 37557.25159
   tps: 25647.10063
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 37531.56492
+  dps: 37526.56681
   tps: 25543.84306
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 38364.22574
+  dps: 38356.2138
   tps: 26072.58195
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Rainsong-55854"
  value: {
-  dps: 36528.31732
+  dps: 36522.82439
   tps: 24880.02575
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Rainsong-56377"
  value: {
-  dps: 36538.10157
+  dps: 36532.60864
   tps: 24901.7607
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 37932.61261
+  dps: 37924.91102
   tps: 25876.259
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ReflectionoftheLight-77986"
  value: {
-  dps: 37769.9037
+  dps: 37762.20212
   tps: 25770.4966
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ReflectionoftheLight-78006"
  value: {
-  dps: 38116.5173
+  dps: 38108.81572
   tps: 25995.79889
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 38912.25836
+  dps: 38904.86169
   tps: 26502.89705
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 38900.97898
+  dps: 38893.86915
   tps: 26490.79917
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 37254.91806
+  dps: 37249.24433
   tps: 25455.20811
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 36822.60766
+  dps: 36815.78707
   tps: 25137.30542
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 36822.60766
+  dps: 36815.78707
   tps: 25137.30542
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RosaryofLight-72901"
  value: {
-  dps: 36956.8085
+  dps: 36950.58475
   tps: 25176.97384
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RottingSkull-77116"
  value: {
-  dps: 37331.65373
+  dps: 37326.5816
   tps: 25465.32241
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RottingSkull-77987"
  value: {
-  dps: 37185.23475
+  dps: 37180.17276
   tps: 25390.03222
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RottingSkull-78007"
  value: {
-  dps: 37387.87459
+  dps: 37383.15059
   tps: 25501.80283
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuneofZeth-68998"
  value: {
-  dps: 38381.78667
+  dps: 38376.1702
   tps: 26091.28243
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ScalesofLife-68915"
  value: {
-  dps: 36549.87176
+  dps: 36543.25511
   tps: 24955.04262
   hps: 357.04731
  }
@@ -1286,7 +1286,7 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-ScalesofLife-69109"
  value: {
-  dps: 36528.46269
+  dps: 36521.88911
   tps: 24947.05971
   hps: 402.74602
  }
@@ -1294,21 +1294,21 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SeaStar-55256"
  value: {
-  dps: 37058.71956
+  dps: 37051.23456
   tps: 25261.28255
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SeaStar-56290"
  value: {
-  dps: 37502.70326
+  dps: 37495.21826
   tps: 25554.40856
  }
 }
@@ -1322,721 +1322,721 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-ShardofWoe-60233"
  value: {
-  dps: 37313.30826
+  dps: 37308.7661
   tps: 25439.46157
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 36634.1625
+  dps: 36628.74613
   tps: 24909.55659
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 36939.16501
+  dps: 36931.74258
   tps: 25273.44768
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 36971.24504
+  dps: 36963.82261
   tps: 25302.80345
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Sorrowsong-55879"
  value: {
-  dps: 37670.12253
+  dps: 37665.01462
   tps: 25775.81989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Sorrowsong-56400"
  value: {
-  dps: 37765.82027
+  dps: 37760.71236
   tps: 25841.71174
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 37067.20701
+  dps: 37060.79135
   tps: 25079.72888
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SoulCasket-58183"
  value: {
-  dps: 38268.94772
+  dps: 38261.52529
   tps: 26157.36074
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 37195.38095
+  dps: 37188.68724
   tps: 25561.51609
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 37171.7042
+  dps: 37165.1161
   tps: 25489.56103
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 37311.34656
+  dps: 37304.96649
   tps: 25717.25397
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 37074.53085
+  dps: 37069.42293
   tps: 25395.48441
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 37074.53085
+  dps: 37069.42293
   tps: 25395.48441
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 37688.67949
+  dps: 37680.1567
   tps: 25678.54823
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 37377.20837
+  dps: 37372.02517
   tps: 25604.23094
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 37952.04848
+  dps: 37948.04839
   tps: 26053.68514
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StayofExecution-68996"
  value: {
-  dps: 36554.20466
+  dps: 36546.78223
   tps: 24921.17844
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 37614.75711
+  dps: 37608.42777
   tps: 25688.90033
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StumpofTime-62465"
  value: {
-  dps: 37990.47741
+  dps: 37983.65683
   tps: 25938.94591
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StumpofTime-62470"
  value: {
-  dps: 38042.73263
+  dps: 38035.91204
   tps: 25944.43019
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 36543.06528
+  dps: 36536.21935
   tps: 24965.88527
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 36564.68658
+  dps: 36557.48128
   tps: 24964.71589
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 37666.37196
+  dps: 37661.05529
   tps: 25712.25265
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TearofBlood-55819"
  value: {
-  dps: 37264.67838
+  dps: 37259.9779
   tps: 25423.47103
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TearofBlood-56351"
  value: {
-  dps: 37498.13873
+  dps: 37492.74984
   tps: 25559.9958
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 37387.1863
+  dps: 37382.07838
   tps: 25525.52604
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 37671.01068
+  dps: 37665.90277
   tps: 25736.23594
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TheHungerer-68927"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TheHungerer-69112"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 38014.85924
+  dps: 38009.44024
   tps: 26125.27779
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 38299.76809
+  dps: 38294.94031
   tps: 26349.42861
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 36939.33979
+  dps: 36934.23188
   tps: 25272.64578
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 36939.33979
+  dps: 36934.23188
   tps: 25272.64578
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 36825.00774
+  dps: 36819.0545
   tps: 25150.95959
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 37727.88171
+  dps: 37720.12407
   tps: 25808.04906
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnheededWarning-59520"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 36544.10209
+  dps: 36536.61709
   tps: 24921.52285
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 36960.59605
+  dps: 36953.17363
   tps: 25290.58862
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 36960.59605
+  dps: 36953.17363
   tps: 25290.58862
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 36960.59605
+  dps: 36953.17363
   tps: 25290.58862
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 37644.15838
+  dps: 37636.8507
   tps: 25641.96323
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 36885.85734
+  dps: 36880.74942
   tps: 25218.46499
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VeilofLies-72900"
  value: {
-  dps: 36554.2986
+  dps: 36547.07092
   tps: 24957.24646
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 36690.89811
+  dps: 36685.83233
   tps: 25025.04498
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 36689.55906
+  dps: 36684.49328
   tps: 25018.59135
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VialofShadows-77207"
  value: {
-  dps: 36714.38711
+  dps: 36709.33475
   tps: 25087.67714
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VialofShadows-77979"
  value: {
-  dps: 36687.02769
+  dps: 36681.97526
   tps: 25062.19711
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VialofShadows-77999"
  value: {
-  dps: 36717.28604
+  dps: 36712.46651
   tps: 25091.12421
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 36543.06528
+  dps: 36536.21935
   tps: 24965.88527
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 36564.68658
+  dps: 36557.48128
   tps: 24964.71589
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 36554.20466
+  dps: 36546.78223
   tps: 24921.17844
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 37632.19668
+  dps: 37624.77425
   tps: 25632.23071
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 36554.20466
+  dps: 36546.78223
   tps: 24921.17844
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 36854.10075
+  dps: 36848.38212
   tps: 25151.49307
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 37018.03338
+  dps: 37013.47415
   tps: 25317.28177
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 37058.47636
+  dps: 37052.52297
   tps: 25336.73775
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 36482.62529
+  dps: 36476.65916
   tps: 24912.51172
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 36887
+  dps: 36881.03388
   tps: 25281.09222
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 36482.62529
+  dps: 36476.65916
   tps: 24912.51172
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 37377.65976
+  dps: 37372.55185
   tps: 25443.5266
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 39320.77087
+  dps: 39314.70286
   tps: 26722.10303
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 38984.76921
+  dps: 38979.09625
   tps: 26514.18155
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WillofUnbinding-77995"
  value: {
-  dps: 39622.15695
+  dps: 39615.29846
   tps: 26902.26808
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 37571.44654
+  dps: 37566.5233
   tps: 25628.7673
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 37953.04789
+  dps: 37947.28138
   tps: 25867.85798
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 36825.13226
+  dps: 36817.70983
   tps: 25167.4519
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 36533.76662
+  dps: 36528.65871
   tps: 24904.12989
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 36656.5531
+  dps: 36649.96845
   tps: 25051.21847
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 36656.5531
+  dps: 36649.96845
   tps: 25051.21847
  }
 }
 dps_results: {
  key: "TestAffliction-Average-Default"
  value: {
-  dps: 39419.04911
+  dps: 39411.76785
   tps: 26925.79976
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p3-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 39787.88043
+  dps: 39780.07847
   tps: 34070.29504
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p3-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38650.10468
+  dps: 38642.22292
   tps: 26634.02601
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p3-Affliction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 47185.24865
+  dps: 47175.64852
   tps: 29711.75194
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p3-Affliction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 25961.12371
+  dps: 25956.13994
   tps: 25223.63619
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p3-Affliction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25961.12371
+  dps: 25956.13994
   tps: 17602.01571
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p3-Affliction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 28787.27045
+  dps: 28784.34634
   tps: 17454.54762
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p3-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 39254.66641
+  dps: 39248.85743
   tps: 33701.30682
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p3-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38333.96362
+  dps: 38326.04121
   tps: 26326.82899
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p3-Affliction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 46982.0519
+  dps: 46973.81235
   tps: 29577.05783
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p3-Affliction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 25827.97868
+  dps: 25823.70045
   tps: 25017.70303
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p3-Affliction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25827.97868
+  dps: 25823.70045
   tps: 17538.98794
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p3-Affliction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 28046.24158
+  dps: 28043.39595
   tps: 16798.82339
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p3-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 39992.2276
+  dps: 39986.12818
   tps: 33901.45996
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p3-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39078.94519
+  dps: 39070.62666
   tps: 26521.07496
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p3-Affliction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 46695.26163
+  dps: 46687.53709
   tps: 29980.02109
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p3-Affliction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 26320.16185
+  dps: 26315.14081
   tps: 25123.03382
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p3-Affliction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 26320.16185
+  dps: 26315.14081
   tps: 17643.56701
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p3-Affliction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 28482.32253
+  dps: 28477.84353
   tps: 17070.09545
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p3-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 39701.62268
+  dps: 39694.86749
   tps: 33990.57556
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p3-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38708.90374
+  dps: 38702.91203
   tps: 26709.94473
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p3-Affliction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 48184.86888
+  dps: 48173.42076
   tps: 30731.4124
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p3-Affliction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 26005.04434
+  dps: 26000.72375
   tps: 25330.19163
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p3-Affliction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 26005.04434
+  dps: 26000.72375
   tps: 17708.57115
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p3-Affliction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 29421.24485
+  dps: 29415.12217
   tps: 17738.23675
  }
 }
 dps_results: {
  key: "TestAffliction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 38946.06436
+  dps: 38937.74583
   tps: 26521.07496
  }
 }

--- a/sim/warlock/demonology/TestDemonology.results
+++ b/sim/warlock/demonology/TestDemonology.results
@@ -38,77 +38,77 @@ character_stats_results: {
 dps_results: {
  key: "TestDemonology-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 40605.80335
+  dps: 40574.00648
   tps: 19498.73052
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 38214.2208
+  dps: 38182.12987
   tps: 18462.92369
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 38551.01591
+  dps: 38519.47267
   tps: 18482.56653
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 38854.07876
+  dps: 38824.67076
   tps: 18742.0784
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 38977.37787
+  dps: 38944.33097
   tps: 18754.68959
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ArrowofTime-72897"
  value: {
-  dps: 38187.74239
+  dps: 38154.55209
   tps: 18322.47261
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 40287.17243
+  dps: 40255.37556
   tps: 19281.30251
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Balespider'sBurningVestments"
  value: {
-  dps: 37406.90912
+  dps: 37377.6478
   tps: 18097.98741
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 37684.63958
+  dps: 37653.74626
   tps: 18175.53995
   hps: 100.54264
  }
@@ -116,532 +116,532 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 39518.89474
+  dps: 39491.70363
   tps: 18920.29081
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 39774.56559
+  dps: 39742.71326
   tps: 19060.38272
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BindingPromise-67037"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 38204.15697
+  dps: 38172.61373
   tps: 18357.83647
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 38204.15697
+  dps: 38172.61373
   tps: 18357.83647
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 38377.58644
+  dps: 38346.0432
   tps: 18420.2015
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 37677.60214
+  dps: 37646.0589
   tps: 18170.27433
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 38971.47855
+  dps: 38942.7928
   tps: 18835.03222
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 38117.07785
+  dps: 38085.32547
   tps: 18486.9277
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.22725
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 38582.32499
+  dps: 38548.51372
   tps: 18392.64206
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 37832.78001
+  dps: 37801.54621
   tps: 18320.36982
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 37815.58875
+  dps: 37784.24706
   tps: 18306.16193
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 37856.53772
+  dps: 37825.17789
   tps: 18342.73149
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BottledLightning-66879"
  value: {
-  dps: 38479.33063
+  dps: 38446.1152
   tps: 18623.32183
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BottledWishes-77114"
  value: {
-  dps: 39592.99851
+  dps: 39561.10155
   tps: 19195.94952
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BottledWishes-77985"
  value: {
-  dps: 39464.12281
+  dps: 39439.92927
   tps: 19084.80362
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BottledWishes-78005"
  value: {
-  dps: 39954.47443
+  dps: 39924.96672
   tps: 19280.4257
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 40501.40319
+  dps: 40470.52704
   tps: 19020.39429
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 40824.12202
+  dps: 40793.24587
   tps: 19617.05241
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 40689.64824
+  dps: 40662.13491
   tps: 19624.67868
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 38123.75312
+  dps: 38092.00074
   tps: 18489.82634
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 38755.46671
+  dps: 38724.34054
   tps: 18724.97923
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 38337.27386
+  dps: 38309.59984
   tps: 18498.20009
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 38496.98048
+  dps: 38461.74343
   tps: 18492.89351
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 38403.80035
+  dps: 38371.00466
   tps: 18545.66357
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CrushingWeight-59506"
  value: {
-  dps: 37869.83776
+  dps: 37842.38218
   tps: 18361.92636
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CrushingWeight-65118"
  value: {
-  dps: 38012.44877
+  dps: 37985.33724
   tps: 18442.66302
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 40757.37202
+  dps: 40723.98396
   tps: 20466.21949
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 40371.01851
+  dps: 40337.24308
   tps: 20191.55086
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CunningoftheCruel-78000"
  value: {
-  dps: 41310.83419
+  dps: 41281.08364
   tps: 20825.98337
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 38755.46671
+  dps: 38724.34054
   tps: 18724.97923
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 37960.01668
+  dps: 37930.26991
   tps: 18396.68832
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 40362.23685
+  dps: 40334.72352
   tps: 19400.56977
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 38540.68932
+  dps: 38513.37957
   tps: 18640.42238
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 38073.1378
+  dps: 38041.61135
   tps: 18529.81489
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 40287.17243
+  dps: 40255.37556
   tps: 19281.30251
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 38315.87246
+  dps: 38287.21882
   tps: 18508.16589
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 40505.25242
+  dps: 40474.37628
   tps: 19402.56884
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 40362.23685
+  dps: 40334.72352
   tps: 19400.56977
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 38551.01591
+  dps: 38519.47267
   tps: 18482.56653
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 40287.17243
+  dps: 40255.37556
   tps: 19281.30251
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FallofMortality-59500"
  value: {
-  dps: 38755.46671
+  dps: 38724.34054
   tps: 18724.97923
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FallofMortality-65124"
  value: {
-  dps: 38923.48143
+  dps: 38891.96875
   tps: 18795.34798
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 38876.73134
+  dps: 38848.66702
   tps: 18692.87498
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 37865.77993
+  dps: 37836.69444
   tps: 18278.77503
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 38603.85111
+  dps: 38573.11995
   tps: 18656.67979
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 39819.86254
+  dps: 39790.34896
   tps: 19311.95468
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 38377.58644
+  dps: 38346.0432
   tps: 18420.2015
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 38724.44538
+  dps: 38692.90214
   tps: 18544.93157
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FireoftheDeep-77988"
  value: {
-  dps: 38551.01591
+  dps: 38519.47267
   tps: 18482.56653
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FireoftheDeep-78008"
  value: {
-  dps: 38897.87485
+  dps: 38866.33161
   tps: 18607.2966
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 40287.17243
+  dps: 40255.37556
   tps: 19281.26322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FluidDeath-58181"
  value: {
-  dps: 37865.77993
+  dps: 37836.69444
   tps: 18278.77503
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 40501.40319
+  dps: 40470.52704
   tps: 19396.59532
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 40244.49064
+  dps: 40211.71215
   tps: 19210.33281
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 38140.1764
+  dps: 38108.42402
   tps: 18501.85934
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GaleofShadows-56138"
  value: {
-  dps: 38641.73038
+  dps: 38611.96013
   tps: 18681.62088
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GaleofShadows-56462"
  value: {
-  dps: 38849.5187
+  dps: 38820.01241
   tps: 18759.10581
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GearDetector-61462"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
@@ -655,630 +655,630 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 38251.97183
+  dps: 38219.88091
   tps: 18479.8097
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HarmlightToken-63839"
  value: {
-  dps: 39021.68015
+  dps: 38994.67985
   tps: 18794.1654
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 39462.32767
+  dps: 39436.36563
   tps: 19150.48377
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 39535.61058
+  dps: 39505.11921
   tps: 19132.04188
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofRage-59224"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofRage-65072"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofSolace-55868"
  value: {
-  dps: 37932.34032
+  dps: 37904.45406
   tps: 18292.90316
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofSolace-56393"
  value: {
-  dps: 37964.1792
+  dps: 37937.235
   tps: 18323.96685
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofThunder-55845"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofThunder-56370"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 40362.23685
+  dps: 40334.72352
   tps: 19400.56977
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 38377.58644
+  dps: 38346.0432
   tps: 18420.2015
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 38377.58644
+  dps: 38346.0432
   tps: 18420.2015
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 38204.1799
+  dps: 38172.63666
   tps: 18357.8594
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 38377.60951
+  dps: 38346.06627
   tps: 18420.22457
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-IndomitablePride-77211"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-IndomitablePride-77983"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-IndomitablePride-78003"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 40883.63559
+  dps: 40860.93265
   tps: 19912.05556
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 40577.32526
+  dps: 40549.29915
   tps: 19686.46114
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 41380.96705
+  dps: 41349.87417
   tps: 20112.14176
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 38839.44571
+  dps: 38811.66637
   tps: 18675.01819
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18186.13447
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18188.06154
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 39005.96169
+  dps: 38974.73444
   tps: 18840.23479
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 39169.64006
+  dps: 39138.4128
   tps: 18919.20558
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 38204.15697
+  dps: 38172.61373
   tps: 18357.83647
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 37865.77993
+  dps: 37836.69444
   tps: 18278.77503
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 37865.77993
+  dps: 37836.69444
   tps: 18278.77503
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 38354.98567
+  dps: 38323.67989
   tps: 18612.92223
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-KiroptyricSigil-77984"
  value: {
-  dps: 38202.64636
+  dps: 38173.76117
   tps: 18475.0737
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-KiroptyricSigil-78004"
  value: {
-  dps: 38501.66072
+  dps: 38471.53738
   tps: 18604.56609
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 37955.7719
+  dps: 37927.15432
   tps: 18220.75866
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 37955.7719
+  dps: 37927.15432
   tps: 18220.75866
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 38001.78875
+  dps: 37974.44499
   tps: 18428.7278
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-LeadenDespair-55816"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-LeadenDespair-56347"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 37865.80244
+  dps: 37836.71695
   tps: 18278.79754
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.19309
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.19309
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 38105.42468
+  dps: 38073.88144
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 38158.1192
+  dps: 38126.57596
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 37865.77993
+  dps: 37836.69444
   tps: 18278.77503
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 37865.77993
+  dps: 37836.69444
   tps: 18278.77503
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 38377.60951
+  dps: 38346.06627
   tps: 18420.22457
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 38377.60951
+  dps: 38346.06627
   tps: 18420.22457
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 39452.89711
+  dps: 39425.60983
   tps: 18828.24238
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 39426.6894
+  dps: 39395.17673
   tps: 18758.51935
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 39937.41941
+  dps: 39911.17671
   tps: 19021.53493
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 40249.7498
+  dps: 40223.5071
   tps: 19138.91175
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 38090.24874
+  dps: 38057.53904
   tps: 18384.71413
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 38674.33642
+  dps: 38643.60527
   tps: 18692.8128
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 38973.52319
+  dps: 38944.39686
   tps: 18669.21185
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 40287.17243
+  dps: 40255.37556
   tps: 19281.30251
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Rainsong-55854"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.37414
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Rainsong-56377"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.25458
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 39058.93419
+  dps: 39031.15485
   tps: 18833.26485
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ReflectionoftheLight-77986"
  value: {
-  dps: 38910.747
+  dps: 38882.96766
   tps: 18764.14027
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ReflectionoftheLight-78006"
  value: {
-  dps: 39226.42547
+  dps: 39198.64612
   tps: 18911.39366
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 40605.80335
+  dps: 40574.00648
   tps: 19498.73052
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 40605.80335
+  dps: 40574.00648
   tps: 19498.63098
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 38423.93809
+  dps: 38394.09767
   tps: 18559.21708
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 37865.77993
+  dps: 37836.69444
   tps: 18278.77503
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 37865.77993
+  dps: 37836.69444
   tps: 18278.77503
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RosaryofLight-72901"
  value: {
-  dps: 37868.80739
+  dps: 37835.3534
   tps: 18323.81204
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RottingSkull-77116"
  value: {
-  dps: 38348.08596
+  dps: 38316.84299
   tps: 18614.22934
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RottingSkull-77987"
  value: {
-  dps: 38362.40421
+  dps: 38332.49251
   tps: 18592.91655
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RottingSkull-78007"
  value: {
-  dps: 38436.24335
+  dps: 38405.74026
   tps: 18649.28873
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RuneofZeth-68998"
  value: {
-  dps: 39495.65322
+  dps: 39465.72646
   tps: 19128.69846
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ScalesofLife-68915"
  value: {
-  dps: 37686.91993
+  dps: 37655.37668
   tps: 18173.05264
   hps: 354.04187
  }
@@ -1286,7 +1286,7 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-ScalesofLife-69109"
  value: {
-  dps: 37686.91993
+  dps: 37655.37668
   tps: 18173.05264
   hps: 399.35591
  }
@@ -1294,21 +1294,21 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SeaStar-55256"
  value: {
-  dps: 38368.58901
+  dps: 38339.90325
   tps: 18513.47451
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SeaStar-56290"
  value: {
-  dps: 38895.61828
+  dps: 38866.93252
   tps: 18794.04776
  }
 }
@@ -1322,1225 +1322,1225 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-ShardofWoe-60233"
  value: {
-  dps: 38197.77249
+  dps: 38169.98516
   tps: 18461.11283
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 37683.89107
+  dps: 37652.34783
   tps: 18170.76388
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 38107.8915
+  dps: 38076.34826
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 38160.89437
+  dps: 38129.35113
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Sorrowsong-55879"
  value: {
-  dps: 38907.1372
+  dps: 38875.59396
   tps: 18689.0396
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Sorrowsong-56400"
  value: {
-  dps: 39176.19591
+  dps: 39144.65267
   tps: 18796.04741
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 37865.77993
+  dps: 37836.69444
   tps: 18278.77503
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SoulCasket-58183"
  value: {
-  dps: 40030.34879
+  dps: 40001.66304
   tps: 19276.60744
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 38874.27426
+  dps: 38845.9648
   tps: 18318.29816
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 38545.2048
+  dps: 38515.84511
   tps: 18177.17389
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 39008.91913
+  dps: 38981.36597
   tps: 18297.45414
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 38551.01591
+  dps: 38519.47267
   tps: 18482.56653
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 38724.44538
+  dps: 38692.90214
   tps: 18544.93157
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 38980.22569
+  dps: 38951.62029
   tps: 18927.26376
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 38670.93005
+  dps: 38641.31087
   tps: 18872.45908
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 39495.67556
+  dps: 39469.14597
   tps: 19196.98192
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-StayofExecution-68996"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 38830.92031
+  dps: 38798.41467
   tps: 18765.98345
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-StumpofTime-62465"
  value: {
-  dps: 39431.91707
+  dps: 39404.76982
   tps: 18943.16313
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-StumpofTime-62470"
  value: {
-  dps: 39317.9726
+  dps: 39288.16265
   tps: 18879.66915
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 39375.80308
+  dps: 39349.73524
   tps: 18798.19736
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TearofBlood-55819"
  value: {
-  dps: 38360.48928
+  dps: 38328.39835
   tps: 18535.54188
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TearofBlood-56351"
  value: {
-  dps: 38603.85111
+  dps: 38573.11995
   tps: 18656.67979
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 39194.6361
+  dps: 39165.80636
   tps: 18613.1403
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 39636.4572
+  dps: 39610.56459
   tps: 18803.67971
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TheHungerer-68927"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TheHungerer-69112"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 39799.54309
+  dps: 39771.51693
   tps: 18895.28254
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 39925.98053
+  dps: 39891.98172
   tps: 18941.78932
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 38204.15697
+  dps: 38172.61373
   tps: 18357.83647
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 38377.58644
+  dps: 38346.0432
   tps: 18420.2015
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 37868.43831
+  dps: 37842.23434
   tps: 18237.6015
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 38713.40849
+  dps: 38688.32944
   tps: 18776.79412
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-UnheededWarning-59520"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.44758
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 38377.58644
+  dps: 38346.0432
   tps: 18420.2015
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 38377.58644
+  dps: 38346.0432
   tps: 18420.2015
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 38377.58644
+  dps: 38346.0432
   tps: 18420.2015
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 38944.23114
+  dps: 38912.48605
   tps: 18735.12909
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 38418.50107
+  dps: 38390.40236
   tps: 18409.73626
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VeilofLies-72900"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 37687.92854
+  dps: 37655.59305
   tps: 18179.21873
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 37653.03352
+  dps: 37619.19334
   tps: 18208.84684
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VialofShadows-77207"
  value: {
-  dps: 37877.27071
+  dps: 37846.09549
   tps: 18367.09824
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VialofShadows-77979"
  value: {
-  dps: 37855.23035
+  dps: 37824.07722
   tps: 18344.99395
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VialofShadows-77999"
  value: {
-  dps: 37887.87816
+  dps: 37856.20226
   tps: 18374.72491
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 39039.35353
+  dps: 39010.66778
   tps: 18871.18675
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 37865.77993
+  dps: 37836.69444
   tps: 18278.77503
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 38178.74322
+  dps: 38152.25492
   tps: 18402.28562
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 38217.16179
+  dps: 38185.02405
   tps: 18518.4079
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 38377.58644
+  dps: 38346.0432
   tps: 18420.2015
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 37683.84155
+  dps: 37652.2983
   tps: 18170.71435
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 38732.53059
+  dps: 38705.51684
   tps: 18709.9663
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 40756.8165
+  dps: 40728.99249
   tps: 19599.4399
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 40344.02159
+  dps: 40316.05774
   tps: 19357.71473
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-WillofUnbinding-77995"
  value: {
-  dps: 41142.26545
+  dps: 41114.87388
   tps: 19777.73453
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 38800.00776
+  dps: 38774.7416
   tps: 18689.00326
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 39251.84318
+  dps: 39226.49109
   tps: 19091.76963
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 38204.15697
+  dps: 38172.61373
   tps: 18357.83647
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 37683.86856
+  dps: 37652.32532
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 38052.73017
+  dps: 38021.18692
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 38052.73017
+  dps: 38021.18692
   tps: 18170.74136
  }
 }
 dps_results: {
  key: "TestDemonology-Average-Default"
  value: {
-  dps: 41229.90005
+  dps: 41199.251
   tps: 19808.07792
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 63424.30767
+  dps: 63395.87363
   tps: 54082.85554
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 40177.27807
+  dps: 40147.89125
   tps: 18824.79567
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 58714.19407
+  dps: 58686.45379
   tps: 25958.18138
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 42789.5083
+  dps: 42765.01422
   tps: 38763.1832
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28736.02405
+  dps: 28708.69585
   tps: 13213.21455
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 36810.58772
+  dps: 36786.72087
   tps: 14794.15875
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 59604.62063
+  dps: 59572.5107
   tps: 48805.049
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39797.4959
+  dps: 39769.50017
   tps: 19375.90792
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 59966.00561
+  dps: 59939.58661
   tps: 28269.40261
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 40625.73412
+  dps: 40603.65518
   tps: 34700.3807
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28478.78408
+  dps: 28452.47554
   tps: 13572.29488
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 36167.69902
+  dps: 36142.06599
   tps: 15509.17617
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 63730.19226
+  dps: 63699.27077
   tps: 53697.97851
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 40840.355
+  dps: 40805.94524
   tps: 19458.23085
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 59715.51758
+  dps: 59682.71901
   tps: 26625.21183
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 42881.36416
+  dps: 42854.83102
   tps: 38715.14803
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29145.48923
+  dps: 29123.20115
   tps: 13546.25675
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 37069.74208
+  dps: 37045.90582
   tps: 15185.92113
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 58526.48702
+  dps: 58491.92499
   tps: 47397.89575
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38897.71844
+  dps: 38870.08092
   tps: 18605.55204
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 58205.72885
+  dps: 58176.2492
   tps: 26244.97699
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 40500.38025
+  dps: 40479.66806
   tps: 34751.12374
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 27737.38264
+  dps: 27710.30757
   tps: 13071.02521
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 35544.29632
+  dps: 35518.33642
   tps: 14830.0474
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 63139.73539
+  dps: 63111.31761
   tps: 53883.09504
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39958.89734
+  dps: 39930.67083
   tps: 18841.70605
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 58499.62289
+  dps: 58475.64494
   tps: 25437.10082
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 42594.32462
+  dps: 42568.18862
   tps: 38567.82963
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28685.0203
+  dps: 28660.81731
   tps: 13121.3628
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 36347.63115
+  dps: 36326.15584
   tps: 14689.67322
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 59239.30861
+  dps: 59207.39523
   tps: 48173.02322
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39782.65157
+  dps: 39753.24571
   tps: 19447.24772
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 58842.9214
+  dps: 58813.94479
   tps: 27589.73503
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 40556.57034
+  dps: 40535.41466
   tps: 34310.17784
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28410.4286
+  dps: 28385.47661
   tps: 13624.39647
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 36163.65204
+  dps: 36146.10586
   tps: 15532.93174
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 63683.03225
+  dps: 63649.99024
   tps: 53833.3131
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 40639.0447
+  dps: 40609.23492
   tps: 19296.04258
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 59309.20639
+  dps: 59280.76401
   tps: 26239.64951
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 43233.72185
+  dps: 43209.34195
   tps: 39130.11585
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29006.44223
+  dps: 28977.01807
   tps: 13460.4884
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 36786.50744
+  dps: 36761.51232
   tps: 15134.71288
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 58101.49506
+  dps: 58070.54969
   tps: 47893.97986
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38619.41707
+  dps: 38589.27266
   tps: 18451.73164
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 57487.09171
+  dps: 57451.73462
   tps: 25426.82916
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 40275.52347
+  dps: 40249.64132
   tps: 34325.66151
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 27638.97009
+  dps: 27612.31436
   tps: 12982.23822
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 35278.55903
+  dps: 35255.67336
   tps: 14610.09008
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 64499.16926
+  dps: 64468.6729
   tps: 54243.88725
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 40958.79604
+  dps: 40929.45762
   tps: 18972.78796
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 60526.84582
+  dps: 60501.66898
   tps: 25787.26972
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 43598.92169
+  dps: 43572.43348
   tps: 38899.09832
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29461.11318
+  dps: 29436.12717
   tps: 13224.12999
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 37808.75711
+  dps: 37786.20804
   tps: 14901.83366
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 60789.76533
+  dps: 60756.25628
   tps: 48795.37564
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 40824.12202
+  dps: 40793.24587
   tps: 19617.05241
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 60822.42606
+  dps: 60792.00062
   tps: 27961.51092
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 41708.07411
+  dps: 41685.86064
   tps: 34696.56139
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29194.75856
+  dps: 29168.2263
   tps: 13731.31058
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 37618.06265
+  dps: 37599.63916
   tps: 15747.22501
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 65006.24769
+  dps: 64970.85982
   tps: 54240.95679
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 41594.02762
+  dps: 41561.82947
   tps: 19419.70318
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 61349.66804
+  dps: 61319.80354
   tps: 26601.0762
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 44240.21699
+  dps: 44214.85793
   tps: 39467.38814
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29788.24395
+  dps: 29756.82874
   tps: 13555.14803
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 38252.27718
+  dps: 38226.03231
   tps: 15350.54533
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 59523.28628
+  dps: 59491.81625
   tps: 48545.15944
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39599.44087
+  dps: 39568.22122
   tps: 18604.89525
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 59362.15015
+  dps: 59325.0252
   tps: 25739.47214
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 41451.27692
+  dps: 41424.10066
   tps: 34752.32284
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28409.75421
+  dps: 28381.46174
   tps: 13093.25454
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 36741.49133
+  dps: 36717.46137
   tps: 14841.3852
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 65736.29255
+  dps: 65705.1256
   tps: 55819.41557
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 40853.55809
+  dps: 40822.29694
   tps: 19300.19264
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 60278.92023
+  dps: 60239.48258
   tps: 26672.96277
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 44257.58616
+  dps: 44228.79867
   tps: 40145.77391
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29024.92262
+  dps: 29002.18504
   tps: 13317.50305
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 37989.99322
+  dps: 37965.70492
   tps: 15634.41813
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 61588.26469
+  dps: 61558.01259
   tps: 50343.79408
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 40128.03035
+  dps: 40101.83858
   tps: 19720.60925
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 61513.78138
+  dps: 61483.56892
   tps: 28948.76102
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 41967.31473
+  dps: 41944.67937
   tps: 35694.22073
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28975.79344
+  dps: 28952.45962
   tps: 13896.09426
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 38299.97011
+  dps: 38278.26035
   tps: 16556.33194
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 66406.83864
+  dps: 66374.71728
   tps: 56629.51344
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 41568.92736
+  dps: 41537.58889
   tps: 19925.36223
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 61647.60234
+  dps: 61614.03384
   tps: 27772.61942
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 45259.74083
+  dps: 45235.98592
   tps: 41127.84845
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29413.47007
+  dps: 29390.73079
   tps: 13686.34116
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 38538.31783
+  dps: 38510.42813
   tps: 16153.53333
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 60612.14574
+  dps: 60579.35104
   tps: 49334.20178
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39412.7347
+  dps: 39384.2885
   tps: 18981.85334
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 60156.21779
+  dps: 60138.44548
   tps: 27557.85573
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 41678.295
+  dps: 41654.45847
   tps: 35397.98296
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28014.13384
+  dps: 27989.77673
   tps: 13184.43122
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 37330.63727
+  dps: 37306.41542
   tps: 15670.90363
  }
 }
 dps_results: {
  key: "TestDemonology-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 40649.38456
+  dps: 40618.50842
   tps: 19617.05241
  }
 }

--- a/sim/warlock/destruction/TestDestruction.results
+++ b/sim/warlock/destruction/TestDestruction.results
@@ -38,77 +38,77 @@ character_stats_results: {
 dps_results: {
  key: "TestDestruction-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 40211.33849
+  dps: 40203.32881
   tps: 23824.68162
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 38906.64821
+  dps: 38898.68561
   tps: 22908.57833
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 38832.20122
+  dps: 38824.28532
   tps: 22883.92688
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 39044.89271
+  dps: 39036.97681
   tps: 22953.2123
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 39087.94754
+  dps: 39080.03165
   tps: 22990.01867
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ArrowofTime-72897"
  value: {
-  dps: 38786.15724
+  dps: 38782.41899
   tps: 22908.46187
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 39782.08377
+  dps: 39774.07409
   tps: 23536.73125
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Balespider'sBurningVestments"
  value: {
-  dps: 37293.91663
+  dps: 37285.78022
   tps: 21959.74703
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 38150.51092
+  dps: 38143.17769
   tps: 22465.95985
   hps: 100.97645
  }
@@ -116,532 +116,532 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 40073.0816
+  dps: 40065.78343
   tps: 23563.78029
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 40328.86291
+  dps: 40321.52101
   tps: 23713.4202
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BindingPromise-67037"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 38581.17701
+  dps: 38573.26111
   tps: 22728.67632
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 38671.48778
+  dps: 38663.57188
   tps: 22775.30976
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 38722.43523
+  dps: 38714.51934
   tps: 22806.88859
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 38249.85503
+  dps: 38241.89243
   tps: 22537.33245
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 39338.42547
+  dps: 39330.46286
   tps: 23096.46877
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 38247.41864
+  dps: 38239.45604
   tps: 22536.76658
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 38732.55093
+  dps: 38725.25277
   tps: 22851.72307
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.09179
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 39312.08287
+  dps: 39304.16698
   tps: 23107.75039
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 38409.01372
+  dps: 38400.78956
   tps: 22656.62151
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 38398.53268
+  dps: 38390.68057
   tps: 22647.72261
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 38430.95985
+  dps: 38422.84968
   tps: 22679.09302
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BottledLightning-66879"
  value: {
-  dps: 39086.44998
+  dps: 39078.41803
   tps: 23038.69137
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BottledWishes-77114"
  value: {
-  dps: 40318.28073
+  dps: 40308.51672
   tps: 23562.4393
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BottledWishes-77985"
  value: {
-  dps: 39902.71569
+  dps: 39896.05679
   tps: 23571.26891
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BottledWishes-78005"
  value: {
-  dps: 40562.57424
+  dps: 40552.16783
   tps: 23920.04321
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 39997.60722
+  dps: 39989.92358
   tps: 23199.22732
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 40430.85764
+  dps: 40423.17399
   tps: 23945.15923
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 40363.00559
+  dps: 40354.68123
   tps: 23924.97797
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 38734.54596
+  dps: 38727.24779
   tps: 22851.1824
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 39400.60089
+  dps: 39393.27731
   tps: 23206.71837
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 38913.80314
+  dps: 38906.09924
   tps: 22935.11234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 38926.0526
+  dps: 38917.54637
   tps: 22911.36556
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 38888.77188
+  dps: 38881.04036
   tps: 22873.84036
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CrushingWeight-59506"
  value: {
-  dps: 38416.11689
+  dps: 38406.97628
   tps: 22718.29867
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CrushingWeight-65118"
  value: {
-  dps: 38624.59802
+  dps: 38616.10183
   tps: 22772.00806
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 41098.45036
+  dps: 41092.08687
   tps: 24740.65349
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 40608.68302
+  dps: 40601.32204
   tps: 24354.5776
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CunningoftheCruel-78000"
  value: {
-  dps: 41394.30833
+  dps: 41385.59478
   tps: 24957.01275
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 39456.99335
+  dps: 39449.40222
   tps: 23232.58786
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 38544.87612
+  dps: 38537.67305
   tps: 22686.89666
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 39925.68561
+  dps: 39917.36125
   tps: 23631.64958
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 39099.56854
+  dps: 39092.31274
   tps: 23017.15189
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 38909.85711
+  dps: 38901.20957
   tps: 22882.20349
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 39782.08377
+  dps: 39774.07409
   tps: 23536.73125
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 38771.11181
+  dps: 38763.14921
   tps: 22792.36153
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 39997.60722
+  dps: 39989.92358
   tps: 23667.97148
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 39925.68561
+  dps: 39917.36125
   tps: 23631.64958
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 38832.20122
+  dps: 38824.28532
   tps: 22883.92688
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 39782.08377
+  dps: 39774.07409
   tps: 23536.73125
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FallofMortality-59500"
  value: {
-  dps: 39456.99335
+  dps: 39449.40222
   tps: 23232.58786
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FallofMortality-65124"
  value: {
-  dps: 39599.86305
+  dps: 39592.27191
   tps: 23309.19206
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 39639.35833
+  dps: 39632.063
   tps: 23355.18046
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 38247.41864
+  dps: 38239.45604
   tps: 22536.76658
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 39275.43049
+  dps: 39267.73544
   tps: 23137.0274
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.35065
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 40299.37432
+  dps: 40291.67928
   tps: 23663.40643
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 38687.49231
+  dps: 38679.52971
   tps: 22809.89737
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 38989.52342
+  dps: 38981.60753
   tps: 22972.4382
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FireoftheDeep-77988"
  value: {
-  dps: 38909.24258
+  dps: 38901.32668
   tps: 22922.67762
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FireoftheDeep-78008"
  value: {
-  dps: 39080.6113
+  dps: 39072.69541
   tps: 23028.89732
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 39867.62347
+  dps: 39859.61379
   tps: 23590.30602
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FluidDeath-58181"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 39997.60722
+  dps: 39989.92358
   tps: 23654.99449
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 40437.88467
+  dps: 40430.29354
   tps: 23818.08119
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 38781.90956
+  dps: 38774.6114
   tps: 22859.16146
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GaleofShadows-56138"
  value: {
-  dps: 39318.63878
+  dps: 39313.9549
   tps: 23248.59909
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GaleofShadows-56462"
  value: {
-  dps: 39507.74504
+  dps: 39499.91475
   tps: 23272.07653
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GearDetector-61462"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
@@ -655,630 +655,630 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 38962.70272
+  dps: 38954.74012
   tps: 22943.49542
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HarmlightToken-63839"
  value: {
-  dps: 39168.10815
+  dps: 39162.10635
   tps: 23119.52462
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 39651.13162
+  dps: 39644.94228
   tps: 23464.30778
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 40043.28329
+  dps: 40035.22268
   tps: 23620.97931
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofRage-59224"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofRage-65072"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofSolace-55868"
  value: {
-  dps: 38497.52601
+  dps: 38492.84212
   tps: 22776.44192
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofSolace-56393"
  value: {
-  dps: 38575.31094
+  dps: 38567.48065
   tps: 22738.96455
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofThunder-55845"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofThunder-56370"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 39925.68561
+  dps: 39917.36125
   tps: 23631.64958
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 38743.08056
+  dps: 38735.11796
   tps: 22844.39811
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 38743.08056
+  dps: 38735.11796
   tps: 22844.39811
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 38671.48778
+  dps: 38663.57188
   tps: 22775.30976
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 38722.43523
+  dps: 38714.51934
   tps: 22806.88859
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-IndomitablePride-77211"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.46531
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-IndomitablePride-77983"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.43091
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-IndomitablePride-78003"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.50412
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 40950.68495
+  dps: 40942.68037
   tps: 24210.84108
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 40948.25392
+  dps: 40940.24697
   tps: 24095.72689
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 41767.86163
+  dps: 41762.01841
   tps: 24639.1458
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 39172.83808
+  dps: 39164.92218
   tps: 23027.2551
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 38315.17399
+  dps: 38307.2581
   tps: 22587.9324
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 38318.05229
+  dps: 38310.13639
   tps: 22591.13135
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 39623.78882
+  dps: 39616.46524
   tps: 23346.83895
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 39803.34212
+  dps: 39796.01854
   tps: 23445.94902
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 38581.17701
+  dps: 38573.26111
   tps: 22728.67632
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 38799.40625
+  dps: 38789.64224
   tps: 22789.06691
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-KiroptyricSigil-77984"
  value: {
-  dps: 38572.60157
+  dps: 38565.94267
   tps: 22893.84137
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-KiroptyricSigil-78004"
  value: {
-  dps: 38870.3795
+  dps: 38859.97309
   tps: 23045.38797
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 38292.67421
+  dps: 38287.45845
   tps: 22575.19917
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 38292.67421
+  dps: 38287.45845
   tps: 22575.19917
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 38353.86048
+  dps: 38345.25665
   tps: 22602.93203
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LeadenDespair-55816"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.30479
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LeadenDespair-56347"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.35065
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 38243.364
+  dps: 38235.4481
   tps: 22519.28475
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 38243.364
+  dps: 38235.4481
   tps: 22519.28475
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.0871
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.0871
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 38675.88968
+  dps: 38667.97378
   tps: 22777.56422
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 38732.52994
+  dps: 38724.61405
   tps: 22811.38653
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 38243.364
+  dps: 38235.4481
   tps: 22519.28475
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 38243.364
+  dps: 38235.4481
   tps: 22519.28475
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 38778.01428
+  dps: 38770.09838
   tps: 22841.33822
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 38778.01428
+  dps: 38770.09838
   tps: 22841.33822
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 39960.35738
+  dps: 39953.05922
   tps: 23535.09482
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 40196.16177
+  dps: 40188.83819
   tps: 23677.80643
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.38725
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 40279.85503
+  dps: 40272.2639
   tps: 23727.9702
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 40542.6516
+  dps: 40535.06047
   tps: 23895.75157
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 38594.46743
+  dps: 38586.69566
   tps: 22723.40314
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 39403.46929
+  dps: 39395.87816
   tps: 23196.61953
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 39366.83282
+  dps: 39359.26709
   tps: 23180.4948
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 39782.08377
+  dps: 39774.07409
   tps: 23536.73125
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Rainsong-55854"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.11195
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Rainsong-56377"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.09554
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 39719.97857
+  dps: 39712.06268
   tps: 23273.81074
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ReflectionoftheLight-77986"
  value: {
-  dps: 39551.6832
+  dps: 39543.7673
   tps: 23187.81444
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ReflectionoftheLight-78006"
  value: {
-  dps: 39910.19748
+  dps: 39902.28158
   tps: 23371.00957
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 40211.33849
+  dps: 40203.32881
   tps: 23824.68162
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 40211.33849
+  dps: 40203.32881
   tps: 23824.66649
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 38889.74825
+  dps: 38881.58931
   tps: 22891.60616
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RosaryofLight-72901"
  value: {
-  dps: 38642.15506
+  dps: 38635.07121
   tps: 22765.84543
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RottingSkull-77116"
  value: {
-  dps: 39030.49887
+  dps: 39023.4354
   tps: 23019.4899
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RottingSkull-77987"
  value: {
-  dps: 38888.18216
+  dps: 38881.17953
   tps: 22920.08398
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RottingSkull-78007"
  value: {
-  dps: 39134.24116
+  dps: 39126.8631
   tps: 23070.71924
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RuneofZeth-68998"
  value: {
-  dps: 40145.88149
+  dps: 40138.06023
   tps: 23565.77491
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ScalesofLife-68915"
  value: {
-  dps: 38151.31786
+  dps: 38144.10604
   tps: 22470.45786
   hps: 357.04731
  }
@@ -1286,7 +1286,7 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-ScalesofLife-69109"
  value: {
-  dps: 38151.31786
+  dps: 38144.10604
   tps: 22470.49093
   hps: 402.74602
  }
@@ -1294,21 +1294,21 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SeaStar-55256"
  value: {
-  dps: 38796.51089
+  dps: 38788.54829
   tps: 22818.38379
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SeaStar-56290"
  value: {
-  dps: 39270.23754
+  dps: 39262.27494
   tps: 23061.38049
  }
 }
@@ -1322,721 +1322,721 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-ShardofWoe-60233"
  value: {
-  dps: 39071.64433
+  dps: 39064.13867
   tps: 23127.08639
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.27612
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 38763.79149
+  dps: 38755.82889
   tps: 22843.74639
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 38831.41174
+  dps: 38823.44914
   tps: 22883.94613
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Sorrowsong-55879"
  value: {
-  dps: 39391.13985
+  dps: 39383.22395
   tps: 23181.99759
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Sorrowsong-56400"
  value: {
-  dps: 39537.56126
+  dps: 39529.64536
   tps: 23267.62488
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 38243.364
+  dps: 38235.4481
   tps: 22519.28475
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SoulCasket-58183"
  value: {
-  dps: 40144.04166
+  dps: 40136.07905
   tps: 23564.54006
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 39394.06331
+  dps: 39386.14742
   tps: 23205.98181
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 39250.37133
+  dps: 39242.45543
   tps: 23116.09492
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 39496.19005
+  dps: 39488.27415
   tps: 23274.63716
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 38873.73375
+  dps: 38865.81785
   tps: 22900.66814
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 38950.92686
+  dps: 38943.01097
   tps: 22948.51485
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 39316.59604
+  dps: 39308.76895
   tps: 23186.34177
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 39305.82563
+  dps: 39296.96208
   tps: 23136.62682
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 39817.2767
+  dps: 39810.60116
   tps: 23564.48363
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-StayofExecution-68996"
  value: {
-  dps: 38247.41864
+  dps: 38239.45604
   tps: 22536.76658
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 39475.03432
+  dps: 39467.94446
   tps: 23280.53037
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-StumpofTime-62465"
  value: {
-  dps: 39480.96077
+  dps: 39473.04488
   tps: 23207.32957
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-StumpofTime-62470"
  value: {
-  dps: 39524.85638
+  dps: 39516.94048
   tps: 23204.77902
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.3749
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.40225
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 39479.04101
+  dps: 39471.07841
   tps: 23247.3223
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TearofBlood-55819"
  value: {
-  dps: 39116.73875
+  dps: 39108.77615
   tps: 23027.18575
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TearofBlood-56351"
  value: {
-  dps: 39316.37981
+  dps: 39308.41721
   tps: 23137.4061
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 39341.81543
+  dps: 39333.89953
   tps: 23147.73412
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 39719.95851
+  dps: 39712.04261
   tps: 23356.32664
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TheHungerer-68927"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TheHungerer-69112"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 40123.81441
+  dps: 40116.22328
   tps: 23645.39751
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 40357.00601
+  dps: 40349.41488
   tps: 23766.11772
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 38671.48778
+  dps: 38663.57188
   tps: 22775.30976
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 38722.43523
+  dps: 38714.51934
   tps: 22806.88859
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 39225.92978
+  dps: 39217.85813
   tps: 23189.36951
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-UnheededWarning-59520"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 38247.41864
+  dps: 38239.45604
   tps: 22536.70207
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 38743.08056
+  dps: 38735.11796
   tps: 22844.39811
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 38743.08056
+  dps: 38735.11796
   tps: 22844.39811
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 38743.08056
+  dps: 38735.11796
   tps: 22844.39811
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 39563.07199
+  dps: 39556.62369
   tps: 23297.34673
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 38697.00349
+  dps: 38689.0876
   tps: 22792.30707
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VeilofLies-72900"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.41592
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 38357.81564
+  dps: 38350.58037
   tps: 22579.80506
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 38369.58939
+  dps: 38362.35412
   tps: 22587.39548
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VialofShadows-77207"
  value: {
-  dps: 38454.19895
+  dps: 38446.63453
   tps: 22705.43975
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VialofShadows-77979"
  value: {
-  dps: 38434.33549
+  dps: 38426.59546
   tps: 22683.02179
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VialofShadows-77999"
  value: {
-  dps: 38458.92301
+  dps: 38451.16236
   tps: 22708.07978
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.3749
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.40225
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 38247.41864
+  dps: 38239.45604
   tps: 22536.76658
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 39399.43572
+  dps: 39391.47311
   tps: 23127.7679
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 38247.41864
+  dps: 38239.45604
   tps: 22536.76658
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 38541.46679
+  dps: 38533.77785
   tps: 22852.42922
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 38823.22078
+  dps: 38815.87888
   tps: 22898.36082
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 38807.34766
+  dps: 38799.43177
   tps: 22859.51997
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 39295.58164
+  dps: 39287.66575
   tps: 23073.91567
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 41400.14615
+  dps: 41392.84798
   tps: 24415.49516
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 41062.09137
+  dps: 41054.7932
   tps: 24221.54934
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WillofUnbinding-77995"
  value: {
-  dps: 41804.32891
+  dps: 41797.03075
   tps: 24659.33125
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 39489.38829
+  dps: 39482.45876
   tps: 23432.26928
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 39898.15053
+  dps: 39889.86894
   tps: 23527.89364
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 38585.58051
+  dps: 38577.61791
   tps: 22746.64603
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 38282.43446
+  dps: 38274.51856
   tps: 22534.16234
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 38619.24941
+  dps: 38611.33351
   tps: 22743.887
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 38619.24941
+  dps: 38611.33351
   tps: 22743.887
  }
 }
 dps_results: {
  key: "TestDestruction-Average-Default"
  value: {
-  dps: 41175.20731
+  dps: 41166.9964
   tps: 24328.35105
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Goblin-p3-Destruction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 41874.8531
+  dps: 41864.09809
   tps: 42556.07876
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Goblin-p3-Destruction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 40184.0362
+  dps: 40173.13039
   tps: 23988.11189
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Goblin-p3-Destruction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 50935.46166
+  dps: 50922.65086
   tps: 28893.19547
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Goblin-p3-Destruction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 26218.72559
+  dps: 26212.52453
   tps: 30090.75669
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Goblin-p3-Destruction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 26218.72559
+  dps: 26212.52453
   tps: 15499.09392
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Goblin-p3-Destruction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 28947.1175
+  dps: 28941.50826
   tps: 15941.99676
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p3-Destruction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 41669.17475
+  dps: 41660.18755
   tps: 42468.7374
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p3-Destruction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39778.3147
+  dps: 39771.28824
   tps: 23787.88979
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p3-Destruction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 50524.81795
+  dps: 50515.20278
   tps: 28644.81873
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p3-Destruction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 25874.35426
+  dps: 25867.65966
   tps: 29610.7387
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p3-Destruction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25874.35426
+  dps: 25867.65966
   tps: 15334.76004
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p3-Destruction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 28755.63205
+  dps: 28752.42555
   tps: 15673.30554
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p3-Destruction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 42332.84978
+  dps: 42323.04784
   tps: 42671.06639
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p3-Destruction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 40430.85764
+  dps: 40423.17399
   tps: 23945.15923
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p3-Destruction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 51821.10749
+  dps: 51811.01157
   tps: 28968.02634
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p3-Destruction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 26314.14576
+  dps: 26306.52943
   tps: 29760.48583
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p3-Destruction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 26314.14576
+  dps: 26306.52943
   tps: 15420.6161
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p3-Destruction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 29560.56129
+  dps: 29557.19447
   tps: 15837.00543
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p3-Destruction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 42183.98636
+  dps: 42173.97165
   tps: 42358.01014
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p3-Destruction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 40439.40418
+  dps: 40429.50648
   tps: 24174.05851
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p3-Destruction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 51853.201
+  dps: 51843.3561
   tps: 29239.19255
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p3-Destruction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 26404.20465
+  dps: 26395.97656
   tps: 30100.626
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p3-Destruction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 26404.20465
+  dps: 26395.97656
   tps: 15687.00182
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p3-Destruction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 30114.05764
+  dps: 30105.54864
   tps: 16575.15434
  }
 }
 dps_results: {
  key: "TestDestruction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 40420.91286
+  dps: 40413.22922
   tps: 23945.15923
  }
 }

--- a/sim/warlock/items.go
+++ b/sim/warlock/items.go
@@ -116,7 +116,7 @@ func (pet *FieryImpPet) registerFlameBlast(warlock *Warlock) {
 		},
 
 		DamageMultiplierAdditive: 1,
-		CritMultiplier:           2,
+		CritMultiplier:           pet.DefaultSpellCritMultiplier(),
 		ThreatMultiplier:         1,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {


### PR DESCRIPTION
- Adjusted the MI base crit, inherited crit and crit damage modifier
  - See screenshot for matches
- Adjusted Warlock Fiery Imp crit damage modifier
  - https://docs.google.com/spreadsheets/d/12jnHZgMAYDTBmkeFjApaHL5yiiDlxXHYDbTXy2QCEBA/edit?gid=1677205971#gid=1677205971
  
**Crit set to 2.0**
![image](https://github.com/user-attachments/assets/d40e4272-27c1-47a1-a175-2e7cb3ec03fc)

**Crit set to 1.5**
![image](https://github.com/user-attachments/assets/9e72172d-3677-4d85-bcef-5d3f1d68d19f)