### PR TITLE
fix warrior rend ticking and "snapshot" behavior

### DIFF
--- a/sim/core/dot.go
+++ b/sim/core/dot.go
@@ -80,6 +80,19 @@ func (dot *Dot) Apply(sim *Simulation) {
 	dot.Activate(sim)
 }
 
+// Rolls over and activates the Dot
+// If the Dot is already active it's duration will be refreshed and the last tick from the previous application will be
+// transfered to the new one
+func (dot *Dot) ApplyRollover(sim *Simulation) {
+	if dot.Spell.Flags&SpellFlagSupressDoTApply > 0 {
+		return
+	}
+
+	dot.TakeSnapshot(sim, true)
+	dot.recomputeAuraDuration(sim)
+	dot.Activate(sim)
+}
+
 func (dot *Dot) recomputeAuraDuration(sim *Simulation) {
 	nextTick := dot.TimeUntilNextTick(sim)
 

--- a/sim/warrior/arms/TestArms.results
+++ b/sim/warrior/arms/TestArms.results
@@ -38,2148 +38,2148 @@ character_stats_results: {
 dps_results: {
  key: "TestArms-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 33461.2509
-  tps: 21715.77446
+  dps: 32224.5086
+  tps: 20420.26605
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 32582.74404
-  tps: 21437.69671
+  dps: 31246.83829
+  tps: 20235.9865
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 33836.49829
-  tps: 22074.44912
+  dps: 32587.27418
+  tps: 20775.46394
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 33942.6615
-  tps: 22143.50333
+  dps: 32596.06326
+  tps: 20792.05141
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ArrowofTime-72897"
  value: {
-  dps: 32505.79043
-  tps: 21186.22078
+  dps: 31254.82267
+  tps: 20031.95282
  }
 }
 dps_results: {
  key: "TestArms-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 32896.43673
-  tps: 21359.33429
+  dps: 31648.28848
+  tps: 20078.49148
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
   hps: 96.7093
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 32128.58117
-  tps: 20928.89453
+  dps: 30892.96269
+  tps: 19682.77831
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 32227.55268
-  tps: 20996.4944
+  dps: 31021.50606
+  tps: 19756.29245
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BindingPromise-67037"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 32105.66145
-  tps: 21054.77695
+  dps: 30698.0619
+  tps: 19744.71962
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 31607.61222
-  tps: 20742.52137
+  dps: 30303.44841
+  tps: 19526.3368
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 31869.3252
-  tps: 20926.85923
+  dps: 30574.68659
+  tps: 19693.86193
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 32065.87601
-  tps: 20910.45271
+  dps: 30778.11054
+  tps: 19636.51925
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 31507.77555
-  tps: 20491.39159
+  dps: 30262.10707
+  tps: 19275.25907
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 32670.94769
-  tps: 21194.98989
+  dps: 31378.35011
+  tps: 19938.93531
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 32085.78131
-  tps: 20900.1971
+  dps: 30826.32787
+  tps: 19636.89648
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 31995.19193
-  tps: 20854.41161
+  dps: 30772.85057
+  tps: 19641.16295
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 32510.45106
-  tps: 21140.54882
+  dps: 31191.84356
+  tps: 19872.25353
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 33760.91585
-  tps: 22283.20079
+  dps: 32806.73476
+  tps: 21254.10421
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 33594.84139
-  tps: 22117.63446
+  dps: 32637.7521
+  tps: 20995.95328
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 34148.13872
-  tps: 22641.21822
+  dps: 33128.55738
+  tps: 21514.59109
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BottledLightning-66879"
  value: {
-  dps: 31762.16114
-  tps: 20688.88572
+  dps: 30503.46236
+  tps: 19449.93525
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BottledWishes-77114"
  value: {
-  dps: 31961.32139
-  tps: 20869.94266
+  dps: 30675.77508
+  tps: 19704.19403
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BottledWishes-77985"
  value: {
-  dps: 31933.47843
-  tps: 20851.30447
+  dps: 30795.97755
+  tps: 19827.34309
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BottledWishes-78005"
  value: {
-  dps: 32134.4155
-  tps: 20973.86131
+  dps: 30795.60837
+  tps: 19693.36027
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 32896.43673
-  tps: 20932.28492
+  dps: 31648.28848
+  tps: 19677.05897
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 34106.77545
-  tps: 22123.34864
+  dps: 32820.69808
+  tps: 20798.68732
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 33355.86639
-  tps: 21644.07541
+  dps: 32096.17362
+  tps: 20347.55771
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 33484.76234
-  tps: 21738.12645
+  dps: 32236.50303
+  tps: 20432.26048
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ColossalDragonplateArmor"
  value: {
-  dps: 27606.58822
-  tps: 18133.14906
+  dps: 26402.70291
+  tps: 17009.01788
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ColossalDragonplateBattlegear"
  value: {
-  dps: 31393.27864
-  tps: 20736.62504
+  dps: 30259.14121
+  tps: 19551.37938
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 32833.17473
-  tps: 21394.66874
+  dps: 31517.27217
+  tps: 20088.65405
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 31507.77555
-  tps: 20491.39159
+  dps: 30262.10707
+  tps: 19275.25907
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 34328.75995
-  tps: 22441.0173
+  dps: 33198.22745
+  tps: 21173.73364
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 34067.99555
-  tps: 22240.60201
+  dps: 32794.39934
+  tps: 20952.41496
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 34662.63745
-  tps: 22681.50347
+  dps: 33409.7268
+  tps: 21362.92987
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CrushingWeight-59506"
  value: {
-  dps: 33028.1539
-  tps: 21657.5347
+  dps: 31629.61323
+  tps: 20252.14511
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CrushingWeight-65118"
  value: {
-  dps: 32813.7077
-  tps: 21444.16174
+  dps: 31537.65921
+  tps: 20327.90005
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CunningoftheCruel-78000"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 33204.58017
-  tps: 21823.37727
+  dps: 31914.00229
+  tps: 20568.55092
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 32685.64097
-  tps: 21528.86889
+  dps: 31431.43363
+  tps: 20286.0799
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 31994.27071
-  tps: 20999.1933
+  dps: 30615.39713
+  tps: 19727.08717
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 32404.11176
-  tps: 21152.07462
+  dps: 30951.74115
+  tps: 19844.63082
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 33020.27178
-  tps: 21450.09488
+  dps: 31783.11695
+  tps: 20160.58535
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 31378.35799
-  tps: 20478.22717
+  dps: 30383.58902
+  tps: 19477.22663
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 33314.45523
-  tps: 21700.35365
+  dps: 32121.11743
+  tps: 20479.42747
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EarthenBattleplate"
  value: {
-  dps: 26998.91065
-  tps: 17632.58235
+  dps: 25883.75043
+  tps: 16660.98776
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EarthenWarplate"
  value: {
-  dps: 29942.09337
-  tps: 19574.06132
+  dps: 28666.18544
+  tps: 18499.93184
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 32896.43673
-  tps: 21359.33429
+  dps: 31648.28848
+  tps: 20078.49148
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 31507.77555
-  tps: 20491.39159
+  dps: 30262.10707
+  tps: 19275.25907
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 32896.43673
-  tps: 21359.33429
+  dps: 31648.28848
+  tps: 20078.49148
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 33020.27178
-  tps: 21450.09488
+  dps: 31783.11695
+  tps: 20160.58535
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 32570.01802
-  tps: 21236.94264
+  dps: 31243.7724
+  tps: 19953.57286
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 32984.00376
-  tps: 21482.39575
+  dps: 31566.83006
+  tps: 20153.23512
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 33153.56739
-  tps: 21778.15222
+  dps: 31707.0807
+  tps: 20550.21858
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 32896.43673
-  tps: 21359.33429
+  dps: 31648.28848
+  tps: 20078.49148
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 34171.45046
-  tps: 22178.77297
+  dps: 32826.94601
+  tps: 20863.68112
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 33866.57578
-  tps: 21984.80395
+  dps: 32533.32084
+  tps: 20681.08306
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 34506.81262
-  tps: 22392.13888
+  dps: 33149.9337
+  tps: 21064.53899
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FallofMortality-59500"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FallofMortality-65124"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 31475.04775
-  tps: 20467.03319
+  dps: 30225.59908
+  tps: 19249.83354
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 32022.99038
-  tps: 20876.99302
+  dps: 30714.00464
+  tps: 19596.32364
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 31507.77555
-  tps: 20491.39159
+  dps: 30262.10707
+  tps: 19275.25907
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 31507.77555
-  tps: 20491.39159
+  dps: 30262.10707
+  tps: 19275.25907
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 33011.23609
-  tps: 21641.8099
+  dps: 31659.40094
+  tps: 20361.59833
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 31851.84063
-  tps: 20988.70838
+  dps: 30828.4161
+  tps: 20038.52663
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FireoftheDeep-77988"
  value: {
-  dps: 31902.54234
-  tps: 21054.72074
+  dps: 30841.32686
+  tps: 19975.61104
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FireoftheDeep-78008"
  value: {
-  dps: 32091.43288
-  tps: 21144.54901
+  dps: 30969.64748
+  tps: 20015.99805
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 32944.50366
-  tps: 21503.00874
+  dps: 31230.07097
+  tps: 20012.58529
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FluidDeath-58181"
  value: {
-  dps: 32070.0477
-  tps: 20887.04207
+  dps: 30806.38639
+  tps: 19630.57303
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 32896.43673
-  tps: 21359.33429
+  dps: 31648.28848
+  tps: 20078.49148
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-GaleofShadows-56138"
  value: {
-  dps: 31695.65525
-  tps: 20580.25797
+  dps: 30374.26244
+  tps: 19458.09739
  }
 }
 dps_results: {
  key: "TestArms-AllItems-GaleofShadows-56462"
  value: {
-  dps: 31781.6032
-  tps: 20692.96359
+  dps: 30906.23218
+  tps: 19683.62483
  }
 }
 dps_results: {
  key: "TestArms-AllItems-GearDetector-61462"
  value: {
-  dps: 31790.08978
-  tps: 20767.23966
+  dps: 30525.30048
+  tps: 19623.38787
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Gladiator'sBattlegear"
  value: {
-  dps: 27147.20495
-  tps: 17676.42116
+  dps: 26062.59557
+  tps: 16642.74022
  }
 }
 dps_results: {
  key: "TestArms-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 31983.80941
-  tps: 20825.67574
+  dps: 30679.45736
+  tps: 19561.13454
  }
 }
 dps_results: {
  key: "TestArms-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 32309.31433
-  tps: 21053.97275
+  dps: 31004.51567
+  tps: 19797.28865
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Gurthalak,VoiceoftheDeeps-77191"
  value: {
-  dps: 35978.8597
-  tps: 22746.71029
+  dps: 34751.03733
+  tps: 21417.10826
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Gurthalak,VoiceoftheDeeps-78478"
  value: {
-  dps: 36228.85822
-  tps: 22917.45826
+  dps: 34894.03564
+  tps: 21546.88244
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Gurthalak,VoiceoftheDeeps-78487"
  value: {
-  dps: 35513.8859
-  tps: 22684.60531
+  dps: 34140.64916
+  tps: 21321.74125
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HarmlightToken-63839"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 32389.78989
-  tps: 21244.47069
+  dps: 31448.13585
+  tps: 20161.23842
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartofRage-59224"
  value: {
-  dps: 32715.56251
-  tps: 21351.37419
+  dps: 31416.96769
+  tps: 20091.19171
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartofSolace-55868"
  value: {
-  dps: 31695.65525
-  tps: 20580.25797
+  dps: 30374.26244
+  tps: 19458.09739
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartofSolace-56393"
  value: {
-  dps: 32880.84447
-  tps: 21478.69808
+  dps: 31967.94897
+  tps: 20430.60975
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartofThunder-55845"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartofThunder-56370"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 31973.22937
-  tps: 20832.48796
+  dps: 30737.41997
+  tps: 19600.22639
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 33020.27178
-  tps: 21450.09488
+  dps: 31783.11695
+  tps: 20160.58535
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 33271.92698
-  tps: 21797.35374
+  dps: 31831.44121
+  tps: 20468.96974
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 33271.92698
-  tps: 21797.35374
+  dps: 31831.44121
+  tps: 20468.96974
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 31607.61222
-  tps: 20742.52137
+  dps: 30303.44841
+  tps: 19526.3368
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 31869.3252
-  tps: 20926.85923
+  dps: 30574.68659
+  tps: 19693.86193
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IndomitablePride-77211"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IndomitablePride-77983"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IndomitablePride-78003"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 31998.64788
-  tps: 21000.76699
+  dps: 31202.67768
+  tps: 20027.1175
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 31753.73064
-  tps: 20641.00844
+  dps: 30947.51881
+  tps: 19857.23056
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 32082.22509
-  tps: 20987.76538
+  dps: 31127.8096
+  tps: 20010.06738
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 31608.42546
-  tps: 20680.69151
+  dps: 30422.98448
+  tps: 19568.60629
  }
 }
 dps_results: {
  key: "TestArms-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 32105.66145
-  tps: 21054.77695
+  dps: 30698.0619
+  tps: 19744.71962
  }
 }
 dps_results: {
  key: "TestArms-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 31931.56656
-  tps: 20804.88176
+  dps: 30616.79932
+  tps: 19518.43915
  }
 }
 dps_results: {
  key: "TestArms-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 32016.09252
-  tps: 20845.0539
+  dps: 30758.32744
+  tps: 19602.60251
  }
 }
 dps_results: {
  key: "TestArms-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 32521.3381
-  tps: 21351.10906
+  dps: 31380.10282
+  tps: 20177.51621
  }
 }
 dps_results: {
  key: "TestArms-AllItems-KiroptyricSigil-77984"
  value: {
-  dps: 32539.90734
-  tps: 21249.26205
+  dps: 31402.11967
+  tps: 20216.32209
  }
 }
 dps_results: {
  key: "TestArms-AllItems-KiroptyricSigil-78004"
  value: {
-  dps: 32921.39087
-  tps: 21493.06036
+  dps: 31565.52915
+  tps: 20192.30591
  }
 }
 dps_results: {
  key: "TestArms-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 31827.64317
-  tps: 20757.39869
+  dps: 30897.37203
+  tps: 19764.86351
  }
 }
 dps_results: {
  key: "TestArms-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 31827.64317
-  tps: 20757.39869
+  dps: 30897.37203
+  tps: 19764.86351
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 31458.52184
-  tps: 20413.13529
+  dps: 30568.41072
+  tps: 19575.16752
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LastWord-50708"
  value: {
-  dps: 33884.55362
-  tps: 21981.47289
+  dps: 32606.46012
+  tps: 20665.23773
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LeadenDespair-55816"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LeadenDespair-56347"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 31822.54495
-  tps: 20725.52242
+  dps: 30636.43295
+  tps: 19526.37518
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 31949.84853
-  tps: 20799.20081
+  dps: 30751.09436
+  tps: 19589.78395
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 32647.07705
-  tps: 21208.9279
+  dps: 31358.82017
+  tps: 19950.69082
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 32219.62384
-  tps: 20929.71185
+  dps: 30949.57709
+  tps: 19696.69363
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 32448.28966
-  tps: 21069.38716
+  dps: 31170.82459
+  tps: 19830.62858
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 32721.51951
-  tps: 21499.26734
+  dps: 31393.96477
+  tps: 20255.5257
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 32822.29864
-  tps: 21586.29368
+  dps: 31367.42297
+  tps: 20182.59777
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 33241.48927
-  tps: 21764.37467
+  dps: 31892.16642
+  tps: 20449.65775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 33482.2888
-  tps: 21917.08942
+  dps: 32254.05012
+  tps: 20677.21712
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 32017.09127
-  tps: 20805.99942
+  dps: 30753.61503
+  tps: 19578.06553
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 32448.28966
-  tps: 21069.38716
+  dps: 31170.82459
+  tps: 19830.62858
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 31994.27071
-  tps: 20999.1933
+  dps: 30615.39713
+  tps: 19727.08717
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 31994.27071
-  tps: 20999.1933
+  dps: 30615.39713
+  tps: 19727.08717
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 32085.78131
-  tps: 20900.1971
+  dps: 30835.22798
+  tps: 19645.79659
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MoltenGiantBattleplate"
  value: {
-  dps: 28121.13435
-  tps: 18606.76023
+  dps: 27284.52162
+  tps: 17567.80203
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MoltenGiantWarplate"
  value: {
-  dps: 32653.00883
-  tps: 21804.31918
+  dps: 31308.82315
+  tps: 20485.89886
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 31895.19229
-  tps: 20938.63689
+  dps: 30814.76373
+  tps: 19905.52556
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-No'Kaled,theElementsofDeath-77188"
  value: {
-  dps: 34145.84509
-  tps: 22290.66669
+  dps: 32900.51139
+  tps: 20972.3331
  }
 }
 dps_results: {
  key: "TestArms-AllItems-No'Kaled,theElementsofDeath-78472"
  value: {
-  dps: 34214.2956
-  tps: 22352.76057
+  dps: 32974.27964
+  tps: 21036.52226
  }
 }
 dps_results: {
  key: "TestArms-AllItems-No'Kaled,theElementsofDeath-78481"
  value: {
-  dps: 34080.28162
-  tps: 22227.11933
+  dps: 32848.1918
+  tps: 20925.72852
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 32596.67225
-  tps: 21239.03041
+  dps: 31241.69453
+  tps: 19927.9682
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 31787.85462
-  tps: 20701.16748
+  dps: 30576.6095
+  tps: 19477.6658
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 31526.75517
-  tps: 20772.78178
+  dps: 30468.85615
+  tps: 19648.07379
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 31754.88078
-  tps: 20799.76724
+  dps: 30749.70554
+  tps: 19793.10734
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 32896.43673
-  tps: 21359.33429
+  dps: 31648.28848
+  tps: 20078.49148
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 32703.77599
-  tps: 21361.10641
+  dps: 31213.49145
+  tps: 20068.54069
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 32805.05623
-  tps: 21403.50679
+  dps: 31215.61958
+  tps: 20066.52907
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Rainsong-55854"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Rainsong-56377"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 31517.29314
-  tps: 20500.70909
+  dps: 30270.03122
+  tps: 19285.32199
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ReflectionoftheLight-77986"
  value: {
-  dps: 31517.29314
-  tps: 20500.70909
+  dps: 30270.03122
+  tps: 19285.32199
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ReflectionoftheLight-78006"
  value: {
-  dps: 31517.29314
-  tps: 20500.70909
+  dps: 30270.03122
+  tps: 19285.32199
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 33525.52785
-  tps: 21752.36309
+  dps: 32259.87371
+  tps: 20449.48658
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 33355.86639
-  tps: 21644.07541
+  dps: 32096.17362
+  tps: 20347.55771
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 32768.39648
-  tps: 21415.3247
+  dps: 31551.37859
+  tps: 20161.27203
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 32397.29795
-  tps: 21063.78225
+  dps: 31112.32117
+  tps: 19805.63132
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 32517.92667
-  tps: 21139.38937
+  dps: 31220.7105
+  tps: 19879.13029
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RosaryofLight-72901"
  value: {
-  dps: 33564.50518
-  tps: 21868.3528
+  dps: 32447.59505
+  tps: 20678.40546
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RottingSkull-77116"
  value: {
-  dps: 33953.18864
-  tps: 22089.40125
+  dps: 32684.99179
+  tps: 20797.35485
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RottingSkull-77987"
  value: {
-  dps: 33686.03882
-  tps: 21914.6769
+  dps: 32451.17682
+  tps: 20639.34187
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RottingSkull-78007"
  value: {
-  dps: 34252.29047
-  tps: 22292.47616
+  dps: 32988.44504
+  tps: 20991.29615
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RuneofZeth-68998"
  value: {
-  dps: 32295.92715
-  tps: 21061.3157
+  dps: 31085.4982
+  tps: 19809.50895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ScalesofLife-68915"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
   hps: 315.97258
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ScalesofLife-69109"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
   hps: 356.41412
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 32015.47399
-  tps: 21023.19585
+  dps: 31115.49732
+  tps: 19966.11015
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SeaStar-55256"
  value: {
-  dps: 31507.77555
-  tps: 20491.39159
+  dps: 30262.10707
+  tps: 19275.25907
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SeaStar-56290"
  value: {
-  dps: 31507.77555
-  tps: 20491.39159
+  dps: 30262.10707
+  tps: 19275.25907
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Shadowmourne-49623"
  value: {
-  dps: 35151.61128
-  tps: 22846.45274
+  dps: 33789.82746
+  tps: 21686.09655
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ShardofWoe-60233"
  value: {
-  dps: 31850.36642
-  tps: 20761.66367
+  dps: 30748.68594
+  tps: 19696.08481
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 32348.70284
-  tps: 21246.90597
+  dps: 31049.30341
+  tps: 20000.35366
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 32123.02687
-  tps: 21183.6082
+  dps: 30899.33777
+  tps: 19957.5216
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 32457.23974
-  tps: 21426.42161
+  dps: 31018.87399
+  tps: 20081.17946
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Sorrowsong-55879"
  value: {
-  dps: 31607.61222
-  tps: 20742.52137
+  dps: 30303.44841
+  tps: 19526.3368
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Sorrowsong-56400"
  value: {
-  dps: 31869.3252
-  tps: 20926.85923
+  dps: 30574.68659
+  tps: 19693.86193
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 32017.09127
-  tps: 20805.99942
+  dps: 30753.61503
+  tps: 19578.06553
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SoulCasket-58183"
  value: {
-  dps: 32027.81008
-  tps: 21027.0325
+  dps: 30645.56481
+  tps: 19753.50584
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Souldrinker-77193"
  value: {
-  dps: 34364.72802
-  tps: 22341.5219
-  hps: 295.97361
+  dps: 33074.80716
+  tps: 21012.7595
+  hps: 296.01435
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Souldrinker-78479"
  value: {
-  dps: 34476.28084
-  tps: 22420.11472
-  hps: 336.85027
+  dps: 33183.16132
+  tps: 21087.94022
+  hps: 336.89664
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Souldrinker-78488"
  value: {
-  dps: 34265.96048
-  tps: 22271.16815
-  hps: 255.53248
+  dps: 32978.79674
+  tps: 20945.34686
+  hps: 255.56766
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 32149.08629
-  tps: 21216.78535
+  dps: 31451.59484
+  tps: 20309.15096
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 32305.93246
-  tps: 21263.06679
+  dps: 31027.23811
+  tps: 20118.57667
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 32502.13136
-  tps: 21563.5272
+  dps: 31391.70324
+  tps: 20454.06197
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 32077.49846
-  tps: 21071.54983
+  dps: 30669.27001
+  tps: 19878.37592
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 32053.97389
-  tps: 21193.61065
+  dps: 30927.05516
+  tps: 20075.90645
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 32766.71481
-  tps: 21460.04084
+  dps: 31785.19133
+  tps: 20456.29169
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 32476.40188
-  tps: 21213.26084
+  dps: 31615.04317
+  tps: 20359.7986
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 32911.33424
-  tps: 21676.04715
+  dps: 31774.35393
+  tps: 20471.27199
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StayofExecution-68996"
  value: {
-  dps: 31507.12591
-  tps: 20492.15646
+  dps: 30263.94494
+  tps: 19276.77951
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StumpofTime-62465"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StumpofTime-62470"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 32441.43538
-  tps: 21234.22957
+  dps: 31192.95181
+  tps: 19901.26941
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TearofBlood-55819"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TearofBlood-56351"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 31737.67582
-  tps: 20810.71609
+  dps: 30426.29958
+  tps: 19568.8063
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 31869.3252
-  tps: 20926.85923
+  dps: 30574.68659
+  tps: 19693.86193
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheHungerer-68927"
  value: {
-  dps: 32344.61827
-  tps: 21192.86368
+  dps: 31228.22399
+  tps: 20102.81774
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheHungerer-69112"
  value: {
-  dps: 32817.54546
-  tps: 21475.82678
+  dps: 31586.89573
+  tps: 20336.21113
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 32008.76568
-  tps: 21056.26514
+  dps: 30735.54745
+  tps: 19807.14895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 32255.70373
-  tps: 21213.80248
+  dps: 31107.09091
+  tps: 20030.98555
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 32126.27062
-  tps: 21107.05036
+  dps: 31210.78397
+  tps: 20157.40232
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 31221.04325
-  tps: 20303.59001
+  dps: 29982.74929
+  tps: 19097.41531
  }
 }
 dps_results: {
  key: "TestArms-AllItems-UnheededWarning-59520"
  value: {
-  dps: 32474.90573
-  tps: 21135.1164
+  dps: 31207.10059
+  tps: 19876.13989
  }
 }
 dps_results: {
  key: "TestArms-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 31507.77555
-  tps: 20491.39159
+  dps: 30262.10707
+  tps: 19275.25907
  }
 }
 dps_results: {
  key: "TestArms-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 32516.39382
-  tps: 21391.98189
+  dps: 31158.69467
+  tps: 20109.10656
  }
 }
 dps_results: {
  key: "TestArms-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 32516.39382
-  tps: 21391.98189
+  dps: 31158.69467
+  tps: 20109.10656
  }
 }
 dps_results: {
  key: "TestArms-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 32516.39382
-  tps: 21391.98189
+  dps: 31158.69467
+  tps: 20109.10656
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 18839.82924
-  tps: 11854.64728
+  dps: 18352.41457
+  tps: 11408.69626
  }
 }
 dps_results: {
  key: "TestArms-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 33365.32941
-  tps: 21888.67115
+  dps: 32189.49105
+  tps: 20797.00246
  }
 }
 dps_results: {
  key: "TestArms-AllItems-VeilofLies-72900"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 33567.47202
-  tps: 21862.43265
+  dps: 32333.36727
+  tps: 20573.27283
  }
 }
 dps_results: {
  key: "TestArms-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 33829.27162
-  tps: 22040.2223
+  dps: 32559.18863
+  tps: 20729.70996
  }
 }
 dps_results: {
  key: "TestArms-AllItems-VialofShadows-77207"
  value: {
-  dps: 32632.65802
-  tps: 21521.09699
+  dps: 31771.52261
+  tps: 20617.28126
  }
 }
 dps_results: {
  key: "TestArms-AllItems-VialofShadows-77979"
  value: {
-  dps: 32668.45824
-  tps: 21421.39223
+  dps: 31528.70951
+  tps: 20452.52008
  }
 }
 dps_results: {
  key: "TestArms-AllItems-VialofShadows-77999"
  value: {
-  dps: 32953.31318
-  tps: 21678.34961
+  dps: 31848.58664
+  tps: 20667.59208
  }
 }
 dps_results: {
  key: "TestArms-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 32100.95301
-  tps: 20920.51697
+  dps: 30791.20229
+  tps: 19645.71324
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 31507.77555
-  tps: 20491.39159
+  dps: 30262.10707
+  tps: 19275.25907
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 32735.9935
-  tps: 21234.33584
+  dps: 31440.7716
+  tps: 19976.04878
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 31731.02487
-  tps: 20720.91574
+  dps: 30439.40431
+  tps: 19508.53274
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 32169.85096
-  tps: 20952.29056
+  dps: 30965.01689
+  tps: 19716.00963
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 32037.12912
-  tps: 21049.34962
+  dps: 30658.43603
+  tps: 19827.97801
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 32021.35145
-  tps: 20876.5531
+  dps: 30863.34474
+  tps: 19700.99778
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 32568.94498
-  tps: 21179.26962
+  dps: 31280.82928
+  tps: 19924.166
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Vishanka,JawsoftheEarth-78359"
  value: {
-  dps: 32972.06443
-  tps: 21489.09789
+  dps: 31838.90483
+  tps: 20279.24585
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Vishanka,JawsoftheEarth-78471"
  value: {
-  dps: 32993.68096
-  tps: 21500.96999
+  dps: 31864.24308
+  tps: 20296.14958
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Vishanka,JawsoftheEarth-78480"
  value: {
-  dps: 32947.44765
-  tps: 21466.10867
+  dps: 31810.38155
+  tps: 20254.70127
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WillofUnbinding-77995"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 31488.55325
-  tps: 20471.84565
+  dps: 30243.04453
+  tps: 19256.8182
  }
 }
 dps_results: {
  key: "TestArms-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 31783.80561
-  tps: 20846.95876
+  dps: 30388.0208
+  tps: 19568.56576
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 32743.77
-  tps: 21408.95907
+  dps: 31566.0441
+  tps: 20190.22877
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 32643.93996
-  tps: 21315.75476
+  dps: 31425.09518
+  tps: 20066.2107
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 32922.34819
-  tps: 21529.48379
+  dps: 31702.22058
+  tps: 20283.55246
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 31962.86862
-  tps: 20964.4275
+  dps: 30560.70208
+  tps: 19653.50924
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 31962.86862
-  tps: 20964.4275
+  dps: 30560.70208
+  tps: 19653.50924
  }
 }
 dps_results: {
  key: "TestArms-Average-Default"
  value: {
-  dps: 33338.32778
-  tps: 21643.9264
+  dps: 32193.0609
+  tps: 20493.86583
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p1_arms_bis-Basic-arms-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 69713.70415
-  tps: 35793.6719
+  dps: 68851.79644
+  tps: 35011.61442
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p1_arms_bis-Basic-arms-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 33525.52785
-  tps: 21752.36309
+  dps: 32259.87371
+  tps: 20449.48658
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p1_arms_bis-Basic-arms-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 39406.32531
-  tps: 27069.53991
+  dps: 38404.9199
+  tps: 25959.10108
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p1_arms_bis-Basic-arms-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 48098.35591
-  tps: 23751.11954
+  dps: 47403.29967
+  tps: 23052.70638
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p1_arms_bis-Basic-arms-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 22827.3442
-  tps: 14729.71171
+  dps: 22036.38994
+  tps: 13883.6336
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p1_arms_bis-Basic-arms-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 26075.85442
-  tps: 17240.27401
+  dps: 24629.29465
+  tps: 15793.06069
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p3_arms_bis-Basic-arms-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 85972.12569
-  tps: 44756.50131
+  dps: 84248.73508
+  tps: 43325.76651
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p3_arms_bis-Basic-arms-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 41450.89426
-  tps: 27530.7984
+  dps: 40124.8586
+  tps: 26181.00039
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p3_arms_bis-Basic-arms-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 48017.07134
-  tps: 32647.17767
+  dps: 46637.1583
+  tps: 31067.99642
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p3_arms_bis-Basic-arms-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 61289.30781
-  tps: 30672.48907
+  dps: 60218.17158
+  tps: 29525.72495
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p3_arms_bis-Basic-arms-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 28898.88936
-  tps: 19043.51136
+  dps: 27553.12991
+  tps: 17822.76514
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p3_arms_bis-Basic-arms-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 31706.97049
-  tps: 21533.53119
+  dps: 30037.25213
+  tps: 19928.16529
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p1_arms_bis-Basic-arms-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 69888.61734
-  tps: 35730.10147
+  dps: 68952.72764
+  tps: 34903.13557
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p1_arms_bis-Basic-arms-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 33594.45019
-  tps: 21838.51803
+  dps: 32401.00779
+  tps: 20556.56197
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p1_arms_bis-Basic-arms-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 39324.3487
-  tps: 27001.5848
+  dps: 38122.28527
+  tps: 25813.88646
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p1_arms_bis-Basic-arms-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 48268.53908
-  tps: 23675.60084
+  dps: 47522.62077
+  tps: 22951.53095
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p1_arms_bis-Basic-arms-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 22864.21314
-  tps: 14771.72535
+  dps: 22222.26124
+  tps: 14011.30959
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p1_arms_bis-Basic-arms-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 25949.53639
-  tps: 17192.3775
+  dps: 24623.43907
+  tps: 15765.10419
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p3_arms_bis-Basic-arms-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 86258.7272
-  tps: 44739.15679
+  dps: 84624.99454
+  tps: 43379.53399
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p3_arms_bis-Basic-arms-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 41592.59172
-  tps: 27673.48306
+  dps: 40141.22815
+  tps: 26225.45368
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p3_arms_bis-Basic-arms-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 47880.4054
-  tps: 32498.57175
+  dps: 46541.58551
+  tps: 30993.4089
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p3_arms_bis-Basic-arms-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 61557.86129
-  tps: 30662.27879
+  dps: 60442.62826
+  tps: 29520.83302
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p3_arms_bis-Basic-arms-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 29072.54331
-  tps: 19224.72017
+  dps: 27700.76064
+  tps: 17965.99009
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p3_arms_bis-Basic-arms-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 31570.41496
-  tps: 21441.21328
+  dps: 30038.58174
+  tps: 19928.22084
  }
 }
 dps_results: {
  key: "TestArms-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 30398.42166
-  tps: 19869.34427
+  dps: 29423.41731
+  tps: 18924.84392
  }
 }

--- a/sim/warrior/arms/TestArms.results
+++ b/sim/warrior/arms/TestArms.results
@@ -38,2148 +38,2148 @@ character_stats_results: {
 dps_results: {
  key: "TestArms-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 32224.5086
-  tps: 20420.26605
+  dps: 32152.14652
+  tps: 20347.90397
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 31246.83829
-  tps: 20235.9865
+  dps: 31167.98143
+  tps: 20157.12965
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 32587.27418
-  tps: 20775.46394
+  dps: 32567.50416
+  tps: 20755.69392
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 32596.06326
-  tps: 20792.05141
+  dps: 32579.29411
+  tps: 20775.28226
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ArrowofTime-72897"
  value: {
-  dps: 31254.82267
-  tps: 20031.95282
+  dps: 31247.23019
+  tps: 20024.36033
  }
 }
 dps_results: {
  key: "TestArms-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 31648.28848
-  tps: 20078.49148
+  dps: 31577.91979
+  tps: 20008.12279
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
   hps: 96.7093
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 30892.96269
-  tps: 19682.77831
+  dps: 30885.29995
+  tps: 19675.11556
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 31021.50606
-  tps: 19756.29245
+  dps: 31012.54723
+  tps: 19747.33363
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BindingPromise-67037"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 30698.0619
-  tps: 19744.71962
+  dps: 30623.10409
+  tps: 19669.76181
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 30303.44841
-  tps: 19526.3368
+  dps: 30297.11362
+  tps: 19520.002
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 30574.68659
-  tps: 19693.86193
+  dps: 30564.85451
+  tps: 19684.02985
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 30778.11054
-  tps: 19636.51925
+  dps: 30704.51251
+  tps: 19562.92121
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 30262.10707
-  tps: 19275.25907
+  dps: 30191.79925
+  tps: 19204.95126
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 31378.35011
-  tps: 19938.93531
+  dps: 31468.65348
+  tps: 20029.23868
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 30826.32787
-  tps: 19636.89648
+  dps: 30819.07285
+  tps: 19629.64146
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 30772.85057
-  tps: 19641.16295
+  dps: 30765.93199
+  tps: 19634.24437
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 31191.84356
-  tps: 19872.25353
+  dps: 31140.13959
+  tps: 19820.54956
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 32806.73476
-  tps: 21254.10421
+  dps: 32792.87772
+  tps: 21240.24717
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 32637.7521
-  tps: 20995.95328
+  dps: 32623.1867
+  tps: 20981.38788
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 33128.55738
-  tps: 21514.59109
+  dps: 33112.91465
+  tps: 21498.94836
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BottledLightning-66879"
  value: {
-  dps: 30503.46236
-  tps: 19449.93525
+  dps: 30431.47475
+  tps: 19377.94764
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BottledWishes-77114"
  value: {
-  dps: 30675.77508
-  tps: 19704.19403
+  dps: 30606.74614
+  tps: 19635.16509
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BottledWishes-77985"
  value: {
-  dps: 30795.97755
-  tps: 19827.34309
+  dps: 30730.38465
+  tps: 19761.75019
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BottledWishes-78005"
  value: {
-  dps: 30795.60837
-  tps: 19693.36027
+  dps: 30727.94877
+  tps: 19625.70067
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 31648.28848
-  tps: 19677.05897
+  dps: 31577.91979
+  tps: 19608.09764
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 32820.69808
-  tps: 20798.68732
+  dps: 32745.94497
+  tps: 20723.9342
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 32096.17362
-  tps: 20347.55771
+  dps: 32025.22474
+  tps: 20276.60883
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 32236.50303
-  tps: 20432.26048
+  dps: 32164.14095
+  tps: 20359.8984
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ColossalDragonplateArmor"
  value: {
-  dps: 26402.70291
-  tps: 17009.01788
+  dps: 26376.82889
+  tps: 16983.14387
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ColossalDragonplateBattlegear"
  value: {
-  dps: 30259.14121
-  tps: 19551.37938
+  dps: 30217.46938
+  tps: 19509.70755
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 31517.27217
-  tps: 20088.65405
+  dps: 31473.13751
+  tps: 20044.51938
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 30262.10707
-  tps: 19275.25907
+  dps: 30191.79925
+  tps: 19204.95126
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 33198.22745
-  tps: 21173.73364
+  dps: 33172.97152
+  tps: 21148.4777
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 32794.39934
-  tps: 20952.41496
+  dps: 32772.83634
+  tps: 20930.85196
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 33409.7268
-  tps: 21362.92987
+  dps: 33383.3105
+  tps: 21336.51357
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CrushingWeight-59506"
  value: {
-  dps: 31629.61323
-  tps: 20252.14511
+  dps: 31615.59891
+  tps: 20238.13079
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CrushingWeight-65118"
  value: {
-  dps: 31537.65921
-  tps: 20327.90005
+  dps: 31526.56621
+  tps: 20316.80705
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CunningoftheCruel-78000"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 31914.00229
-  tps: 20568.55092
+  dps: 31904.69864
+  tps: 20559.24727
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 31431.43363
-  tps: 20286.0799
+  dps: 31424.72163
+  tps: 20279.3679
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 30615.39713
-  tps: 19727.08717
+  dps: 30610.12273
+  tps: 19721.81278
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 30951.74115
-  tps: 19844.63082
+  dps: 30934.9128
+  tps: 19827.80246
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 31783.11695
-  tps: 20160.58535
+  dps: 31711.35224
+  tps: 20088.82065
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 30383.58902
-  tps: 19477.22663
+  dps: 30375.75459
+  tps: 19469.3922
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 32121.11743
-  tps: 20479.42747
+  dps: 32104.25858
+  tps: 20462.56862
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EarthenBattleplate"
  value: {
-  dps: 25883.75043
-  tps: 16660.98776
+  dps: 25866.54956
+  tps: 16643.78689
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EarthenWarplate"
  value: {
-  dps: 28666.18544
-  tps: 18499.93184
+  dps: 28611.73728
+  tps: 18445.48368
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 31648.28848
-  tps: 20078.49148
+  dps: 31577.91979
+  tps: 20008.12279
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 30262.10707
-  tps: 19275.25907
+  dps: 30191.79925
+  tps: 19204.95126
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 31648.28848
-  tps: 20078.49148
+  dps: 31577.91979
+  tps: 20008.12279
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 31783.11695
-  tps: 20160.58535
+  dps: 31711.35224
+  tps: 20088.82065
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 31243.7724
-  tps: 19953.57286
+  dps: 31233.98866
+  tps: 19943.78912
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 31566.83006
-  tps: 20153.23512
+  dps: 31553.54377
+  tps: 20139.94883
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 31707.0807
-  tps: 20550.21858
+  dps: 31761.2906
+  tps: 20604.42849
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 31648.28848
-  tps: 20078.49148
+  dps: 31577.91979
+  tps: 20008.12279
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 32826.94601
-  tps: 20863.68112
+  dps: 32688.96328
+  tps: 20725.69839
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 32533.32084
-  tps: 20681.08306
+  dps: 32410.51906
+  tps: 20558.28127
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 33149.9337
-  tps: 21064.53899
+  dps: 32995.25193
+  tps: 20909.85722
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FallofMortality-59500"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FallofMortality-65124"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 30225.59908
-  tps: 19249.83354
+  dps: 30155.16128
+  tps: 19179.39574
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 30714.00464
-  tps: 19596.32364
+  dps: 30640.58671
+  tps: 19522.90572
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 30262.10707
-  tps: 19275.25907
+  dps: 30191.79925
+  tps: 19204.95126
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 30262.10707
-  tps: 19275.25907
+  dps: 30191.79925
+  tps: 19204.95126
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 31659.40094
-  tps: 20361.59833
+  dps: 31735.95674
+  tps: 20438.15413
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 30828.4161
-  tps: 20038.52663
+  dps: 30825.6391
+  tps: 20035.74963
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FireoftheDeep-77988"
  value: {
-  dps: 30841.32686
-  tps: 19975.61104
+  dps: 30834.44739
+  tps: 19968.73157
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FireoftheDeep-78008"
  value: {
-  dps: 30969.64748
-  tps: 20015.99805
+  dps: 30961.25158
+  tps: 20007.60214
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 31230.07097
-  tps: 20012.58529
+  dps: 31162.91178
+  tps: 19945.42611
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FluidDeath-58181"
  value: {
-  dps: 30806.38639
-  tps: 19630.57303
+  dps: 30799.06534
+  tps: 19623.25197
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 31648.28848
-  tps: 20078.49148
+  dps: 31577.91979
+  tps: 20008.12279
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-GaleofShadows-56138"
  value: {
-  dps: 30374.26244
-  tps: 19458.09739
+  dps: 30369.39371
+  tps: 19453.22867
  }
 }
 dps_results: {
  key: "TestArms-AllItems-GaleofShadows-56462"
  value: {
-  dps: 30906.23218
-  tps: 19683.62483
+  dps: 30894.92354
+  tps: 19672.31619
  }
 }
 dps_results: {
  key: "TestArms-AllItems-GearDetector-61462"
  value: {
-  dps: 30525.30048
-  tps: 19623.38787
+  dps: 30521.83014
+  tps: 19619.91753
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Gladiator'sBattlegear"
  value: {
-  dps: 26062.59557
-  tps: 16642.74022
+  dps: 26045.05957
+  tps: 16625.20421
  }
 }
 dps_results: {
  key: "TestArms-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 30679.45736
-  tps: 19561.13454
+  dps: 30672.98905
+  tps: 19554.66623
  }
 }
 dps_results: {
  key: "TestArms-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 31004.51567
-  tps: 19797.28865
+  dps: 30996.46773
+  tps: 19789.24071
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Gurthalak,VoiceoftheDeeps-77191"
  value: {
-  dps: 34751.03733
-  tps: 21417.10826
+  dps: 34671.06271
+  tps: 21337.13364
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Gurthalak,VoiceoftheDeeps-78478"
  value: {
-  dps: 34894.03564
-  tps: 21546.88244
+  dps: 34814.11507
+  tps: 21466.96187
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Gurthalak,VoiceoftheDeeps-78487"
  value: {
-  dps: 34140.64916
-  tps: 21321.74125
+  dps: 34061.26779
+  tps: 21242.35988
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HarmlightToken-63839"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 31448.13585
-  tps: 20161.23842
+  dps: 31435.32482
+  tps: 20148.4274
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartofRage-59224"
  value: {
-  dps: 31416.96769
-  tps: 20091.19171
+  dps: 31351.58195
+  tps: 20025.80597
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartofSolace-55868"
  value: {
-  dps: 30374.26244
-  tps: 19458.09739
+  dps: 30369.39371
+  tps: 19453.22867
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartofSolace-56393"
  value: {
-  dps: 31967.94897
-  tps: 20430.60975
+  dps: 31901.59488
+  tps: 20364.25566
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartofThunder-55845"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartofThunder-56370"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 30737.41997
-  tps: 19600.22639
+  dps: 30730.70858
+  tps: 19593.515
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 31783.11695
-  tps: 20160.58535
+  dps: 31711.35224
+  tps: 20088.82065
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 31831.44121
-  tps: 20468.96974
+  dps: 31932.45506
+  tps: 20569.98359
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 31831.44121
-  tps: 20468.96974
+  dps: 31932.45506
+  tps: 20569.98359
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 30303.44841
-  tps: 19526.3368
+  dps: 30297.11362
+  tps: 19520.002
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 30574.68659
-  tps: 19693.86193
+  dps: 30564.85451
+  tps: 19684.02985
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IndomitablePride-77211"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IndomitablePride-77983"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IndomitablePride-78003"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 31202.67768
-  tps: 20027.1175
+  dps: 31191.09949
+  tps: 20015.53932
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 30947.51881
-  tps: 19857.23056
+  dps: 30942.81302
+  tps: 19852.52477
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 31127.8096
-  tps: 20010.06738
+  dps: 31114.3364
+  tps: 19996.59418
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 30422.98448
-  tps: 19568.60629
+  dps: 30352.69336
+  tps: 19498.31518
  }
 }
 dps_results: {
  key: "TestArms-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 30698.0619
-  tps: 19744.71962
+  dps: 30623.10409
+  tps: 19669.76181
  }
 }
 dps_results: {
  key: "TestArms-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 30616.79932
-  tps: 19518.43915
+  dps: 30609.82396
+  tps: 19511.46379
  }
 }
 dps_results: {
  key: "TestArms-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 30758.32744
-  tps: 19602.60251
+  dps: 30750.80441
+  tps: 19595.07948
  }
 }
 dps_results: {
  key: "TestArms-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 31380.10282
-  tps: 20177.51621
+  dps: 31307.11931
+  tps: 20104.53269
  }
 }
 dps_results: {
  key: "TestArms-AllItems-KiroptyricSigil-77984"
  value: {
-  dps: 31402.11967
-  tps: 20216.32209
+  dps: 31330.65898
+  tps: 20144.86141
  }
 }
 dps_results: {
  key: "TestArms-AllItems-KiroptyricSigil-78004"
  value: {
-  dps: 31565.52915
-  tps: 20192.30591
+  dps: 31493.75213
+  tps: 20120.5289
  }
 }
 dps_results: {
  key: "TestArms-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 30897.37203
-  tps: 19764.86351
+  dps: 30914.72873
+  tps: 19782.22021
  }
 }
 dps_results: {
  key: "TestArms-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 30897.37203
-  tps: 19764.86351
+  dps: 30914.72873
+  tps: 19782.22021
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 30568.41072
-  tps: 19575.16752
+  dps: 30492.60418
+  tps: 19499.36099
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LastWord-50708"
  value: {
-  dps: 32606.46012
-  tps: 20665.23773
+  dps: 32516.78015
+  tps: 20575.55776
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LeadenDespair-55816"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LeadenDespair-56347"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 30636.43295
-  tps: 19526.37518
+  dps: 30629.12355
+  tps: 19519.06578
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 30751.09436
-  tps: 19589.78395
+  dps: 30743.44485
+  tps: 19582.13444
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 31358.82017
-  tps: 19950.69082
+  dps: 31296.74215
+  tps: 19888.6128
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 30949.57709
-  tps: 19696.69363
+  dps: 30994.28059
+  tps: 19741.39713
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 31170.82459
-  tps: 19830.62858
+  dps: 31253.16642
+  tps: 19912.97041
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 31393.96477
-  tps: 20255.5257
+  dps: 31313.16154
+  tps: 20174.72246
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 31367.42297
-  tps: 20182.59777
+  dps: 31287.45486
+  tps: 20102.62967
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 31892.16642
-  tps: 20449.65775
+  dps: 31874.93835
+  tps: 20432.42969
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 32254.05012
-  tps: 20677.21712
+  dps: 32232.60619
+  tps: 20655.77319
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 30753.61503
-  tps: 19578.06553
+  dps: 30764.98172
+  tps: 19589.43222
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 31170.82459
-  tps: 19830.62858
+  dps: 31253.16642
+  tps: 19912.97041
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 30615.39713
-  tps: 19727.08717
+  dps: 30610.12273
+  tps: 19721.81278
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 30615.39713
-  tps: 19727.08717
+  dps: 30610.12273
+  tps: 19721.81278
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 30835.22798
-  tps: 19645.79659
+  dps: 30827.97296
+  tps: 19638.54157
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MoltenGiantBattleplate"
  value: {
-  dps: 27284.52162
-  tps: 17567.80203
+  dps: 27258.73533
+  tps: 17542.01573
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MoltenGiantWarplate"
  value: {
-  dps: 31308.82315
-  tps: 20485.89886
+  dps: 31410.97197
+  tps: 20588.04769
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 30814.76373
-  tps: 19905.52556
+  dps: 30736.73678
+  tps: 19827.49861
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-No'Kaled,theElementsofDeath-77188"
  value: {
-  dps: 32900.51139
-  tps: 20972.3331
+  dps: 32825.5618
+  tps: 20897.38351
  }
 }
 dps_results: {
  key: "TestArms-AllItems-No'Kaled,theElementsofDeath-78472"
  value: {
-  dps: 32974.27964
-  tps: 21036.52226
+  dps: 32898.86925
+  tps: 20961.11186
  }
 }
 dps_results: {
  key: "TestArms-AllItems-No'Kaled,theElementsofDeath-78481"
  value: {
-  dps: 32848.1918
-  tps: 20925.72852
+  dps: 32773.5669
+  tps: 20851.10362
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 31241.69453
-  tps: 19927.9682
+  dps: 31165.7013
+  tps: 19851.97497
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 30576.6095
-  tps: 19477.6658
+  dps: 30571.03371
+  tps: 19472.09
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 30468.85615
-  tps: 19648.07379
+  dps: 30462.54687
+  tps: 19641.7645
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 30749.70554
-  tps: 19793.10734
+  dps: 30742.35434
+  tps: 19785.75614
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 31648.28848
-  tps: 20078.49148
+  dps: 31577.91979
+  tps: 20008.12279
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 31213.49145
-  tps: 20068.54069
+  dps: 31206.71431
+  tps: 20061.76356
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 31215.61958
-  tps: 20066.52907
+  dps: 31209.03976
+  tps: 20059.94925
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Rainsong-55854"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Rainsong-56377"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 30270.03122
-  tps: 19285.32199
+  dps: 30199.13127
+  tps: 19214.42204
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ReflectionoftheLight-77986"
  value: {
-  dps: 30270.03122
-  tps: 19285.32199
+  dps: 30199.13127
+  tps: 19214.42204
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ReflectionoftheLight-78006"
  value: {
-  dps: 30270.03122
-  tps: 19285.32199
+  dps: 30199.13127
+  tps: 19214.42204
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 32259.87371
-  tps: 20449.48658
+  dps: 32188.06529
+  tps: 20377.67816
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 32096.17362
-  tps: 20347.55771
+  dps: 32025.22474
+  tps: 20276.60883
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 31551.37859
-  tps: 20161.27203
+  dps: 31470.43784
+  tps: 20080.33128
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 31112.32117
-  tps: 19805.63132
+  dps: 31059.80615
+  tps: 19753.11629
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 31220.7105
-  tps: 19879.13029
+  dps: 31163.8331
+  tps: 19822.25289
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RosaryofLight-72901"
  value: {
-  dps: 32447.59505
-  tps: 20678.40546
+  dps: 32427.88373
+  tps: 20658.69414
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RottingSkull-77116"
  value: {
-  dps: 32684.99179
-  tps: 20797.35485
+  dps: 32858.77966
+  tps: 20971.14272
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RottingSkull-77987"
  value: {
-  dps: 32451.17682
-  tps: 20639.34187
+  dps: 32596.24603
+  tps: 20784.41107
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RottingSkull-78007"
  value: {
-  dps: 32988.44504
-  tps: 20991.29615
+  dps: 33194.85857
+  tps: 21197.70967
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RuneofZeth-68998"
  value: {
-  dps: 31085.4982
-  tps: 19809.50895
+  dps: 31008.20948
+  tps: 19732.22023
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ScalesofLife-68915"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
   hps: 315.97258
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ScalesofLife-69109"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
   hps: 356.41412
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 31115.49732
-  tps: 19966.11015
+  dps: 31104.92727
+  tps: 19955.5401
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SeaStar-55256"
  value: {
-  dps: 30262.10707
-  tps: 19275.25907
+  dps: 30191.79925
+  tps: 19204.95126
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SeaStar-56290"
  value: {
-  dps: 30262.10707
-  tps: 19275.25907
+  dps: 30191.79925
+  tps: 19204.95126
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Shadowmourne-49623"
  value: {
-  dps: 33789.82746
-  tps: 21686.09655
+  dps: 33676.19948
+  tps: 21572.46857
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ShardofWoe-60233"
  value: {
-  dps: 30748.68594
-  tps: 19696.08481
+  dps: 30675.04979
+  tps: 19622.44866
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 31049.30341
-  tps: 20000.35366
+  dps: 31043.8584
+  tps: 19994.90865
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 30899.33777
-  tps: 19957.5216
+  dps: 30823.28514
+  tps: 19881.46897
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 31018.87399
-  tps: 20081.17946
+  dps: 30942.39517
+  tps: 20004.70063
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Sorrowsong-55879"
  value: {
-  dps: 30303.44841
-  tps: 19526.3368
+  dps: 30297.11362
+  tps: 19520.002
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Sorrowsong-56400"
  value: {
-  dps: 30574.68659
-  tps: 19693.86193
+  dps: 30564.85451
+  tps: 19684.02985
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 30753.61503
-  tps: 19578.06553
+  dps: 30764.98172
+  tps: 19589.43222
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SoulCasket-58183"
  value: {
-  dps: 30645.56481
-  tps: 19753.50584
+  dps: 30572.59885
+  tps: 19680.53988
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Souldrinker-77193"
  value: {
-  dps: 33074.80716
-  tps: 21012.7595
+  dps: 32999.49695
+  tps: 20937.44928
   hps: 296.01435
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Souldrinker-78479"
  value: {
-  dps: 33183.16132
-  tps: 21087.94022
+  dps: 33107.3895
+  tps: 21012.1684
   hps: 336.89664
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Souldrinker-78488"
  value: {
-  dps: 32978.79674
-  tps: 20945.34686
+  dps: 32903.88445
+  tps: 20870.43458
   hps: 255.56766
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 31451.59484
-  tps: 20309.15096
+  dps: 31440.98344
+  tps: 20298.53955
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 31027.23811
-  tps: 20118.57667
+  dps: 31014.11766
+  tps: 20105.45622
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 31391.70324
-  tps: 20454.06197
+  dps: 31381.39003
+  tps: 20443.74876
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 30669.27001
-  tps: 19878.37592
+  dps: 30663.86674
+  tps: 19872.97265
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 30927.05516
-  tps: 20075.90645
+  dps: 30921.03804
+  tps: 20069.88933
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 31785.19133
-  tps: 20456.29169
+  dps: 31774.54946
+  tps: 20445.64982
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 31615.04317
-  tps: 20359.7986
+  dps: 31599.61129
+  tps: 20344.36672
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 31774.35393
-  tps: 20471.27199
+  dps: 31765.61208
+  tps: 20462.53013
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StayofExecution-68996"
  value: {
-  dps: 30263.94494
-  tps: 19276.77951
+  dps: 30193.92383
+  tps: 19206.7584
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StumpofTime-62465"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StumpofTime-62470"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 31192.95181
-  tps: 19901.26941
+  dps: 31185.57299
+  tps: 19893.89059
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TearofBlood-55819"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TearofBlood-56351"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 30426.29958
-  tps: 19568.8063
+  dps: 30420.19901
+  tps: 19562.70574
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 30574.68659
-  tps: 19693.86193
+  dps: 30564.85451
+  tps: 19684.02985
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheHungerer-68927"
  value: {
-  dps: 31228.22399
-  tps: 20102.81774
+  dps: 31218.65965
+  tps: 20093.2534
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheHungerer-69112"
  value: {
-  dps: 31586.89573
-  tps: 20336.21113
+  dps: 31575.85335
+  tps: 20325.16874
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 30735.54745
-  tps: 19807.14895
+  dps: 30726.25655
+  tps: 19797.85805
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 31107.09091
-  tps: 20030.98555
+  dps: 31093.25325
+  tps: 20017.14789
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 31210.78397
-  tps: 20157.40232
+  dps: 31200.05284
+  tps: 20146.67119
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 29982.74929
-  tps: 19097.41531
+  dps: 29925.0104
+  tps: 19039.67642
  }
 }
 dps_results: {
  key: "TestArms-AllItems-UnheededWarning-59520"
  value: {
-  dps: 31207.10059
-  tps: 19876.13989
+  dps: 31173.44703
+  tps: 19842.48633
  }
 }
 dps_results: {
  key: "TestArms-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 30262.10707
-  tps: 19275.25907
+  dps: 30191.79925
+  tps: 19204.95126
  }
 }
 dps_results: {
  key: "TestArms-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 31158.69467
-  tps: 20109.10656
+  dps: 31079.84313
+  tps: 20030.25502
  }
 }
 dps_results: {
  key: "TestArms-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 31158.69467
-  tps: 20109.10656
+  dps: 31079.84313
+  tps: 20030.25502
  }
 }
 dps_results: {
  key: "TestArms-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 31158.69467
-  tps: 20109.10656
+  dps: 31079.84313
+  tps: 20030.25502
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 18352.41457
-  tps: 11408.69626
+  dps: 18356.02196
+  tps: 11412.30366
  }
 }
 dps_results: {
  key: "TestArms-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 32189.49105
-  tps: 20797.00246
+  dps: 32175.10257
+  tps: 20782.61399
  }
 }
 dps_results: {
  key: "TestArms-AllItems-VeilofLies-72900"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 32333.36727
-  tps: 20573.27283
+  dps: 32317.4593
+  tps: 20557.36486
  }
 }
 dps_results: {
  key: "TestArms-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 32559.18863
-  tps: 20729.70996
+  dps: 32541.91737
+  tps: 20712.4387
  }
 }
 dps_results: {
  key: "TestArms-AllItems-VialofShadows-77207"
  value: {
-  dps: 31771.52261
-  tps: 20617.28126
+  dps: 31765.68308
+  tps: 20611.44173
  }
 }
 dps_results: {
  key: "TestArms-AllItems-VialofShadows-77979"
  value: {
-  dps: 31528.70951
-  tps: 20452.52008
+  dps: 31520.96968
+  tps: 20444.78025
  }
 }
 dps_results: {
  key: "TestArms-AllItems-VialofShadows-77999"
  value: {
-  dps: 31848.58664
-  tps: 20667.59208
+  dps: 31845.87713
+  tps: 20664.88257
  }
 }
 dps_results: {
  key: "TestArms-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 30791.20229
-  tps: 19645.71324
+  dps: 30717.08568
+  tps: 19571.59662
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 30262.10707
-  tps: 19275.25907
+  dps: 30191.79925
+  tps: 19204.95126
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 31440.7716
-  tps: 19976.04878
+  dps: 31540.05652
+  tps: 20075.3337
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 30439.40431
-  tps: 19508.53274
+  dps: 30435.15933
+  tps: 19504.28776
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 30965.01689
-  tps: 19716.00963
+  dps: 30956.28422
+  tps: 19707.27696
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 30658.43603
-  tps: 19827.97801
+  dps: 30654.19963
+  tps: 19823.74161
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 30863.34474
-  tps: 19700.99778
+  dps: 30856.00462
+  tps: 19693.65765
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 31280.82928
-  tps: 19924.166
+  dps: 31223.60809
+  tps: 19866.94481
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Vishanka,JawsoftheEarth-78359"
  value: {
-  dps: 31838.90483
-  tps: 20279.24585
+  dps: 31764.43324
+  tps: 20204.77426
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Vishanka,JawsoftheEarth-78471"
  value: {
-  dps: 31864.24308
-  tps: 20296.14958
+  dps: 31789.33595
+  tps: 20221.24244
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Vishanka,JawsoftheEarth-78480"
  value: {
-  dps: 31810.38155
-  tps: 20254.70127
+  dps: 31736.09954
+  tps: 20180.41926
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WillofUnbinding-77995"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 30243.04453
-  tps: 19256.8182
+  dps: 30238.65409
+  tps: 19252.42775
  }
 }
 dps_results: {
  key: "TestArms-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 30388.0208
-  tps: 19568.56576
+  dps: 30315.72518
+  tps: 19496.27013
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 31566.0441
-  tps: 20190.22877
+  dps: 31554.60934
+  tps: 20178.79402
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 31425.09518
-  tps: 20066.2107
+  dps: 31414.13197
+  tps: 20055.24749
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 31702.22058
-  tps: 20283.55246
+  dps: 31689.87246
+  tps: 20271.20434
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 30560.70208
-  tps: 19653.50924
+  dps: 30483.88259
+  tps: 19576.68975
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 30560.70208
-  tps: 19653.50924
+  dps: 30483.88259
+  tps: 19576.68975
  }
 }
 dps_results: {
  key: "TestArms-Average-Default"
  value: {
-  dps: 32193.0609
-  tps: 20493.86583
+  dps: 32117.14067
+  tps: 20417.9456
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p1_arms_bis-Basic-arms-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 68851.79644
-  tps: 35011.61442
+  dps: 69145.9072
+  tps: 35305.72518
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p1_arms_bis-Basic-arms-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 32259.87371
-  tps: 20449.48658
+  dps: 32188.06529
+  tps: 20377.67816
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p1_arms_bis-Basic-arms-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 38404.9199
-  tps: 25959.10108
+  dps: 38155.29614
+  tps: 25709.47733
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p1_arms_bis-Basic-arms-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 47403.29967
-  tps: 23052.70638
+  dps: 47489.56147
+  tps: 23138.96818
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p1_arms_bis-Basic-arms-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 22036.38994
-  tps: 13883.6336
+  dps: 21842.72412
+  tps: 13689.96779
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p1_arms_bis-Basic-arms-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 24629.29465
-  tps: 15793.06069
+  dps: 24360.74663
+  tps: 15524.51267
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p3_arms_bis-Basic-arms-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 84248.73508
-  tps: 43325.76651
+  dps: 84549.7361
+  tps: 43626.76754
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p3_arms_bis-Basic-arms-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 40124.8586
-  tps: 26181.00039
+  dps: 40344.99984
+  tps: 26401.14163
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p3_arms_bis-Basic-arms-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 46637.1583
-  tps: 31067.99642
+  dps: 46766.11765
+  tps: 31196.95577
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p3_arms_bis-Basic-arms-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 60218.17158
-  tps: 29525.72495
+  dps: 60290.31792
+  tps: 29597.87129
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p3_arms_bis-Basic-arms-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 27553.12991
-  tps: 17822.76514
+  dps: 27567.08256
+  tps: 17836.7178
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p3_arms_bis-Basic-arms-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 30037.25213
-  tps: 19928.16529
+  dps: 30024.12504
+  tps: 19915.03819
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p1_arms_bis-Basic-arms-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 68952.72764
-  tps: 34903.13557
+  dps: 69187.50935
+  tps: 35137.91728
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p1_arms_bis-Basic-arms-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 32401.00779
-  tps: 20556.56197
+  dps: 32262.53067
+  tps: 20418.08485
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p1_arms_bis-Basic-arms-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 38122.28527
-  tps: 25813.88646
+  dps: 37807.14682
+  tps: 25498.74801
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p1_arms_bis-Basic-arms-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 47522.62077
-  tps: 22951.53095
+  dps: 47560.44593
+  tps: 22989.35611
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p1_arms_bis-Basic-arms-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 22222.26124
-  tps: 14011.30959
+  dps: 21978.00025
+  tps: 13767.04859
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p1_arms_bis-Basic-arms-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 24623.43907
-  tps: 15765.10419
+  dps: 24306.66048
+  tps: 15448.3256
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p3_arms_bis-Basic-arms-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 84624.99454
-  tps: 43379.53399
+  dps: 84854.73359
+  tps: 43609.27303
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p3_arms_bis-Basic-arms-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 40141.22815
-  tps: 26225.45368
+  dps: 40286.87194
+  tps: 26371.09746
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p3_arms_bis-Basic-arms-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 46541.58551
-  tps: 30993.4089
+  dps: 46603.38527
+  tps: 31055.20866
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p3_arms_bis-Basic-arms-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 60442.62826
-  tps: 29520.83302
+  dps: 60458.4576
+  tps: 29536.66237
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p3_arms_bis-Basic-arms-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 27700.76064
-  tps: 17965.99009
+  dps: 27657.05213
+  tps: 17922.28158
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p3_arms_bis-Basic-arms-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 30038.58174
-  tps: 19928.22084
+  dps: 29974.0868
+  tps: 19863.7259
  }
 }
 dps_results: {
  key: "TestArms-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 29423.41731
-  tps: 18924.84392
+  dps: 29355.14922
+  tps: 18856.57583
  }
 }

--- a/sim/warrior/arms/talents.go
+++ b/sim/warrior/arms/talents.go
@@ -122,7 +122,7 @@ func (war *ArmsWarrior) TriggerSlaughter(sim *core.Simulation, target *core.Unit
 
 	rend := war.Rend.Dot(target)
 	if rend != nil && rend.IsActive() {
-		rend.Apply(sim)
+		rend.ApplyRollover(sim)
 	}
 
 	if !war.slaughter.IsActive() {

--- a/sim/warrior/arms/talents.go
+++ b/sim/warrior/arms/talents.go
@@ -123,7 +123,6 @@ func (war *ArmsWarrior) TriggerSlaughter(sim *core.Simulation, target *core.Unit
 	rend := war.Rend.Dot(target)
 	if rend != nil && rend.IsActive() {
 		rend.Apply(sim)
-		rend.TickOnce(sim)
 	}
 
 	if !war.slaughter.IsActive() {

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -38,2235 +38,2235 @@ character_stats_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 4698.33758
-  tps: 28646.98102
+  dps: 4406.1523
+  tps: 27147.58908
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AgonyandTorment"
  value: {
-  dps: 4090.17781
-  tps: 24025.40622
+  dps: 3854.10687
+  tps: 22877.19905
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 4749.79163
-  tps: 29011.66239
+  dps: 4506.6605
+  tps: 27817.42434
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 4767.0836
-  tps: 29041.04649
+  dps: 4507.77656
+  tps: 27758.14871
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 4936.95466
-  tps: 30131.6396
+  dps: 4637.76464
+  tps: 28602.57342
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 4973.22975
-  tps: 30354.29135
+  dps: 4672.29792
+  tps: 28816.25691
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ArrowofTime-72897"
  value: {
-  dps: 4877.8264
-  tps: 29517.61858
+  dps: 4577.23188
+  tps: 28066.97954
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 4764.19816
-  tps: 29002.94648
+  dps: 4477.63629
+  tps: 27550.53431
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 4773.48339
-  tps: 29051.09113
+  dps: 4487.5371
+  tps: 27605.19389
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BindingPromise-67037"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlackBruise-50692"
  value: {
-  dps: 4184.80944
-  tps: 25991.36715
+  dps: 4001.13306
+  tps: 25102.49986
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 4760.2773
-  tps: 28977.70162
+  dps: 4469.65476
+  tps: 27499.64554
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 4748.5139
-  tps: 28919.99364
+  dps: 4458.47298
+  tps: 27453.79349
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 4881.77662
-  tps: 29791.56727
+  dps: 4572.33619
+  tps: 28205.34622
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 5454.33939
-  tps: 32767.45212
+  dps: 5187.00401
+  tps: 31464.11565
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 5327.50586
-  tps: 32065.14721
+  dps: 5074.94204
+  tps: 30848.51046
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 5588.59212
-  tps: 33485.64569
+  dps: 5317.26139
+  tps: 32175.09912
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BottledLightning-66879"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BottledWishes-77114"
  value: {
-  dps: 4721.07121
-  tps: 28702.51351
+  dps: 4495.7441
+  tps: 27588.92243
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BottledWishes-77985"
  value: {
-  dps: 4738.9331
-  tps: 28788.23285
+  dps: 4499.32529
+  tps: 27581.13014
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BottledWishes-78005"
  value: {
-  dps: 4719.7886
-  tps: 28605.05846
+  dps: 4487.41931
+  tps: 27480.66158
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 4659.08749
-  tps: 27857.61133
+  dps: 4373.23975
+  tps: 26426.44938
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 4682.21129
-  tps: 28556.97214
+  dps: 4394.24315
+  tps: 27084.13297
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 4701.99629
-  tps: 28667.09617
+  dps: 4410.05414
+  tps: 27169.18881
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ColossalDragonplateArmor"
  value: {
-  dps: 4597.17686
-  tps: 28012.07496
+  dps: 4335.71914
+  tps: 26651.47136
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ColossalDragonplateBattlegear"
  value: {
-  dps: 5520.56479
-  tps: 33520.72215
+  dps: 5220.94801
+  tps: 32017.47784
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 4835.3777
-  tps: 29440.39671
+  dps: 4534.46286
+  tps: 27916.08911
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 5228.62207
-  tps: 31788.73626
+  dps: 4932.05131
+  tps: 30279.85905
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 5196.18816
-  tps: 31583.36245
+  dps: 4909.37908
+  tps: 30142.255
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 5312.73651
-  tps: 32274.58418
+  dps: 5009.95091
+  tps: 30711.88043
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CrushingWeight-59506"
  value: {
-  dps: 4966.39099
-  tps: 30237.1367
+  dps: 4729.45266
+  tps: 29071.74137
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CrushingWeight-65118"
  value: {
-  dps: 5014.08183
-  tps: 30408.43046
+  dps: 4740.0804
+  tps: 29028.13409
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CunningoftheCruel-78000"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 5080.11886
-  tps: 30648.9232
+  dps: 4802.95742
+  tps: 29290.63659
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 4932.22882
-  tps: 29698.95017
+  dps: 4670.44577
+  tps: 28424.64039
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 4801.98764
-  tps: 29248.6178
+  dps: 4532.86835
+  tps: 27847.88726
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 4678.15595
-  tps: 28532.03465
+  dps: 4388.42469
+  tps: 27047.34381
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 4704.80178
-  tps: 28704.5028
+  dps: 4392.38868
+  tps: 27126.55272
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 5061.40507
-  tps: 30811.84722
+  dps: 4752.97661
+  tps: 29226.18652
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EarthenBattleplate"
  value: {
-  dps: 4739.07464
-  tps: 28930.37392
+  dps: 4486.89896
+  tps: 27680.80823
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EarthenWarplate"
  value: {
-  dps: 5238.00055
-  tps: 31691.50824
+  dps: 4901.57881
+  tps: 29938.2122
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 4678.15595
-  tps: 28532.03465
+  dps: 4388.42469
+  tps: 27047.34381
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 4858.48461
-  tps: 29511.03921
+  dps: 4577.21351
+  tps: 28085.91273
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 4892.3815
-  tps: 29715.38302
+  dps: 4599.46949
+  tps: 28248.99944
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 5284.88725
-  tps: 32264.30974
+  dps: 4928.52081
+  tps: 30446.84632
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 5213.77364
-  tps: 31828.15264
+  dps: 4865.42069
+  tps: 30051.26809
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 5363.11222
-  tps: 32744.08256
+  dps: 4997.93094
+  tps: 30881.98237
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FallofMortality-59500"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FallofMortality-65124"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 4767.0836
-  tps: 29041.04649
+  dps: 4507.77656
+  tps: 27758.14871
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FireoftheDeep-77988"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FireoftheDeep-78008"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FluidDeath-58181"
  value: {
-  dps: 4883.27821
-  tps: 29670.41557
+  dps: 4686.07474
+  tps: 28752.02456
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 4764.19816
-  tps: 29002.94648
+  dps: 4477.63629
+  tps: 27550.53431
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GaleofShadows-56138"
  value: {
-  dps: 4704.21833
-  tps: 28655.44545
+  dps: 4419.19381
+  tps: 27198.50507
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GaleofShadows-56462"
  value: {
-  dps: 4709.11404
-  tps: 28647.07127
+  dps: 4456.4681
+  tps: 27403.74145
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GearDetector-61462"
  value: {
-  dps: 4712.12875
-  tps: 28700.99682
+  dps: 4476.55958
+  tps: 27473.70731
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Gladiator'sBattlegear"
  value: {
-  dps: 4660.39872
-  tps: 28354.10316
+  dps: 4441.05216
+  tps: 27289.98457
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 4742.2907
-  tps: 28890.95663
+  dps: 4458.51127
+  tps: 27435.09007
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 4794.47996
-  tps: 29167.72161
+  dps: 4512.22711
+  tps: 27726.99348
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HarmlightToken-63839"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 4828.8549
-  tps: 29468.13739
+  dps: 4534.85548
+  tps: 27965.79661
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HeartofRage-59224"
  value: {
-  dps: 5139.20461
-  tps: 31388.73333
+  dps: 4846.43696
+  tps: 29897.11791
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HeartofRage-65072"
  value: {
-  dps: 5204.25113
-  tps: 31859.02861
+  dps: 4934.76477
+  tps: 30475.7239
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HeartofSolace-55868"
  value: {
-  dps: 4863.11942
-  tps: 29625.17417
+  dps: 4560.99272
+  tps: 28085.54598
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HeartofSolace-56393"
  value: {
-  dps: 4958.46436
-  tps: 30174.93671
+  dps: 4710.52443
+  tps: 28952.32767
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HeartofThunder-55845"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HeartofThunder-56370"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 4753.19561
-  tps: 28946.02062
+  dps: 4471.08688
+  tps: 27505.71312
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Heartpierce-50641"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 4678.15595
-  tps: 28532.03465
+  dps: 4388.42469
+  tps: 27047.34381
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IndomitablePride-77211"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IndomitablePride-77983"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IndomitablePride-78003"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 4805.48038
-  tps: 29151.4369
+  dps: 4517.93425
+  tps: 27688.08988
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 4763.02199
-  tps: 28899.79574
+  dps: 4507.63817
+  tps: 27655.74861
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 4796.99504
-  tps: 29045.35942
+  dps: 4534.41536
+  tps: 27750.04818
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 4836.9222
-  tps: 29512.26041
+  dps: 4550.26875
+  tps: 28044.368
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 4865.76326
-  tps: 29579.5715
+  dps: 4590.65751
+  tps: 28209.18905
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 4721.07121
-  tps: 28702.51351
+  dps: 4495.7441
+  tps: 27588.92243
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-KiroptyricSigil-77984"
  value: {
-  dps: 4738.9331
-  tps: 28788.23285
+  dps: 4499.32529
+  tps: 27581.13014
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-KiroptyricSigil-78004"
  value: {
-  dps: 4719.7886
-  tps: 28605.05846
+  dps: 4487.41931
+  tps: 27480.66158
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 4726.74348
-  tps: 28749.91386
+  dps: 4401.95159
+  tps: 27118.95036
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 4726.74348
-  tps: 28749.91386
+  dps: 4401.95159
+  tps: 27118.95036
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-LastWord-50708"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-LeadenDespair-55816"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-LeadenDespair-56347"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 4851.27373
-  tps: 29520.63692
+  dps: 4615.68105
+  tps: 28365.51065
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 4899.0359
-  tps: 29796.21501
+  dps: 4629.28629
+  tps: 28447.97601
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 5064.26405
-  tps: 30852.93346
+  dps: 4837.65883
+  tps: 29768.6894
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 4708.91345
-  tps: 28720.10114
+  dps: 4475.75679
+  tps: 27564.90552
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 4825.45925
-  tps: 29401.68071
+  dps: 4559.0083
+  tps: 28046.87874
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 4841.91393
-  tps: 29548.29202
+  dps: 4547.28746
+  tps: 28042.72267
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 4865.85549
-  tps: 29695.24217
+  dps: 4570.07942
+  tps: 28183.75377
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 4764.19816
-  tps: 29002.94648
+  dps: 4475.9188
+  tps: 27539.96443
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 4772.6023
-  tps: 29046.68566
+  dps: 4486.65601
+  tps: 27600.78842
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 4764.90991
-  tps: 29094.57674
+  dps: 4514.97937
+  tps: 27872.96133
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 4767.0836
-  tps: 29041.04649
+  dps: 4507.77656
+  tps: 27758.14871
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 4761.80131
-  tps: 28990.96224
+  dps: 4469.94308
+  tps: 27501.0871
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MoltenGiantBattleplate"
  value: {
-  dps: 5021.42724
-  tps: 30400.62746
+  dps: 4799.21881
+  tps: 29302.35618
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MoltenGiantWarplate"
  value: {
-  dps: 5795.29934
-  tps: 35065.2852
+  dps: 5531.55712
+  tps: 33709.74363
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-No'Kaled,theElementsofDeath-77188"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-No'Kaled,theElementsofDeath-78472"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-No'Kaled,theElementsofDeath-78481"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 4799.83483
-  tps: 29290.01599
+  dps: 4507.22886
+  tps: 27794.84982
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 4710.65805
-  tps: 28711.22651
+  dps: 4429.76806
+  tps: 27279.17631
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 4820.29356
-  tps: 29264.97038
+  dps: 4578.59173
+  tps: 28017.45139
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 4795.52951
-  tps: 29131.4449
+  dps: 4559.29935
+  tps: 27950.86577
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Rainsong-55854"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Rainsong-56377"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Rathrak,thePoisonousMind-77195"
  value: {
-  dps: 4162.58906
-  tps: 25862.7909
+  dps: 3990.52742
+  tps: 24999.25406
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Rathrak,thePoisonousMind-78475"
  value: {
-  dps: 4279.04846
-  tps: 26445.08789
+  dps: 4097.87062
+  tps: 25535.97003
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Rathrak,thePoisonousMind-78484"
  value: {
-  dps: 4059.11737
-  tps: 25345.43243
+  dps: 3895.1544
+  tps: 24522.38896
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ReflectionoftheLight-77986"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ReflectionoftheLight-78006"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 4721.58269
-  tps: 28798.55095
+  dps: 4431.7182
+  tps: 27315.93326
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 4682.21129
-  tps: 28556.97214
+  dps: 4394.24315
+  tps: 27084.13297
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 4745.66673
-  tps: 28900.68813
+  dps: 4459.80758
+  tps: 27450.40961
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 4911.06029
-  tps: 29985.79949
+  dps: 4645.33634
+  tps: 28688.70993
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 4943.60014
-  tps: 30095.33289
+  dps: 4674.57277
+  tps: 28780.15278
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RosaryofLight-72901"
  value: {
-  dps: 5100.17961
-  tps: 31036.13959
+  dps: 4804.81557
+  tps: 29554.92372
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RottingSkull-77116"
  value: {
-  dps: 4828.39971
-  tps: 29351.79206
+  dps: 4535.75064
+  tps: 27877.51074
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RottingSkull-77987"
  value: {
-  dps: 4799.62948
-  tps: 29190.92825
+  dps: 4512.62996
+  tps: 27737.78901
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RottingSkull-78007"
  value: {
-  dps: 4853.40212
-  tps: 29494.93358
+  dps: 4556.4586
+  tps: 27992.3978
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RuneofZeth-68998"
  value: {
-  dps: 4784.48155
-  tps: 29111.49228
+  dps: 4498.53656
+  tps: 27665.60352
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ScalesofLife-68915"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ScalesofLife-69109"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 4714.685
-  tps: 28737.00183
+  dps: 4430.85663
+  tps: 27286.33767
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SeaStar-55256"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SeaStar-56290"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShardofWoe-60233"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 4830.22206
-  tps: 29478.42768
+  dps: 4564.5085
+  tps: 28136.31967
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 4716.54745
-  tps: 28746.31406
+  dps: 4433.51933
+  tps: 27301.36969
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 4729.44544
-  tps: 28812.19554
+  dps: 4442.8085
+  tps: 27349.53401
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Sorrowsong-55879"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Sorrowsong-56400"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 4749.79163
-  tps: 29011.66239
+  dps: 4506.6605
+  tps: 27817.42434
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SoulCasket-58183"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Souldrinker-77193"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Souldrinker-78479"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Souldrinker-78488"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 4937.26079
-  tps: 29896.17627
+  dps: 4637.64396
+  tps: 28442.0434
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 4902.12609
-  tps: 29746.11765
+  dps: 4640.33919
+  tps: 28378.21298
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 4928.23933
-  tps: 29829.48733
+  dps: 4705.55896
+  tps: 28741.34559
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StayofExecution-68996"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StumpofTime-62465"
  value: {
-  dps: 4784.20199
-  tps: 29139.56849
+  dps: 4583.64436
+  tps: 28182.64674
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StumpofTime-62470"
  value: {
-  dps: 4784.20199
-  tps: 29139.56849
+  dps: 4583.64436
+  tps: 28182.64674
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 4848.43495
-  tps: 29580.45975
+  dps: 4591.56634
+  tps: 28231.38622
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TearofBlood-55819"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TearofBlood-56351"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheHungerer-68927"
  value: {
-  dps: 4830.52366
-  tps: 29295.84655
+  dps: 4581.60334
+  tps: 28102.65788
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheHungerer-69112"
  value: {
-  dps: 4791.84575
-  tps: 29035.57616
+  dps: 4598.06068
+  tps: 28163.53618
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 4730.16629
-  tps: 28815.61144
+  dps: 4443.45106
+  tps: 27352.55852
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 4742.26416
-  tps: 28881.76844
+  dps: 4455.08654
+  tps: 27423.51372
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 4728.07347
-  tps: 28730.24262
+  dps: 4477.5264
+  tps: 27490.4791
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-UnheededWarning-59520"
  value: {
-  dps: 4856.5475
-  tps: 29586.17972
+  dps: 4566.77286
+  tps: 28109.24644
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 3792.44544
-  tps: 24078.49029
+  dps: 3631.35495
+  tps: 23281.87832
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 4936.95466
-  tps: 30131.6396
+  dps: 4637.76464
+  tps: 28602.57342
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-VeilofLies-72900"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 5029.47513
-  tps: 30637.00514
+  dps: 4743.95496
+  tps: 29201.12282
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 5079.19463
-  tps: 30938.85649
+  dps: 4794.93155
+  tps: 29521.6062
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-VialofShadows-77207"
  value: {
-  dps: 5137.96363
-  tps: 30880.96866
+  dps: 4888.68592
+  tps: 29664.30195
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-VialofShadows-77979"
  value: {
-  dps: 5103.66606
-  tps: 30735.83445
+  dps: 4845.26666
+  tps: 29442.15859
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-VialofShadows-77999"
  value: {
-  dps: 5239.27562
-  tps: 31465.59012
+  dps: 4976.93517
+  tps: 30152.109
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 4811.30526
-  tps: 29305.36862
+  dps: 4603.7382
+  tps: 28302.83377
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 4755.39081
-  tps: 28901.38942
+  dps: 4467.50881
+  tps: 27465.69283
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 4767.53781
-  tps: 29019.64471
+  dps: 4482.09075
+  tps: 27577.96216
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 4868.76102
-  tps: 29770.63203
+  dps: 4623.0464
+  tps: 28510.55024
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 4752.60153
-  tps: 28931.68938
+  dps: 4460.56628
+  tps: 27454.07779
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 4888.17326
-  tps: 29820.75036
+  dps: 4585.2434
+  tps: 28273.1795
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Vishanka,JawsoftheEarth-78359"
  value: {
-  dps: 4631.38672
-  tps: 28182.81722
+  dps: 4358.13707
+  tps: 26792.31304
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Vishanka,JawsoftheEarth-78471"
  value: {
-  dps: 4731.82386
-  tps: 28719.46275
+  dps: 4412.15712
+  tps: 27024.30754
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Vishanka,JawsoftheEarth-78480"
  value: {
-  dps: 4615.83833
-  tps: 28112.84179
+  dps: 4348.08167
+  tps: 26777.755
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WillofUnbinding-77995"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 4899.25761
-  tps: 29743.2421
+  dps: 4604.43878
+  tps: 28259.37267
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 4870.32069
-  tps: 29581.30542
+  dps: 4574.55358
+  tps: 28090.07298
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 4930.43609
-  tps: 29908.77391
+  dps: 4630.35881
+  tps: 28409.38742
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 4659.08749
-  tps: 28426.12721
+  dps: 4373.23975
+  tps: 26965.75787
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Average-Default"
  value: {
-  dps: 14596.88538
-  tps: 84084.22982
+  dps: 13659.78076
+  tps: 79406.82472
   dtps: 14665.21819
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p1_bis-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 24352.81032
-  tps: 139555.02707
+  dps: 20307.32993
+  tps: 119372.28482
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p1_bis-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 5260.49504
-  tps: 32206.26926
+  dps: 5017.68689
+  tps: 30983.77653
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p1_bis-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 5765.71231
-  tps: 34864.73599
+  dps: 5414.24072
+  tps: 33046.97582
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p1_bis-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17522.8975
-  tps: 100586.19335
+  dps: 14536.09946
+  tps: 85645.065
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p1_bis-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 3460.16763
-  tps: 21367.40141
+  dps: 3318.27677
+  tps: 20647.17566
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p1_bis-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 3232.96084
-  tps: 20146.32217
+  dps: 3139.87375
+  tps: 19688.22931
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p3_bis-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 25612.96911
-  tps: 145809.65396
+  dps: 21402.11926
+  tps: 124806.80967
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p3_bis-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 5770.80829
-  tps: 34690.95168
+  dps: 5545.56544
+  tps: 33586.27738
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p3_bis-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 6368.7395
-  tps: 37832.72128
+  dps: 6118.6539
+  tps: 36617.99748
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p3_bis-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 18296.42887
-  tps: 104120.99834
+  dps: 15169.30478
+  tps: 88492.43106
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p3_bis-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 3819.0004
-  tps: 23199.21977
+  dps: 3641.95467
+  tps: 22301.5849
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p3_bis-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 3639.51228
-  tps: 22264.50853
+  dps: 3434.12404
+  tps: 21167.82734
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-preraid-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 22251.17998
-  tps: 127438.69449
+  dps: 18575.16839
+  tps: 109142.55822
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-preraid-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 4818.69582
-  tps: 29541.40244
+  dps: 4554.0423
+  tps: 28153.20387
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-preraid-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 5282.53303
-  tps: 31978.78139
+  dps: 4949.45706
+  tps: 30238.25169
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-preraid-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 16007.36812
-  tps: 91870.74531
+  dps: 13274.71472
+  tps: 78205.102
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-preraid-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 3158.95467
-  tps: 19589.18309
+  dps: 3029.33845
+  tps: 18934.06223
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-preraid-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2993.66673
-  tps: 18698.71693
+  dps: 2896.88319
+  tps: 18214.6045
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p1_bis-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 24288.98731
-  tps: 139262.25247
+  dps: 20188.31882
+  tps: 118770.51547
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p1_bis-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 5231.25574
-  tps: 31917.22316
+  dps: 4976.4978
+  tps: 30644.03591
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p1_bis-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 5775.20924
-  tps: 34848.06562
+  dps: 5402.17757
+  tps: 32902.55183
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p1_bis-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17514.24706
-  tps: 100528.62392
+  dps: 14536.12964
+  tps: 85626.05942
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p1_bis-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 3424.26634
-  tps: 21157.30114
+  dps: 3290.22243
+  tps: 20487.12196
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p1_bis-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 3212.46042
-  tps: 19999.3573
+  dps: 3106.17596
+  tps: 19460.68957
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p3_bis-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 25515.76678
-  tps: 145295.10342
+  dps: 21308.28118
+  tps: 124281.70117
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p3_bis-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 5765.29119
-  tps: 34575.97436
+  dps: 5535.88695
+  tps: 33464.46875
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p3_bis-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 6346.22533
-  tps: 37685.58736
+  dps: 6093.1692
+  tps: 36396.41586
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p3_bis-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 18297.78476
-  tps: 104219.71529
+  dps: 15154.60267
+  tps: 88508.16219
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p3_bis-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 3800.32221
-  tps: 23100.89898
+  dps: 3615.94693
+  tps: 22146.91911
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p3_bis-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 3607.46174
-  tps: 22051.47425
+  dps: 3412.23534
+  tps: 21026.4299
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-preraid-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 22264.54339
-  tps: 127549.22716
+  dps: 18583.6766
+  tps: 109212.85685
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-preraid-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 4794.27409
-  tps: 29365.57546
+  dps: 4558.26874
+  tps: 28199.43159
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-preraid-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 5271.44441
-  tps: 31922.90035
+  dps: 4945.29162
+  tps: 30244.3213
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-preraid-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 16014.92567
-  tps: 91895.08585
+  dps: 13287.83136
+  tps: 78258.55346
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-preraid-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 3153.66334
-  tps: 19514.67763
+  dps: 3019.28371
+  tps: 18831.51505
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-preraid-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 2951.54452
-  tps: 18439.31704
+  dps: 2864.99045
+  tps: 18013.32124
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 16921.6699
-  tps: 97216.20763
+  dps: 16017.71869
+  tps: 92721.34031
   dtps: 14796.67444
  }
 }

--- a/sim/warrior/rend.go
+++ b/sim/warrior/rend.go
@@ -45,7 +45,11 @@ func (warrior *Warrior) RegisterRendSpell() {
 			NumberOfTicks: dotTicks,
 			TickLength:    time.Second * 3,
 
-			OnSnapshot: func(sim *core.Simulation, target *core.Unit, dot *core.Dot, _ bool) {
+			OnSnapshot: func(sim *core.Simulation, target *core.Unit, dot *core.Dot, isRollover bool) {
+				if isRollover {
+					return
+				}
+
 				weaponMH := warrior.AutoAttacks.MH()
 				avgMHDamage := weaponMH.CalculateAverageWeaponDamage(dot.Spell.MeleeAttackPower())
 

--- a/sim/warrior/rend.go
+++ b/sim/warrior/rend.go
@@ -61,7 +61,7 @@ func (warrior *Warrior) RegisterRendSpell() {
 			if result.Landed() {
 				dot := spell.Dot(target)
 
-				// Rend ticks once on application, including on refreshes
+				// Rend ticks once on application
 				dot.Apply(sim)
 				dot.TickOnce(sim)
 			} else {

--- a/sim/warrior/talents.go
+++ b/sim/warrior/talents.go
@@ -252,8 +252,14 @@ func (warrior *Warrior) applyBloodAndThunder() {
 			for _, target := range sim.Encounter.TargetUnits {
 				rend := warrior.Rend.Dot(target)
 				lastAppliedTime = int64(sim.CurrentTime)
-				rend.Apply(sim)
-				rend.TickOnce(sim)
+
+				if rend.IsActive() {
+					rend.ApplyRollover(sim)
+				} else {
+					rend.Apply(sim)
+					rend.TickOnce(sim)
+				}
+
 			}
 		},
 	})


### PR DESCRIPTION
rend ticking on mortal strike/thunder clap refreshes was fixed with the new patch.

old:
![image](https://github.com/user-attachments/assets/acf6942a-54ac-4dad-ade1-7ebd83a974de)

new:
![image](https://github.com/user-attachments/assets/8e8d6872-544f-4ce7-851a-fcc282a4fcdd)
![image](https://github.com/user-attachments/assets/19d4f9e0-1081-4a86-9248-46bd2b336169)
