### PR TITLE
[Rogue] Implement MH weapon optimization for Human/Orc Combat Rogues.

### DIFF
--- a/ui/rogue/combat/sim.ts
+++ b/ui/rogue/combat/sim.ts
@@ -6,7 +6,7 @@ import { IndividualSimUI, registerSpecConfig } from '../../core/individual_sim_u
 import { Player } from '../../core/player';
 import { PlayerClasses } from '../../core/player_classes';
 import { APLRotation } from '../../core/proto/apl';
-import { Debuffs, Faction, IndividualBuffs, ItemSlot, PartyBuffs, PseudoStat, Race, RaidBuffs, Spec, Stat } from '../../core/proto/common';
+import { Debuffs, Faction, IndividualBuffs, ItemSlot, PartyBuffs, PseudoStat, Race, RaidBuffs, Spec, Stat, WeaponType } from '../../core/proto/common';
 import { RogueOptions_PoisonImbue } from '../../core/proto/rogue';
 import { StatCapType } from '../../core/proto/ui';
 import { StatCap, Stats, UnitStat } from '../../core/proto_utils/stats';
@@ -205,6 +205,16 @@ export class CombatRogueSimUI extends IndividualSimUI<Spec.SpecCombatRogue> {
 					}
 
 					return softCaps;
+				},
+				updateGearStatsModifier(baseStats: Stats) {
+					// Human/Orc racials for MH. Maxing Expertise for OH is a DPS loss when the MH matches the racial.
+					const mhWepType = player.getEquippedItem(ItemSlot.ItemSlotMainHand)?.item.weaponType;
+					if ((player.getRace() == Race.RaceHuman && (mhWepType == WeaponType.WeaponTypeSword || mhWepType ==  WeaponType.WeaponTypeMace) ||
+						(player.getRace() == Race.RaceOrc && mhWepType == WeaponType.WeaponTypeAxe)))
+					{
+						return baseStats.addStat(Stat.StatExpertiseRating, 90);
+					}
+					return baseStats
 				},
 			});
 		});


### PR DESCRIPTION
Currently these two races will reforge for the full 6.5% Expertise, ignoring the MH weapon type. In-game, this results in 29/26 Expertise, wasting 90 rating that the MH doesn't benefit from.

This will make it reforge for 5.75% when the MH type matches their racial. In most cases, this is a ~90 DPS increase - fairly minor, but it's also free DPS.