### PR TITLE
Blacklist proc trinkets with extra proc conditions from APL aura sets

### DIFF
--- a/sim/common/cata/stat_bonus_procs.go
+++ b/sim/common/cata/stat_bonus_procs.go
@@ -321,7 +321,7 @@ func init() {
 		ICD:        time.Second * 50,
 	})
 
-	shared.NewProcStatBonusEffectWithCustomCondition(shared.ProcStatBonusEffect{
+	shared.NewProcStatBonusEffect(shared.ProcStatBonusEffect{
 		Name:       "Sorrowsong",
 		ID:         55879,
 		AuraID:     90990,
@@ -332,11 +332,13 @@ func init() {
 		Outcome:    core.OutcomeLanded,
 		ProcChance: 1.0,
 		ICD:        time.Second * 20,
-	}, func(sim *core.Simulation, _ *core.Spell, _ *core.SpellResult) bool {
-		return sim.IsExecutePhase35()
+
+		CustomProcCondition: func(sim *core.Simulation, _ *core.Aura) bool {
+			return sim.IsExecutePhase35()
+		},
 	})
 
-	shared.NewProcStatBonusEffectWithCustomCondition(shared.ProcStatBonusEffect{
+	shared.NewProcStatBonusEffect(shared.ProcStatBonusEffect{
 		Name:       "Sorrowsong (Heroic)",
 		ID:         56400,
 		AuraID:     91002,
@@ -347,8 +349,10 @@ func init() {
 		Outcome:    core.OutcomeLanded,
 		ProcChance: 1.0,
 		ICD:        time.Second * 20,
-	}, func(sim *core.Simulation, _ *core.Spell, _ *core.SpellResult) bool {
-		return sim.IsExecutePhase35()
+
+		CustomProcCondition: func(sim *core.Simulation, _ *core.Aura) bool {
+			return sim.IsExecutePhase35()
+		},
 	})
 
 	shared.NewProcStatBonusEffect(shared.ProcStatBonusEffect{
@@ -605,7 +609,7 @@ func init() {
 		ICD:        time.Second * 100,
 	})
 
-	shared.NewProcStatBonusEffectWithCustomCondition(shared.ProcStatBonusEffect{
+	shared.NewProcStatBonusEffect(shared.ProcStatBonusEffect{
 		Name:       "Symbiotic Worm",
 		ID:         59332,
 		AuraID:     92235,
@@ -616,11 +620,13 @@ func init() {
 		Outcome:    core.OutcomeLanded,
 		ProcChance: 1,
 		ICD:        time.Second * 30,
-	}, func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) bool {
-		return result.Target.CurrentHealthPercent() < 0.35
+
+		CustomProcCondition: func(_ *core.Simulation, aura *core.Aura) bool {
+			return aura.Unit.CurrentHealthPercent() < 0.35
+		},
 	})
 
-	shared.NewProcStatBonusEffectWithCustomCondition(shared.ProcStatBonusEffect{
+	shared.NewProcStatBonusEffect(shared.ProcStatBonusEffect{
 		Name:       "Symbiotic Worm (Heroic)",
 		ID:         65048,
 		AuraID:     92355,
@@ -631,8 +637,10 @@ func init() {
 		Outcome:    core.OutcomeLanded,
 		ProcChance: 1,
 		ICD:        time.Second * 30,
-	}, func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) bool {
-		return result.Target.CurrentHealthPercent() < 0.35
+
+		CustomProcCondition: func(_ *core.Simulation, aura *core.Aura) bool {
+			return aura.Unit.CurrentHealthPercent() < 0.35
+		},
 	})
 
 	shared.NewProcStatBonusEffect(shared.ProcStatBonusEffect{
@@ -739,7 +747,7 @@ func init() {
 		ICD:        time.Second * 75,
 	})
 
-	shared.NewProcStatBonusEffectWithCustomCondition(shared.ProcStatBonusEffect{
+	shared.NewProcStatBonusEffect(shared.ProcStatBonusEffect{
 		Name:       "Bedrock Talisman",
 		ID:         58182,
 		AuraID:     92233,
@@ -750,8 +758,10 @@ func init() {
 		Outcome:    core.OutcomeLanded,
 		ProcChance: 1,
 		ICD:        time.Second * 30,
-	}, func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) bool {
-		return result.Target.CurrentHealthPercent() < 0.35
+
+		CustomProcCondition: func(_ *core.Simulation, aura *core.Aura) bool {
+			return aura.Unit.CurrentHealthPercent() < 0.35
+		},
 	})
 
 	shared.NewProcStatBonusEffect(shared.ProcStatBonusEffect{

--- a/sim/common/shared/shared_utils.go
+++ b/sim/common/shared/shared_utils.go
@@ -23,6 +23,9 @@ type ProcStatBonusEffect struct {
 
 	// For ignoring a hardcoded spell.
 	IgnoreSpellID int32
+
+	// Any other custom proc conditions not covered by the above fields.
+	CustomProcCondition core.CustomStatBuffProcCondition
 }
 
 type DamageEffect struct {
@@ -39,8 +42,7 @@ type ExtraSpellInfo struct {
 	Trigger func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult)
 }
 
-type CustomProcHandler func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult, procAura *core.Aura)
-type ProcCondition func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) bool
+type CustomProcHandler func(sim *core.Simulation, procAura *core.StatBuffAura)
 
 func NewProcStatBonusEffectWithDamageProc(config ProcStatBonusEffect, damage DamageEffect) {
 	procMask := core.ProcMaskEmpty
@@ -48,7 +50,7 @@ func NewProcStatBonusEffectWithDamageProc(config ProcStatBonusEffect, damage Dam
 		procMask = damage.ProcMask
 	}
 
-	factory_StatBonusEffect(config, nil, func(agent core.Agent) ExtraSpellInfo {
+	factory_StatBonusEffect(config, func(agent core.Agent) ExtraSpellInfo {
 		character := agent.GetCharacter()
 		procSpell := character.RegisterSpell(core.SpellConfig{
 			ActionID:                 core.ActionID{SpellID: damage.SpellID},
@@ -74,20 +76,7 @@ func NewProcStatBonusEffectWithDamageProc(config ProcStatBonusEffect, damage Dam
 	})
 }
 
-func NewProcStatBonusEffectWithCustomCondition(config ProcStatBonusEffect, condition ProcCondition) {
-	factory_StatBonusEffect(config, func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult, procAura *core.Aura) {
-		if condition(sim, spell, result) {
-			procAura.Activate(sim)
-		} else {
-			// reset ICD condition was not fulfilled
-			if procAura.Icd != nil && procAura.Icd.Duration != 0 {
-				procAura.Icd.Reset()
-			}
-		}
-	}, nil)
-}
-
-func factory_StatBonusEffect(config ProcStatBonusEffect, customHandler CustomProcHandler, extraSpell func(agent core.Agent) ExtraSpellInfo) {
+func factory_StatBonusEffect(config ProcStatBonusEffect, extraSpell func(agent core.Agent) ExtraSpellInfo) {
 	core.NewItemEffect(config.ID, func(agent core.Agent) {
 		character := agent.GetCharacter()
 
@@ -96,6 +85,22 @@ func factory_StatBonusEffect(config ProcStatBonusEffect, customHandler CustomPro
 			procID = core.ActionID{ItemID: config.ID}
 		}
 		procAura := character.NewTemporaryStatsAura(config.Name+" Proc", procID, config.Bonus, config.Duration)
+
+		var customHandler CustomProcHandler
+		if config.CustomProcCondition != nil {
+			procAura.CustomProcCondition = config.CustomProcCondition
+			customHandler = func(sim *core.Simulation, procAura *core.StatBuffAura) {
+				if procAura.CanProc(sim) {
+					procAura.Activate(sim)
+				} else {
+					// reset ICD condition was not fulfilled
+					if procAura.Icd != nil && procAura.Icd.Duration != 0 {
+						procAura.Icd.Reset()
+					}
+				}
+			}
+		}
+
 		var procSpell ExtraSpellInfo
 		if extraSpell != nil {
 			procSpell = extraSpell(agent)
@@ -103,8 +108,7 @@ func factory_StatBonusEffect(config ProcStatBonusEffect, customHandler CustomPro
 
 		handler := func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 			if customHandler != nil {
-				customHandler(sim, spell, result, procAura.Aura)
-
+				customHandler(sim, procAura)
 			} else {
 				procAura.Activate(sim)
 				if procSpell.Spell != nil {
@@ -118,7 +122,7 @@ func factory_StatBonusEffect(config ProcStatBonusEffect, customHandler CustomPro
 			handler = func(sim *core.Simulation, spell *core.Spell, result *core.SpellResult) {
 				if !spell.IsSpellAction(ignoreSpellID) {
 					if customHandler != nil {
-						customHandler(sim, spell, result, procAura.Aura)
+						customHandler(sim, procAura)
 					} else {
 						procAura.Activate(sim)
 						if procSpell.Spell != nil {
@@ -143,15 +147,12 @@ func factory_StatBonusEffect(config ProcStatBonusEffect, customHandler CustomPro
 		})
 
 		procAura.Icd = triggerAura.Icd
-
-		if customHandler == nil {
-			character.TrinketProcBuffs = append(character.TrinketProcBuffs, procAura)
-		}
+		character.TrinketProcBuffs = append(character.TrinketProcBuffs, procAura)
 	})
 }
 
 func NewProcStatBonusEffect(config ProcStatBonusEffect) {
-	factory_StatBonusEffect(config, nil, nil)
+	factory_StatBonusEffect(config, nil)
 }
 
 type StatCDFactory func(itemID int32, duration time.Duration, cooldown time.Duration)

--- a/sim/common/shared/shared_utils.go
+++ b/sim/common/shared/shared_utils.go
@@ -143,7 +143,10 @@ func factory_StatBonusEffect(config ProcStatBonusEffect, customHandler CustomPro
 		})
 
 		procAura.Icd = triggerAura.Icd
-		character.TrinketProcBuffs = append(character.TrinketProcBuffs, procAura)
+
+		if customHandler == nil {
+			character.TrinketProcBuffs = append(character.TrinketProcBuffs, procAura)
+		}
 	})
 }
 

--- a/sim/core/apl_values_aura_sets.go
+++ b/sim/core/apl_values_aura_sets.go
@@ -70,7 +70,7 @@ func (value *APLValueAllTrinketStatProcsActive) Type() proto.APLValueType {
 }
 func (value *APLValueAllTrinketStatProcsActive) GetBool(sim *Simulation) bool {
 	for _, aura := range value.matchingAuras {
-		if !aura.IsActive() || (aura.GetStacks() < aura.MaxStacks) {
+		if (!aura.IsActive() || (aura.GetStacks() < aura.MaxStacks)) && aura.CanProc(sim) {
 			return false
 		}
 	}

--- a/sim/core/aura_helpers.go
+++ b/sim/core/aura_helpers.go
@@ -194,6 +194,8 @@ func MakeProcTriggerAura(unit *Unit, config ProcTrigger) *Aura {
 	return unit.GetOrRegisterAura(aura)
 }
 
+type CustomStatBuffProcCondition func(sim *Simulation, aura *Aura) bool
+
 // Analog to an Aura "sub-class" that additionally links the Aura to one or more
 // Stats. Used within APL snapshotting wrappers.
 type StatBuffAura struct {
@@ -202,6 +204,10 @@ type StatBuffAura struct {
 	// All Stat types that are buffed (before dependencies) when this Aura
 	// is activated.
 	BuffedStatTypes []stats.Stat
+
+	// Any special conditions (beyond standard ICD checks etc.) that must be
+	// satisfied before this Aura can be activated.
+	CustomProcCondition CustomStatBuffProcCondition
 }
 
 func (aura *StatBuffAura) BuffsMatchingStat(statTypesToMatch []stats.Stat) bool {
@@ -210,6 +216,10 @@ func (aura *StatBuffAura) BuffsMatchingStat(statTypesToMatch []stats.Stat) bool 
 	}
 
 	return CheckSliceOverlap(aura.BuffedStatTypes, statTypesToMatch)
+}
+
+func (aura *StatBuffAura) CanProc(sim *Simulation) bool {
+	return (aura.CustomProcCondition == nil) || aura.CustomProcCondition(sim, aura.Aura)
 }
 
 type StackingStatAura struct {

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -1434,15 +1434,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Sorrowsong-55879"
  value: {
-  dps: 40692.24187
-  tps: 631.9279
+  dps: 40709.31238
+  tps: 629.69729
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Sorrowsong-56400"
  value: {
-  dps: 40726.92683
-  tps: 635.69441
+  dps: 40824.08732
+  tps: 634.25982
  }
 }
 dps_results: {

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -1434,15 +1434,15 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Sorrowsong-55879"
  value: {
-  dps: 40106.97106
-  tps: 634.57265
+  dps: 40692.24187
+  tps: 631.9279
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Sorrowsong-56400"
  value: {
-  dps: 40255.08429
-  tps: 637.71639
+  dps: 40726.92683
+  tps: 635.69441
  }
 }
 dps_results: {

--- a/sim/warlock/demonology/TestDemonology.results
+++ b/sim/warlock/demonology/TestDemonology.results
@@ -1357,15 +1357,15 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-Sorrowsong-55879"
  value: {
-  dps: 37678.72388
-  tps: 18743.23277
+  dps: 37450.94757
+  tps: 18568.2434
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Sorrowsong-56400"
  value: {
-  dps: 37881.95662
-  tps: 18813.67115
+  dps: 37651.71738
+  tps: 18638.05195
  }
 }
 dps_results: {
@@ -1469,15 +1469,15 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 36487.44175
-  tps: 18209.44855
+  dps: 36274.30071
+  tps: 18039.45663
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 36487.44175
-  tps: 18209.44855
+  dps: 36274.30071
+  tps: 18039.47167
  }
 }
 dps_results: {


### PR DESCRIPTION
Currently only affects the Sorrowsong trinket.