### PR TITLE
[DK] Move Frost Death Knight to phase 3 and fix APL for normal trinkets

### DIFF
--- a/sim/common/cata/stat_bonus_procs.go
+++ b/sim/common/cata/stat_bonus_procs.go
@@ -437,7 +437,7 @@ func init() {
 		Duration:   time.Second * 20,
 		Callback:   core.CallbackOnSpellHitDealt,
 		ProcMask:   core.ProcMaskMeleeOrMeleeProc,
-		Outcome:    core.OutcomeParry,
+		Outcome:    core.OutcomeLanded,
 		ProcChance: 0.1,
 		ICD:        time.Second * 100,
 	})

--- a/sim/death_knight/blood/TestBlood.results
+++ b/sim/death_knight/blood/TestBlood.results
@@ -846,8 +846,8 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-HeartofSolace-55868"
  value: {
-  dps: 22309.53102
-  tps: 111836.44905
+  dps: 22651.4274
+  tps: 113660.8777
   hps: 5482.62922
  }
 }

--- a/sim/death_knight/frost/TestFrost.results
+++ b/sim/death_knight/frost/TestFrost.results
@@ -6,9 +6,9 @@ character_stats_results: {
   final_stats: 7965.3
   final_stats: 55.65
   final_stats: 85
-  final_stats: 816
+  final_stats: 818
   final_stats: 676
-  final_stats: 1756
+  final_stats: 1754
   final_stats: 411.08159
   final_stats: 122
   final_stats: 2202.20268
@@ -28,8 +28,8 @@ character_stats_results: {
   final_stats: 154539.2
   final_stats: 0
   final_stats: 326
-  final_stats: 9.79384
-  final_stats: 16.96519
+  final_stats: 9.81049
+  final_stats: 16.98471
   final_stats: 11.72817
   final_stats: 8.77064
   final_stats: 5
@@ -38,3080 +38,2504 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 40084.81291
-  tps: 37373.90035
-  hps: 516.93362
+  dps: 40479.79054
+  tps: 37753.19823
+  hps: 517.70632
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 603.85033
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 606.11809
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 38237.45384
-  tps: 36167.95
-  hps: 508.43397
+  dps: 38777.98861
+  tps: 36515.27197
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 37826.69415
-  tps: 35724.43995
-  hps: 517.70632
+  dps: 38263.07224
+  tps: 35988.54982
+  hps: 516.16093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 37870.67287
-  tps: 35777.74561
-  hps: 519.25171
+  dps: 38332.4058
+  tps: 36048.22353
+  hps: 518.47902
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 38945.11361
-  tps: 36807.85556
-  hps: 508.43397
+  dps: 40090.21311
+  tps: 37755.68717
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ArrowofTime-72897"
  value: {
-  dps: 38374.44268
-  tps: 36102.09644
-  hps: 531.61485
+  dps: 38868.3902
+  tps: 36400.41524
+  hps: 523.88789
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 39590.95425
-  tps: 36889.17515
-  hps: 520.13787
+  dps: 39935.59771
+  tps: 37225.2653
+  hps: 521.69516
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 37576.0562
-  tps: 35506.55236
-  hps: 508.43397
+  dps: 38109.97941
+  tps: 35847.26277
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 37933.87212
-  tps: 35832.89605
+  dps: 38535.77968
+  tps: 36239.18096
   hps: 516.16093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 37975.66508
-  tps: 35869.53245
+  dps: 38582.97778
+  tps: 36284.08138
   hps: 516.16093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BindingPromise-67037"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 37930.37531
-  tps: 35860.87147
-  hps: 508.43397
+  dps: 38468.02102
+  tps: 36205.30438
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 37992.1655
-  tps: 35922.66166
-  hps: 508.43397
+  dps: 38530.39255
+  tps: 36267.67591
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 38053.95569
-  tps: 35984.45185
-  hps: 508.43397
+  dps: 38592.76408
+  tps: 36330.04744
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 37892.63582
-  tps: 35793.16738
+  dps: 38491.44692
+  tps: 36197.45481
   hps: 516.16093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 37711.99813
-  tps: 35611.52163
+  dps: 38313.6419
+  tps: 36032.43926
   hps: 508.43397
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 38743.48203
-  tps: 36606.08239
-  hps: 508.43397
+  dps: 39271.47519
+  tps: 36962.58159
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 40016.19326
-  tps: 37876.4643
-  hps: 508.43397
+  dps: 40499.45095
+  tps: 38143.29284
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 39738.25359
-  tps: 37605.51311
-  hps: 508.43397
+  dps: 40211.17789
+  tps: 37872.6602
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 40370.40388
-  tps: 38222.20403
-  hps: 508.43397
+  dps: 40846.75945
+  tps: 38478.98328
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BottledLightning-66879"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BottledWishes-77114"
  value: {
-  dps: 38036.6637
-  tps: 35746.66232
-  hps: 537.02372
+  dps: 38451.73771
+  tps: 36054.61359
+  hps: 533.16024
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BottledWishes-77985"
  value: {
-  dps: 38296.77327
-  tps: 36061.8505
-  hps: 520.7971
+  dps: 38343.75641
+  tps: 36054.57453
+  hps: 515.38823
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BottledWishes-78005"
  value: {
-  dps: 38093.97979
-  tps: 35848.00088
-  hps: 540.1145
+  dps: 38450.95052
+  tps: 35959.94593
+  hps: 532.38754
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 39571.64259
-  tps: 36132.46622
-  hps: 516.16093
+  dps: 39916.27127
+  tps: 36461.82009
+  hps: 517.70632
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 40280.33101
-  tps: 37567.63192
-  hps: 516.16093
+  dps: 40630.61652
+  tps: 37909.40966
+  hps: 517.70632
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 40075.25046
-  tps: 37373.47136
-  hps: 516.16093
+  dps: 40425.48135
+  tps: 37715.14894
+  hps: 517.70632
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 40118.8061
-  tps: 37406.86486
-  hps: 516.93362
+  dps: 40515.24779
+  tps: 37786.6988
+  hps: 517.70632
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 38590.59569
-  tps: 36490.99356
+  dps: 39196.90335
+  tps: 36902.23977
   hps: 516.16093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 39806.97625
-  tps: 37503.78126
-  hps: 536.25102
+  dps: 40369.69808
+  tps: 37847.16713
+  hps: 540.8872
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 39500.81919
-  tps: 37266.93742
-  hps: 534.70563
+  dps: 40174.5346
+  tps: 37715.30361
+  hps: 537.79642
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 40128.5081
-  tps: 37843.68892
-  hps: 538.56911
+  dps: 40768.67906
+  tps: 38212.54877
+  hps: 544.75068
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CrushingWeight-59506"
  value: {
-  dps: 39062.52008
-  tps: 36727.15776
-  hps: 520.7971
+  dps: 39666.38748
+  tps: 37099.71456
+  hps: 524.66058
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CrushingWeight-65118"
  value: {
-  dps: 39687.98851
-  tps: 37176.70569
-  hps: 529.29676
+  dps: 40060.69979
+  tps: 37549.27383
+  hps: 525.43328
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 37918.254
-  tps: 35848.75016
-  hps: 508.43397
+  dps: 38483.03077
+  tps: 36220.31413
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 37820.51427
-  tps: 35751.01043
-  hps: 508.43397
+  dps: 38440.32056
+  tps: 36177.60392
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CunningoftheCruel-78000"
  value: {
-  dps: 37997.62087
-  tps: 35928.11703
-  hps: 508.43397
+  dps: 38569.84012
+  tps: 36307.12348
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 39442.27052
-  tps: 37291.56919
-  hps: 502.2524
+  dps: 39791.33913
+  tps: 37486.89295
+  hps: 504.57049
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 38457.46554
-  tps: 36333.22784
-  hps: 502.2524
+  dps: 38800.8492
+  tps: 36525.27279
+  hps: 504.57049
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 38154.63326
-  tps: 36085.12942
-  hps: 508.43397
+  dps: 38699.52028
+  tps: 36436.80364
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 38419.59418
-  tps: 36260.11749
-  hps: 519.25171
+  dps: 38651.05374
+  tps: 36245.19611
+  hps: 522.3425
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 39612.81124
-  tps: 36900.87
-  hps: 516.93362
+  dps: 40002.68929
+  tps: 37274.1403
+  hps: 517.70632
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 37645.17415
-  tps: 35662.36515
-  hps: 512.29745
+  dps: 38045.52166
+  tps: 35912.13047
+  hps: 513.07014
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 39356.29986
-  tps: 37177.26695
-  hps: 518.47902
+  dps: 40015.8176
+  tps: 37629.13602
+  hps: 519.25171
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 39571.64259
-  tps: 36869.86349
-  hps: 520.13787
+  dps: 39916.27127
+  tps: 37205.93887
+  hps: 521.69516
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ElementiumDeathplateBattlearmor"
  value: {
-  dps: 33317.43131
-  tps: 30988.88686
-  hps: 471.31558
+  dps: 33976.06886
+  tps: 31600.66436
+  hps: 470.54546
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ElementiumDeathplateBattlegear"
  value: {
-  dps: 36331.12103
-  tps: 33782.04938
-  hps: 516.75287
+  dps: 36744.46997
+  tps: 34127.59601
+  hps: 519.06324
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 39571.64259
-  tps: 36869.86349
-  hps: 516.16093
+  dps: 39916.27127
+  tps: 37205.93887
+  hps: 517.70632
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 39612.81124
-  tps: 36900.87
-  hps: 516.93362
+  dps: 40002.68929
+  tps: 37274.1403
+  hps: 517.70632
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 38181.32001
-  tps: 36023.98542
-  hps: 521.5698
+  dps: 38672.06267
+  tps: 36318.2565
+  hps: 520.02441
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 38237.58584
-  tps: 36104.14302
-  hps: 519.25171
+  dps: 38825.03109
+  tps: 36473.19452
+  hps: 522.3425
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 39414.07178
-  tps: 37265.42748
+  dps: 39946.51635
+  tps: 37645.20785
   hps: 507.66127
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 39571.64259
-  tps: 36869.86349
-  hps: 520.13787
+  dps: 39916.27127
+  tps: 37205.93887
+  hps: 521.69516
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 40771.88406
-  tps: 38548.23464
-  hps: 508.43397
+  dps: 41323.27259
+  tps: 38891.51033
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 40402.38736
-  tps: 38196.25448
-  hps: 508.43397
+  dps: 40951.77581
+  tps: 38539.22328
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 41178.33043
-  tps: 38935.41281
-  hps: 508.43397
+  dps: 41731.91906
+  tps: 39279.02609
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FallofMortality-59500"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38007.45724
+  tps: 35743.74972
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FallofMortality-65124"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 37870.67287
-  tps: 35777.74561
-  hps: 519.25171
+  dps: 38332.4058
+  tps: 36048.22353
+  hps: 518.47902
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 529.08497
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 529.88905
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 38053.95569
-  tps: 35984.45185
-  hps: 508.43397
+  dps: 38592.76408
+  tps: 36330.04744
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 38377.8861
-  tps: 36308.38226
-  hps: 508.43397
+  dps: 38919.74208
+  tps: 36657.02544
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FireoftheDeep-77988"
  value: {
-  dps: 38280.51973
-  tps: 36211.0159
-  hps: 508.43397
+  dps: 38821.45967
+  tps: 36558.74304
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FireoftheDeep-78008"
  value: {
-  dps: 38488.35947
-  tps: 36418.85564
-  hps: 508.43397
+  dps: 39031.25481
+  tps: 36768.53817
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 39676.50146
-  tps: 36974.72236
-  hps: 516.16093
+  dps: 40021.35827
+  tps: 37311.02586
+  hps: 517.70632
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FluidDeath-58181"
  value: {
-  dps: 38121.57445
-  tps: 35989.83181
-  hps: 520.02441
+  dps: 38594.47436
+  tps: 36283.93513
+  hps: 518.47902
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 39571.64259
-  tps: 36869.86349
-  hps: 516.16093
+  dps: 39916.27127
+  tps: 37205.93887
+  hps: 517.70632
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 38355.74124
-  tps: 36286.2374
-  hps: 508.43397
+  dps: 38910.97593
+  tps: 36648.25929
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 37933.87212
-  tps: 35832.89605
+  dps: 38535.77968
+  tps: 36239.18096
   hps: 516.16093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GaleofShadows-56138"
  value: {
-  dps: 37863.21086
-  tps: 35631.88466
-  hps: 507.66127
+  dps: 38304.01604
+  tps: 35981.88407
+  hps: 509.97936
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GaleofShadows-56462"
  value: {
-  dps: 38241.70783
-  tps: 36022.01086
+  dps: 38294.14722
+  tps: 36009.10901
   hps: 516.16093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GearDetector-61462"
  value: {
-  dps: 37954.5763
-  tps: 35671.2525
-  hps: 523.88789
+  dps: 38402.99888
+  tps: 36002.98872
+  hps: 519.25171
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 37779.87575
-  tps: 35691.24086
-  hps: 511.52475
+  dps: 38367.70264
+  tps: 36068.92283
+  hps: 509.97936
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 37851.67353
-  tps: 35709.95789
-  hps: 520.7971
+  dps: 38513.86647
+  tps: 36158.2995
+  hps: 515.38823
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Gurthalak,VoiceoftheDeeps-77191"
  value: {
-  dps: 40280.33101
-  tps: 37567.63192
-  hps: 516.16093
+  dps: 40630.61652
+  tps: 37909.40966
+  hps: 517.70632
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Gurthalak,VoiceoftheDeeps-78478"
  value: {
-  dps: 40280.33101
-  tps: 37567.63192
-  hps: 516.16093
+  dps: 40630.61652
+  tps: 37909.40966
+  hps: 517.70632
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Gurthalak,VoiceoftheDeeps-78487"
  value: {
-  dps: 40280.33101
-  tps: 37567.63192
-  hps: 516.16093
+  dps: 40630.61652
+  tps: 37909.40966
+  hps: 517.70632
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HarmlightToken-63839"
  value: {
-  dps: 37634.65227
-  tps: 35565.14843
-  hps: 508.43397
+  dps: 38169.74567
+  tps: 35907.02903
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 38772.80077
-  tps: 36661.9014
-  hps: 508.43397
+  dps: 39309.29847
+  tps: 37001.22397
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartofRage-59224"
  value: {
-  dps: 39535.55752
-  tps: 37297.80427
-  hps: 514.61554
+  dps: 40251.789
+  tps: 37535.9124
+  hps: 509.97936
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartofSolace-55868"
  value: {
-  dps: 37863.21086
-  tps: 35631.88466
-  hps: 507.66127
+  dps: 38268.06479
+  tps: 35940.09783
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartofSolace-56393"
  value: {
-  dps: 39750.687
-  tps: 37116.66721
+  dps: 40048.70252
+  tps: 37400.75987
   hps: 516.16093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartofThunder-55845"
  value: {
-  dps: 37557.66315
-  tps: 35488.15931
-  hps: 508.43397
+  dps: 38091.54168
+  tps: 35828.82504
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartofThunder-56370"
  value: {
-  dps: 37569.72275
-  tps: 35500.21891
-  hps: 508.43397
+  dps: 38103.63057
+  tps: 35840.91393
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 37832.10936
-  tps: 35743.06269
-  hps: 511.52475
+  dps: 38360.25355
+  tps: 36056.71046
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 39612.81124
-  tps: 36900.87
-  hps: 516.93362
+  dps: 40002.68929
+  tps: 37274.1403
+  hps: 517.70632
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 38121.36318
-  tps: 36051.85934
-  hps: 508.43397
+  dps: 39797.55995
+  tps: 37401.68877
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 39265.92627
-  tps: 37122.85803
-  hps: 506.88858
+  dps: 39797.55995
+  tps: 37401.68877
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 37992.1655
-  tps: 35922.66166
-  hps: 508.43397
+  dps: 38530.39255
+  tps: 36267.67591
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 38053.95569
-  tps: 35984.45185
-  hps: 508.43397
+  dps: 38592.76408
+  tps: 36330.04744
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IndomitablePride-77211"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 541.65935
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 542.48254
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IndomitablePride-77983"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 537.88704
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 538.70449
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IndomitablePride-78003"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 545.91529
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 546.74495
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 38005.45533
-  tps: 35850.92776
-  hps: 539.34181
+  dps: 38589.2054
+  tps: 36237.51541
+  hps: 536.25102
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 38214.53789
-  tps: 35902.17969
-  hps: 538.56911
+  dps: 38505.42908
+  tps: 36189.48101
+  hps: 530.84215
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 38238.09083
-  tps: 35868.89326
-  hps: 536.25102
+  dps: 38648.51006
+  tps: 36261.16775
+  hps: 543.97798
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 37883.56456
-  tps: 35814.06072
-  hps: 508.43397
+  dps: 38420.76987
+  tps: 36158.05323
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 37930.37531
-  tps: 35860.87147
-  hps: 508.43397
+  dps: 38468.02102
+  tps: 36205.30438
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 38027.48237
-  tps: 35885.67606
+  dps: 38319.80599
+  tps: 36022.74265
   hps: 514.61554
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 38119.37231
-  tps: 36009.57381
-  hps: 519.25171
+  dps: 38549.33697
+  tps: 36253.368
+  hps: 516.93362
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 38036.6637
-  tps: 35746.66232
-  hps: 537.02372
+  dps: 38451.73771
+  tps: 36054.61359
+  hps: 533.16024
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KiroptyricSigil-77984"
  value: {
-  dps: 38296.77327
-  tps: 36061.8505
-  hps: 520.7971
+  dps: 38343.75641
+  tps: 36054.57453
+  hps: 515.38823
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KiroptyricSigil-78004"
  value: {
-  dps: 38093.97979
-  tps: 35848.00088
-  hps: 540.1145
+  dps: 38450.95052
+  tps: 35959.94593
+  hps: 532.38754
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 37667.52281
-  tps: 35673.91774
-  hps: 512.29745
+  dps: 38120.12389
+  tps: 35893.6134
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 37667.52281
-  tps: 35673.91774
-  hps: 512.29745
+  dps: 38120.12389
+  tps: 35893.6134
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LastWord-50708"
  value: {
-  dps: 40280.33101
-  tps: 37567.63192
-  hps: 516.16093
+  dps: 40630.61652
+  tps: 37909.40966
+  hps: 517.70632
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LeadenDespair-55816"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 524.05522
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 524.85165
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LeadenDespair-56347"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 529.08497
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 529.88905
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 38134.49404
-  tps: 36005.57791
-  hps: 507.66127
+  dps: 38482.37728
+  tps: 36195.36968
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 38221.02028
-  tps: 36096.26549
-  hps: 510.75206
+  dps: 38591.18159
+  tps: 36293.06196
+  hps: 513.07014
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 39284.60443
-  tps: 37111.84456
-  hps: 520.02441
+  dps: 39771.53664
+  tps: 37416.34756
+  hps: 518.47902
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MagmaPlatedBattlearmor"
  value: {
-  dps: 31646.83975
-  tps: 29335.70051
-  hps: 444.3798
+  dps: 31983.33803
+  tps: 29619.17609
+  hps: 446.5797
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MagmaPlatedBattlegear"
  value: {
-  dps: 34694.418
-  tps: 32110.81208
-  hps: 499.3773
+  dps: 34962.58219
+  tps: 32350.61718
+  hps: 496.4441
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 37852.24035
-  tps: 35748.63962
-  hps: 507.66127
+  dps: 38220.28904
+  tps: 35971.66174
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 37966.46259
-  tps: 35859.82076
-  hps: 510.75206
+  dps: 38307.80295
+  tps: 36055.03195
+  hps: 516.16093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 38457.77976
-  tps: 36343.69612
-  hps: 508.43397
+  dps: 38996.61688
+  tps: 36685.05332
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 38580.54325
-  tps: 36460.62178
-  hps: 508.43397
+  dps: 39120.04159
+  tps: 36802.08141
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 38756.05546
-  tps: 36655.8816
+  dps: 39384.32455
+  tps: 37088.4368
   hps: 508.43397
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 38914.03649
-  tps: 36809.3084
+  dps: 39531.96206
+  tps: 37233.79995
   hps: 508.43397
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 37820.04606
-  tps: 35693.70313
-  hps: 512.29745
+  dps: 38084.82012
+  tps: 35796.89376
+  hps: 514.61554
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 37870.67287
-  tps: 35777.74561
-  hps: 519.25171
+  dps: 38332.4058
+  tps: 36048.22353
+  hps: 518.47902
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 38121.36318
-  tps: 36051.85934
-  hps: 508.43397
+  dps: 38660.80574
+  tps: 36398.0891
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 38121.36318
-  tps: 36051.85934
-  hps: 508.43397
+  dps: 38660.80574
+  tps: 36398.0891
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 37897.14282
-  tps: 35797.54069
+  dps: 38498.88502
+  tps: 36204.22144
   hps: 516.16093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 533.0991
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 533.90928
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 38228.38689
-  tps: 36158.88305
-  hps: 508.43397
+  dps: 38768.65492
+  tps: 36505.93828
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 38319.16557
-  tps: 36249.66173
-  hps: 508.43397
+  dps: 38860.26441
+  tps: 36597.54777
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-NecroticBoneplateBattlegear"
  value: {
-  dps: 35526.93814
-  tps: 32918.4679
-  hps: 509.40313
+  dps: 35570.84218
+  tps: 32995.81199
+  hps: 502.60102
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-No'Kaled,theElementsofDeath-77188"
  value: {
-  dps: 40280.33101
-  tps: 37567.63192
-  hps: 516.16093
+  dps: 40630.61652
+  tps: 37909.40966
+  hps: 517.70632
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-No'Kaled,theElementsofDeath-78472"
  value: {
-  dps: 40280.33101
-  tps: 37567.63192
-  hps: 516.16093
+  dps: 40630.61652
+  tps: 37909.40966
+  hps: 517.70632
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-No'Kaled,theElementsofDeath-78481"
  value: {
-  dps: 40280.33101
-  tps: 37567.63192
-  hps: 516.16093
+  dps: 40630.61652
+  tps: 37909.40966
+  hps: 517.70632
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 38242.01363
-  tps: 36138.19042
-  hps: 508.43397
+  dps: 38779.6886
+  tps: 36479.36758
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 37701.22016
-  tps: 35634.81716
-  hps: 508.43397
+  dps: 38036.02249
+  tps: 35738.2504
+  hps: 507.66127
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 37552.24067
-  tps: 35482.73684
-  hps: 508.43397
+  dps: 38086.10602
+  tps: 35823.38938
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 37769.087
-  tps: 35684.80665
-  hps: 513.07014
+  dps: 38294.63984
+  tps: 36014.37072
+  hps: 513.84284
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 37897.31205
-  tps: 35827.80821
-  hps: 508.43397
+  dps: 38436.80514
+  tps: 36174.0885
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 38214.90642
-  tps: 36145.40258
-  hps: 508.43397
+  dps: 38755.11367
+  tps: 36492.39703
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 39571.64259
-  tps: 36869.86349
-  hps: 520.13787
+  dps: 39916.27127
+  tps: 37205.93887
+  hps: 521.69516
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 38169.51186
-  tps: 36024.11315
-  hps: 523.11519
+  dps: 38547.35728
+  tps: 36281.6432
+  hps: 532.38754
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 38149.11823
-  tps: 35983.89022
-  hps: 535.47833
+  dps: 38748.53123
+  tps: 36419.06649
+  hps: 531.61485
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Rainsong-55854"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Rainsong-56377"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReflectionoftheLight-77986"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReflectionoftheLight-78006"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 40280.33101
-  tps: 37567.63192
-  hps: 516.16093
+  dps: 40630.61652
+  tps: 37909.40966
+  hps: 517.70632
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 40075.25046
-  tps: 37373.47136
-  hps: 516.16093
+  dps: 40425.48135
+  tps: 37715.14894
+  hps: 517.70632
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 37757.67005
-  tps: 35662.42984
-  hps: 508.43397
+  dps: 38276.06186
+  tps: 35983.98596
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 38864.99942
-  tps: 36713.08546
-  hps: 517.70632
+  dps: 39322.57617
+  tps: 36978.57482
+  hps: 516.16093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 39053.84773
-  tps: 36912.34721
-  hps: 519.25171
+  dps: 39537.66624
+  tps: 37196.99226
+  hps: 518.47902
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RosaryofLight-72901"
  value: {
-  dps: 39593.90465
-  tps: 37407.25608
-  hps: 519.25171
+  dps: 40241.59176
+  tps: 37845.89322
+  hps: 521.5698
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RottingSkull-77116"
  value: {
-  dps: 38091.94509
-  tps: 35976.27257
-  hps: 518.47902
+  dps: 38694.28199
+  tps: 36380.69727
+  hps: 517.70632
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RottingSkull-77987"
  value: {
-  dps: 38031.79763
-  tps: 35920.81003
-  hps: 517.70632
+  dps: 38639.63163
+  tps: 36334.65778
+  hps: 516.93362
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RottingSkull-78007"
  value: {
-  dps: 38174.97133
-  tps: 36052.45654
-  hps: 520.02441
+  dps: 38775.86063
+  tps: 36454.90731
+  hps: 519.25171
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuneofZeth-68998"
  value: {
-  dps: 37996.53306
-  tps: 35889.14966
+  dps: 38604.74465
+  tps: 36302.27435
   hps: 516.93362
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScalesofLife-68915"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 536.24269
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 537.05765
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScalesofLife-69109"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 539.86992
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 540.69039
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 38068.55048
-  tps: 35982.4974
-  hps: 508.43397
+  dps: 38592.33786
+  tps: 36311.3424
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SeaStar-55256"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SeaStar-56290"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Shadowmourne-49623"
  value: {
-  dps: 40280.33101
-  tps: 37567.63192
-  hps: 516.16093
+  dps: 40630.61652
+  tps: 37909.40966
+  hps: 517.70632
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShardofWoe-60233"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 38655.2886
-  tps: 36396.61423
-  hps: 517.70632
+  dps: 38946.85026
+  tps: 36549.0392
+  hps: 516.93362
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 520.91162
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 521.70328
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 37704.44294
-  tps: 35616.68878
-  hps: 508.43397
+  dps: 38234.35116
+  tps: 35952.01145
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 37722.3175
-  tps: 35631.05043
-  hps: 508.43397
+  dps: 38245.0738
+  tps: 35959.87649
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sorrowsong-55879"
  value: {
-  dps: 37992.1655
-  tps: 35922.66166
-  hps: 508.43397
+  dps: 38530.39255
+  tps: 36267.67591
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sorrowsong-56400"
  value: {
-  dps: 38053.95569
-  tps: 35984.45185
-  hps: 508.43397
+  dps: 38592.76408
+  tps: 36330.04744
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 37826.69415
-  tps: 35724.43995
-  hps: 517.70632
+  dps: 38263.07224
+  tps: 35988.54982
+  hps: 516.16093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SoulCasket-58183"
  value: {
-  dps: 38121.36318
-  tps: 36051.85934
-  hps: 508.43397
+  dps: 38660.80574
+  tps: 36398.0891
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Souldrinker-77193"
  value: {
-  dps: 40280.33101
-  tps: 37567.63192
-  hps: 516.16093
+  dps: 40630.61652
+  tps: 37909.40966
+  hps: 517.70632
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Souldrinker-78479"
  value: {
-  dps: 40280.33101
-  tps: 37567.63192
-  hps: 516.16093
+  dps: 40630.61652
+  tps: 37909.40966
+  hps: 517.70632
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Souldrinker-78488"
  value: {
-  dps: 40280.33101
-  tps: 37567.63192
-  hps: 516.16093
+  dps: 40630.61652
+  tps: 37909.40966
+  hps: 517.70632
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 38650.61341
-  tps: 36581.10957
-  hps: 541.65935
+  dps: 39219.70823
+  tps: 36956.99159
+  hps: 542.48254
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 38521.24959
-  tps: 36451.74575
-  hps: 537.88704
+  dps: 39103.21247
+  tps: 36840.49583
+  hps: 538.70449
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 38799.10296
-  tps: 36729.59912
-  hps: 545.91529
+  dps: 39377.88596
+  tps: 37115.16932
+  hps: 546.74495
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 38237.45384
-  tps: 36167.95
-  hps: 508.43397
+  dps: 38777.98861
+  tps: 36515.27197
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 38331.07535
-  tps: 36261.57151
-  hps: 508.43397
+  dps: 38872.49092
+  tps: 36609.77428
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 38393.4972
-  tps: 36231.85973
+  dps: 38761.16214
+  tps: 36445.51507
   hps: 538.56911
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 38158.92667
-  tps: 35848.84885
-  hps: 532.38754
+  dps: 38620.64884
+  tps: 36300.77233
+  hps: 531.61485
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 38517.31395
-  tps: 36233.90085
-  hps: 542.43259
+  dps: 38999.54633
+  tps: 36578.58014
+  hps: 534.70563
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-StayofExecution-68996"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 37845.67911
-  tps: 35758.20889
+  dps: 38390.00621
+  tps: 36082.76556
   hps: 510.75206
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-StumpofTime-62465"
  value: {
-  dps: 37866.84059
-  tps: 35761.84048
-  hps: 520.02441
+  dps: 38347.5807
+  tps: 36066.02053
+  hps: 518.47902
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-StumpofTime-62470"
  value: {
-  dps: 37866.84059
-  tps: 35761.84048
-  hps: 520.02441
+  dps: 38347.5807
+  tps: 36066.02053
+  hps: 518.47902
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 531.74493
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 532.55306
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 534.74344
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 535.55612
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 37898.01466
-  tps: 35828.51082
-  hps: 508.43397
+  dps: 38433.4535
+  tps: 36170.73686
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 38678.58723
-  tps: 36394.31237
+  dps: 38901.53309
+  tps: 36514.45961
   hps: 524.66058
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TearofBlood-55819"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TearofBlood-56351"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 37922.88559
-  tps: 35853.38175
-  hps: 508.43397
+  dps: 38460.46084
+  tps: 36197.7442
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 38053.95569
-  tps: 35984.45185
-  hps: 508.43397
+  dps: 38592.76408
+  tps: 36330.04744
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheHungerer-68927"
  value: {
-  dps: 38275.61732
-  tps: 36018.63519
-  hps: 533.93294
+  dps: 38644.31042
+  tps: 36217.97712
+  hps: 532.38754
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheHungerer-69112"
  value: {
-  dps: 38268.79623
-  tps: 35949.0161
-  hps: 534.70563
+  dps: 38782.27353
+  tps: 36410.57756
+  hps: 533.93294
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 38151.55514
-  tps: 36082.0513
-  hps: 508.43397
+  dps: 38679.37918
+  tps: 36416.66254
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 38210.8636
-  tps: 36141.35976
-  hps: 508.43397
+  dps: 38770.31592
+  tps: 36507.59928
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 38193.91736
-  tps: 36107.78216
-  hps: 508.43397
+  dps: 38724.82727
+  tps: 36443.05355
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 38281.55011
-  tps: 36192.37302
-  hps: 508.43397
+  dps: 38809.49534
+  tps: 36523.8698
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 38026.05549
-  tps: 35933.31484
-  hps: 550.15955
+  dps: 38351.40022
+  tps: 36088.03448
+  hps: 543.20529
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UnheededWarning-59520"
  value: {
-  dps: 38224.52224
-  tps: 36130.86969
-  hps: 508.43397
+  dps: 38753.74316
+  tps: 36464.83667
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 38121.36318
-  tps: 36051.85934
-  hps: 508.43397
+  dps: 38660.80574
+  tps: 36398.0891
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 38121.36318
-  tps: 36051.85934
-  hps: 508.43397
+  dps: 38660.80574
+  tps: 36398.0891
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 38121.36318
-  tps: 36051.85934
-  hps: 508.43397
+  dps: 38660.80574
+  tps: 36398.0891
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 33803.56815
-  tps: 31268.93267
-  hps: 515.69744
+  dps: 34075.17798
+  tps: 31436.37948
+  hps: 511.71448
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 37832.51139
-  tps: 35763.23181
-  hps: 508.43397
+  dps: 38309.51762
+  tps: 36046.65091
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 37790.29476
-  tps: 35719.39074
-  hps: 507.66127
+  dps: 38372.28518
+  tps: 36109.56854
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 39841.83495
-  tps: 37704.57689
-  hps: 508.43397
+  dps: 40380.20057
+  tps: 38043.24436
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-VeilofLies-72900"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 536.24269
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 537.05765
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 39564.08744
-  tps: 37389.92373
+  dps: 40103.99525
+  tps: 37725.11674
   hps: 517.70632
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 39818.2659
-  tps: 37631.56484
+  dps: 40355.93374
+  tps: 37959.43922
   hps: 518.47902
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-VialofShadows-77207"
  value: {
-  dps: 38193.84238
-  tps: 36066.56948
-  hps: 509.20666
+  dps: 38728.26515
+  tps: 36442.28521
+  hps: 508.43397
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-VialofShadows-77979"
  value: {
-  dps: 38129.43209
-  tps: 36006.09753
-  hps: 509.20666
+  dps: 38651.66944
+  tps: 36364.5631
+  hps: 508.43397
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-VialofShadows-77999"
  value: {
-  dps: 38309.78472
-  tps: 36172.62798
-  hps: 509.20666
+  dps: 38826.77041
+  tps: 36526.36534
+  hps: 508.43397
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 531.74493
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 532.55306
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 534.74344
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 535.55612
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 37904.40885
-  tps: 35795.65798
-  hps: 521.5698
+  dps: 38333.78744
+  tps: 36049.49912
+  hps: 519.25171
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 38003.37782
-  tps: 35800.58167
-  hps: 516.16093
+  dps: 38442.24435
+  tps: 36175.2644
+  hps: 518.47902
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 37943.30112
-  tps: 35840.82197
+  dps: 38545.06104
+  tps: 36248.00395
   hps: 516.16093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 38011.3415
-  tps: 35913.44828
-  hps: 512.29745
+  dps: 38412.6433
+  tps: 36157.00719
+  hps: 511.52475
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 38156.93935
-  tps: 36087.43551
-  hps: 508.43397
+  dps: 38696.71662
+  tps: 36433.99998
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 37738.05058
-  tps: 35641.22845
+  dps: 38335.67708
+  tps: 36062.93599
   hps: 508.43397
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 38857.62177
-  tps: 36714.96996
-  hps: 508.43397
+  dps: 39362.68022
+  tps: 37058.40162
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WillofUnbinding-77995"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 508.43397
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 37778.98961
-  tps: 35637.82908
+  dps: 38124.51595
+  tps: 35790.37487
   hps: 520.02441
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 37925.15671
-  tps: 35787.1675
-  hps: 521.5698
+  dps: 38256.15308
+  tps: 35931.53642
+  hps: 522.3425
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 37930.37531
-  tps: 35860.87147
-  hps: 508.43397
+  dps: 38468.02102
+  tps: 36205.30438
+  hps: 509.20666
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 38050.42546
-  tps: 35924.96593
+  dps: 38661.85422
+  tps: 36339.95708
   hps: 508.43397
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 37983.25616
-  tps: 35865.66855
+  dps: 38575.79137
+  tps: 36264.63528
   hps: 508.43397
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 38127.55758
-  tps: 35995.96103
+  dps: 38752.32807
+  tps: 36418.18006
   hps: 508.43397
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 524.3454
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 525.14227
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 37520.31312
-  tps: 35450.80928
-  hps: 524.3454
+  dps: 38054.10089
+  tps: 35791.38425
+  hps: 525.14227
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 40568.12968
-  tps: 37901.25547
-  hps: 483.40253
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-DefaultTalents-Basic-2h-FullBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 88737.59411
-  tps: 86685.81583
-  hps: 618.098
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-DefaultTalents-Basic-2h-FullBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 36640.67259
-  tps: 34277.50512
-  hps: 572.51327
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-DefaultTalents-Basic-2h-FullBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 47580.29383
-  tps: 40395.74731
-  hps: 625.82423
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-DefaultTalents-Basic-2h-NoBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 58953.52661
-  tps: 57325.33413
-  hps: 515.73285
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-DefaultTalents-Basic-2h-NoBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 24929.34448
-  tps: 23257.61105
-  hps: 476.59865
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-DefaultTalents-Basic-2h-NoBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 30483.78285
-  tps: 25390.88176
-  hps: 524.11875
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-DefaultTalents-Basic-dw-FullBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 87801.53286
-  tps: 85736.09737
-  hps: 615.78013
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-DefaultTalents-Basic-dw-FullBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 36599.48825
-  tps: 34236.32079
-  hps: 572.51327
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-DefaultTalents-Basic-dw-FullBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 47572.19941
-  tps: 40387.65289
-  hps: 625.82423
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-DefaultTalents-Basic-dw-NoBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 58071.69841
-  tps: 56449.60773
-  hps: 512.23873
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-DefaultTalents-Basic-dw-NoBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 24895.15846
-  tps: 23223.42504
-  hps: 476.59865
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-DefaultTalents-Basic-dw-NoBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 30469.94047
-  tps: 25377.03937
-  hps: 524.11875
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-DefaultTalents-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 132164.45683
-  tps: 129586.52356
-  hps: 557.83344
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-DefaultTalents-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 39961.91555
-  tps: 37390.72255
-  hps: 515.33921
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-DefaultTalents-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 49807.02617
-  tps: 43548.95351
-  hps: 610.37177
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-DefaultTalents-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 88219.35414
-  tps: 86403.50892
-  hps: 459.82685
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-DefaultTalents-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 26769.27902
-  tps: 24988.92239
-  hps: 410.21027
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-DefaultTalents-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 31123.30929
-  tps: 26521.74383
-  hps: 461.2245
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-DualWield-Basic-2h-FullBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 73666.11092
-  tps: 71835.98066
-  hps: 244.14871
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-DualWield-Basic-2h-FullBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 25638.25508
-  tps: 23394.42547
-  hps: 239.51298
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-DualWield-Basic-2h-FullBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 34129.71158
-  tps: 27577.67797
-  hps: 254.96543
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-DualWield-Basic-2h-NoBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 48970.85346
-  tps: 47412.66766
-  hps: 190.0804
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-DualWield-Basic-2h-NoBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 17595.41536
-  tps: 15905.94757
-  hps: 188.68275
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-DualWield-Basic-2h-NoBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 21333.64783
-  tps: 16822.44072
-  hps: 164.22387
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-DualWield-Basic-dw-FullBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 73623.44649
-  tps: 71822.74611
-  hps: 244.14871
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-DualWield-Basic-dw-FullBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 25636.6362
-  tps: 23392.80659
-  hps: 239.51298
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-DualWield-Basic-dw-FullBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 34129.71158
-  tps: 27577.67797
-  hps: 254.96543
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-DualWield-Basic-dw-NoBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 48970.85346
-  tps: 47412.66766
-  hps: 190.0804
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-DualWield-Basic-dw-NoBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 17592.83589
-  tps: 15903.3681
-  hps: 188.68275
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-DualWield-Basic-dw-NoBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 21333.64783
-  tps: 16822.44072
-  hps: 164.22387
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-DualWield-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 129094.06084
-  tps: 126725.51821
-  hps: 247.2392
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-DualWield-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 29871.90607
-  tps: 27534.94812
-  hps: 243.37609
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-DualWield-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 38478.85056
-  tps: 32152.28612
-  hps: 258.82854
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-DualWield-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 84275.75725
-  tps: 82540.50505
-  hps: 186.58627
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-DualWield-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 19958.60567
-  tps: 18222.67956
-  hps: 190.77922
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-DualWield-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 23674.93268
-  tps: 19065.19098
-  hps: 160.72975
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-TwoHand-Basic-2h-FullBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 73666.11092
-  tps: 71835.98066
-  hps: 244.14871
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-TwoHand-Basic-2h-FullBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 25638.25508
-  tps: 23394.42547
-  hps: 239.51298
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-TwoHand-Basic-2h-FullBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 34129.71158
-  tps: 27577.67797
-  hps: 254.96543
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-TwoHand-Basic-2h-NoBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 48970.85346
-  tps: 47412.66766
-  hps: 190.0804
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-TwoHand-Basic-2h-NoBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 17595.41536
-  tps: 15905.94757
-  hps: 188.68275
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-TwoHand-Basic-2h-NoBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 21333.64783
-  tps: 16822.44072
-  hps: 164.22387
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-TwoHand-Basic-dw-FullBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 73623.44649
-  tps: 71822.74611
-  hps: 244.14871
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-TwoHand-Basic-dw-FullBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 25636.6362
-  tps: 23392.80659
-  hps: 239.51298
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-TwoHand-Basic-dw-FullBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 34129.71158
-  tps: 27577.67797
-  hps: 254.96543
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-TwoHand-Basic-dw-NoBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 48970.85346
-  tps: 47412.66766
-  hps: 190.0804
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-TwoHand-Basic-dw-NoBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 17592.83589
-  tps: 15903.3681
-  hps: 188.68275
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-TwoHand-Basic-dw-NoBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 21333.64783
-  tps: 16822.44072
-  hps: 164.22387
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-TwoHand-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 129094.06084
-  tps: 126725.51821
-  hps: 247.2392
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-TwoHand-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 29871.90607
-  tps: 27534.94812
-  hps: 243.37609
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-TwoHand-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 38478.85056
-  tps: 32152.28612
-  hps: 258.82854
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-TwoHand-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 84275.75725
-  tps: 82540.50505
-  hps: 186.58627
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-TwoHand-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 19958.60567
-  tps: 18222.67956
-  hps: 190.77922
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Human-p3.masterfrost-TwoHand-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 23674.93268
-  tps: 19065.19098
-  hps: 160.72975
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-DefaultTalents-Basic-2h-FullBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 89467.64804
-  tps: 87277.121
-  hps: 616.61141
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-DefaultTalents-Basic-2h-FullBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 36919.63703
-  tps: 34495.5602
-  hps: 577.97661
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-DefaultTalents-Basic-2h-FullBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 48472.67754
-  tps: 41027.92041
-  hps: 629.74724
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-DefaultTalents-Basic-2h-NoBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 59502.52407
-  tps: 57813.41827
-  hps: 513.68782
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-DefaultTalents-Basic-2h-NoBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 25327.74157
-  tps: 23530.46349
-  hps: 473.85081
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-DefaultTalents-Basic-2h-NoBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 30686.91602
-  tps: 25461.00404
-  hps: 513.68783
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-DefaultTalents-Basic-dw-FullBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 88423.79538
-  tps: 86230.40951
-  hps: 618.1568
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-DefaultTalents-Basic-dw-FullBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 36875.93936
-  tps: 34451.86253
-  hps: 577.97661
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-DefaultTalents-Basic-dw-FullBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 48464.58025
-  tps: 41019.82312
-  hps: 629.74724
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-DefaultTalents-Basic-dw-NoBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 58812.00705
-  tps: 57118.60032
-  hps: 511.59114
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-DefaultTalents-Basic-dw-NoBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 25295.19564
-  tps: 23497.91756
-  hps: 473.85081
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-DefaultTalents-Basic-dw-NoBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 30665.90913
-  tps: 25439.99715
-  hps: 513.68783
+  dps: 40890.97934
+  tps: 38165.52051
+  hps: 483.40518
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3.masterfrost-DefaultTalents-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 134515.90107
-  tps: 131816.1646
-  hps: 559.4319
+  dps: 135932.85398
+  tps: 133193.27512
+  hps: 562.52269
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3.masterfrost-DefaultTalents-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 40280.33101
-  tps: 37567.63192
-  hps: 516.16093
+  dps: 40630.61652
+  tps: 37909.40966
+  hps: 517.70632
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3.masterfrost-DefaultTalents-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 50631.35963
-  tps: 44166.72923
+  dps: 50820.42154
+  tps: 44348.81205
   hps: 610.42984
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3.masterfrost-DefaultTalents-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 89659.5134
-  tps: 87768.73211
-  hps: 459.17401
+  dps: 89510.53987
+  tps: 87626.71129
+  hps: 461.96959
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3.masterfrost-DefaultTalents-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 27171.33554
-  tps: 25298.42384
-  hps: 415.14363
+  dps: 27074.12998
+  tps: 25207.8102
+  hps: 412.34805
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3.masterfrost-DefaultTalents-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 31808.23691
-  tps: 27077.2493
-  hps: 468.25965
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-DualWield-Basic-2h-FullBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 74339.06407
-  tps: 72397.13832
-  hps: 248.03542
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-DualWield-Basic-2h-FullBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 25844.7429
-  tps: 23573.96022
-  hps: 245.71733
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-DualWield-Basic-2h-FullBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 34945.64954
-  tps: 28210.47657
-  hps: 251.1262
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-DualWield-Basic-2h-NoBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 49530.40984
-  tps: 47996.59164
-  hps: 190.09944
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-DualWield-Basic-2h-NoBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 17748.84855
-  tps: 16022.68267
-  hps: 192.19612
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-DualWield-Basic-2h-NoBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 21649.41763
-  tps: 17025.16578
-  hps: 160.74585
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-DualWield-Basic-dw-FullBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 74264.14238
-  tps: 72322.21663
-  hps: 248.03542
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-DualWield-Basic-dw-FullBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 25841.50398
-  tps: 23570.7213
-  hps: 245.71733
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-DualWield-Basic-dw-FullBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 34945.64954
-  tps: 28210.47657
-  hps: 251.1262
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-DualWield-Basic-dw-NoBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 49530.40984
-  tps: 47996.59164
-  hps: 190.09944
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-DualWield-Basic-dw-NoBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 17747.70017
-  tps: 16021.53428
-  hps: 192.19612
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-DualWield-Basic-dw-NoBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 21649.41763
-  tps: 17025.16578
-  hps: 160.74585
+  dps: 31547.99954
+  tps: 26813.54228
+  hps: 461.2707
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3.masterfrost-DualWield-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 130903.94845
-  tps: 128470.18458
-  hps: 248.80811
+  dps: 128996.51574
+  tps: 126262.21492
+  hps: 562.52269
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3.masterfrost-DualWield-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 30019.33988
-  tps: 27586.90921
-  hps: 241.08115
+  dps: 40159.44963
+  tps: 37438.17562
+  hps: 506.88858
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3.masterfrost-DualWield-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 39414.82841
-  tps: 32868.40145
-  hps: 270.4436
+  dps: 50549.3532
+  tps: 44083.85575
+  hps: 614.29332
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3.masterfrost-DualWield-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 85351.06009
-  tps: 83521.81113
-  hps: 189.40055
+  dps: 85264.65067
+  tps: 83373.30593
+  hps: 462.66849
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3.masterfrost-DualWield-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 20233.51225
-  tps: 18449.36535
-  hps: 192.89502
+  dps: 27055.96653
+  tps: 25180.82161
+  hps: 412.34805
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3.masterfrost-DualWield-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 24222.30868
-  tps: 19463.56757
-  hps: 164.24033
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-TwoHand-Basic-2h-FullBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 74339.06407
-  tps: 72397.13832
-  hps: 248.03542
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-TwoHand-Basic-2h-FullBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 25844.7429
-  tps: 23573.96022
-  hps: 245.71733
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-TwoHand-Basic-2h-FullBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 34945.64954
-  tps: 28210.47657
-  hps: 251.1262
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-TwoHand-Basic-2h-NoBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 49530.40984
-  tps: 47996.59164
-  hps: 190.09944
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-TwoHand-Basic-2h-NoBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 17748.84855
-  tps: 16022.68267
-  hps: 192.19612
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-TwoHand-Basic-2h-NoBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 21649.41763
-  tps: 17025.16578
-  hps: 160.74585
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-TwoHand-Basic-dw-FullBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 74264.14238
-  tps: 72322.21663
-  hps: 248.03542
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-TwoHand-Basic-dw-FullBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 25841.50398
-  tps: 23570.7213
-  hps: 245.71733
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-TwoHand-Basic-dw-FullBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 34945.64954
-  tps: 28210.47657
-  hps: 251.1262
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-TwoHand-Basic-dw-NoBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 49530.40984
-  tps: 47996.59164
-  hps: 190.09944
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-TwoHand-Basic-dw-NoBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 17747.70017
-  tps: 16021.53428
-  hps: 192.19612
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-TwoHand-Basic-dw-NoBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 21649.41763
-  tps: 17025.16578
-  hps: 160.74585
+  dps: 31455.93416
+  tps: 26704.19461
+  hps: 457.77622
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3.masterfrost-TwoHand-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 130903.94845
-  tps: 128470.18458
-  hps: 248.80811
+  dps: 130843.16336
+  tps: 128233.13287
+  hps: 244.94463
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3.masterfrost-TwoHand-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 30019.33988
-  tps: 27586.90921
-  hps: 241.08115
+  dps: 30481.68826
+  tps: 27888.92371
+  hps: 248.80811
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3.masterfrost-TwoHand-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 39414.82841
-  tps: 32868.40145
-  hps: 270.4436
+  dps: 39416.74877
+  tps: 32916.54626
+  hps: 266.58012
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3.masterfrost-TwoHand-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 85351.06009
-  tps: 83521.81113
-  hps: 189.40055
+  dps: 85014.22171
+  tps: 83142.82757
+  hps: 190.09944
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3.masterfrost-TwoHand-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 20233.51225
-  tps: 18449.36535
+  dps: 20222.66644
+  tps: 18441.02178
   hps: 192.89502
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3.masterfrost-TwoHand-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 24222.30868
-  tps: 19463.56757
-  hps: 164.24033
+  dps: 24086.8647
+  tps: 19321.15834
+  hps: 157.25138
+ }
+}
+dps_results: {
+ key: "TestFrost-Settings-Worgen-p3.masterfrost-DefaultTalents-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
+ value: {
+  dps: 134767.10071
+  tps: 132091.04837
+  hps: 565.55967
+ }
+}
+dps_results: {
+ key: "TestFrost-Settings-Worgen-p3.masterfrost-DefaultTalents-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
+ value: {
+  dps: 40381.37048
+  tps: 37731.21699
+  hps: 515.33921
+ }
+}
+dps_results: {
+ key: "TestFrost-Settings-Worgen-p3.masterfrost-DefaultTalents-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
+ value: {
+  dps: 50449.91205
+  tps: 44114.37286
+  hps: 621.96111
+ }
+}
+dps_results: {
+ key: "TestFrost-Settings-Worgen-p3.masterfrost-DefaultTalents-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
+ value: {
+  dps: 89614.66773
+  tps: 87772.98113
+  hps: 460.52568
+ }
+}
+dps_results: {
+ key: "TestFrost-Settings-Worgen-p3.masterfrost-DefaultTalents-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
+ value: {
+  dps: 27046.19304
+  tps: 25231.21487
+  hps: 417.89735
+ }
+}
+dps_results: {
+ key: "TestFrost-Settings-Worgen-p3.masterfrost-DefaultTalents-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
+ value: {
+  dps: 31266.85902
+  tps: 26594.3189
+  hps: 457.73038
+ }
+}
+dps_results: {
+ key: "TestFrost-Settings-Worgen-p3.masterfrost-DualWield-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
+ value: {
+  dps: 129126.06307
+  tps: 126469.33399
+  hps: 564.78705
+ }
+}
+dps_results: {
+ key: "TestFrost-Settings-Worgen-p3.masterfrost-DualWield-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
+ value: {
+  dps: 39994.95282
+  tps: 37350.24462
+  hps: 513.79396
+ }
+}
+dps_results: {
+ key: "TestFrost-Settings-Worgen-p3.masterfrost-DualWield-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
+ value: {
+  dps: 50044.32144
+  tps: 43714.46185
+  hps: 621.96111
+ }
+}
+dps_results: {
+ key: "TestFrost-Settings-Worgen-p3.masterfrost-DualWield-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
+ value: {
+  dps: 85372.28618
+  tps: 83542.07812
+  hps: 464.0198
+ }
+}
+dps_results: {
+ key: "TestFrost-Settings-Worgen-p3.masterfrost-DualWield-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
+ value: {
+  dps: 26752.96072
+  tps: 24944.2399
+  hps: 415.10205
+ }
+}
+dps_results: {
+ key: "TestFrost-Settings-Worgen-p3.masterfrost-DualWield-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
+ value: {
+  dps: 31083.66964
+  tps: 26392.85802
+  hps: 464.71863
+ }
+}
+dps_results: {
+ key: "TestFrost-Settings-Worgen-p3.masterfrost-TwoHand-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
+ value: {
+  dps: 131250.2157
+  tps: 128719.66146
+  hps: 248.01182
+ }
+}
+dps_results: {
+ key: "TestFrost-Settings-Worgen-p3.masterfrost-TwoHand-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
+ value: {
+  dps: 30406.90718
+  tps: 27875.43019
+  hps: 249.55707
+ }
+}
+dps_results: {
+ key: "TestFrost-Settings-Worgen-p3.masterfrost-TwoHand-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
+ value: {
+  dps: 38922.56032
+  tps: 32546.35839
+  hps: 262.69165
+ }
+}
+dps_results: {
+ key: "TestFrost-Settings-Worgen-p3.masterfrost-TwoHand-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
+ value: {
+  dps: 85266.06685
+  tps: 83494.87419
+  hps: 192.8757
+ }
+}
+dps_results: {
+ key: "TestFrost-Settings-Worgen-p3.masterfrost-TwoHand-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
+ value: {
+  dps: 20072.34289
+  tps: 18310.39327
+  hps: 193.57452
+ }
+}
+dps_results: {
+ key: "TestFrost-Settings-Worgen-p3.masterfrost-TwoHand-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
+ value: {
+  dps: 23871.5202
+  tps: 19187.85284
+  hps: 164.22388
  }
 }
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 37798.677
-  tps: 35439.51896
-  hps: 488.34387
+  dps: 38038.47065
+  tps: 35560.55474
+  hps: 486.79848
  }
 }

--- a/sim/death_knight/frost/TestFrost.results
+++ b/sim/death_knight/frost/TestFrost.results
@@ -838,9 +838,9 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-HeartofSolace-55868"
  value: {
-  dps: 38268.06479
-  tps: 35940.09783
-  hps: 509.20666
+  dps: 39969.18481
+  tps: 37325.23921
+  hps: 515.38823
  }
 }
 dps_results: {

--- a/sim/death_knight/frost/frost_test.go
+++ b/sim/death_knight/frost/frost_test.go
@@ -16,7 +16,7 @@ func TestFrost(t *testing.T) {
 	core.RunTestSuite(t, t.Name(), core.FullCharacterTestSuiteGenerator(core.CharacterSuiteConfig{
 		Class:      proto.Class_ClassDeathKnight,
 		Race:       proto.Race_RaceOrc,
-		OtherRaces: []proto.Race{proto.Race_RaceHuman},
+		OtherRaces: []proto.Race{proto.Race_RaceWorgen},
 
 		GearSet: core.GetGearSet("../../../ui/death_knight/frost/gear_sets", "p3.masterfrost"),
 		Talents: MasterfrostTalents,
@@ -36,16 +36,12 @@ func TestFrost(t *testing.T) {
 		Consumes:    FullConsumes,
 		SpecOptions: core.SpecOptionsCombo{Label: "Basic", SpecOptions: PlayerOptionsFrost},
 		Rotation:    core.GetAplRotation("../../../ui/death_knight/frost/apls", "masterfrost"),
-		OtherRotations: []core.RotationCombo{
-			core.GetAplRotation("../../../ui/death_knight/frost/apls", "2h"),
-			core.GetAplRotation("../../../ui/death_knight/frost/apls", "dw"),
-		},
 
 		ItemFilter: ItemFilter,
 	}))
 }
 
-var DualWieldTalents = "103-32030022233112012031-033"
+var DualWieldTalents = "2032-20330022233112012301-003"
 var TwoHandTalents = "103-32030022233112012031-033"
 var MasterfrostTalents = "2032-20330022233112012301-03"
 
@@ -74,11 +70,18 @@ var FullConsumes = &proto.Consumes{
 	DefaultPotion: proto.Potions_GolembloodPotion,
 	PrepopPotion:  proto.Potions_GolembloodPotion,
 	Food:          proto.Food_FoodBeerBasedCrocolisk,
+	TinkerHands:   proto.TinkerHands_TinkerHandsSynapseSprings,
 }
 
 var ItemFilter = core.ItemFilter{
 	ArmorType: proto.ArmorType_ArmorTypePlate,
 
+	HandTypes: []proto.HandType{
+		proto.HandType_HandTypeMainHand,
+		proto.HandType_HandTypeOffHand,
+		proto.HandType_HandTypeOneHand,
+		proto.HandType_HandTypeTwoHand,
+	},
 	WeaponTypes: []proto.WeaponType{
 		proto.WeaponType_WeaponTypeAxe,
 		proto.WeaponType_WeaponTypeSword,

--- a/sim/death_knight/unholy/TestUnholy.results
+++ b/sim/death_knight/unholy/TestUnholy.results
@@ -846,8 +846,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-HeartofSolace-55868"
  value: {
-  dps: 39862.95271
-  tps: 29502.12027
+  dps: 41343.57179
+  tps: 30506.56098
   hps: 652.77837
  }
 }

--- a/sim/death_knight/unholy/TestUnholy.results
+++ b/sim/death_knight/unholy/TestUnholy.results
@@ -838,17 +838,17 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-HeartofRage-59224"
  value: {
-  dps: 41550.44112
-  tps: 30772.59537
-  hps: 659.04755
+  dps: 41651.47082
+  tps: 30852.7826
+  hps: 655.91296
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HeartofSolace-55868"
  value: {
-  dps: 41343.57179
-  tps: 30506.56098
-  hps: 652.77837
+  dps: 41581.70927
+  tps: 30689.63805
+  hps: 655.12931
  }
 }
 dps_results: {

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -725,8 +725,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-55868"
  value: {
-  dps: 30887.36356
-  tps: 42704.70978
+  dps: 31349.74044
+  tps: 43122.0873
  }
 }
 dps_results: {

--- a/sim/druid/guardian/TestGuardian.results
+++ b/sim/druid/guardian/TestGuardian.results
@@ -830,8 +830,8 @@ dps_results: {
 dps_results: {
  key: "TestGuardian-AllItems-HeartofSolace-55868"
  value: {
-  dps: 9778.76326
-  tps: 48961.10399
+  dps: 9828.87285
+  tps: 49211.65198
   hps: 319.10667
  }
 }

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -760,8 +760,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-HeartofSolace-55868"
  value: {
-  dps: 36882.96566
-  tps: 36755.33926
+  dps: 37839.62146
+  tps: 37711.99505
  }
 }
 dps_results: {

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -732,7 +732,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-HeartofSolace-55868"
  value: {
-  dps: 38203.77832
+  dps: 38198.48411
   tps: 32565.08142
  }
 }

--- a/sim/rogue/assassination/TestAssassination.results
+++ b/sim/rogue/assassination/TestAssassination.results
@@ -748,8 +748,8 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-HeartofSolace-55868"
  value: {
-  dps: 27828.16199
-  tps: 19757.99502
+  dps: 28340.5694
+  tps: 20121.80427
  }
 }
 dps_results: {

--- a/sim/rogue/combat/TestCombat.results
+++ b/sim/rogue/combat/TestCombat.results
@@ -725,8 +725,8 @@ dps_results: {
 dps_results: {
  key: "TestCombat-AllItems-HeartofSolace-55868"
  value: {
-  dps: 28250.03858
-  tps: 20057.52739
+  dps: 28751.81201
+  tps: 20413.78653
  }
 }
 dps_results: {

--- a/sim/rogue/subtlety/TestSubtlety.results
+++ b/sim/rogue/subtlety/TestSubtlety.results
@@ -711,8 +711,8 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-HeartofSolace-55868"
  value: {
-  dps: 22347.02249
-  tps: 15866.38597
+  dps: 22701.59734
+  tps: 16118.13411
  }
 }
 dps_results: {

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -739,8 +739,8 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-HeartofSolace-55868"
  value: {
-  dps: 34885.46993
-  tps: 22419.37188
+  dps: 35437.50812
+  tps: 22740.13169
  }
 }
 dps_results: {

--- a/sim/warrior/arms/TestArms.results
+++ b/sim/warrior/arms/TestArms.results
@@ -760,8 +760,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-HeartofSolace-55868"
  value: {
-  dps: 30303.70846
-  tps: 19356.93407
+  dps: 31188.01864
+  tps: 19980.78928
  }
 }
 dps_results: {

--- a/sim/warrior/fury/TestFury.results
+++ b/sim/warrior/fury/TestFury.results
@@ -774,8 +774,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-HeartofSolace-55868"
  value: {
-  dps: 29420.86165
-  tps: 24399.58922
+  dps: 30576.32774
+  tps: 25444.23728
  }
 }
 dps_results: {

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -759,8 +759,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HeartofSolace-55868"
  value: {
-  dps: 4581.74085
-  tps: 28211.09597
+  dps: 4643.8244
+  tps: 28587.66841
  }
 }
 dps_results: {

--- a/ui/core/launched_sims.ts
+++ b/ui/core/launched_sims.ts
@@ -34,7 +34,7 @@ export const simLaunchStatuses: Record<Spec, SimStatus> = {
 		status: LaunchStatus.Launched,
 	},
 	[Spec.SpecFrostDeathKnight]: {
-		phase: Phase.Phase2,
+		phase: Phase.Phase3,
 		status: LaunchStatus.Launched,
 	},
 	[Spec.SpecUnholyDeathKnight]: {

--- a/ui/death_knight/frost/apls/2h.apl.json
+++ b/ui/death_knight/frost/apls/2h.apl.json
@@ -1,32 +1,364 @@
 {
 	"type": "TypeAPL",
 	"prepullActions": [
-	  {"action":{"castSpell":{"spellId":{"spellId":48265}}},"doAtValue":{"const":{"val":"-20s"}}},
-	  {"action":{"castSpell":{"spellId":{"spellId":42650}}},"doAtValue":{"const":{"val":"-6s"}}},
-	  {"action":{"castSpell":{"spellId":{"spellId":57330}}},"doAtValue":{"const":{"val":"-1s"}}}
+		{ "action": { "castSpell": { "spellId": { "spellId": 48265 } } }, "doAtValue": { "const": { "val": "-20s" } } },
+		{ "action": { "castSpell": { "spellId": { "spellId": 42650 } } }, "doAtValue": { "const": { "val": "-6s" } } },
+		{ "action": { "castSpell": { "spellId": { "spellId": 57330 } } }, "doAtValue": { "const": { "val": "-1s" } } },
+		{ "action": { "castSpell": { "spellId": { "otherId": "OtherActionPotion" } } }, "doAtValue": { "const": { "val": "-0.1s" } } }
 	],
 	"priorityList": [
-	  {"action":{"castSpell":{"spellId":{"spellId":2825,"tag":-1}}}},
-	  {"action":{"condition":{"and":{"vals":[{"cmp":{"op":"OpEq","lhs":{"currentRuneCount":{"runeType":"RuneDeath"}},"rhs":{"const":{"val":"0"}}}},{"cmp":{"op":"OpEq","lhs":{"currentRuneCount":{"runeType":"RuneFrost"}},"rhs":{"const":{"val":"0"}}}},{"cmp":{"op":"OpEq","lhs":{"currentRuneCount":{"runeType":"RuneUnholy"}},"rhs":{"const":{"val":"0"}}}},{"cmp":{"op":"OpGe","lhs":{"nextRuneCooldown":{"runeType":"RuneBlood"}},"rhs":{"const":{"val":"3.5s"}}}},{"cmp":{"op":"OpGe","lhs":{"nextRuneCooldown":{"runeType":"RuneFrost"}},"rhs":{"const":{"val":"3.5s"}}}},{"cmp":{"op":"OpGe","lhs":{"nextRuneCooldown":{"runeType":"RuneUnholy"}},"rhs":{"const":{"val":"3.5s"}}}},{"cmp":{"op":"OpLe","lhs":{"currentRunicPower":{}},"rhs":{"const":{"val":"30"}}}},{"cmp":{"op":"OpGt","lhs":{"currentTime":{}},"rhs":{"const":{"val":"10s"}}}}]}},"castSpell":{"spellId":{"spellId":47568}}}},
-	  {"action":{"condition":{"and":{"vals":[{"cmp":{"op":"OpEq","lhs":{"currentRuneCount":{"runeType":"RuneBlood"}},"rhs":{"const":{"val":"0"}}}},{"cmp":{"op":"OpGt","lhs":{"runeCooldown":{"runeType":"RuneBlood"}},"rhs":{"const":{"val":"5s"}}}}]}},"castSpell":{"spellId":{"spellId":45529}}}},
-	  {"action":{"condition":{"spellIsReady":{"spellId":{"spellId":51271}}},"castSpell":{"spellId":{"spellId":51271}}}},
-	  {"action":{"condition":{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":51271}}},{"spellIsReady":{"spellId":{"itemId":62469}}}]}},"castSpell":{"spellId":{"itemId":62469}}}},
-	  {"action":{"condition":{"or":{"vals":[{"spellIsReady":{"spellId":{"spellId":82174}}},{"cmp":{"op":"OpGt","lhs":{"currentTime":{}},"rhs":{"const":{"val":"20s"}}}}]}},"castSpell":{"spellId":{"spellId":82174}}}},
-	  {"action":{"condition":{"or":{"vals":[{"spellIsReady":{"spellId":{"spellId":82174}}},{"or":{"vals":[{"cmp":{"op":"OpGt","lhs":{"currentTime":{}},"rhs":{"const":{"val":"10s"}}}},{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":53365}}},{"auraIsActive":{"auraId":{"spellId":92342}}}]}}]}},{"not":{"val":{"auraIsKnown":{"auraId":{"itemId":62469}}}}}]}},"castSpell":{"spellId":{"spellId":82174}}}},
-	  {"action":{"condition":{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":51271}}},{"or":{"vals":[{"cmp":{"op":"OpGt","lhs":{"currentTime":{}},"rhs":{"const":{"val":"5s"}}}},{"auraIsActive":{"auraId":{"spellId":53365}}}]}},{"or":{"vals":[{"cmp":{"op":"OpGt","lhs":{"currentTime":{}},"rhs":{"const":{"val":"5s"}}}},{"auraIsActive":{"auraId":{"spellId":92342}}}]}}]}},"castSpell":{"spellId":{"spellId":33697}}}},
-	  {"action":{"condition":{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":51271}}},{"or":{"vals":[{"cmp":{"op":"OpGt","lhs":{"currentTime":{}},"rhs":{"const":{"val":"10s"}}}},{"auraIsActive":{"auraId":{"spellId":53365}}}]}},{"or":{"vals":[{"cmp":{"op":"OpGt","lhs":{"currentTime":{}},"rhs":{"const":{"val":"10s"}}}},{"auraIsActive":{"auraId":{"spellId":92342}}}]}}]}},"castSpell":{"spellId":{"spellId":26297}}}},
-	  {"action":{"condition":{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":51271}}},{"cmp":{"op":"OpGt","lhs":{"currentTime":{}},"rhs":{"const":{"val":"5s"}}}}]}},"castSpell":{"spellId":{"spellId":33697}}}},
-	  {"action":{"condition":{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":51271}}},{"cmp":{"op":"OpGt","lhs":{"currentTime":{}},"rhs":{"const":{"val":"10s"}}}}]}},"castSpell":{"spellId":{"spellId":26297}}}},
-	  {"action":{"condition":{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":51271}}},{"auraIsActive":{"auraId":{"itemId":58146}}},{"or":{"vals":[{"auraIsActive":{"auraId":{"itemId":62469}}},{"and":{"vals":[{"not":{"val":{"auraIsKnown":{"auraId":{"itemId":62469}}}}},{"or":{"vals":[{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":91364}}},{"auraIsActive":{"auraId":{"spellId":92345}}},{"auraIsActive":{"auraId":{"spellId":92342}}}]}},{"cmp":{"op":"OpLt","lhs":{"auraRemainingTime":{"auraId":{"spellId":51271}}},"rhs":{"const":{"val":"1s"}}}}]}}]}}]}},{"or":{"vals":[{"auraIsActive":{"auraId":{"spellId":53365}}},{"or":{"vals":[{"cmp":{"op":"OpLt","lhs":{"auraRemainingTime":{"auraId":{"spellId":51271}}},"rhs":{"const":{"val":"1s"}}}},{"cmp":{"op":"OpLt","lhs":{"auraRemainingTime":{"auraId":{"spellId":92342}}},"rhs":{"const":{"val":"1s"}}}}]}}]}},{"or":{"vals":[{"auraIsActive":{"auraId":{"spellId":92345}}},{"auraIsActive":{"auraId":{"spellId":91364}}},{"or":{"vals":[{"cmp":{"op":"OpLt","lhs":{"auraRemainingTime":{"auraId":{"spellId":51271}}},"rhs":{"const":{"val":"1s"}}}},{"cmp":{"op":"OpLt","lhs":{"auraRemainingTime":{"auraId":{"spellId":92342}}},"rhs":{"const":{"val":"1s"}}}}]}}]}}]}},"castSpell":{"spellId":{"spellId":46584}}}},
-	  {"action":{"condition":{"or":{"vals":[{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":51271}}}]}}]}},"castSpell":{"spellId":{"spellId":77575}}}},
-	  {"action":{"condition":{"cmp":{"op":"OpGe","lhs":{"currentRunicPower":{}},"rhs":{"const":{"val":"100"}}}},"castSpell":{"spellId":{"spellId":49143,"tag":1}}}},
-	  {"action":{"condition":{"not":{"val":{"dotIsActive":{"spellId":{"spellId":55095}}}}},"castSpell":{"spellId":{"spellId":49184}}}},
-	  {"action":{"condition":{"not":{"val":{"dotIsActive":{"spellId":{"spellId":55078}}}}},"castSpell":{"spellId":{"spellId":45462,"tag":1}}}},
-	  {"action":{"condition":{"auraIsActive":{"auraId":{"spellId":59052}}},"castSpell":{"spellId":{"spellId":49184}}}},
-	  {"action":{"castSpell":{"spellId":{"spellId":49020,"tag":1}}}},
-	  {"action":{"castSpell":{"spellId":{"spellId":49143,"tag":1}}}},
-	  {"action":{"condition":{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":51271}}},{"or":{"vals":[{"auraIsActive":{"auraId":{"spellId":53365}}},{"auraIsActive":{"auraId":{"spellId":92342}}}]}},{"spellIsReady":{"spellId":{"spellId":46584}}}]}},"castSpell":{"spellId":{"otherId":"OtherActionPotion"}}}},
-	  {"action":{"condition":{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":51271}}},{"or":{"vals":[{"auraIsActive":{"auraId":{"spellId":53365}}},{"auraIsActive":{"auraId":{"spellId":92342}}}]}},{"auraIsActive":{"auraId":{"itemId":58146}}}]}},"castSpell":{"spellId":{"spellId":46584}}}},
-	  {"action":{"castSpell":{"spellId":{"spellId":57330}}}}
-  ]
+		{ "action": { "castSpell": { "spellId": { "spellId": 2825, "tag": -1 } } } },
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "cmp": { "op": "OpEq", "lhs": { "currentRuneCount": { "runeType": "RuneDeath" } }, "rhs": { "const": { "val": "0" } } } },
+							{ "cmp": { "op": "OpEq", "lhs": { "currentRuneCount": { "runeType": "RuneFrost" } }, "rhs": { "const": { "val": "0" } } } },
+							{ "cmp": { "op": "OpEq", "lhs": { "currentRuneCount": { "runeType": "RuneUnholy" } }, "rhs": { "const": { "val": "0" } } } },
+							{ "cmp": { "op": "OpGe", "lhs": { "nextRuneCooldown": { "runeType": "RuneBlood" } }, "rhs": { "const": { "val": "3.5s" } } } },
+							{ "cmp": { "op": "OpGe", "lhs": { "nextRuneCooldown": { "runeType": "RuneFrost" } }, "rhs": { "const": { "val": "3.5s" } } } },
+							{ "cmp": { "op": "OpGe", "lhs": { "nextRuneCooldown": { "runeType": "RuneUnholy" } }, "rhs": { "const": { "val": "3.5s" } } } },
+							{ "cmp": { "op": "OpLe", "lhs": { "currentRunicPower": {} }, "rhs": { "const": { "val": "30" } } } },
+							{ "cmp": { "op": "OpGt", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "10s" } } } }
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 47568 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "cmp": { "op": "OpEq", "lhs": { "currentRuneCount": { "runeType": "RuneBlood" } }, "rhs": { "const": { "val": "0" } } } },
+							{ "cmp": { "op": "OpGt", "lhs": { "runeCooldown": { "runeType": "RuneBlood" } }, "rhs": { "const": { "val": "5s" } } } }
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 45529 } }
+			}
+		},
+		{ "action": { "castSpell": { "spellId": { "spellId": 51271 } } } },
+		{ "action": { "condition": { "auraIsActive": { "auraId": { "spellId": 51271 } } }, "castSpell": { "spellId": { "itemId": 62469 } } } },
+		{ "action": { "condition": { "auraIsActive": { "auraId": { "spellId": 51271 } } }, "castSpell": { "spellId": { "itemId": 62464 } } } },
+		{
+			"action": {
+				"condition": { "cmp": { "op": "OpGt", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "20s" } } } },
+				"castSpell": { "spellId": { "spellId": 82174 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"or": {
+						"vals": [
+							{
+								"or": {
+									"vals": [
+										{ "cmp": { "op": "OpGt", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "10s" } } } },
+										{
+											"and": {
+												"vals": [
+													{ "auraIsActive": { "auraId": { "spellId": 53365 } } },
+													{ "auraIsActive": { "auraId": { "spellId": 92342 } } },
+													{ "auraIsActive": { "auraId": { "spellId": 91821 } } }
+												]
+											}
+										}
+									]
+								}
+							},
+							{
+								"and": {
+									"vals": [
+										{ "not": { "val": { "auraIsKnown": { "auraId": { "itemId": 62469 } } } } },
+										{ "not": { "val": { "auraIsKnown": { "auraId": { "itemId": 62464 } } } } }
+									]
+								}
+							}
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 82174 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "auraIsActive": { "auraId": { "spellId": 51271 } } },
+							{
+								"or": {
+									"vals": [
+										{ "cmp": { "op": "OpGt", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "5s" } } } },
+										{ "auraIsActive": { "auraId": { "spellId": 53365 } } }
+									]
+								}
+							},
+							{
+								"or": {
+									"vals": [
+										{ "cmp": { "op": "OpGt", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "5s" } } } },
+										{ "auraIsActive": { "auraId": { "spellId": 92342 } } },
+										{ "auraIsActive": { "auraId": { "spellId": 91821 } } }
+									]
+								}
+							}
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 33697 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "auraIsActive": { "auraId": { "spellId": 51271 } } },
+							{
+								"or": {
+									"vals": [
+										{ "cmp": { "op": "OpGt", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "10s" } } } },
+										{ "auraIsActive": { "auraId": { "spellId": 53365 } } }
+									]
+								}
+							},
+							{
+								"or": {
+									"vals": [
+										{ "cmp": { "op": "OpGt", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "10s" } } } },
+										{ "auraIsActive": { "auraId": { "spellId": 92342 } } },
+										{ "auraIsActive": { "auraId": { "spellId": 91821 } } }
+									]
+								}
+							}
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 26297 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "auraIsActive": { "auraId": { "spellId": 51271 } } },
+							{ "cmp": { "op": "OpGt", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "5s" } } } }
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 33697 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "auraIsActive": { "auraId": { "spellId": 51271 } } },
+							{ "cmp": { "op": "OpGt", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "10s" } } } }
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 26297 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "auraIsActive": { "auraId": { "spellId": 51271 } } },
+							{ "auraIsActive": { "auraId": { "itemId": 58146 } } },
+							{
+								"or": {
+									"vals": [
+										{ "auraIsActive": { "auraId": { "itemId": 62469 } } },
+										{ "auraIsActive": { "auraId": { "itemId": 62464 } } },
+										{
+											"and": {
+												"vals": [
+													{ "not": { "val": { "auraIsKnown": { "auraId": { "itemId": 62469 } } } } },
+													{ "not": { "val": { "auraIsKnown": { "auraId": { "itemId": 62464 } } } } },
+													{
+														"or": {
+															"vals": [
+																{
+																	"and": {
+																		"vals": [
+																			{ "auraIsActive": { "auraId": { "spellId": 91364 } } },
+																			{ "auraIsActive": { "auraId": { "spellId": 91363 } } },
+																			{ "auraIsActive": { "auraId": { "spellId": 92345 } } },
+																			{ "auraIsActive": { "auraId": { "spellId": 91816 } } },
+																			{ "auraIsActive": { "auraId": { "spellId": 92342 } } },
+																			{ "auraIsActive": { "auraId": { "spellId": 91821 } } }
+																		]
+																	}
+																},
+																{
+																	"cmp": {
+																		"op": "OpLt",
+																		"lhs": { "auraRemainingTime": { "auraId": { "spellId": 51271 } } },
+																		"rhs": { "const": { "val": "1s" } }
+																	}
+																}
+															]
+														}
+													}
+												]
+											}
+										}
+									]
+								}
+							},
+							{
+								"or": {
+									"vals": [
+										{ "auraIsActive": { "auraId": { "spellId": 53365 } } },
+										{
+											"or": {
+												"vals": [
+													{
+														"cmp": {
+															"op": "OpLt",
+															"lhs": { "auraRemainingTime": { "auraId": { "spellId": 51271 } } },
+															"rhs": { "const": { "val": "1s" } }
+														}
+													},
+													{
+														"cmp": {
+															"op": "OpLt",
+															"lhs": { "auraRemainingTime": { "auraId": { "spellId": 92342 } } },
+															"rhs": { "const": { "val": "1s" } }
+														}
+													},
+													{
+														"cmp": {
+															"op": "OpLt",
+															"lhs": { "auraRemainingTime": { "auraId": { "spellId": 91821 } } },
+															"rhs": { "const": { "val": "1s" } }
+														}
+													}
+												]
+											}
+										}
+									]
+								}
+							},
+							{
+								"or": {
+									"vals": [
+										{ "auraIsActive": { "auraId": { "spellId": 92345 } } },
+										{ "auraIsActive": { "auraId": { "spellId": 91816 } } },
+										{ "auraIsActive": { "auraId": { "spellId": 91364 } } },
+										{ "auraIsActive": { "auraId": { "spellId": 91363 } } },
+										{
+											"or": {
+												"vals": [
+													{
+														"cmp": {
+															"op": "OpLt",
+															"lhs": { "auraRemainingTime": { "auraId": { "spellId": 51271 } } },
+															"rhs": { "const": { "val": "1s" } }
+														}
+													},
+													{
+														"cmp": {
+															"op": "OpLt",
+															"lhs": { "auraRemainingTime": { "auraId": { "spellId": 92342 } } },
+															"rhs": { "const": { "val": "1s" } }
+														}
+													},
+													{
+														"cmp": {
+															"op": "OpLt",
+															"lhs": { "auraRemainingTime": { "auraId": { "spellId": 91821 } } },
+															"rhs": { "const": { "val": "1s" } }
+														}
+													}
+												]
+											}
+										}
+									]
+								}
+							}
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 46584 } }
+			}
+		},
+		{ "action": { "condition": { "auraIsActive": { "auraId": { "spellId": 51271 } } }, "castSpell": { "spellId": { "spellId": 77575 } } } },
+		{
+			"action": {
+				"condition": { "cmp": { "op": "OpGe", "lhs": { "currentRunicPower": {} }, "rhs": { "const": { "val": "100" } } } },
+				"castSpell": { "spellId": { "spellId": 49143, "tag": 1 } }
+			}
+		},
+		{
+			"action": {
+				"condition": { "not": { "val": { "dotIsActive": { "spellId": { "spellId": 55095 } } } } },
+				"castSpell": { "spellId": { "spellId": 49184 } }
+			}
+		},
+		{
+			"action": {
+				"condition": { "not": { "val": { "dotIsActive": { "spellId": { "spellId": 55078 } } } } },
+				"castSpell": { "spellId": { "spellId": 45462, "tag": 1 } }
+			}
+		},
+		{ "action": { "condition": { "auraIsActive": { "auraId": { "spellId": 59052 } } }, "castSpell": { "spellId": { "spellId": 49184 } } } },
+		{ "action": { "castSpell": { "spellId": { "spellId": 49020, "tag": 1 } } } },
+		{ "action": { "castSpell": { "spellId": { "spellId": 49143, "tag": 1 } } } },
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "auraIsActive": { "auraId": { "spellId": 51271 } } },
+							{
+								"or": {
+									"vals": [
+										{ "auraIsActive": { "auraId": { "spellId": 53365 } } },
+										{ "auraIsActive": { "auraId": { "spellId": 92342 } } },
+										{ "auraIsActive": { "auraId": { "spellId": 91821 } } }
+									]
+								}
+							},
+							{ "spellIsReady": { "spellId": { "spellId": 46584 } } }
+						]
+					}
+				},
+				"castSpell": { "spellId": { "otherId": "OtherActionPotion" } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "auraIsActive": { "auraId": { "spellId": 51271 } } },
+							{
+								"or": {
+									"vals": [
+										{ "auraIsActive": { "auraId": { "spellId": 53365 } } },
+										{ "auraIsActive": { "auraId": { "spellId": 92342 } } },
+										{ "auraIsActive": { "auraId": { "spellId": 91821 } } }
+									]
+								}
+							},
+							{ "auraIsActive": { "auraId": { "itemId": 58146 } } }
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 46584 } }
+			}
+		},
+		{ "action": { "castSpell": { "spellId": { "spellId": 57330 } } } }
+	]
 }

--- a/ui/death_knight/frost/apls/dw.apl.json
+++ b/ui/death_knight/frost/apls/dw.apl.json
@@ -1,32 +1,379 @@
 {
-  "type": "TypeAPL",
-  "prepullActions": [
-	{"action":{"castSpell":{"spellId":{"spellId":48265}}},"doAtValue":{"const":{"val":"-20s"}}},
-	{"action":{"castSpell":{"spellId":{"spellId":42650}}},"doAtValue":{"const":{"val":"-6s"}}},
-	{"action":{"castSpell":{"spellId":{"spellId":57330}}},"doAtValue":{"const":{"val":"-1s"}}}
-  ],
-  "priorityList": [
-	{"action":{"castSpell":{"spellId":{"spellId":2825,"tag":-1}}}},
-	{"action":{"condition":{"and":{"vals":[{"cmp":{"op":"OpEq","lhs":{"currentRuneCount":{"runeType":"RuneDeath"}},"rhs":{"const":{"val":"0"}}}},{"cmp":{"op":"OpEq","lhs":{"currentRuneCount":{"runeType":"RuneFrost"}},"rhs":{"const":{"val":"0"}}}},{"cmp":{"op":"OpEq","lhs":{"currentRuneCount":{"runeType":"RuneUnholy"}},"rhs":{"const":{"val":"0"}}}},{"cmp":{"op":"OpGe","lhs":{"nextRuneCooldown":{"runeType":"RuneBlood"}},"rhs":{"const":{"val":"3.5s"}}}},{"cmp":{"op":"OpGe","lhs":{"nextRuneCooldown":{"runeType":"RuneFrost"}},"rhs":{"const":{"val":"3.5s"}}}},{"cmp":{"op":"OpGe","lhs":{"nextRuneCooldown":{"runeType":"RuneUnholy"}},"rhs":{"const":{"val":"3.5s"}}}},{"cmp":{"op":"OpLe","lhs":{"currentRunicPower":{}},"rhs":{"const":{"val":"30"}}}},{"cmp":{"op":"OpGt","lhs":{"currentTime":{}},"rhs":{"const":{"val":"10s"}}}}]}},"castSpell":{"spellId":{"spellId":47568}}}},
-	{"action":{"condition":{"and":{"vals":[{"cmp":{"op":"OpEq","lhs":{"currentRuneCount":{"runeType":"RuneBlood"}},"rhs":{"const":{"val":"0"}}}},{"cmp":{"op":"OpGt","lhs":{"runeCooldown":{"runeType":"RuneBlood"}},"rhs":{"const":{"val":"5s"}}}}]}},"castSpell":{"spellId":{"spellId":45529}}}},
-	{"action":{"condition":{"spellIsReady":{"spellId":{"spellId":51271}}},"castSpell":{"spellId":{"spellId":51271}}}},
-	{"action":{"condition":{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":51271}}},{"spellIsReady":{"spellId":{"itemId":62469}}}]}},"castSpell":{"spellId":{"itemId":62469}}}},
-	{"action":{"condition":{"or":{"vals":[{"spellIsReady":{"spellId":{"spellId":82174}}},{"cmp":{"op":"OpGt","lhs":{"currentTime":{}},"rhs":{"const":{"val":"20s"}}}}]}},"castSpell":{"spellId":{"spellId":82174}}}},
-	{"action":{"condition":{"or":{"vals":[{"spellIsReady":{"spellId":{"spellId":82174}}},{"or":{"vals":[{"cmp":{"op":"OpGt","lhs":{"currentTime":{}},"rhs":{"const":{"val":"10s"}}}},{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":53365}}},{"auraIsActive":{"auraId":{"spellId":92342}}}]}}]}},{"not":{"val":{"auraIsKnown":{"auraId":{"itemId":62469}}}}}]}},"castSpell":{"spellId":{"spellId":82174}}}},
-	{"action":{"condition":{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":51271}}},{"or":{"vals":[{"cmp":{"op":"OpGt","lhs":{"currentTime":{}},"rhs":{"const":{"val":"5s"}}}},{"auraIsActive":{"auraId":{"spellId":53365}}}]}},{"or":{"vals":[{"cmp":{"op":"OpGt","lhs":{"currentTime":{}},"rhs":{"const":{"val":"5s"}}}},{"auraIsActive":{"auraId":{"spellId":92342}}}]}}]}},"castSpell":{"spellId":{"spellId":33697}}}},
-	{"action":{"condition":{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":51271}}},{"or":{"vals":[{"cmp":{"op":"OpGt","lhs":{"currentTime":{}},"rhs":{"const":{"val":"10s"}}}},{"auraIsActive":{"auraId":{"spellId":53365}}}]}},{"or":{"vals":[{"cmp":{"op":"OpGt","lhs":{"currentTime":{}},"rhs":{"const":{"val":"10s"}}}},{"auraIsActive":{"auraId":{"spellId":92342}}}]}}]}},"castSpell":{"spellId":{"spellId":26297}}}},
-	{"action":{"condition":{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":51271}}},{"cmp":{"op":"OpGt","lhs":{"currentTime":{}},"rhs":{"const":{"val":"5s"}}}}]}},"castSpell":{"spellId":{"spellId":33697}}}},
-	{"action":{"condition":{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":51271}}},{"cmp":{"op":"OpGt","lhs":{"currentTime":{}},"rhs":{"const":{"val":"10s"}}}}]}},"castSpell":{"spellId":{"spellId":26297}}}},
-	{"action":{"condition":{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":51271}}},{"auraIsActive":{"auraId":{"itemId":58146}}},{"or":{"vals":[{"auraIsActive":{"auraId":{"itemId":62469}}},{"and":{"vals":[{"not":{"val":{"auraIsKnown":{"auraId":{"itemId":62469}}}}},{"or":{"vals":[{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":91364}}},{"auraIsActive":{"auraId":{"spellId":92345}}},{"auraIsActive":{"auraId":{"spellId":92342}}}]}},{"cmp":{"op":"OpLt","lhs":{"auraRemainingTime":{"auraId":{"spellId":51271}}},"rhs":{"const":{"val":"1s"}}}}]}}]}}]}},{"or":{"vals":[{"auraIsActive":{"auraId":{"spellId":53365}}},{"or":{"vals":[{"cmp":{"op":"OpLt","lhs":{"auraRemainingTime":{"auraId":{"spellId":51271}}},"rhs":{"const":{"val":"1s"}}}},{"cmp":{"op":"OpLt","lhs":{"auraRemainingTime":{"auraId":{"spellId":92342}}},"rhs":{"const":{"val":"1s"}}}}]}}]}},{"or":{"vals":[{"auraIsActive":{"auraId":{"spellId":92345}}},{"auraIsActive":{"auraId":{"spellId":91364}}},{"or":{"vals":[{"cmp":{"op":"OpLt","lhs":{"auraRemainingTime":{"auraId":{"spellId":51271}}},"rhs":{"const":{"val":"1s"}}}},{"cmp":{"op":"OpLt","lhs":{"auraRemainingTime":{"auraId":{"spellId":92342}}},"rhs":{"const":{"val":"1s"}}}}]}}]}}]}},"castSpell":{"spellId":{"spellId":46584}}}},
-	{"action":{"condition":{"or":{"vals":[{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":51271}}}]}}]}},"castSpell":{"spellId":{"spellId":77575}}}},
-	{"action":{"condition":{"cmp":{"op":"OpGe","lhs":{"currentRunicPower":{}},"rhs":{"const":{"val":"100"}}}},"castSpell":{"spellId":{"spellId":49143,"tag":1}}}},
-	{"action":{"condition":{"not":{"val":{"dotIsActive":{"spellId":{"spellId":55095}}}}},"castSpell":{"spellId":{"spellId":45477}}}},
-	{"action":{"condition":{"not":{"val":{"dotIsActive":{"spellId":{"spellId":55078}}}}},"castSpell":{"spellId":{"spellId":45462,"tag":1}}}},
-	{"action":{"condition":{"auraIsActive":{"auraId":{"spellId":59052}}},"castSpell":{"spellId":{"spellId":49184}}}},
-	{"action":{"castSpell":{"spellId":{"spellId":49020,"tag":1}}}},
-	{"action":{"castSpell":{"spellId":{"spellId":49143,"tag":1}}}},
-	{"action":{"condition":{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":51271}}},{"or":{"vals":[{"auraIsActive":{"auraId":{"spellId":53365}}},{"auraIsActive":{"auraId":{"spellId":92342}}}]}},{"spellIsReady":{"spellId":{"spellId":46584}}}]}},"castSpell":{"spellId":{"otherId":"OtherActionPotion"}}}},
-	{"action":{"condition":{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":51271}}},{"or":{"vals":[{"auraIsActive":{"auraId":{"spellId":53365}}},{"auraIsActive":{"auraId":{"spellId":92342}}}]}},{"auraIsActive":{"auraId":{"itemId":58146}}}]}},"castSpell":{"spellId":{"spellId":46584}}}},
-	{"action":{"castSpell":{"spellId":{"spellId":57330}}}}
-  ]
+	"type": "TypeAPL",
+	"prepullActions": [
+		{ "action": { "castSpell": { "spellId": { "spellId": 48265 } } }, "doAtValue": { "const": { "val": "-20s" } } },
+		{ "action": { "castSpell": { "spellId": { "spellId": 42650 } } }, "doAtValue": { "const": { "val": "-6s" } } },
+		{ "action": { "castSpell": { "spellId": { "spellId": 57330 } } }, "doAtValue": { "const": { "val": "-1s" } } },
+		{ "action": { "castSpell": { "spellId": { "otherId": "OtherActionPotion" } } }, "doAtValue": { "const": { "val": "-0.1s" } } }
+	],
+	"priorityList": [
+		{ "action": { "castSpell": { "spellId": { "spellId": 2825, "tag": -1 } } } },
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "cmp": { "op": "OpEq", "lhs": { "currentRuneCount": { "runeType": "RuneDeath" } }, "rhs": { "const": { "val": "0" } } } },
+							{ "cmp": { "op": "OpEq", "lhs": { "currentRuneCount": { "runeType": "RuneFrost" } }, "rhs": { "const": { "val": "0" } } } },
+							{ "cmp": { "op": "OpEq", "lhs": { "currentRuneCount": { "runeType": "RuneUnholy" } }, "rhs": { "const": { "val": "0" } } } },
+							{ "cmp": { "op": "OpGe", "lhs": { "nextRuneCooldown": { "runeType": "RuneBlood" } }, "rhs": { "const": { "val": "3.5s" } } } },
+							{ "cmp": { "op": "OpGe", "lhs": { "nextRuneCooldown": { "runeType": "RuneFrost" } }, "rhs": { "const": { "val": "3.5s" } } } },
+							{ "cmp": { "op": "OpGe", "lhs": { "nextRuneCooldown": { "runeType": "RuneUnholy" } }, "rhs": { "const": { "val": "3.5s" } } } },
+							{ "cmp": { "op": "OpLe", "lhs": { "currentRunicPower": {} }, "rhs": { "const": { "val": "30" } } } },
+							{ "cmp": { "op": "OpGt", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "10s" } } } }
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 47568 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "cmp": { "op": "OpEq", "lhs": { "currentRuneCount": { "runeType": "RuneBlood" } }, "rhs": { "const": { "val": "0" } } } },
+							{ "cmp": { "op": "OpGt", "lhs": { "runeCooldown": { "runeType": "RuneBlood" } }, "rhs": { "const": { "val": "5s" } } } }
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 45529 } }
+			}
+		},
+		{ "action": { "condition": { "spellIsReady": { "spellId": { "spellId": 51271 } } }, "castSpell": { "spellId": { "spellId": 51271 } } } },
+		{
+			"action": {
+				"condition": {
+					"auraIsActive": { "auraId": { "spellId": 51271 } }
+				},
+				"castSpell": { "spellId": { "itemId": 62469 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"auraIsActive": { "auraId": { "spellId": 51271 } }
+				},
+				"castSpell": { "spellId": { "itemId": 62464 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"cmp": { "op": "OpGt", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "20s" } } }
+				},
+				"castSpell": { "spellId": { "spellId": 82174 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"or": {
+						"vals": [
+							{
+								"or": {
+									"vals": [
+										{ "cmp": { "op": "OpGt", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "10s" } } } },
+										{
+											"and": {
+												"vals": [
+													{ "auraIsActive": { "auraId": { "spellId": 53365 } } },
+													{ "auraIsActive": { "auraId": { "spellId": 91821 } } },
+													{ "auraIsActive": { "auraId": { "spellId": 92342 } } }
+												]
+											}
+										}
+									]
+								}
+							},
+							{ "not": { "val": { "auraIsKnown": { "auraId": { "itemId": 62469 } } } } },
+							{ "not": { "val": { "auraIsKnown": { "auraId": { "itemId": 62464 } } } } }
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 82174 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "auraIsActive": { "auraId": { "spellId": 51271 } } },
+							{
+								"or": {
+									"vals": [
+										{ "cmp": { "op": "OpGt", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "5s" } } } },
+										{ "auraIsActive": { "auraId": { "spellId": 53365 } } }
+									]
+								}
+							},
+							{
+								"or": {
+									"vals": [
+										{ "cmp": { "op": "OpGt", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "5s" } } } },
+										{ "auraIsActive": { "auraId": { "spellId": 92342 } } },
+										{ "auraIsActive": { "auraId": { "spellId": 91821 } } }
+									]
+								}
+							}
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 33697 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "auraIsActive": { "auraId": { "spellId": 51271 } } },
+							{
+								"or": {
+									"vals": [
+										{ "cmp": { "op": "OpGt", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "10s" } } } },
+										{ "auraIsActive": { "auraId": { "spellId": 53365 } } }
+									]
+								}
+							},
+							{
+								"or": {
+									"vals": [
+										{ "cmp": { "op": "OpGt", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "10s" } } } },
+										{ "auraIsActive": { "auraId": { "spellId": 92342 } } },
+										{ "auraIsActive": { "auraId": { "spellId": 91821 } } }
+									]
+								}
+							}
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 26297 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "auraIsActive": { "auraId": { "spellId": 51271 } } },
+							{ "cmp": { "op": "OpGt", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "5s" } } } }
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 33697 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "auraIsActive": { "auraId": { "spellId": 51271 } } },
+							{ "cmp": { "op": "OpGt", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "10s" } } } }
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 26297 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "auraIsActive": { "auraId": { "spellId": 51271 } } },
+							{ "auraIsActive": { "auraId": { "itemId": 58146 } } },
+							{
+								"or": {
+									"vals": [
+										{ "auraIsActive": { "auraId": { "itemId": 62469 } } },
+										{ "auraIsActive": { "auraId": { "itemId": 62464 } } },
+										{
+											"and": {
+												"vals": [
+													{ "not": { "val": { "auraIsKnown": { "auraId": { "itemId": 62469 } } } } },
+													{ "not": { "val": { "auraIsKnown": { "auraId": { "itemId": 62464 } } } } },
+													{
+														"or": {
+															"vals": [
+																{
+																	"and": {
+																		"vals": [
+																			{ "auraIsActive": { "auraId": { "spellId": 91364 } } },
+																			{ "auraIsActive": { "auraId": { "spellId": 91363 } } },
+																			{ "auraIsActive": { "auraId": { "spellId": 92345 } } },
+																			{ "auraIsActive": { "auraId": { "spellId": 91816 } } },
+																			{ "auraIsActive": { "auraId": { "spellId": 92342 } } },
+																			{ "auraIsActive": { "auraId": { "spellId": 91821 } } }
+																		]
+																	}
+																},
+																{
+																	"cmp": {
+																		"op": "OpLt",
+																		"lhs": { "auraRemainingTime": { "auraId": { "spellId": 51271 } } },
+																		"rhs": { "const": { "val": "1s" } }
+																	}
+																}
+															]
+														}
+													}
+												]
+											}
+										}
+									]
+								}
+							},
+							{
+								"or": {
+									"vals": [
+										{ "auraIsActive": { "auraId": { "spellId": 53365 } } },
+										{
+											"or": {
+												"vals": [
+													{
+														"cmp": {
+															"op": "OpLt",
+															"lhs": { "auraRemainingTime": { "auraId": { "spellId": 51271 } } },
+															"rhs": { "const": { "val": "1s" } }
+														}
+													},
+													{
+														"cmp": {
+															"op": "OpLt",
+															"lhs": { "auraRemainingTime": { "auraId": { "spellId": 92342 } } },
+															"rhs": { "const": { "val": "1s" } }
+														}
+													},
+													{
+														"cmp": {
+															"op": "OpLt",
+															"lhs": { "auraRemainingTime": { "auraId": { "spellId": 91821 } } },
+															"rhs": { "const": { "val": "1s" } }
+														}
+													}
+												]
+											}
+										}
+									]
+								}
+							},
+							{
+								"or": {
+									"vals": [
+										{ "auraIsActive": { "auraId": { "spellId": 92345 } } },
+										{ "auraIsActive": { "auraId": { "spellId": 91816 } } },
+										{ "auraIsActive": { "auraId": { "spellId": 91364 } } },
+										{ "auraIsActive": { "auraId": { "spellId": 91363 } } },
+										{
+											"or": {
+												"vals": [
+													{
+														"cmp": {
+															"op": "OpLt",
+															"lhs": { "auraRemainingTime": { "auraId": { "spellId": 51271 } } },
+															"rhs": { "const": { "val": "1s" } }
+														}
+													},
+													{
+														"cmp": {
+															"op": "OpLt",
+															"lhs": { "auraRemainingTime": { "auraId": { "spellId": 92342 } } },
+															"rhs": { "const": { "val": "1s" } }
+														}
+													},
+													{
+														"cmp": {
+															"op": "OpLt",
+															"lhs": { "auraRemainingTime": { "auraId": { "spellId": 91821 } } },
+															"rhs": { "const": { "val": "1s" } }
+														}
+													}
+												]
+											}
+										}
+									]
+								}
+							}
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 46584 } }
+			}
+		},
+		{
+			"action": {
+				"condition": { "or": { "vals": [{ "and": { "vals": [{ "auraIsActive": { "auraId": { "spellId": 51271 } } }] } }] } },
+				"castSpell": { "spellId": { "spellId": 77575 } }
+			}
+		},
+		{
+			"action": {
+				"condition": { "cmp": { "op": "OpGe", "lhs": { "currentRunicPower": {} }, "rhs": { "const": { "val": "100" } } } },
+				"castSpell": { "spellId": { "spellId": 49143, "tag": 1 } }
+			}
+		},
+		{
+			"action": {
+				"condition": { "not": { "val": { "dotIsActive": { "spellId": { "spellId": 55095 } } } } },
+				"castSpell": { "spellId": { "spellId": 45477 } }
+			}
+		},
+		{
+			"action": {
+				"condition": { "not": { "val": { "dotIsActive": { "spellId": { "spellId": 55078 } } } } },
+				"castSpell": { "spellId": { "spellId": 45462, "tag": 1 } }
+			}
+		},
+		{ "action": { "condition": { "auraIsActive": { "auraId": { "spellId": 59052 } } }, "castSpell": { "spellId": { "spellId": 49184 } } } },
+		{ "action": { "castSpell": { "spellId": { "spellId": 49020, "tag": 1 } } } },
+		{ "action": { "castSpell": { "spellId": { "spellId": 49143, "tag": 1 } } } },
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "auraIsActive": { "auraId": { "spellId": 51271 } } },
+							{
+								"or": {
+									"vals": [
+										{ "auraIsActive": { "auraId": { "spellId": 53365 } } },
+										{ "auraIsActive": { "auraId": { "spellId": 92342 } } },
+										{ "auraIsActive": { "auraId": { "spellId": 91821 } } }
+									]
+								}
+							},
+							{ "spellIsReady": { "spellId": { "spellId": 46584 } } }
+						]
+					}
+				},
+				"castSpell": { "spellId": { "otherId": "OtherActionPotion" } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "auraIsActive": { "auraId": { "spellId": 51271 } } },
+							{
+								"or": {
+									"vals": [
+										{ "auraIsActive": { "auraId": { "spellId": 53365 } } },
+										{ "auraIsActive": { "auraId": { "spellId": 92342 } } },
+										{ "auraIsActive": { "auraId": { "spellId": 91821 } } }
+									]
+								}
+							},
+							{ "auraIsActive": { "auraId": { "itemId": 58146 } } }
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 46584 } }
+			}
+		},
+		{ "action": { "castSpell": { "spellId": { "spellId": 57330 } } } }
+	]
 }

--- a/ui/death_knight/frost/apls/masterfrost.apl.json
+++ b/ui/death_knight/frost/apls/masterfrost.apl.json
@@ -1,50 +1,995 @@
 {
 	"type": "TypeAPL",
 	"prepullActions": [
-	  {"action":{"castSpell":{"spellId":{"spellId":48265}}},"doAtValue":{"const":{"val":"-20s"}}},
-	  {"action":{"castSpell":{"spellId":{"spellId":42650}}},"doAtValue":{"const":{"val":"-6s"}}},
-	  {"action":{"castSpell":{"spellId":{"spellId":57330}}},"doAtValue":{"const":{"val":"-1s"}}}
+		{ "action": { "castSpell": { "spellId": { "spellId": 48265 } } }, "doAtValue": { "const": { "val": "-20s" } } },
+		{ "action": { "castSpell": { "spellId": { "spellId": 57330 } } }, "doAtValue": { "const": { "val": "-7s" } } },
+		{ "action": { "castSpell": { "spellId": { "spellId": 42650 } } }, "doAtValue": { "const": { "val": "-6s" } } },
+		{ "action": { "castSpell": { "spellId": { "otherId": "OtherActionPotion" } } }, "doAtValue": { "const": { "val": "-0.1s" } } }
 	],
 	"priorityList": [
-	  {"action":{"castSpell":{"spellId":{"spellId":2825,"tag":-1}}}},
-	  {"action":{"condition":{"and":{"vals":[{"cmp":{"op":"OpEq","lhs":{"currentRuneCount":{"runeType":"RuneDeath"}},"rhs":{"const":{"val":"0"}}}},{"cmp":{"op":"OpEq","lhs":{"currentRuneCount":{"runeType":"RuneFrost"}},"rhs":{"const":{"val":"0"}}}},{"cmp":{"op":"OpEq","lhs":{"currentRuneCount":{"runeType":"RuneUnholy"}},"rhs":{"const":{"val":"0"}}}},{"cmp":{"op":"OpGe","lhs":{"nextRuneCooldown":{"runeType":"RuneBlood"}},"rhs":{"const":{"val":"3s"}}}},{"cmp":{"op":"OpGe","lhs":{"nextRuneCooldown":{"runeType":"RuneFrost"}},"rhs":{"const":{"val":"3s"}}}},{"cmp":{"op":"OpGe","lhs":{"nextRuneCooldown":{"runeType":"RuneUnholy"}},"rhs":{"const":{"val":"3s"}}}},{"cmp":{"op":"OpLe","lhs":{"currentRunicPower":{}},"rhs":{"const":{"val":"30"}}}},{"cmp":{"op":"OpGt","lhs":{"currentTime":{}},"rhs":{"const":{"val":"10s"}}}}]}},"castSpell":{"spellId":{"spellId":47568}}}},
-	  {"action":{"condition":{"and":{"vals":[{"cmp":{"op":"OpLe","lhs":{"currentRuneCount":{"runeType":"RuneDeath"}},"rhs":{"const":{"val":"1"}}}},{"cmp":{"op":"OpGt","lhs":{"runeCooldown":{"runeType":"RuneBlood"}},"rhs":{"const":{"val":"5.5s"}}}}]}},"castSpell":{"spellId":{"spellId":45529}}}},
-	  {"action":{"condition":{"cmp":{"op":"OpLt","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"20s"}}}},"castSpell":{"spellId":{"spellId":51271}}}},
-	  {"action":{"condition":{"cmp":{"op":"OpLt","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"20s"}}}},"castSpell":{"spellId":{"spellId":26297}}}},
-	  {"action":{"condition":{"cmp":{"op":"OpLt","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"60s"}}}},"castSpell":{"spellId":{"spellId":46584}}}},
-	  {"action":{"condition":{"and":{"vals":[{"cmp":{"op":"OpGt","lhs":{"currentTime":{}},"rhs":{"const":{"val":"180s"}}}},{"not":{"val":{"spellIsReady":{"spellId":{"spellId":46584}}}}},{"cmp":{"op":"OpLt","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"85s"}}}}]}},"castSpell":{"spellId":{"spellId":51271}}}},
-	  {"action":{"condition":{"and":{"vals":[{"cmp":{"op":"OpGt","lhs":{"currentTime":{}},"rhs":{"const":{"val":"180s"}}}},{"spellIsReady":{"spellId":{"spellId":46584}}},{"spellIsReady":{"spellId":{"itemId":58146}}},{"auraIsActive":{"auraId":{"spellId":53365}}},{"or":{"vals":[{"auraIsActive":{"auraId":{"spellId":92345}}},{"or":{"vals":[{"auraIsActive":{"auraId":{"spellId":92342}}},{"auraIsActive":{"auraId":{"spellId":91364}}}]}},{"cmp":{"op":"OpLt","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"85s"}}}}]}},{"spellIsReady":{"spellId":{"spellId":26297}}}]}},"strictSequence":{"actions":[{"castSpell":{"spellId":{"spellId":51271}}},{"castSpell":{"spellId":{"itemId":58146}}},{"castSpell":{"spellId":{"spellId":26297}}},{"castSpell":{"spellId":{"spellId":46584}}}]}}},
-	  {"action":{"condition":{"cmp":{"op":"OpLt","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"8s"}}}},"castSpell":{"spellId":{"spellId":49020,"tag":1}}}},
-	  {"action":{"condition":{"cmp":{"op":"OpLt","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"8s"}}}},"castSpell":{"spellId":{"spellId":49143,"tag":1}}}},
-	  {"action":{"condition":{"cmp":{"op":"OpLt","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"8s"}}}},"castSpell":{"spellId":{"spellId":49184}}}},
-	  {"action":{"condition":{"and":{"vals":[{"cmp":{"op":"OpLt","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"75"}}}},{"auraIsActive":{"auraId":{"spellId":51271}}},{"auraIsActive":{"auraId":{"spellId":53365}}}]}},"strictSequence":{"actions":[{"castSpell":{"spellId":{"itemId":58146}}},{"castSpell":{"spellId":{"spellId":46584}}}]}}},
-	  {"action":{"condition":{"and":{"vals":[{"spellIsReady":{"spellId":{"spellId":51271}}},{"cmp":{"op":"OpLt","lhs":{"currentTime":{}},"rhs":{"const":{"val":"170s"}}}},{"or":{"vals":[{"cmp":{"op":"OpGt","lhs":{"currentTime":{}},"rhs":{"const":{"val":"5s"}}}},{"or":{"vals":[{"cmp":{"op":"OpEq","lhs":{"auraNumStacks":{"auraId":{"spellId":96923}}},"rhs":{"const":{"val":"5"}}}},{"auraIsActive":{"auraId":{"spellId":96928}}},{"auraIsActive":{"auraId":{"spellId":96927}}},{"auraIsActive":{"auraId":{"spellId":96929}}}]}}]}}]}},"castSpell":{"spellId":{"spellId":51271}}}},
-	  {"action":{"condition":{"auraIsActive":{"auraId":{"spellId":51271}}},"castSpell":{"spellId":{"spellId":74497}}}},
-	  {"action":{"condition":{"cmp":{"op":"OpGt","lhs":{"currentTime":{}},"rhs":{"const":{"val":"5"}}}},"castSpell":{"spellId":{"itemId":69002}}}},
-	  {"action":{"condition":{"cmp":{"op":"OpEq","lhs":{"auraNumStacks":{"auraId":{"spellId":96923}}},"rhs":{"const":{"val":"5"}}}},"castSpell":{"spellId":{"itemId":69113}}}},
-	  {"action":{"condition":{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":51271}}},{"spellIsReady":{"spellId":{"itemId":62469}}}]}},"castSpell":{"spellId":{"itemId":62469}}}},
-	  {"action":{"condition":{"and":{"vals":[{"spellIsReady":{"spellId":{"spellId":82174}}},{"cmp":{"op":"OpGt","lhs":{"currentTime":{}},"rhs":{"const":{"val":"20s"}}}}]}},"castSpell":{"spellId":{"spellId":82174}}}},
-	  {"action":{"condition":{"and":{"vals":[{"spellIsReady":{"spellId":{"spellId":82174}}},{"not":{"val":{"auraIsKnown":{"auraId":{"itemId":62469}}}}},{"or":{"vals":[{"cmp":{"op":"OpGt","lhs":{"currentTime":{}},"rhs":{"const":{"val":"10s"}}}},{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":53365}}},{"auraIsActive":{"auraId":{"spellId":92342}}},{"or":{"vals":[{"auraIsActive":{"auraId":{"spellId":92345}}},{"auraIsActive":{"auraId":{"spellId":91364}}}]}}]}}]}}]}},"castSpell":{"spellId":{"spellId":82174}}}},
-	  {"action":{"condition":{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":51271}}},{"or":{"vals":[{"auraIsActive":{"auraId":{"spellId":53365}}},{"cmp":{"op":"OpGt","lhs":{"currentTime":{}},"rhs":{"const":{"val":"5s"}}}}]}},{"or":{"vals":[{"auraIsActive":{"auraId":{"spellId":92342}}},{"cmp":{"op":"OpGt","lhs":{"currentTime":{}},"rhs":{"const":{"val":"5s"}}}}]}}]}},"castSpell":{"spellId":{"spellId":33697}}}},
-	  {"action":{"condition":{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":51271}}},{"or":{"vals":[{"auraIsActive":{"auraId":{"spellId":53365}}},{"cmp":{"op":"OpGt","lhs":{"currentTime":{}},"rhs":{"const":{"val":"10s"}}}}]}},{"or":{"vals":[{"auraIsActive":{"auraId":{"spellId":92342}}},{"cmp":{"op":"OpGt","lhs":{"currentTime":{}},"rhs":{"const":{"val":"10s"}}}}]}},{"cmp":{"op":"OpLt","lhs":{"currentTime":{}},"rhs":{"const":{"val":"170s"}}}}]}},"castSpell":{"spellId":{"spellId":26297}}}},
-	  {"action":{"condition":{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":51271}}},{"cmp":{"op":"OpGt","lhs":{"currentTime":{}},"rhs":{"const":{"val":"5s"}}}}]}},"castSpell":{"spellId":{"spellId":33697}}}},
-	  {"action":{"condition":{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":51271}}},{"cmp":{"op":"OpGt","lhs":{"currentTime":{}},"rhs":{"const":{"val":"10s"}}}},{"cmp":{"op":"OpLt","lhs":{"currentTime":{}},"rhs":{"const":{"val":"170s"}}}}]}},"castSpell":{"spellId":{"spellId":26297}}}},
-	  {"action":{"condition":{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":51271}}},{"or":{"vals":[{"auraIsActive":{"auraId":{"spellId":53365}}},{"or":{"vals":[{"cmp":{"op":"OpLt","lhs":{"auraRemainingTime":{"auraId":{"spellId":51271}}},"rhs":{"const":{"val":"3s"}}}},{"cmp":{"op":"OpLt","lhs":{"auraRemainingTime":{"auraId":{"spellId":92342}}},"rhs":{"const":{"val":"3s"}}}}]}}]}},{"or":{"vals":[{"auraIsActive":{"auraId":{"itemId":62469}}},{"and":{"vals":[{"not":{"val":{"auraIsKnown":{"auraId":{"itemId":62469}}}}},{"or":{"vals":[{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":92345}}},{"auraIsActive":{"auraId":{"spellId":91364}}},{"auraIsActive":{"auraId":{"spellId":92342}}}]}},{"cmp":{"op":"OpLt","lhs":{"auraRemainingTime":{"auraId":{"spellId":51271}}},"rhs":{"const":{"val":"3s"}}}}]}}]}}]}},{"auraIsActive":{"auraId":{"itemId":58146}}},{"or":{"vals":[{"auraIsActive":{"auraId":{"spellId":91364}}},{"auraIsActive":{"auraId":{"spellId":92345}}},{"or":{"vals":[{"cmp":{"op":"OpLt","lhs":{"auraRemainingTime":{"auraId":{"spellId":51271}}},"rhs":{"const":{"val":"3s"}}}},{"cmp":{"op":"OpLt","lhs":{"auraRemainingTime":{"auraId":{"spellId":92342}}},"rhs":{"const":{"val":"3s"}}}}]}}]}}]}},"castSpell":{"spellId":{"spellId":46584}}}},
-	  {"action":{"condition":{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":53365}}},{"auraIsActive":{"auraId":{"spellId":51271}}},{"spellIsReady":{"spellId":{"spellId":46584}}}]}},"strictSequence":{"actions":[{"castSpell":{"spellId":{"itemId":58146}}},{"castSpell":{"spellId":{"spellId":46584}}}]}}},
-	  {"action":{"condition":{"and":{"vals":[{"cmp":{"op":"OpLe","lhs":{"currentTime":{}},"rhs":{"const":{"val":"10s"}}}},{"auraIsActive":{"auraId":{"spellId":51124}}},{"cmp":{"op":"OpLt","lhs":{"auraNumStacks":{"auraId":{"spellId":96923}}},"rhs":{"const":{"val":"4"}}}}]}},"castSpell":{"spellId":{"spellId":49143,"tag":1}}}},
-	  {"action":{"condition":{"and":{"vals":[{"cmp":{"op":"OpGe","lhs":{"currentRunicPower":{}},"rhs":{"const":{"val":"105"}}}}]}},"castSpell":{"spellId":{"spellId":49143,"tag":1}}}},
-	  {"action":{"condition":{"and":{"vals":[{"spellIsReady":{"spellId":{"spellId":77575}}},{"or":{"vals":[{"cmp":{"op":"OpLt","lhs":{"dotRemainingTime":{"spellId":{"spellId":55078}}},"rhs":{"const":{"val":"3s"}}}},{"not":{"val":{"dotIsActive":{"spellId":{"spellId":55078}}}}}]}}]}},"castSpell":{"spellId":{"spellId":77575}}}},
-	  {"action":{"condition":{"auraIsActive":{"auraId":{"spellId":59052}}},"castSpell":{"spellId":{"spellId":49184}}}},
-	  {"action":{"condition":{"not":{"val":{"dotIsActive":{"spellId":{"spellId":55095}}}}},"castSpell":{"spellId":{"spellId":49184}}}},
-	  {"action":{"condition":{"and":{"vals":[{"cmp":{"op":"OpGe","lhs":{"currentRunicPower":{}},"rhs":{"const":{"val":"100"}}}},{"or":{"vals":[{"cmp":{"op":"OpEq","lhs":{"currentRuneCount":{"runeType":"RuneFrost"}},"rhs":{"const":{"val":"0"}}}},{"cmp":{"op":"OpEq","lhs":{"currentRuneCount":{"runeType":"RuneDeath"}},"rhs":{"const":{"val":"0"}}}}]}},{"cmp":{"op":"OpGe","lhs":{"currentRuneCount":{"runeType":"RuneUnholy"}},"rhs":{"const":{"val":"1"}}}}]}},"castSpell":{"spellId":{"spellId":49143,"tag":1}}}},
-	  {"action":{"condition":{"and":{"vals":[{"not":{"val":{"dotIsActive":{"spellId":{"spellId":55078}}}}},{"or":{"vals":[{"cmp":{"op":"OpEq","lhs":{"currentRuneCount":{"runeType":"RuneUnholy"}},"rhs":{"const":{"val":"2"}}}},{"and":{"vals":[{"cmp":{"op":"OpGe","lhs":{"currentRuneCount":{"runeType":"RuneUnholy"}},"rhs":{"const":{"val":"1"}}}},{"cmp":{"op":"OpLe","lhs":{"nextRuneCooldown":{"runeType":"RuneUnholy"}},"rhs":{"const":{"val":"1s"}}}}]}}]}},{"not":{"val":{"auraIsActive":{"auraId":{"spellId":51124}}}}}]}},"castSpell":{"spellId":{"spellId":45462,"tag":1}}}},
-	  {"action":{"condition":{"and":{"vals":[{"cmp":{"op":"OpLe","lhs":{"currentRunicPower":{}},"rhs":{"const":{"val":"90"}}}},{"or":{"vals":[{"cmp":{"op":"OpEq","lhs":{"currentRuneCount":{"runeType":"RuneUnholy"}},"rhs":{"const":{"val":"2"}}}},{"and":{"vals":[{"cmp":{"op":"OpGe","lhs":{"currentRuneCount":{"runeType":"RuneUnholy"}},"rhs":{"const":{"val":"1"}}}},{"cmp":{"op":"OpLe","lhs":{"nextRuneCooldown":{"runeType":"RuneUnholy"}},"rhs":{"const":{"val":"1s"}}}}]}}]}},{"or":{"vals":[{"dotIsActive":{"spellId":{"spellId":55078}}},{"dotIsActive":{"spellId":{"spellId":98957}}}]}}]}},"castSpell":{"spellId":{"spellId":49020,"tag":1}}}},
-	  {"action":{"condition":{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":51124}}},{"cmp":{"op":"OpGe","lhs":{"currentRuneCount":{"runeType":"RuneUnholy"}},"rhs":{"const":{"val":"1"}}}},{"or":{"vals":[{"and":{"vals":[{"cmp":{"op":"OpEq","lhs":{"currentRuneCount":{"runeType":"RuneFrost"}},"rhs":{"const":{"val":"0"}}}},{"cmp":{"op":"OpEq","lhs":{"currentRuneCount":{"runeType":"RuneDeath"}},"rhs":{"const":{"val":"1"}}}}]}},{"and":{"vals":[{"cmp":{"op":"OpEq","lhs":{"currentRuneCount":{"runeType":"RuneFrost"}},"rhs":{"const":{"val":"1"}}}},{"cmp":{"op":"OpEq","lhs":{"currentRuneCount":{"runeType":"RuneDeath"}},"rhs":{"const":{"val":"0"}}}}]}}]}}]}},"castSpell":{"spellId":{"spellId":49143,"tag":1}}}},
-	  {"action":{"condition":{"and":{"vals":[{"or":{"vals":[{"and":{"vals":[{"cmp":{"op":"OpLe","lhs":{"currentRunicPower":{}},"rhs":{"const":{"val":"90"}}}},{"cmp":{"op":"OpLt","lhs":{"runeCooldown":{"runeType":"RuneUnholy"}},"rhs":{"const":{"val":"2s"}}}},{"or":{"vals":[{"cmp":{"op":"OpEq","lhs":{"currentRuneCount":{"runeType":"RuneDeath"}},"rhs":{"const":{"val":"2"}}}},{"cmp":{"op":"OpEq","lhs":{"currentRuneCount":{"runeType":"RuneFrost"}},"rhs":{"const":{"val":"2"}}}},{"and":{"vals":[{"cmp":{"op":"OpEq","lhs":{"currentRuneCount":{"runeType":"RuneDeath"}},"rhs":{"const":{"val":"1"}}}},{"cmp":{"op":"OpEq","lhs":{"currentRuneCount":{"runeType":"RuneFrost"}},"rhs":{"const":{"val":"1"}}}}]}},{"or":{"vals":[{"cmp":{"op":"OpLt","lhs":{"runeCooldown":{"runeType":"RuneBlood"}},"rhs":{"const":{"val":"1s"}}}},{"cmp":{"op":"OpLt","lhs":{"runeCooldown":{"runeType":"RuneFrost"}},"rhs":{"const":{"val":"1s"}}}}]}}]}}]}},{"and":{"vals":[{"cmp":{"op":"OpLe","lhs":{"currentRunicPower":{}},"rhs":{"const":{"val":"70"}}}},{"cmp":{"op":"OpLt","lhs":{"runeCooldown":{"runeType":"RuneUnholy"}},"rhs":{"const":{"val":"3s"}}}},{"or":{"vals":[{"and":{"vals":[{"cmp":{"op":"OpEq","lhs":{"currentRuneCount":{"runeType":"RuneDeath"}},"rhs":{"const":{"val":"2"}}}},{"cmp":{"op":"OpGe","lhs":{"currentRuneCount":{"runeType":"RuneFrost"}},"rhs":{"const":{"val":"1"}}}}]}},{"and":{"vals":[{"cmp":{"op":"OpGe","lhs":{"currentRuneCount":{"runeType":"RuneDeath"}},"rhs":{"const":{"val":"1"}}}},{"cmp":{"op":"OpEq","lhs":{"currentRuneCount":{"runeType":"RuneFrost"}},"rhs":{"const":{"val":"2"}}}}]}},{"and":{"vals":[{"cmp":{"op":"OpEq","lhs":{"currentRuneCount":{"runeType":"RuneDeath"}},"rhs":{"const":{"val":"1"}}}},{"cmp":{"op":"OpEq","lhs":{"currentRuneCount":{"runeType":"RuneFrost"}},"rhs":{"const":{"val":"1"}}}},{"or":{"vals":[{"cmp":{"op":"OpLt","lhs":{"runeCooldown":{"runeType":"RuneBlood"}},"rhs":{"const":{"val":"2s"}}}},{"cmp":{"op":"OpLt","lhs":{"runeCooldown":{"runeType":"RuneFrost"}},"rhs":{"const":{"val":"2s"}}}}]}}]}},{"or":{"vals":[{"and":{"vals":[{"cmp":{"op":"OpLt","lhs":{"runeCooldown":{"runeType":"RuneBlood"}},"rhs":{"const":{"val":"2s"}}}},{"cmp":{"op":"OpLt","lhs":{"runeCooldown":{"runeType":"RuneFrost"}},"rhs":{"const":{"val":"1s"}}}}]}},{"and":{"vals":[{"cmp":{"op":"OpLt","lhs":{"runeCooldown":{"runeType":"RuneBlood"}},"rhs":{"const":{"val":"1s"}}}},{"cmp":{"op":"OpLt","lhs":{"runeCooldown":{"runeType":"RuneFrost"}},"rhs":{"const":{"val":"2s"}}}}]}}]}}]}}]}}]}},{"or":{"vals":[{"dotIsActive":{"spellId":{"spellId":55078}}},{"dotIsActive":{"spellId":{"spellId":98957}}}]}},{"auraIsActive":{"auraId":{"spellId":51124}}},{"cmp":{"op":"OpEq","lhs":{"currentRuneCount":{"runeType":"RuneUnholy"}},"rhs":{"const":{"val":"1"}}}}]}},"castSpell":{"spellId":{"spellId":49020,"tag":1}}}},
-	  {"action":{"castSpell":{"spellId":{"spellId":49184}}}},
-	  {"action":{"condition":{"or":{"vals":[{"not":{"val":{"auraIsActive":{"auraId":{"spellId":57330}}}}},{"not":{"val":{"auraIsActive":{"auraId":{"spellId":98971}}}}}]}},"castSpell":{"spellId":{"spellId":57330}}}},
-	  {"action":{"castSpell":{"spellId":{"spellId":49143,"tag":1}}}},
-	  {"action":{"castSpell":{"spellId":{"spellId":57330}}}},
-	  {"action":{"condition":{"and":{"vals":[{"cmp":{"op":"OpEq","lhs":{"currentRuneCount":{"runeType":"RuneFrost"}},"rhs":{"const":{"val":"0"}}}},{"cmp":{"op":"OpEq","lhs":{"currentRuneCount":{"runeType":"RuneDeath"}},"rhs":{"const":{"val":"0"}}}},{"cmp":{"op":"OpGe","lhs":{"currentRuneCount":{"runeType":"RuneUnholy"}},"rhs":{"const":{"val":"1"}}}},{"cmp":{"op":"OpGt","lhs":{"runeCooldown":{"runeType":"RuneFrost"}},"rhs":{"const":{"val":"2.5s"}}}},{"cmp":{"op":"OpGt","lhs":{"runeCooldown":{"runeType":"RuneBlood"}},"rhs":{"const":{"val":"2.5s"}}}},{"spellIsReady":{"spellId":{"spellId":47568}}}]}},"castSpell":{"spellId":{"spellId":45462,"tag":1}}}}
-  ]
+		{ "action": { "castSpell": { "spellId": { "spellId": 2825, "tag": -1 } } } },
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "cmp": { "op": "OpEq", "lhs": { "currentRuneCount": { "runeType": "RuneDeath" } }, "rhs": { "const": { "val": "0" } } } },
+							{ "cmp": { "op": "OpEq", "lhs": { "currentRuneCount": { "runeType": "RuneFrost" } }, "rhs": { "const": { "val": "0" } } } },
+							{ "cmp": { "op": "OpEq", "lhs": { "currentRuneCount": { "runeType": "RuneUnholy" } }, "rhs": { "const": { "val": "0" } } } },
+							{ "cmp": { "op": "OpGe", "lhs": { "nextRuneCooldown": { "runeType": "RuneBlood" } }, "rhs": { "const": { "val": "3s" } } } },
+							{ "cmp": { "op": "OpGe", "lhs": { "nextRuneCooldown": { "runeType": "RuneFrost" } }, "rhs": { "const": { "val": "3s" } } } },
+							{ "cmp": { "op": "OpGe", "lhs": { "nextRuneCooldown": { "runeType": "RuneUnholy" } }, "rhs": { "const": { "val": "3s" } } } },
+							{ "cmp": { "op": "OpLe", "lhs": { "currentRunicPower": {} }, "rhs": { "const": { "val": "30" } } } },
+							{ "cmp": { "op": "OpGt", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "10s" } } } }
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 47568 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "cmp": { "op": "OpLe", "lhs": { "currentRuneCount": { "runeType": "RuneDeath" } }, "rhs": { "const": { "val": "1" } } } },
+							{ "cmp": { "op": "OpGt", "lhs": { "runeCooldown": { "runeType": "RuneBlood" } }, "rhs": { "const": { "val": "5.5s" } } } }
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 45529 } }
+			}
+		},
+		{
+			"action": {
+				"condition": { "cmp": { "op": "OpLt", "lhs": { "remainingTime": {} }, "rhs": { "const": { "val": "20s" } } } },
+				"castSpell": { "spellId": { "spellId": 51271 } }
+			}
+		},
+		{
+			"action": {
+				"condition": { "cmp": { "op": "OpLt", "lhs": { "remainingTime": {} }, "rhs": { "const": { "val": "20s" } } } },
+				"castSpell": { "spellId": { "spellId": 26297 } }
+			}
+		},
+		{
+			"action": {
+				"condition": { "cmp": { "op": "OpLt", "lhs": { "remainingTime": {} }, "rhs": { "const": { "val": "60s" } } } },
+				"castSpell": { "spellId": { "spellId": 46584 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "cmp": { "op": "OpGt", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "180s" } } } },
+							{ "not": { "val": { "spellIsReady": { "spellId": { "spellId": 46584 } } } } },
+							{ "cmp": { "op": "OpLt", "lhs": { "remainingTime": {} }, "rhs": { "const": { "val": "85s" } } } }
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 51271 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "cmp": { "op": "OpGt", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "180s" } } } },
+							{ "spellIsReady": { "spellId": { "spellId": 46584 } } },
+							{ "spellIsReady": { "spellId": { "itemId": 58146 } } },
+							{ "auraIsActive": { "auraId": { "spellId": 53365 } } },
+							{
+								"or": {
+									"vals": [
+										{ "auraIsActive": { "auraId": { "spellId": 92345 } } },
+										{ "auraIsActive": { "auraId": { "spellId": 91816 } } },
+										{
+											"or": {
+												"vals": [
+													{ "auraIsActive": { "auraId": { "spellId": 92342 } } },
+													{ "auraIsActive": { "auraId": { "spellId": 91821 } } },
+													{ "auraIsActive": { "auraId": { "spellId": 91364 } } },
+													{ "auraIsActive": { "auraId": { "spellId": 91363 } } }
+												]
+											}
+										},
+										{ "cmp": { "op": "OpLt", "lhs": { "remainingTime": {} }, "rhs": { "const": { "val": "85s" } } } }
+									]
+								}
+							},
+							{ "spellIsReady": { "spellId": { "spellId": 26297 } } }
+						]
+					}
+				},
+				"strictSequence": {
+					"actions": [
+						{ "castSpell": { "spellId": { "spellId": 51271 } } },
+						{ "castSpell": { "spellId": { "itemId": 58146 } } },
+						{ "castSpell": { "spellId": { "spellId": 26297 } } },
+						{ "castSpell": { "spellId": { "spellId": 46584 } } }
+					]
+				}
+			}
+		},
+		{
+			"action": {
+				"condition": { "cmp": { "op": "OpLt", "lhs": { "remainingTime": {} }, "rhs": { "const": { "val": "8s" } } } },
+				"castSpell": { "spellId": { "spellId": 49020, "tag": 1 } }
+			}
+		},
+		{
+			"action": {
+				"condition": { "cmp": { "op": "OpLt", "lhs": { "remainingTime": {} }, "rhs": { "const": { "val": "8s" } } } },
+				"castSpell": { "spellId": { "spellId": 49143, "tag": 1 } }
+			}
+		},
+		{
+			"action": {
+				"condition": { "cmp": { "op": "OpLt", "lhs": { "remainingTime": {} }, "rhs": { "const": { "val": "8s" } } } },
+				"castSpell": { "spellId": { "spellId": 49184 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "cmp": { "op": "OpLt", "lhs": { "remainingTime": {} }, "rhs": { "const": { "val": "75" } } } },
+							{ "auraIsActive": { "auraId": { "spellId": 51271 } } },
+							{ "auraIsActive": { "auraId": { "spellId": 53365 } } }
+						]
+					}
+				},
+				"strictSequence": { "actions": [{ "castSpell": { "spellId": { "itemId": 58146 } } }, { "castSpell": { "spellId": { "spellId": 46584 } } }] }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "spellIsReady": { "spellId": { "spellId": 51271 } } },
+							{ "cmp": { "op": "OpLt", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "170s" } } } },
+							{
+								"or": {
+									"vals": [
+										{ "cmp": { "op": "OpGt", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "5s" } } } },
+										{
+											"or": {
+												"vals": [
+													{
+														"cmp": {
+															"op": "OpEq",
+															"lhs": { "auraNumStacks": { "auraId": { "spellId": 96923 } } },
+															"rhs": { "const": { "val": "5" } }
+														}
+													},
+													{ "auraIsActive": { "auraId": { "spellId": 96928 } } },
+													{ "auraIsActive": { "auraId": { "spellId": 96927 } } },
+													{ "auraIsActive": { "auraId": { "spellId": 96929 } } }
+												]
+											}
+										}
+									]
+								}
+							}
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 51271 } }
+			}
+		},
+		{ "action": { "condition": { "auraIsActive": { "auraId": { "spellId": 51271 } } }, "castSpell": { "spellId": { "spellId": 74497 } } } },
+		{
+			"action": {
+				"condition": { "cmp": { "op": "OpGt", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "5" } } } },
+				"castSpell": { "spellId": { "itemId": 69002 } }
+			}
+		},
+		{
+			"action": {
+				"condition": { "cmp": { "op": "OpEq", "lhs": { "auraNumStacks": { "auraId": { "spellId": 96923 } } }, "rhs": { "const": { "val": "5" } } } },
+				"castSpell": { "spellId": { "itemId": 69113 } }
+			}
+		},
+		{
+			"action": {
+				"condition": { "cmp": { "op": "OpEq", "lhs": { "auraNumStacks": { "auraId": { "spellId": 96923 } } }, "rhs": { "const": { "val": "5" } } } },
+				"castSpell": { "spellId": { "itemId": 68972 } }
+			}
+		},
+		{ "action": { "condition": { "auraIsActive": { "auraId": { "spellId": 51271 } } }, "castSpell": { "spellId": { "itemId": 62469 } } } },
+		{ "action": { "condition": { "auraIsActive": { "auraId": { "spellId": 51271 } } }, "castSpell": { "spellId": { "itemId": 62464 } } } },
+		{
+			"action": {
+				"condition": { "cmp": { "op": "OpGt", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "20s" } } } },
+				"castSpell": { "spellId": { "spellId": 82174 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "not": { "val": { "auraIsKnown": { "auraId": { "itemId": 62469 } } } } },
+							{ "not": { "val": { "auraIsKnown": { "auraId": { "itemId": 62464 } } } } },
+							{
+								"or": {
+									"vals": [
+										{ "cmp": { "op": "OpGt", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "10s" } } } },
+										{
+											"and": {
+												"vals": [
+													{ "auraIsActive": { "auraId": { "spellId": 53365 } } },
+													{ "auraIsActive": { "auraId": { "spellId": 92342 } } },
+													{ "auraIsActive": { "auraId": { "spellId": 91821 } } },
+													{
+														"or": {
+															"vals": [
+																{ "auraIsActive": { "auraId": { "spellId": 92345 } } },
+																{ "auraIsActive": { "auraId": { "spellId": 91816 } } },
+																{ "auraIsActive": { "auraId": { "spellId": 91364 } } },
+																{ "auraIsActive": { "auraId": { "spellId": 91363 } } }
+															]
+														}
+													}
+												]
+											}
+										}
+									]
+								}
+							}
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 82174 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "auraIsActive": { "auraId": { "spellId": 51271 } } },
+							{
+								"or": {
+									"vals": [
+										{ "auraIsActive": { "auraId": { "spellId": 53365 } } },
+										{ "cmp": { "op": "OpGt", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "5s" } } } }
+									]
+								}
+							},
+							{
+								"or": {
+									"vals": [
+										{ "auraIsActive": { "auraId": { "spellId": 92342 } } },
+										{ "auraIsActive": { "auraId": { "spellId": 91821 } } },
+										{ "cmp": { "op": "OpGt", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "5s" } } } }
+									]
+								}
+							}
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 33697 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "auraIsActive": { "auraId": { "spellId": 51271 } } },
+							{
+								"or": {
+									"vals": [
+										{ "auraIsActive": { "auraId": { "spellId": 53365 } } },
+										{ "cmp": { "op": "OpGt", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "10s" } } } }
+									]
+								}
+							},
+							{
+								"or": {
+									"vals": [
+										{ "auraIsActive": { "auraId": { "spellId": 92342 } } },
+										{ "auraIsActive": { "auraId": { "spellId": 91821 } } },
+										{ "cmp": { "op": "OpGt", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "10s" } } } }
+									]
+								}
+							},
+							{ "cmp": { "op": "OpLt", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "170s" } } } }
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 26297 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "auraIsActive": { "auraId": { "spellId": 51271 } } },
+							{ "cmp": { "op": "OpGt", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "5s" } } } }
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 33697 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "auraIsActive": { "auraId": { "spellId": 51271 } } },
+							{ "cmp": { "op": "OpGt", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "10s" } } } },
+							{ "cmp": { "op": "OpLt", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "170s" } } } }
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 26297 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "auraIsActive": { "auraId": { "spellId": 51271 } } },
+							{
+								"or": {
+									"vals": [
+										{ "auraIsActive": { "auraId": { "spellId": 53365 } } },
+										{
+											"or": {
+												"vals": [
+													{
+														"cmp": {
+															"op": "OpLt",
+															"lhs": { "auraRemainingTime": { "auraId": { "spellId": 51271 } } },
+															"rhs": { "const": { "val": "3s" } }
+														}
+													},
+													{
+														"cmp": {
+															"op": "OpLt",
+															"lhs": { "auraRemainingTime": { "auraId": { "spellId": 92342 } } },
+															"rhs": { "const": { "val": "3s" } }
+														}
+													},
+													{
+														"cmp": {
+															"op": "OpLt",
+															"lhs": { "auraRemainingTime": { "auraId": { "spellId": 91821 } } },
+															"rhs": { "const": { "val": "3s" } }
+														}
+													}
+												]
+											}
+										}
+									]
+								}
+							},
+							{
+								"or": {
+									"vals": [
+										{ "auraIsActive": { "auraId": { "itemId": 62469 } } },
+										{ "auraIsActive": { "auraId": { "itemId": 62464 } } },
+										{
+											"and": {
+												"vals": [
+													{ "not": { "val": { "auraIsKnown": { "auraId": { "itemId": 62469 } } } } },
+													{ "not": { "val": { "auraIsKnown": { "auraId": { "itemId": 62464 } } } } },
+													{
+														"or": {
+															"vals": [
+																{
+																	"and": {
+																		"vals": [
+																			{ "auraIsActive": { "auraId": { "spellId": 92345 } } },
+																			{ "auraIsActive": { "auraId": { "spellId": 91816 } } },
+																			{ "auraIsActive": { "auraId": { "spellId": 91364 } } },
+																			{ "auraIsActive": { "auraId": { "spellId": 91363 } } },
+																			{ "auraIsActive": { "auraId": { "spellId": 92342 } } },
+																			{ "auraIsActive": { "auraId": { "spellId": 91821 } } }
+																		]
+																	}
+																},
+																{
+																	"cmp": {
+																		"op": "OpLt",
+																		"lhs": { "auraRemainingTime": { "auraId": { "spellId": 51271 } } },
+																		"rhs": { "const": { "val": "3s" } }
+																	}
+																}
+															]
+														}
+													}
+												]
+											}
+										}
+									]
+								}
+							},
+							{ "auraIsActive": { "auraId": { "itemId": 58146 } } },
+							{
+								"or": {
+									"vals": [
+										{ "auraIsActive": { "auraId": { "spellId": 91364 } } },
+										{ "auraIsActive": { "auraId": { "spellId": 91363 } } },
+										{ "auraIsActive": { "auraId": { "spellId": 92345 } } },
+										{ "auraIsActive": { "auraId": { "spellId": 91816 } } },
+										{
+											"or": {
+												"vals": [
+													{
+														"cmp": {
+															"op": "OpLt",
+															"lhs": { "auraRemainingTime": { "auraId": { "spellId": 51271 } } },
+															"rhs": { "const": { "val": "3s" } }
+														}
+													},
+													{
+														"cmp": {
+															"op": "OpLt",
+															"lhs": { "auraRemainingTime": { "auraId": { "spellId": 92342 } } },
+															"rhs": { "const": { "val": "3s" } }
+														}
+													},
+													{
+														"cmp": {
+															"op": "OpLt",
+															"lhs": { "auraRemainingTime": { "auraId": { "spellId": 91821 } } },
+															"rhs": { "const": { "val": "3s" } }
+														}
+													}
+												]
+											}
+										}
+									]
+								}
+							}
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 46584 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "auraIsActive": { "auraId": { "spellId": 53365 } } },
+							{ "auraIsActive": { "auraId": { "spellId": 51271 } } },
+							{ "spellIsReady": { "spellId": { "spellId": 46584 } } }
+						]
+					}
+				},
+				"strictSequence": { "actions": [{ "castSpell": { "spellId": { "itemId": 58146 } } }, { "castSpell": { "spellId": { "spellId": 46584 } } }] }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "cmp": { "op": "OpLe", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "10s" } } } },
+							{ "auraIsActive": { "auraId": { "spellId": 51124 } } },
+							{ "cmp": { "op": "OpLt", "lhs": { "auraNumStacks": { "auraId": { "spellId": 96923 } } }, "rhs": { "const": { "val": "4" } } } }
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 49143, "tag": 1 } }
+			}
+		},
+		{
+			"action": {
+				"condition": { "and": { "vals": [{ "cmp": { "op": "OpGe", "lhs": { "currentRunicPower": {} }, "rhs": { "const": { "val": "105" } } } }] } },
+				"castSpell": { "spellId": { "spellId": 49143, "tag": 1 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "spellIsReady": { "spellId": { "spellId": 77575 } } },
+							{
+								"or": {
+									"vals": [
+										{
+											"cmp": {
+												"op": "OpLt",
+												"lhs": { "dotRemainingTime": { "spellId": { "spellId": 55078 } } },
+												"rhs": { "const": { "val": "3s" } }
+											}
+										},
+										{ "not": { "val": { "dotIsActive": { "spellId": { "spellId": 55078 } } } } }
+									]
+								}
+							}
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 77575 } }
+			}
+		},
+		{ "action": { "condition": { "auraIsActive": { "auraId": { "spellId": 59052 } } }, "castSpell": { "spellId": { "spellId": 49184 } } } },
+		{
+			"action": {
+				"condition": { "not": { "val": { "dotIsActive": { "spellId": { "spellId": 55095 } } } } },
+				"castSpell": { "spellId": { "spellId": 49184 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "cmp": { "op": "OpGe", "lhs": { "currentRunicPower": {} }, "rhs": { "const": { "val": "100" } } } },
+							{
+								"or": {
+									"vals": [
+										{
+											"cmp": {
+												"op": "OpEq",
+												"lhs": { "currentRuneCount": { "runeType": "RuneFrost" } },
+												"rhs": { "const": { "val": "0" } }
+											}
+										},
+										{
+											"cmp": {
+												"op": "OpEq",
+												"lhs": { "currentRuneCount": { "runeType": "RuneDeath" } },
+												"rhs": { "const": { "val": "0" } }
+											}
+										}
+									]
+								}
+							},
+							{ "cmp": { "op": "OpGe", "lhs": { "currentRuneCount": { "runeType": "RuneUnholy" } }, "rhs": { "const": { "val": "1" } } } }
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 49143, "tag": 1 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "not": { "val": { "dotIsActive": { "spellId": { "spellId": 55078 } } } } },
+							{
+								"or": {
+									"vals": [
+										{
+											"cmp": {
+												"op": "OpEq",
+												"lhs": { "currentRuneCount": { "runeType": "RuneUnholy" } },
+												"rhs": { "const": { "val": "2" } }
+											}
+										},
+										{
+											"and": {
+												"vals": [
+													{
+														"cmp": {
+															"op": "OpGe",
+															"lhs": { "currentRuneCount": { "runeType": "RuneUnholy" } },
+															"rhs": { "const": { "val": "1" } }
+														}
+													},
+													{
+														"cmp": {
+															"op": "OpLe",
+															"lhs": { "nextRuneCooldown": { "runeType": "RuneUnholy" } },
+															"rhs": { "const": { "val": "1s" } }
+														}
+													}
+												]
+											}
+										}
+									]
+								}
+							},
+							{ "not": { "val": { "auraIsActive": { "auraId": { "spellId": 51124 } } } } }
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 45462, "tag": 1 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "cmp": { "op": "OpLe", "lhs": { "currentRunicPower": {} }, "rhs": { "const": { "val": "90" } } } },
+							{
+								"or": {
+									"vals": [
+										{
+											"cmp": {
+												"op": "OpEq",
+												"lhs": { "currentRuneCount": { "runeType": "RuneUnholy" } },
+												"rhs": { "const": { "val": "2" } }
+											}
+										},
+										{
+											"and": {
+												"vals": [
+													{
+														"cmp": {
+															"op": "OpGe",
+															"lhs": { "currentRuneCount": { "runeType": "RuneUnholy" } },
+															"rhs": { "const": { "val": "1" } }
+														}
+													},
+													{
+														"cmp": {
+															"op": "OpLe",
+															"lhs": { "nextRuneCooldown": { "runeType": "RuneUnholy" } },
+															"rhs": { "const": { "val": "1s" } }
+														}
+													}
+												]
+											}
+										}
+									]
+								}
+							},
+							{
+								"or": {
+									"vals": [{ "dotIsActive": { "spellId": { "spellId": 55078 } } }, { "dotIsActive": { "spellId": { "spellId": 98957 } } }]
+								}
+							}
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 49020, "tag": 1 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "auraIsActive": { "auraId": { "spellId": 51124 } } },
+							{ "cmp": { "op": "OpGe", "lhs": { "currentRuneCount": { "runeType": "RuneUnholy" } }, "rhs": { "const": { "val": "1" } } } },
+							{
+								"or": {
+									"vals": [
+										{
+											"and": {
+												"vals": [
+													{
+														"cmp": {
+															"op": "OpEq",
+															"lhs": { "currentRuneCount": { "runeType": "RuneFrost" } },
+															"rhs": { "const": { "val": "0" } }
+														}
+													},
+													{
+														"cmp": {
+															"op": "OpEq",
+															"lhs": { "currentRuneCount": { "runeType": "RuneDeath" } },
+															"rhs": { "const": { "val": "1" } }
+														}
+													}
+												]
+											}
+										},
+										{
+											"and": {
+												"vals": [
+													{
+														"cmp": {
+															"op": "OpEq",
+															"lhs": { "currentRuneCount": { "runeType": "RuneFrost" } },
+															"rhs": { "const": { "val": "1" } }
+														}
+													},
+													{
+														"cmp": {
+															"op": "OpEq",
+															"lhs": { "currentRuneCount": { "runeType": "RuneDeath" } },
+															"rhs": { "const": { "val": "0" } }
+														}
+													}
+												]
+											}
+										}
+									]
+								}
+							}
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 49143, "tag": 1 } }
+			}
+		},
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{
+								"or": {
+									"vals": [
+										{
+											"and": {
+												"vals": [
+													{ "cmp": { "op": "OpLe", "lhs": { "currentRunicPower": {} }, "rhs": { "const": { "val": "90" } } } },
+													{
+														"cmp": {
+															"op": "OpLt",
+															"lhs": { "runeCooldown": { "runeType": "RuneUnholy" } },
+															"rhs": { "const": { "val": "2s" } }
+														}
+													},
+													{
+														"or": {
+															"vals": [
+																{
+																	"cmp": {
+																		"op": "OpEq",
+																		"lhs": { "currentRuneCount": { "runeType": "RuneDeath" } },
+																		"rhs": { "const": { "val": "2" } }
+																	}
+																},
+																{
+																	"cmp": {
+																		"op": "OpEq",
+																		"lhs": { "currentRuneCount": { "runeType": "RuneFrost" } },
+																		"rhs": { "const": { "val": "2" } }
+																	}
+																},
+																{
+																	"and": {
+																		"vals": [
+																			{
+																				"cmp": {
+																					"op": "OpEq",
+																					"lhs": { "currentRuneCount": { "runeType": "RuneDeath" } },
+																					"rhs": { "const": { "val": "1" } }
+																				}
+																			},
+																			{
+																				"cmp": {
+																					"op": "OpEq",
+																					"lhs": { "currentRuneCount": { "runeType": "RuneFrost" } },
+																					"rhs": { "const": { "val": "1" } }
+																				}
+																			}
+																		]
+																	}
+																},
+																{
+																	"or": {
+																		"vals": [
+																			{
+																				"cmp": {
+																					"op": "OpLt",
+																					"lhs": { "runeCooldown": { "runeType": "RuneBlood" } },
+																					"rhs": { "const": { "val": "1s" } }
+																				}
+																			},
+																			{
+																				"cmp": {
+																					"op": "OpLt",
+																					"lhs": { "runeCooldown": { "runeType": "RuneFrost" } },
+																					"rhs": { "const": { "val": "1s" } }
+																				}
+																			}
+																		]
+																	}
+																}
+															]
+														}
+													}
+												]
+											}
+										},
+										{
+											"and": {
+												"vals": [
+													{ "cmp": { "op": "OpLe", "lhs": { "currentRunicPower": {} }, "rhs": { "const": { "val": "70" } } } },
+													{
+														"cmp": {
+															"op": "OpLt",
+															"lhs": { "runeCooldown": { "runeType": "RuneUnholy" } },
+															"rhs": { "const": { "val": "3s" } }
+														}
+													},
+													{
+														"or": {
+															"vals": [
+																{
+																	"and": {
+																		"vals": [
+																			{
+																				"cmp": {
+																					"op": "OpEq",
+																					"lhs": { "currentRuneCount": { "runeType": "RuneDeath" } },
+																					"rhs": { "const": { "val": "2" } }
+																				}
+																			},
+																			{
+																				"cmp": {
+																					"op": "OpGe",
+																					"lhs": { "currentRuneCount": { "runeType": "RuneFrost" } },
+																					"rhs": { "const": { "val": "1" } }
+																				}
+																			}
+																		]
+																	}
+																},
+																{
+																	"and": {
+																		"vals": [
+																			{
+																				"cmp": {
+																					"op": "OpGe",
+																					"lhs": { "currentRuneCount": { "runeType": "RuneDeath" } },
+																					"rhs": { "const": { "val": "1" } }
+																				}
+																			},
+																			{
+																				"cmp": {
+																					"op": "OpEq",
+																					"lhs": { "currentRuneCount": { "runeType": "RuneFrost" } },
+																					"rhs": { "const": { "val": "2" } }
+																				}
+																			}
+																		]
+																	}
+																},
+																{
+																	"and": {
+																		"vals": [
+																			{
+																				"cmp": {
+																					"op": "OpEq",
+																					"lhs": { "currentRuneCount": { "runeType": "RuneDeath" } },
+																					"rhs": { "const": { "val": "1" } }
+																				}
+																			},
+																			{
+																				"cmp": {
+																					"op": "OpEq",
+																					"lhs": { "currentRuneCount": { "runeType": "RuneFrost" } },
+																					"rhs": { "const": { "val": "1" } }
+																				}
+																			},
+																			{
+																				"or": {
+																					"vals": [
+																						{
+																							"cmp": {
+																								"op": "OpLt",
+																								"lhs": { "runeCooldown": { "runeType": "RuneBlood" } },
+																								"rhs": { "const": { "val": "2s" } }
+																							}
+																						},
+																						{
+																							"cmp": {
+																								"op": "OpLt",
+																								"lhs": { "runeCooldown": { "runeType": "RuneFrost" } },
+																								"rhs": { "const": { "val": "2s" } }
+																							}
+																						}
+																					]
+																				}
+																			}
+																		]
+																	}
+																},
+																{
+																	"or": {
+																		"vals": [
+																			{
+																				"and": {
+																					"vals": [
+																						{
+																							"cmp": {
+																								"op": "OpLt",
+																								"lhs": { "runeCooldown": { "runeType": "RuneBlood" } },
+																								"rhs": { "const": { "val": "2s" } }
+																							}
+																						},
+																						{
+																							"cmp": {
+																								"op": "OpLt",
+																								"lhs": { "runeCooldown": { "runeType": "RuneFrost" } },
+																								"rhs": { "const": { "val": "1s" } }
+																							}
+																						}
+																					]
+																				}
+																			},
+																			{
+																				"and": {
+																					"vals": [
+																						{
+																							"cmp": {
+																								"op": "OpLt",
+																								"lhs": { "runeCooldown": { "runeType": "RuneBlood" } },
+																								"rhs": { "const": { "val": "1s" } }
+																							}
+																						},
+																						{
+																							"cmp": {
+																								"op": "OpLt",
+																								"lhs": { "runeCooldown": { "runeType": "RuneFrost" } },
+																								"rhs": { "const": { "val": "2s" } }
+																							}
+																						}
+																					]
+																				}
+																			}
+																		]
+																	}
+																}
+															]
+														}
+													}
+												]
+											}
+										}
+									]
+								}
+							},
+							{
+								"or": {
+									"vals": [{ "dotIsActive": { "spellId": { "spellId": 55078 } } }, { "dotIsActive": { "spellId": { "spellId": 98957 } } }]
+								}
+							},
+							{ "auraIsActive": { "auraId": { "spellId": 51124 } } },
+							{ "cmp": { "op": "OpEq", "lhs": { "currentRuneCount": { "runeType": "RuneUnholy" } }, "rhs": { "const": { "val": "1" } } } }
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 49020, "tag": 1 } }
+			}
+		},
+		{ "action": { "castSpell": { "spellId": { "spellId": 49184 } } } },
+		{
+			"action": {
+				"condition": {
+					"or": {
+						"vals": [
+							{ "not": { "val": { "auraIsActive": { "auraId": { "spellId": 57330 } } } } },
+							{ "not": { "val": { "auraIsActive": { "auraId": { "spellId": 98971 } } } } }
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 57330 } }
+			}
+		},
+		{ "action": { "castSpell": { "spellId": { "spellId": 49143, "tag": 1 } } } },
+		{ "action": { "castSpell": { "spellId": { "spellId": 57330 } } } },
+		{
+			"action": {
+				"condition": {
+					"and": {
+						"vals": [
+							{ "cmp": { "op": "OpEq", "lhs": { "currentRuneCount": { "runeType": "RuneFrost" } }, "rhs": { "const": { "val": "0" } } } },
+							{ "cmp": { "op": "OpEq", "lhs": { "currentRuneCount": { "runeType": "RuneDeath" } }, "rhs": { "const": { "val": "0" } } } },
+							{ "cmp": { "op": "OpGe", "lhs": { "currentRuneCount": { "runeType": "RuneUnholy" } }, "rhs": { "const": { "val": "1" } } } },
+							{ "cmp": { "op": "OpGt", "lhs": { "runeCooldown": { "runeType": "RuneFrost" } }, "rhs": { "const": { "val": "2.5s" } } } },
+							{ "cmp": { "op": "OpGt", "lhs": { "runeCooldown": { "runeType": "RuneBlood" } }, "rhs": { "const": { "val": "2.5s" } } } },
+							{ "spellIsReady": { "spellId": { "spellId": 47568 } } }
+						]
+					}
+				},
+				"castSpell": { "spellId": { "spellId": 45462, "tag": 1 } }
+			}
+		}
+	]
 }

--- a/ui/death_knight/frost/gear_sets/p1.2h.gear.json
+++ b/ui/death_knight/frost/gear_sets/p1.2h.gear.json
@@ -1,19 +1,21 @@
-{"items": [
-	{"id":65130,"enchant":4208,"gems":[68779,52213]},
-	{"id":65025,"reforging":138},
-	{"id":65183,"enchant":4202,"gems":[52206]},
-	{"id":65117,"enchant":4100},
-	{"id":65179,"enchant":4102,"gems":[52206,52213]},
-	{"id":65085,"enchant":4256,"gems":[0]},
-	{"id":65180,"enchant":4106,"gems":[52235,0]},
-	{"id":65040,"gems":[52206,52206],"reforging":138},
-	{"id":65182,"enchant":4126,"gems":[52206,52206]},
-	{"id":65075,"gems":[52206]},
-	{"id":65106,"enchant":4078},
-	{"id":60226,"enchant":4078,"gems":[52214],"reforging":145},
-	{"id":65072,"reforging":160},
-	{"id":65118},
-	{"id":65003,"enchant":3368,"reforging":140},
-	{},
-	{"id":64674,"gems":[52206],"reforging":145}
-  ]}
+{
+	"items": [
+		{ "id": 65130, "enchant": 4208, "gems": [68779, 52213], "reforging": 146 },
+		{ "id": 65025, "reforging": 167 },
+		{ "id": 65183, "enchant": 4202, "gems": [52255], "reforging": 140 },
+		{ "id": 65117, "enchant": 4100, "reforging": 147 },
+		{ "id": 65179, "enchant": 4102, "gems": [52255, 52213], "reforging": 146 },
+		{ "id": 65085, "enchant": 4256, "gems": [0], "reforging": 140 },
+		{ "id": 65180, "enchant": 4106, "gems": [52235, 0] },
+		{ "id": 65040, "gems": [52206, 52206], "reforging": 145 },
+		{ "id": 65182, "enchant": 4126, "gems": [52255, 52206], "reforging": 167 },
+		{ "id": 65075, "gems": [52206], "reforging": 167 },
+		{ "id": 65106 },
+		{ "id": 60226, "gems": [52214], "reforging": 167 },
+		{ "id": 65072, "reforging": 160 },
+		{ "id": 65118 },
+		{ "id": 65003, "enchant": 3368, "reforging": 138 },
+		{},
+		{ "id": 64674, "gems": [52206], "reforging": 145 }
+	]
+}

--- a/ui/death_knight/frost/gear_sets/p1.dw.gear.json
+++ b/ui/death_knight/frost/gear_sets/p1.dw.gear.json
@@ -1,19 +1,21 @@
-{"items": [
-	{"id":65181,"enchant":4208,"gems":[68779,52214],"reforging":159},
-	{"id":69885,"randomSuffix":-122},
-	{"id":65183,"enchant":4202,"gems":[52255]},
-	{"id":65117,"enchant":4100,"reforging":144},
-	{"id":65179,"enchant":4102,"gems":[52255,52213]},
-	{"id":65085,"enchant":4256,"gems":[0],"reforging":137},
-	{"id":65180,"gems":[52213,0],"reforging":166},
-	{"id":65369,"randomSuffix":-222,"gems":[52214,52206]},
-	{"id":65379,"randomSuffix":-175,"enchant":4126,"gems":[52255,52213]},
-	{"id":65075,"gems":[52206]},
-	{"id":60226,"gems":[52214],"reforging":167},
-	{"id":65382,"randomSuffix":-122},
-	{"id":58180},
-	{"id":59224},
-	{"id":65047,"enchant":3370},
-	{"id":65047,"enchant":3368},
-	{"id":64674,"gems":[0],"reforging":160}
-]}
+{
+	"items": [
+		{ "id": 65181, "enchant": 4208, "gems": [68779, 52214], "reforging": 158 },
+		{ "id": 69885, "randomSuffix": -122, "reforging": 144 },
+		{ "id": 65183, "enchant": 4202, "gems": [52255], "reforging": 140 },
+		{ "id": 65117, "enchant": 4100, "reforging": 147 },
+		{ "id": 65179, "enchant": 4102, "gems": [52255, 52213], "reforging": 147 },
+		{ "id": 65085, "enchant": 4256, "gems": [0], "reforging": 140 },
+		{ "id": 65180, "gems": [52213, 0], "reforging": 165 },
+		{ "id": 65369, "randomSuffix": -222, "gems": [52214, 52206], "reforging": 147 },
+		{ "id": 65379, "randomSuffix": -175, "enchant": 4126, "gems": [52255, 52213], "reforging": 144 },
+		{ "id": 65075, "gems": [52206], "reforging": 160 },
+		{ "id": 60226, "gems": [52214], "reforging": 167 },
+		{ "id": 65382, "randomSuffix": -122, "reforging": 147 },
+		{ "id": 58180, "reforging": 138 },
+		{ "id": 65072, "reforging": 160 },
+		{ "id": 65047, "enchant": 3370, "reforging": 144 },
+		{ "id": 65047, "enchant": 3368, "reforging": 144 },
+		{ "id": 64674, "gems": [52206], "reforging": 160 }
+	]
+}

--- a/ui/death_knight/frost/gear_sets/p1.masterfrost.gear.json
+++ b/ui/death_knight/frost/gear_sets/p1.masterfrost.gear.json
@@ -1,19 +1,21 @@
-{"items": [
-	{"id":65181,"enchant":4208,"gems":[68779,52214],"reforging":161},
-	{"id":69885,"randomSuffix":-118,"reforging":151},
-	{"id":65183,"enchant":4202,"gems":[52255],"reforging":154},
-	{"id":69879,"randomSuffix":-118,"enchant":4100,"reforging":151},
-	{"id":65179,"enchant":4102,"gems":[52255,52213],"reforging":154},
-	{"id":60228,"enchant":4256,"gems":[52206,0],"reforging":147},
-	{"id":65180,"enchant":4106,"gems":[52206,0],"reforging":151},
-	{"id":65369,"randomSuffix":-223,"gems":[52206,52206],"reforging":151},
-	{"id":65379,"randomSuffix":-176,"enchant":4126,"gems":[52255,52213],"reforging":151},
-	{"id":65075,"enchant":4069,"gems":[52213],"reforging":158},
-	{"id":60226,"gems":[52206],"reforging":144},
-	{"id":65382,"randomSuffix":-118,"reforging":151},
-	{"id":62469},
-	{"id":65072,"reforging":161},
-	{"id":68131,"randomSuffix":-118,"enchant":3370,"reforging":151},
-	{"id":65047,"enchant":3368,"reforging":154},
-	{"id":64674,"gems":[52206],"reforging":158}
-]}
+{
+	"items": [
+		{ "id": 65181, "enchant": 4208, "gems": [68779, 52214], "reforging": 161 },
+		{ "id": 69885, "randomSuffix": -118, "reforging": 151 },
+		{ "id": 65183, "enchant": 4202, "gems": [52255], "reforging": 154 },
+		{ "id": 69879, "randomSuffix": -118, "enchant": 4100, "reforging": 151 },
+		{ "id": 65179, "enchant": 4102, "gems": [52255, 52213], "reforging": 147 },
+		{ "id": 60228, "enchant": 4256, "gems": [52206, 0], "reforging": 147 },
+		{ "id": 65180, "enchant": 4106, "gems": [52206, 0], "reforging": 151 },
+		{ "id": 65369, "randomSuffix": -223, "gems": [52206, 52206], "reforging": 151 },
+		{ "id": 65379, "randomSuffix": -176, "enchant": 4126, "gems": [52255, 52213], "reforging": 151 },
+		{ "id": 65075, "enchant": 4069, "gems": [52213], "reforging": 158 },
+		{ "id": 60226, "gems": [52206], "reforging": 144 },
+		{ "id": 65382, "randomSuffix": -118, "reforging": 151 },
+		{ "id": 62469 },
+		{ "id": 65072, "reforging": 161 },
+		{ "id": 68131, "randomSuffix": -118, "enchant": 3370, "reforging": 151 },
+		{ "id": 65047, "enchant": 3368, "reforging": 147 },
+		{ "id": 64674, "gems": [52206], "reforging": 161 }
+	]
+}

--- a/ui/death_knight/frost/gear_sets/p3.masterfrost.gear.json
+++ b/ui/death_knight/frost/gear_sets/p3.masterfrost.gear.json
@@ -1,19 +1,21 @@
-{"items": [
-  {"id":71478,"enchant":4208,"gems":[68779,52206],"reforging":140},
-  {"id":71446,"reforging":147},
-  {"id":71480,"enchant":4202,"gems":[52255]},
-  {"id":69879,"randomSuffix":-118,"enchant":4100,"reforging":151},
-  {"id":71469,"enchant":4102,"gems":[52255,52213]},
-  {"id":71418,"enchant":4256,"gems":[0],"reforging":147},
-  {"id":71482,"enchant":4106,"gems":[52206,0],"reforging":122},
-  {"id":65369,"randomSuffix":-223,"gems":[52206,52206],"reforging":151},
-  {"id":71484,"enchant":4126,"gems":[52255,52206],"reforging":131},
-  {"id":71404,"enchant":4094,"gems":[52206],"reforging":147},
-  {"id":71215,"gems":[52206],"reforging":147},
-  {"id":71433,"gems":[52206],"reforging":161},
-  {"id":69113},
-  {"id":65072,"reforging":161},
-  {"id":71562,"enchant":3370,"reforging":138},
-  {"id":71562,"enchant":3368},
-  {"id":71587,"gems":[52206],"reforging":147}
-]}
+{
+	"items": [
+		{ "id": 71478, "enchant": 4208, "gems": [68779, 52206], "reforging": 140 },
+		{ "id": 71446, "reforging": 147 },
+		{ "id": 71480, "enchant": 4202, "gems": [52255], "reforging": 151 },
+		{ "id": 69879, "randomSuffix": -118, "enchant": 4100, "reforging": 151 },
+		{ "id": 71469, "enchant": 4102, "gems": [52255, 52213], "reforging": 151 },
+		{ "id": 71418, "enchant": 4256, "gems": [0], "reforging": 147 },
+		{ "id": 71482, "enchant": 4106, "gems": [52206, 0], "reforging": 124 },
+		{ "id": 65369, "randomSuffix": -223, "gems": [52206, 52206] },
+		{ "id": 71484, "enchant": 4126, "gems": [52255, 52206], "reforging": 131 },
+		{ "id": 71404, "enchant": 4094, "gems": [52206], "reforging": 147 },
+		{ "id": 71215, "gems": [52206], "reforging": 147 },
+		{ "id": 71433, "gems": [52206], "reforging": 161 },
+		{ "id": 69113 },
+		{ "id": 65072, "reforging": 161 },
+		{ "id": 71562, "enchant": 3370, "reforging": 138 },
+		{ "id": 71562, "enchant": 3368, "reforging": 138 },
+		{ "id": 71587, "gems": [52206], "reforging": 147 }
+	]
+}

--- a/ui/death_knight/frost/gear_sets/prebis.gear.json
+++ b/ui/death_knight/frost/gear_sets/prebis.gear.json
@@ -1,0 +1,21 @@
+{
+	"items": [
+		{ "id": 60341, "enchant": 4208, "gems": [68779, 52214], "reforging": 161 },
+		{ "id": 69885, "randomSuffix": -118 },
+		{ "id": 60343, "enchant": 4202, "gems": [52255], "reforging": 154 },
+		{ "id": 69879, "randomSuffix": -118, "enchant": 4100 },
+		{ "id": 71058, "enchant": 4102, "gems": [52255, 52206], "reforging": 145 },
+		{ "id": 60228, "enchant": 4256, "gems": [52206, 0], "reforging": 147 },
+		{ "id": 69936, "enchant": 4106, "gems": [52206, 0], "reforging": 147 },
+		{ "id": 65369, "randomSuffix": -223, "gems": [52206, 52206] },
+		{ "id": 71061, "enchant": 4126, "gems": [52255, 52213], "reforging": 161 },
+		{ "id": 69946, "enchant": 4094, "gems": [52206], "reforging": 147 },
+		{ "id": 65382, "randomSuffix": -118, "reforging": 151 },
+		{ "id": 60226, "gems": [52206], "reforging": 144 },
+		{ "id": 68972 },
+		{ "id": 65072, "reforging": 161 },
+		{ "id": 71362, "enchant": 3370 },
+		{ "id": 71362, "enchant": 3368, "reforging": 138 },
+		{ "id": 71147, "gems": [52206], "reforging": 147 }
+	]
+}

--- a/ui/death_knight/frost/presets.ts
+++ b/ui/death_knight/frost/presets.ts
@@ -2,6 +2,7 @@ import * as Mechanics from '../../core/constants/mechanics';
 import { Player } from '../../core/player';
 import * as PresetUtils from '../../core/preset_utils';
 import { makeSpecChangeWarningToast } from '../../core/preset_utils';
+import { APLRotation_Type as APLRotationType } from '../../core/proto/apl';
 import { Consumes, Flask, Food, Glyphs, HandType, ItemSlot, Potions, Profession, PseudoStat, Spec, Stat, TinkerHands } from '../../core/proto/common';
 import { DeathKnightMajorGlyph, DeathKnightMinorGlyph, DeathKnightPrimeGlyph, FrostDeathKnight_Options } from '../../core/proto/death_knight';
 import { SavedTalents } from '../../core/proto/ui';
@@ -13,6 +14,7 @@ import P12HGear from '../../death_knight/frost/gear_sets/p1.2h.gear.json';
 import P1DWGear from '../../death_knight/frost/gear_sets/p1.dw.gear.json';
 import P1MasterfrostGear from '../../death_knight/frost/gear_sets/p1.masterfrost.gear.json';
 import P3MasterfrostGear from '../../death_knight/frost/gear_sets/p3.masterfrost.gear.json';
+import PreBISGear from '../../death_knight/frost/gear_sets/prebis.gear.json';
 
 // Preset options for this spec.
 // Eventually we will import these values for the raid sim too, so its good to
@@ -57,16 +59,63 @@ const TWOHAND_PRESET_OPTIONS = {
 	},
 };
 
-export const P1_DW_GEAR_PRESET = PresetUtils.makePresetGear('P1 Dual Wield', P1DWGear, DW_PRESET_OPTIONS);
+export const P1_DW_GEAR_PRESET = PresetUtils.makePresetGear('P1 DW Obliterate', P1DWGear, DW_PRESET_OPTIONS);
 export const P1_2H_GEAR_PRESET = PresetUtils.makePresetGear('P1 Two Hand', P12HGear, TWOHAND_PRESET_OPTIONS);
 export const P1_MASTERFROST_GEAR_PRESET = PresetUtils.makePresetGear('P1 Masterfrost', P1MasterfrostGear, DW_PRESET_OPTIONS);
 export const P3_MASTERFROST_GEAR_PRESET = PresetUtils.makePresetGear('P3 Masterfrost', P3MasterfrostGear, DW_PRESET_OPTIONS);
+export const PREBIS_MASTERFROST_GEAR_PRESET = PresetUtils.makePresetGear('Pre-bis Masterfrost', PreBISGear, DW_PRESET_OPTIONS);
 
-export const DUAL_WIELD_ROTATION_PRESET_DEFAULT = PresetUtils.makePresetAPLRotation('Dual Wield', DualWieldAPL, DW_PRESET_OPTIONS);
+export const DUAL_WIELD_ROTATION_PRESET_DEFAULT = PresetUtils.makePresetAPLRotation('DW Obliterate', DualWieldAPL, DW_PRESET_OPTIONS);
 export const TWO_HAND_ROTATION_PRESET_DEFAULT = PresetUtils.makePresetAPLRotation('Two Hand', TwoHandAPL, TWOHAND_PRESET_OPTIONS);
 export const MASTERFROST_ROTATION_PRESET_DEFAULT = PresetUtils.makePresetAPLRotation('Masterfrost', MasterFrostAPL, DW_PRESET_OPTIONS);
 
 // Preset options for EP weights
+export const P1_DUAL_WIELD_EP_PRESET = PresetUtils.makePresetEpWeights(
+	'P1 DW Obliterate',
+	Stats.fromMap(
+		{
+			[Stat.StatStrength]: 2.92,
+			[Stat.StatArmor]: 0.03,
+			[Stat.StatAttackPower]: 1,
+			[Stat.StatExpertiseRating]: 0.56,
+			[Stat.StatHasteRating]: 1.3,
+			[Stat.StatHitRating]: 1.22,
+			[Stat.StatCritRating]: 1.06,
+			[Stat.StatMasteryRating]: 1.11,
+		},
+		{
+			[PseudoStat.PseudoStatMainHandDps]: 6.05,
+			[PseudoStat.PseudoStatOffHandDps]: 3.85,
+			[PseudoStat.PseudoStatPhysicalHitPercent]: 146.53,
+			[PseudoStat.PseudoStatSpellHitPercent]: 41.91,
+		},
+	),
+	DW_PRESET_OPTIONS,
+);
+
+export const P1_TWOHAND_EP_PRESET = PresetUtils.makePresetEpWeights(
+	'P1 Two Hand',
+	Stats.fromMap(
+		{
+			[Stat.StatStrength]: 2.98,
+			[Stat.StatArmor]: 0.03,
+			[Stat.StatAttackPower]: 1,
+			[Stat.StatExpertiseRating]: 1.34,
+			[Stat.StatHasteRating]: 1.94,
+			[Stat.StatHitRating]: 1.61,
+			[Stat.StatCritRating]: 1.24,
+			[Stat.StatMasteryRating]: 1.26,
+		},
+		{
+			[PseudoStat.PseudoStatMainHandDps]: 10.08,
+			[PseudoStat.PseudoStatOffHandDps]: 0,
+			[PseudoStat.PseudoStatPhysicalHitPercent]: 1.61 * Mechanics.PHYSICAL_HIT_RATING_PER_HIT_PERCENT,
+			[PseudoStat.PseudoStatSpellHitPercent]: 0,
+		},
+	),
+	TWOHAND_PRESET_OPTIONS,
+);
+
 export const P1_MASTERFROST_EP_PRESET = PresetUtils.makePresetEpWeights(
 	'P1 Masterfrost',
 	Stats.fromMap(
@@ -76,15 +125,15 @@ export const P1_MASTERFROST_EP_PRESET = PresetUtils.makePresetEpWeights(
 			[Stat.StatAttackPower]: 1,
 			[Stat.StatExpertiseRating]: 0.75,
 			[Stat.StatHasteRating]: 1.38,
-			[Stat.StatHitRating]: 1.08 + 0.59,
+			[Stat.StatHitRating]: 1.67 + 1.4,
 			[Stat.StatCritRating]: 0.64 + 0.43,
 			[Stat.StatMasteryRating]: 1.41,
 		},
 		{
 			[PseudoStat.PseudoStatMainHandDps]: 4.5,
 			[PseudoStat.PseudoStatOffHandDps]: 2.84,
-			[PseudoStat.PseudoStatPhysicalHitPercent]: 1.08 * Mechanics.PHYSICAL_HIT_RATING_PER_HIT_PERCENT,
-			[PseudoStat.PseudoStatSpellHitPercent]: 0.59 * Mechanics.SPELL_HIT_RATING_PER_HIT_PERCENT,
+			[PseudoStat.PseudoStatPhysicalHitPercent]: 1.67 * Mechanics.PHYSICAL_HIT_RATING_PER_HIT_PERCENT,
+			[PseudoStat.PseudoStatSpellHitPercent]: 1.4 * Mechanics.SPELL_HIT_RATING_PER_HIT_PERCENT,
 		},
 	),
 	DW_PRESET_OPTIONS,
@@ -94,7 +143,7 @@ export const P1_MASTERFROST_EP_PRESET = PresetUtils.makePresetEpWeights(
 // https://wotlk.wowhead.com/talent-calc and copy the numbers in the url.
 
 export const DualWieldTalents = {
-	name: 'Dual Wield',
+	name: 'DW Obliterate',
 	data: SavedTalents.create({
 		talentsString: '2032-20330022233112012301-003',
 		glyphs: Glyphs.create({
@@ -171,20 +220,30 @@ export const DefaultConsumes = Consumes.create({
 	tinkerHands: TinkerHands.TinkerHandsSynapseSprings,
 });
 
-export const PRESET_BUILD_DW = PresetUtils.makePresetBuild('Dual Wield', {
+export const PRESET_BUILD_DW = PresetUtils.makePresetBuild('DW Obliterate', {
 	gear: P1_DW_GEAR_PRESET,
 	talents: DualWieldTalents,
-	rotation: DUAL_WIELD_ROTATION_PRESET_DEFAULT,
+	rotationType: APLRotationType.TypeAuto,
+	epWeights: P1_DUAL_WIELD_EP_PRESET,
 });
 
 export const PRESET_BUILD_2H = PresetUtils.makePresetBuild('Two Hand', {
 	gear: P1_2H_GEAR_PRESET,
 	talents: TwoHandTalents,
-	rotation: TWO_HAND_ROTATION_PRESET_DEFAULT,
+	rotationType: APLRotationType.TypeAuto,
+	epWeights: P1_TWOHAND_EP_PRESET,
 });
 
 export const PRESET_BUILD_MASTERFROST = PresetUtils.makePresetBuild('Masterfrost', {
-	gear: P1_MASTERFROST_GEAR_PRESET,
+	gear: P3_MASTERFROST_GEAR_PRESET,
 	talents: MasterfrostTalents,
-	rotation: MASTERFROST_ROTATION_PRESET_DEFAULT,
+	rotationType: APLRotationType.TypeAuto,
+	epWeights: P1_MASTERFROST_EP_PRESET,
+});
+
+export const PRESET_BUILD_PREBIS = PresetUtils.makePresetBuild('Pre-bis', {
+	gear: PREBIS_MASTERFROST_GEAR_PRESET,
+	talents: MasterfrostTalents,
+	rotationType: APLRotationType.TypeAuto,
+	epWeights: P1_MASTERFROST_EP_PRESET,
 });

--- a/ui/death_knight/unholy/apls/default.apl.json
+++ b/ui/death_knight/unholy/apls/default.apl.json
@@ -41,7 +41,9 @@
 									"vals": [
 										{ "auraIsActive": { "auraId": { "spellId": 53365 } } },
 										{ "auraIsActive": { "auraId": { "spellId": 92345 } } },
-										{ "auraIsActive": { "auraId": { "spellId": 91364 } } }
+										{ "auraIsActive": { "auraId": { "spellId": 91816 } } },
+										{ "auraIsActive": { "auraId": { "spellId": 91364 } } },
+										{ "auraIsActive": { "auraId": { "spellId": 91363 } } }
 									]
 								}
 							},
@@ -66,7 +68,9 @@
 											"or": {
 												"vals": [
 													{ "auraIsActive": { "auraId": { "spellId": 92345 } } },
-													{ "auraIsActive": { "auraId": { "spellId": 91364 } } }
+													{ "auraIsActive": { "auraId": { "spellId": 91816 } } },
+													{ "auraIsActive": { "auraId": { "spellId": 91364 } } },
+													{ "auraIsActive": { "auraId": { "spellId": 91363 } } }
 												]
 											}
 										}
@@ -90,7 +94,9 @@
 									"vals": [
 										{ "auraIsActive": { "auraId": { "spellId": 53365 } } },
 										{ "auraIsActive": { "auraId": { "spellId": 92345 } } },
-										{ "auraIsActive": { "auraId": { "spellId": 91364 } } }
+										{ "auraIsActive": { "auraId": { "spellId": 91816 } } },
+										{ "auraIsActive": { "auraId": { "spellId": 91364 } } },
+										{ "auraIsActive": { "auraId": { "spellId": 91363 } } }
 									]
 								}
 							},
@@ -117,11 +123,39 @@
 													{
 														"and": {
 															"vals": [
+																{ "auraIsActive": { "auraId": { "spellId": 91363 } } },
+																{
+																	"cmp": {
+																		"op": "OpLt",
+																		"lhs": { "auraRemainingTime": { "auraId": { "spellId": 91363 } } },
+																		"rhs": { "const": { "val": "10.5s" } }
+																	}
+																}
+															]
+														}
+													},
+													{
+														"and": {
+															"vals": [
 																{ "auraIsActive": { "auraId": { "spellId": 92345 } } },
 																{
 																	"cmp": {
 																		"op": "OpLt",
 																		"lhs": { "auraRemainingTime": { "auraId": { "spellId": 92345 } } },
+																		"rhs": { "const": { "val": "10.5s" } }
+																	}
+																}
+															]
+														}
+													},
+													{
+														"and": {
+															"vals": [
+																{ "auraIsActive": { "auraId": { "spellId": 91816 } } },
+																{
+																	"cmp": {
+																		"op": "OpLt",
+																		"lhs": { "auraRemainingTime": { "auraId": { "spellId": 91816 } } },
 																		"rhs": { "const": { "val": "10.5s" } }
 																	}
 																}
@@ -177,8 +211,9 @@
 									"vals": [
 										{ "auraIsActive": { "auraId": { "spellId": 53365 } } },
 										{ "auraIsActive": { "auraId": { "spellId": 91364 } } },
+										{ "auraIsActive": { "auraId": { "spellId": 91363 } } },
 										{ "auraIsActive": { "auraId": { "spellId": 92345 } } },
-										{ "spellIsKnown": { "spellId": { "spellId": 26297 } } }
+										{ "auraIsActive": { "auraId": { "spellId": 91816 } } }
 									]
 								}
 							},
@@ -210,19 +245,11 @@
 													}
 												]
 											}
-										},
-										{ "spellIsKnown": { "spellId": { "spellId": 26297 } } }
+										}
 									]
 								}
 							},
-							{
-								"and": {
-									"vals": [
-										{ "cmp": { "op": "OpLt", "lhs": { "remainingTime": {} }, "rhs": { "const": { "val": "10.5s" } } } },
-										{ "spellIsKnown": { "spellId": { "spellId": 26297 } } }
-									]
-								}
-							}
+							{ "cmp": { "op": "OpLt", "lhs": { "remainingTime": {} }, "rhs": { "const": { "val": "10.5s" } } } }
 						]
 					}
 				},
@@ -238,7 +265,9 @@
 								"and": {
 									"vals": [
 										{ "auraIsActive": { "auraId": { "spellId": 91364 } } },
+										{ "auraIsActive": { "auraId": { "spellId": 91363 } } },
 										{ "auraIsActive": { "auraId": { "spellId": 92345 } } },
+										{ "auraIsActive": { "auraId": { "spellId": 91816 } } },
 										{
 											"or": {
 												"vals": [
@@ -253,7 +282,21 @@
 													{
 														"cmp": {
 															"op": "OpLe",
+															"lhs": { "auraRemainingTime": { "auraId": { "spellId": 91816 } } },
+															"rhs": { "const": { "val": "15s" } }
+														}
+													},
+													{
+														"cmp": {
+															"op": "OpLe",
 															"lhs": { "auraRemainingTime": { "auraId": { "spellId": 91364 } } },
+															"rhs": { "const": { "val": "15s" } }
+														}
+													},
+													{
+														"cmp": {
+															"op": "OpLe",
+															"lhs": { "auraRemainingTime": { "auraId": { "spellId": 91363 } } },
 															"rhs": { "const": { "val": "15s" } }
 														}
 													}
@@ -289,11 +332,39 @@
 																{
 																	"cmp": {
 																		"op": "OpLt",
+																		"lhs": { "auraRemainingTime": { "auraId": { "spellId": 91363 } } },
+																		"rhs": { "const": { "val": "15s" } }
+																	}
+																},
+																{ "auraIsActive": { "auraId": { "spellId": 91363 } } }
+															]
+														}
+													},
+													{
+														"and": {
+															"vals": [
+																{
+																	"cmp": {
+																		"op": "OpLt",
 																		"lhs": { "auraRemainingTime": { "auraId": { "spellId": 92345 } } },
 																		"rhs": { "const": { "val": "15s" } }
 																	}
 																},
 																{ "auraIsActive": { "auraId": { "spellId": 92345 } } }
+															]
+														}
+													},
+													{
+														"and": {
+															"vals": [
+																{
+																	"cmp": {
+																		"op": "OpLt",
+																		"lhs": { "auraRemainingTime": { "auraId": { "spellId": 91816 } } },
+																		"rhs": { "const": { "val": "15s" } }
+																	}
+																},
+																{ "auraIsActive": { "auraId": { "spellId": 91816 } } }
 															]
 														}
 													}
@@ -373,7 +444,9 @@
 								"and": {
 									"vals": [
 										{ "auraIsActive": { "auraId": { "spellId": 91364 } } },
+										{ "auraIsActive": { "auraId": { "spellId": 91363 } } },
 										{ "auraIsActive": { "auraId": { "spellId": 92345 } } },
+										{ "auraIsActive": { "auraId": { "spellId": 91816 } } },
 										{ "auraIsActive": { "auraId": { "spellId": 53365 } } },
 										{ "auraIsActive": { "auraId": { "itemId": 58146 } } },
 										{
@@ -419,11 +492,39 @@
 																{
 																	"cmp": {
 																		"op": "OpLt",
+																		"lhs": { "auraRemainingTime": { "auraId": { "spellId": 91363 } } },
+																		"rhs": { "const": { "val": "4s" } }
+																	}
+																},
+																{ "auraIsActive": { "auraId": { "spellId": 91363 } } }
+															]
+														}
+													},
+													{
+														"and": {
+															"vals": [
+																{
+																	"cmp": {
+																		"op": "OpLt",
 																		"lhs": { "auraRemainingTime": { "auraId": { "spellId": 92345 } } },
 																		"rhs": { "const": { "val": "4s" } }
 																	}
 																},
 																{ "auraIsActive": { "auraId": { "spellId": 92345 } } }
+															]
+														}
+													},
+													{
+														"and": {
+															"vals": [
+																{
+																	"cmp": {
+																		"op": "OpLt",
+																		"lhs": { "auraRemainingTime": { "auraId": { "spellId": 91816 } } },
+																		"rhs": { "const": { "val": "4s" } }
+																	}
+																},
+																{ "auraIsActive": { "auraId": { "spellId": 91816 } } }
 															]
 														}
 													}
@@ -442,7 +543,9 @@
 											"and": {
 												"vals": [
 													{ "auraIsActive": { "auraId": { "spellId": 91364 } } },
-													{ "auraIsActive": { "auraId": { "spellId": 92345 } } }
+													{ "auraIsActive": { "auraId": { "spellId": 91363 } } },
+													{ "auraIsActive": { "auraId": { "spellId": 92345 } } },
+													{ "auraIsActive": { "auraId": { "spellId": 91816 } } }
 												]
 											}
 										},
@@ -459,7 +562,21 @@
 													{
 														"cmp": {
 															"op": "OpLt",
+															"lhs": { "auraRemainingTime": { "auraId": { "spellId": 91363 } } },
+															"rhs": { "const": { "val": "4s" } }
+														}
+													},
+													{
+														"cmp": {
+															"op": "OpLt",
 															"lhs": { "auraRemainingTime": { "auraId": { "spellId": 92345 } } },
+															"rhs": { "const": { "val": "4s" } }
+														}
+													},
+													{
+														"cmp": {
+															"op": "OpLt",
+															"lhs": { "auraRemainingTime": { "auraId": { "spellId": 91816 } } },
 															"rhs": { "const": { "val": "4s" } }
 														}
 													}
@@ -538,7 +655,9 @@
 						"vals": [
 							{ "auraIsActive": { "auraId": { "spellId": 53365 } } },
 							{ "auraIsActive": { "auraId": { "spellId": 92345 } } },
+							{ "auraIsActive": { "auraId": { "spellId": 91816 } } },
 							{ "auraIsActive": { "auraId": { "spellId": 91364 } } },
+							{ "auraIsActive": { "auraId": { "spellId": 91363 } } },
 							{ "cmp": { "op": "OpGt", "lhs": { "currentTime": {} }, "rhs": { "const": { "val": "8s" } } } },
 							{
 								"or": {
@@ -559,7 +678,33 @@
 										{
 											"cmp": {
 												"op": "OpLt",
+												"lhs": { "auraRemainingTime": { "auraId": { "spellId": 91363 } } },
+												"rhs": {
+													"math": {
+														"op": "OpSub",
+														"lhs": { "spellTimeToReady": { "spellId": { "spellId": 82174 } } },
+														"rhs": { "const": { "val": "1" } }
+													}
+												}
+											}
+										},
+										{
+											"cmp": {
+												"op": "OpLt",
 												"lhs": { "auraRemainingTime": { "auraId": { "spellId": 92345 } } },
+												"rhs": {
+													"math": {
+														"op": "OpSub",
+														"lhs": { "spellTimeToReady": { "spellId": { "spellId": 82174 } } },
+														"rhs": { "const": { "val": "1" } }
+													}
+												}
+											}
+										},
+										{
+											"cmp": {
+												"op": "OpLt",
+												"lhs": { "auraRemainingTime": { "auraId": { "spellId": 91816 } } },
 												"rhs": {
 													"math": {
 														"op": "OpSub",
@@ -605,7 +750,8 @@
 											"and": {
 												"vals": [
 													{ "auraIsActive": { "auraId": { "spellId": 53365 } } },
-													{ "auraIsActive": { "auraId": { "spellId": 91364 } } }
+													{ "auraIsActive": { "auraId": { "spellId": 91364 } } },
+													{ "auraIsActive": { "auraId": { "spellId": 91363 } } }
 												]
 											}
 										},
@@ -613,7 +759,8 @@
 											"and": {
 												"vals": [
 													{ "auraIsActive": { "auraId": { "spellId": 53365 } } },
-													{ "auraIsActive": { "auraId": { "spellId": 92345 } } }
+													{ "auraIsActive": { "auraId": { "spellId": 92345 } } },
+													{ "auraIsActive": { "auraId": { "spellId": 91816 } } }
 												]
 											}
 										},
@@ -621,7 +768,9 @@
 											"and": {
 												"vals": [
 													{ "auraIsActive": { "auraId": { "spellId": 91364 } } },
-													{ "auraIsActive": { "auraId": { "spellId": 92345 } } }
+													{ "auraIsActive": { "auraId": { "spellId": 91363 } } },
+													{ "auraIsActive": { "auraId": { "spellId": 92345 } } },
+													{ "auraIsActive": { "auraId": { "spellId": 91816 } } }
 												]
 											}
 										}
@@ -662,6 +811,22 @@
 											"and": {
 												"vals": [
 													{ "auraIsActive": { "auraId": { "spellId": 53365 } } },
+													{ "auraIsActive": { "auraId": { "spellId": 91363 } } },
+													{
+														"cmp": {
+															"op": "OpLt",
+															"lhs": { "auraRemainingTime": { "auraId": { "spellId": 91363 } } },
+															"rhs": { "const": { "val": "2s" } }
+														}
+													},
+													{ "auraIsKnown": { "auraId": { "spellId": 91363 } } }
+												]
+											}
+										},
+										{
+											"and": {
+												"vals": [
+													{ "auraIsActive": { "auraId": { "spellId": 53365 } } },
 													{ "auraIsActive": { "auraId": { "spellId": 92345 } } },
 													{
 														"cmp": {
@@ -677,8 +842,26 @@
 										{
 											"and": {
 												"vals": [
+													{ "auraIsActive": { "auraId": { "spellId": 53365 } } },
+													{ "auraIsActive": { "auraId": { "spellId": 91816 } } },
+													{
+														"cmp": {
+															"op": "OpLt",
+															"lhs": { "auraRemainingTime": { "auraId": { "spellId": 91816 } } },
+															"rhs": { "const": { "val": "2s" } }
+														}
+													},
+													{ "auraIsKnown": { "auraId": { "spellId": 91816 } } }
+												]
+											}
+										},
+										{
+											"and": {
+												"vals": [
 													{ "auraIsActive": { "auraId": { "spellId": 91364 } } },
+													{ "auraIsActive": { "auraId": { "spellId": 91363 } } },
 													{ "auraIsActive": { "auraId": { "spellId": 92345 } } },
+													{ "auraIsActive": { "auraId": { "spellId": 91816 } } },
 													{
 														"or": {
 															"vals": [
@@ -692,7 +875,21 @@
 																{
 																	"cmp": {
 																		"op": "OpLt",
+																		"lhs": { "auraRemainingTime": { "auraId": { "spellId": 91363 } } },
+																		"rhs": { "const": { "val": "2s" } }
+																	}
+																},
+																{
+																	"cmp": {
+																		"op": "OpLt",
 																		"lhs": { "auraRemainingTime": { "auraId": { "spellId": 92345 } } },
+																		"rhs": { "const": { "val": "2s" } }
+																	}
+																},
+																{
+																	"cmp": {
+																		"op": "OpLt",
+																		"lhs": { "auraRemainingTime": { "auraId": { "spellId": 91816 } } },
 																		"rhs": { "const": { "val": "2s" } }
 																	}
 																}


### PR DESCRIPTION
* [[Frost] Move Frost Death Knight to phase 3](https://github.com/wowsims/cata/pull/1149/commits/4658203ae6a713225a4561c6f2a231a11f17530a)
  * Updated presets
  * Updated ep weights
  * Updated APLs with support for normal versions of Heart of Solace, Heart of Rage, Crushing Weight and Apparatus as well as the horde/alliance versions of Impatience of Youth
* [[Item] Fix outcome flag for normal Heart of Solace](https://github.com/wowsims/cata/pull/1149/commits/39a4cf9cc525c4d19119d437ac6e2f1872f3ed4b)
  * Was copy-pasted wrong to be "on parry" instead of "on hit" 🙈 
* [[Unholy] Update APL with support for normal version of trinkets](https://github.com/wowsims/cata/pull/1149/commits/1b916e377dae4fb8a66e0a61144942e014c06043)
  * Added support for normal version of Heart of Solace and Heart of Rage