### PR TITLE
[DK] Add delay to Raise Dead start attack

### DIFF
--- a/sim/core/pet.go
+++ b/sim/core/pet.go
@@ -50,6 +50,9 @@ type Pet struct {
 	// Some pets expire after a certain duration. This is the pending action that disables
 	// the pet on expiration.
 	timeoutAction *PendingAction
+
+	// DK Raise Dead is doing its whole RP thing by climbing out of the ground before attacking.
+	startAttackDelay time.Duration
 }
 
 func NewPet(name string, owner *Character, baseStats stats.Stats, statInheritance PetStatInheritance, enabledOnStart bool, isGuardian bool) Pet {
@@ -171,12 +174,12 @@ func (pet *Pet) Enable(sim *Simulation, petAgent PetAgent) {
 		pet.OnPetEnable(sim)
 	}
 
-	pet.SetGCDTimer(sim, max(0, sim.CurrentTime))
-	if sim.CurrentTime >= 0 {
+	pet.SetGCDTimer(sim, max(0, sim.CurrentTime+pet.startAttackDelay, sim.CurrentTime))
+	if sim.CurrentTime >= 0 && pet.startAttackDelay <= 0 {
 		pet.AutoAttacks.EnableAutoSwing(sim)
 	} else {
 		sim.AddPendingAction(&PendingAction{
-			NextActionAt: 0,
+			NextActionAt: max(0, sim.CurrentTime+pet.startAttackDelay),
 			OnAction: func(sim *Simulation) {
 				if pet.enabled {
 					pet.AutoAttacks.EnableAutoSwing(sim)
@@ -196,6 +199,11 @@ func (pet *Pet) Enable(sim *Simulation, petAgent PetAgent) {
 	if pet.HasFocusBar() {
 		pet.focusBar.enable(sim, sim.CurrentTime)
 	}
+}
+
+func (pet *Pet) EnableWithStartAttackDelay(sim *Simulation, petAgent PetAgent, startAttackDelay time.Duration) {
+	pet.startAttackDelay = startAttackDelay
+	pet.Enable(sim, petAgent)
 }
 
 // Helper for enabling a pet that will expire after a certain duration.

--- a/sim/death_knight/blood/TestBlood.results
+++ b/sim/death_knight/blood/TestBlood.results
@@ -38,2538 +38,2538 @@ character_stats_results: {
 dps_results: {
  key: "TestBlood-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 21727.53707
-  tps: 108698.57605
-  hps: 5951.89331
+  dps: 21917.33561
+  tps: 110272.47952
+  hps: 5935.7523
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5455.17897
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5441.79957
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 21969.4273
-  tps: 109986.80251
-  hps: 5312.923
+  dps: 22166.65601
+  tps: 111503.84005
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 21797.52081
-  tps: 109212.75887
-  hps: 5340.31221
+  dps: 21648.78122
+  tps: 108583.39016
+  hps: 5354.80978
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 21875.05461
-  tps: 109566.34389
-  hps: 5321.85302
+  dps: 21722.83822
+  tps: 108793.959
+  hps: 5349.10514
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 22795.83332
-  tps: 114465.10706
-  hps: 5434.04251
+  dps: 22786.62325
+  tps: 114619.08232
+  hps: 5412.38274
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 22948.2932
-  tps: 114947.04441
-  hps: 5408.65559
+  dps: 22700.04428
+  tps: 114423.18665
+  hps: 5388.08526
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ArrowofTime-72897"
  value: {
-  dps: 22360.38724
-  tps: 112127.63593
-  hps: 5455.33093
+  dps: 22421.52215
+  tps: 113080.67543
+  hps: 5445.11512
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 21516.71556
-  tps: 107550.38173
-  hps: 5988.36231
+  dps: 21700.70104
+  tps: 109050.42872
+  hps: 5972.25002
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5399.98179
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5385.40641
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 21809.59064
-  tps: 109167.12498
-  hps: 5314.81299
+  dps: 22002.53125
+  tps: 110721.35497
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 22108.78732
-  tps: 110823.77211
-  hps: 5324.30587
+  dps: 22307.12367
+  tps: 112343.28352
+  hps: 5309.79177
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 22154.93631
-  tps: 111079.9897
-  hps: 5326.4154
+  dps: 22353.41442
+  tps: 112606.34338
+  hps: 5311.9013
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BindingPromise-67037"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 21872.86784
-  tps: 109476.26389
-  hps: 5312.923
+  dps: 22046.32685
+  tps: 110918.01729
+  hps: 5302.76001
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 21954.05322
-  tps: 109735.10881
-  hps: 5311.29711
+  dps: 22165.08178
+  tps: 111515.05641
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 21735.85069
-  tps: 108775.77583
-  hps: 5314.81299
+  dps: 21929.14491
+  tps: 110331.68873
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 22355.43224
-  tps: 111935.42459
-  hps: 5314.81299
+  dps: 22543.07396
+  tps: 113497.08871
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 22101.43948
-  tps: 110787.60603
-  hps: 5418.53593
+  dps: 22281.74425
+  tps: 112210.03546
+  hps: 5404.25156
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5410.02124
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5395.73686
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5410.02124
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5395.73686
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 21999.39424
-  tps: 110137.37167
-  hps: 5314.81299
+  dps: 22165.79176
+  tps: 111575.10164
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 22345.71592
-  tps: 112045.24616
-  hps: 5314.81299
+  dps: 22541.82792
+  tps: 113631.93649
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 23222.67868
-  tps: 116944.53488
-  hps: 5314.81299
+  dps: 23424.28147
+  tps: 118188.41604
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 23093.3983
-  tps: 116140.46978
-  hps: 5314.81299
+  dps: 23230.5138
+  tps: 117184.18846
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 23543.48335
-  tps: 118931.77322
-  hps: 5314.81299
+  dps: 23603.87306
+  tps: 119230.67645
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BottledLightning-66879"
  value: {
-  dps: 21853.14369
-  tps: 109332.44126
-  hps: 5319.03205
+  dps: 22056.73872
+  tps: 110926.58775
+  hps: 5304.51795
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BottledWishes-77114"
  value: {
-  dps: 22109.39152
-  tps: 111033.90028
-  hps: 5528.65098
+  dps: 22008.04554
+  tps: 110830.55799
+  hps: 5505.56168
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BottledWishes-77985"
  value: {
-  dps: 22039.91882
-  tps: 110276.40264
-  hps: 5471.82575
+  dps: 21786.47028
+  tps: 109347.52633
+  hps: 5480.77391
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BottledWishes-78005"
  value: {
-  dps: 22166.99454
-  tps: 110591.72593
-  hps: 5504.37325
+  dps: 21863.69877
+  tps: 109789.05841
+  hps: 5524.89076
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 21500.17233
-  tps: 105307.04077
-  hps: 5950.59171
+  dps: 21683.9709
+  tps: 106775.92703
+  hps: 5934.59532
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 22910.67609
-  tps: 114257.00691
-  hps: 6079.35727
+  dps: 22619.06096
+  tps: 113242.68581
+  hps: 6041.01216
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 21679.33153
-  tps: 108458.88604
-  hps: 5951.89331
+  dps: 21871.17886
+  tps: 110003.48361
+  hps: 5935.7523
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CataclysmicGladiator'sBadgeofConquest-73648"
  value: {
-  dps: 22083.26415
-  tps: 110584.81114
-  hps: 5314.81299
+  dps: 22275.32268
+  tps: 112102.06117
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CataclysmicGladiator'sBadgeofDominance-73498"
  value: {
-  dps: 21735.85069
-  tps: 108775.77583
-  hps: 5314.81299
+  dps: 21929.14491
+  tps: 110331.68873
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CataclysmicGladiator'sBadgeofVictory-73496"
  value: {
-  dps: 22721.88212
-  tps: 113804.19054
-  hps: 5314.81299
+  dps: 22906.18068
+  tps: 115369.2562
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CataclysmicGladiator'sInsigniaofConquest-73643"
  value: {
-  dps: 22078.27886
-  tps: 110509.3346
-  hps: 5314.81299
+  dps: 22236.36336
+  tps: 111909.36328
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CataclysmicGladiator'sInsigniaofDominance-73497"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CataclysmicGladiator'sInsigniaofVictory-73491"
  value: {
-  dps: 22683.29802
-  tps: 113804.94923
-  hps: 5314.81299
+  dps: 22883.95456
+  tps: 115444.86938
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 21740.58158
-  tps: 108763.24007
-  hps: 5954.12095
+  dps: 21940.3013
+  tps: 110384.96858
+  hps: 5937.97994
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 22312.50227
-  tps: 111963.31994
-  hps: 5323.25111
+  dps: 22480.52391
+  tps: 113327.17908
+  hps: 5308.73701
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 21735.85069
-  tps: 108775.77583
-  hps: 5314.81299
+  dps: 21929.14491
+  tps: 110331.68873
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 23266.29114
-  tps: 116736.12562
-  hps: 5344.3464
+  dps: 23430.75159
+  tps: 118273.02193
+  hps: 5331.94182
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 23100.46995
-  tps: 115731.21663
-  hps: 5333.79875
+  dps: 23288.37342
+  tps: 117396.71963
+  hps: 5321.39418
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 23454.037
-  tps: 117831.49075
-  hps: 5335.90828
+  dps: 23596.51401
+  tps: 119243.01036
+  hps: 5326.668
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CrushingWeight-59506"
  value: {
-  dps: 22705.23255
-  tps: 114140.29444
-  hps: 5394.13322
+  dps: 22590.02134
+  tps: 113748.902
+  hps: 5408.89327
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CrushingWeight-65118"
  value: {
-  dps: 22986.84808
-  tps: 114941.36147
-  hps: 5430.17181
+  dps: 22731.68052
+  tps: 113933.94742
+  hps: 5446.99019
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 22199.40273
-  tps: 111254.59495
-  hps: 5314.81299
+  dps: 22391.70018
+  tps: 112810.11281
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 22140.35255
-  tps: 110952.11531
-  hps: 5314.81299
+  dps: 22335.8522
+  tps: 112526.88861
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-CunningoftheCruel-78000"
  value: {
-  dps: 22245.4478
-  tps: 111496.49705
-  hps: 5314.81299
+  dps: 22441.57363
+  tps: 113074.68941
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5411.17133
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5396.88972
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 22749.05548
-  tps: 114134.80609
-  hps: 5335.27607
+  dps: 22630.53815
+  tps: 114244.93254
+  hps: 5309.0638
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 22402.51159
-  tps: 112310.51703
-  hps: 5335.27607
+  dps: 22276.74021
+  tps: 112405.78079
+  hps: 5309.0638
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 21808.76869
-  tps: 109171.05098
-  hps: 5314.81299
+  dps: 22002.76669
+  tps: 110720.24164
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 22153.50056
-  tps: 111075.56742
-  hps: 5357.84041
+  dps: 22315.85826
+  tps: 112750.97802
+  hps: 5325.6215
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 21558.32742
-  tps: 107743.29049
-  hps: 5952.81934
+  dps: 21749.44934
+  tps: 109314.91906
+  hps: 5936.82296
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 21964.63127
-  tps: 109986.17151
-  hps: 5423.14651
+  dps: 21751.61672
+  tps: 108950.47326
+  hps: 5427.78812
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 22761.38556
-  tps: 114237.2909
-  hps: 5324.30587
+  dps: 22933.82988
+  tps: 115749.76438
+  hps: 5311.9013
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 21500.17233
-  tps: 107456.16405
-  hps: 5988.36231
+  dps: 21683.9709
+  tps: 108955.02758
+  hps: 5972.25002
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 21735.85069
-  tps: 108775.77583
-  hps: 5314.81299
+  dps: 21929.14491
+  tps: 110331.68873
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ElementiumDeathplateBattlearmor"
  value: {
-  dps: 18517.47712
-  tps: 92499.51328
-  hps: 5186.73286
+  dps: 18494.43852
+  tps: 92325.53229
+  hps: 5167.36941
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ElementiumDeathplateBattlegear"
  value: {
-  dps: 21085.61848
-  tps: 106095.54973
-  hps: 5572.94248
+  dps: 21142.55854
+  tps: 106854.40162
+  hps: 5639.81071
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 21500.17233
-  tps: 107456.16405
-  hps: 5950.59171
+  dps: 21683.9709
+  tps: 108955.02758
+  hps: 5934.59532
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 21558.32742
-  tps: 107743.29049
-  hps: 5952.81934
+  dps: 21749.44934
+  tps: 109314.91906
+  hps: 5936.82296
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 22330.84578
-  tps: 112027.90451
-  hps: 5326.4154
+  dps: 22517.68619
+  tps: 113567.67861
+  hps: 5312.95606
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 22421.69719
-  tps: 112420.4975
-  hps: 5331.68922
+  dps: 22616.44196
+  tps: 113836.08553
+  hps: 5314.01083
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 22389.03444
-  tps: 112126.75246
-  hps: 5312.923
+  dps: 22587.36125
+  tps: 113648.29563
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 21500.17233
-  tps: 107456.16405
-  hps: 5988.36231
+  dps: 21683.9709
+  tps: 108955.02758
+  hps: 5972.25002
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 23357.14474
-  tps: 117491.31386
-  hps: 5314.81299
+  dps: 23561.69065
+  tps: 119163.16247
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 23177.77215
-  tps: 116525.37043
-  hps: 5314.81299
+  dps: 23380.95845
+  tps: 118183.59531
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 23554.45459
-  tps: 118553.85163
-  hps: 5314.81299
+  dps: 23760.49607
+  tps: 120240.68635
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FallofMortality-59500"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FallofMortality-65124"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 21659.37861
-  tps: 108379.07506
-  hps: 5314.81299
+  dps: 21842.25845
+  tps: 109877.58935
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 22038.07447
-  tps: 110402.98622
-  hps: 5321.85302
+  dps: 21893.62064
+  tps: 109709.21356
+  hps: 5349.10514
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 21735.85069
-  tps: 108775.77583
-  hps: 5314.81299
+  dps: 21929.14491
+  tps: 110331.68873
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5514.04107
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5498.87715
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 21735.85069
-  tps: 108775.77583
-  hps: 5314.81299
+  dps: 21929.14491
+  tps: 110331.68873
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 22316.70839
-  tps: 111737.94655
-  hps: 5314.81299
+  dps: 22504.70339
+  tps: 113299.25121
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FireoftheDeep-77988"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FireoftheDeep-78008"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 21500.17233
-  tps: 107456.16405
-  hps: 5950.59171
+  dps: 21683.9709
+  tps: 108955.02758
+  hps: 5934.59532
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FluidDeath-58181"
  value: {
-  dps: 22214.48492
-  tps: 111559.66125
-  hps: 5311.64708
+  dps: 22082.56579
+  tps: 110862.70102
+  hps: 5339.4538
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 21500.17233
-  tps: 107456.16405
-  hps: 5950.59171
+  dps: 21683.9709
+  tps: 108955.02758
+  hps: 5934.59532
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 22808.87442
-  tps: 114761.06392
-  hps: 5324.30587
+  dps: 22992.30832
+  tps: 116160.63163
+  hps: 5309.79177
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GaleofShadows-56138"
  value: {
-  dps: 22069.71514
-  tps: 110599.13399
-  hps: 5482.62922
+  dps: 21999.93302
+  tps: 110319.43264
+  hps: 5458.89621
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GaleofShadows-56462"
  value: {
-  dps: 22029.77494
-  tps: 110499.07029
-  hps: 5495.7535
+  dps: 21960.75516
+  tps: 110293.74692
+  hps: 5431.40479
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GearDetector-61462"
  value: {
-  dps: 22126.50381
-  tps: 111016.42604
-  hps: 5417.28683
+  dps: 21895.2472
+  tps: 110604.12162
+  hps: 5354.66301
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5386.90499
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5372.05589
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 22051.23225
-  tps: 110471.47499
-  hps: 5320.08681
+  dps: 22222.73493
+  tps: 111897.84996
+  hps: 5305.57271
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 22180.55964
-  tps: 111047.81218
-  hps: 5328.52493
+  dps: 22357.95518
+  tps: 112534.29232
+  hps: 5311.9013
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Gurthalak,VoiceoftheDeeps-77191"
  value: {
-  dps: 23636.0766
-  tps: 118220.30064
-  hps: 6340.27181
+  dps: 23517.88671
+  tps: 118196.87646
+  hps: 6382.29601
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Gurthalak,VoiceoftheDeeps-78478"
  value: {
-  dps: 23818.43258
-  tps: 119197.74564
-  hps: 6386.79742
+  dps: 23697.96379
+  tps: 119166.01537
+  hps: 6429.20264
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Gurthalak,VoiceoftheDeeps-78487"
  value: {
-  dps: 23475.3602
-  tps: 117358.84325
-  hps: 6298.44576
+  dps: 23359.18149
+  tps: 117342.75842
+  hps: 6340.12743
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HarmlightToken-63839"
  value: {
-  dps: 21848.77386
-  tps: 109369.58285
-  hps: 5314.81299
+  dps: 22048.40359
+  tps: 110959.97501
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 22209.11525
-  tps: 111296.8894
-  hps: 5314.81299
+  dps: 22404.8772
+  tps: 112880.75209
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 21953.78257
-  tps: 109966.99012
-  hps: 5390.76088
+  dps: 21998.74654
+  tps: 110488.9012
+  hps: 5363.15717
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 22046.99392
-  tps: 110430.39915
-  hps: 5355.13173
+  dps: 22032.95218
+  tps: 110628.26849
+  hps: 5377.82147
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HeartofRage-59224"
  value: {
-  dps: 22966.74601
-  tps: 115243.55309
-  hps: 5355.64339
+  dps: 22778.62776
+  tps: 115177.81571
+  hps: 5354.68438
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HeartofSolace-55868"
  value: {
-  dps: 22651.4274
-  tps: 113660.8777
-  hps: 5482.62922
+  dps: 22592.53455
+  tps: 113345.21419
+  hps: 5458.89621
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HeartofSolace-56393"
  value: {
-  dps: 22675.68796
-  tps: 113835.24169
-  hps: 5495.7535
+  dps: 22606.19192
+  tps: 113703.67929
+  hps: 5431.40479
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HeartofThunder-55845"
  value: {
-  dps: 21799.38671
-  tps: 109109.01444
-  hps: 5356.35099
+  dps: 21992.20876
+  tps: 110662.49535
+  hps: 5341.94009
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HeartofThunder-56370"
  value: {
-  dps: 21806.07702
-  tps: 109147.11522
-  hps: 5369.87499
+  dps: 21998.97681
+  tps: 110701.08727
+  hps: 5355.49769
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 22024.04168
-  tps: 110359.00925
-  hps: 5320.08681
+  dps: 22222.23712
+  tps: 111923.71494
+  hps: 5306.62748
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 21558.32742
-  tps: 107743.29049
-  hps: 5952.81934
+  dps: 21749.44934
+  tps: 109314.91906
+  hps: 5936.82296
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 22390.07989
-  tps: 112112.11548
-  hps: 5314.81299
+  dps: 22577.40552
+  tps: 113674.10121
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 22390.07989
-  tps: 112112.11548
-  hps: 5314.81299
+  dps: 22577.40552
+  tps: 113674.10121
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IndomitablePride-77211"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5635.3509
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5619.79131
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IndomitablePride-77983"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5598.95795
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5583.51706
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-IndomitablePride-78003"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5676.40961
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5660.7161
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5352.29916
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5337.87819
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 22340.64147
-  tps: 111573.63384
-  hps: 5482.27279
+  dps: 22312.46167
+  tps: 112230.23172
+  hps: 5484.72241
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 22100.36741
-  tps: 111044.37998
-  hps: 5491.88945
+  dps: 22065.56884
+  tps: 111226.79165
+  hps: 5485.88604
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 22041.91248
-  tps: 111646.5423
-  hps: 5498.52669
+  dps: 22200.38879
+  tps: 112665.65089
+  hps: 5516.8885
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 21677.89182
-  tps: 108569.98305
-  hps: 5312.923
+  dps: 21873.67515
+  tps: 110045.99068
+  hps: 5302.76001
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 21872.86784
-  tps: 109476.26389
-  hps: 5312.923
+  dps: 22046.32685
+  tps: 110918.01729
+  hps: 5302.76001
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 22030.72738
-  tps: 110317.44802
-  hps: 5345.03304
+  dps: 21758.36934
+  tps: 109059.30259
+  hps: 5356.33003
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 22100.17584
-  tps: 110761.11017
-  hps: 5321.85302
+  dps: 21967.71989
+  tps: 110114.95627
+  hps: 5349.10514
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 22476.87941
-  tps: 112750.47841
-  hps: 5528.65098
+  dps: 22399.63763
+  tps: 112753.10801
+  hps: 5505.56168
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-KiroptyricSigil-77984"
  value: {
-  dps: 22370.16459
-  tps: 111826.42641
-  hps: 5471.82575
+  dps: 22111.19632
+  tps: 110925.12639
+  hps: 5480.77391
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-KiroptyricSigil-78004"
  value: {
-  dps: 22504.39391
-  tps: 112231.01469
-  hps: 5504.37325
+  dps: 22262.21955
+  tps: 111769.27131
+  hps: 5524.89076
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 22272.39637
-  tps: 111697.26197
-  hps: 5428.08689
+  dps: 22213.3857
+  tps: 111380.96834
+  hps: 5449.78294
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 22272.39637
-  tps: 111697.26197
-  hps: 5428.08689
+  dps: 22213.3857
+  tps: 111380.96834
+  hps: 5449.78294
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 21655.38572
-  tps: 109086.33629
-  hps: 5368.25924
+  dps: 21601.15559
+  tps: 109193.01373
+  hps: 5355.6071
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LeadenDespair-55816"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5465.51713
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5450.51148
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LeadenDespair-56347"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5514.04107
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5498.87715
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 22268.81534
-  tps: 111538.42506
-  hps: 5334.19328
+  dps: 22129.89001
+  tps: 111350.38049
+  hps: 5327.29518
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 22262.51368
-  tps: 111713.2102
-  hps: 5348.76847
+  dps: 22128.42425
+  tps: 111414.16195
+  hps: 5325.50095
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 22636.2358
-  tps: 113745.83826
-  hps: 5311.64708
+  dps: 22493.75392
+  tps: 112932.08205
+  hps: 5339.4538
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MagmaPlatedBattlearmor"
  value: {
-  dps: 17842.27731
-  tps: 88504.28566
-  hps: 4952.94658
+  dps: 17742.69073
+  tps: 87814.82435
+  hps: 4938.04872
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MagmaPlatedBattlegear"
  value: {
-  dps: 19786.96098
-  tps: 97907.40046
-  hps: 5287.45532
+  dps: 19804.99121
+  tps: 98212.48084
+  hps: 5287.11221
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 22387.94033
-  tps: 111965.23765
-  hps: 5304.84151
+  dps: 22281.49044
+  tps: 112170.15502
+  hps: 5331.76019
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 22613.1312
-  tps: 113362.32253
-  hps: 5349.14646
+  dps: 22491.29931
+  tps: 112992.4801
+  hps: 5316.42901
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 22141.6072
-  tps: 111055.52585
-  hps: 5312.923
+  dps: 22340.83104
+  tps: 112564.39575
+  hps: 5302.76001
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 22202.33184
-  tps: 111381.0136
-  hps: 5312.923
+  dps: 22402.00621
+  tps: 112894.18689
+  hps: 5302.76001
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 22426.91869
-  tps: 112471.65935
-  hps: 5504.74137
+  dps: 22382.39232
+  tps: 112749.00601
+  hps: 5484.89901
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 22670.64233
-  tps: 113859.56752
-  hps: 5480.26728
+  dps: 22463.13124
+  tps: 113001.82163
+  hps: 5480.66343
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 22188.09159
-  tps: 111012.89965
-  hps: 5341.47261
+  dps: 21909.93634
+  tps: 109739.57115
+  hps: 5346.60773
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 22399.07578
-  tps: 112040.05836
-  hps: 5321.85302
+  dps: 22248.69932
+  tps: 111275.72934
+  hps: 5348.53401
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 22101.51366
-  tps: 110787.60603
-  hps: 5323.25111
+  dps: 22281.81844
+  tps: 112210.03546
+  hps: 5308.73701
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 21735.85069
-  tps: 108775.77583
-  hps: 5314.81299
+  dps: 21929.14491
+  tps: 110331.68873
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5552.7669
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5537.47667
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-NecroticBoneplateBattlegear"
  value: {
-  dps: 19730.427
-  tps: 97801.63008
-  hps: 5484.29776
+  dps: 19718.12125
+  tps: 98110.86434
+  hps: 5510.60889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 22335.86571
-  tps: 111883.80255
-  hps: 5325.36064
+  dps: 22530.64872
+  tps: 113487.63049
+  hps: 5310.84653
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 22040.87682
-  tps: 110467.61345
-  hps: 5427.38875
+  dps: 21934.3309
+  tps: 109831.19638
+  hps: 5383.13823
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 21796.37847
-  tps: 109091.8828
-  hps: 5314.81299
+  dps: 21989.16558
+  tps: 110645.14287
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 21960.32215
-  tps: 109981.2975
-  hps: 5317.97729
+  dps: 22137.99238
+  tps: 111466.23821
+  hps: 5303.46318
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 21500.17233
-  tps: 107456.16405
-  hps: 5988.36231
+  dps: 21683.9709
+  tps: 108955.02758
+  hps: 5972.25002
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 22257.95805
-  tps: 111511.97372
-  hps: 5423.14166
+  dps: 22207.83045
+  tps: 112166.5592
+  hps: 5429.4884
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 22476.42364
-  tps: 112967.37629
-  hps: 5461.93188
+  dps: 22199.85712
+  tps: 111680.52102
+  hps: 5421.7964
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Rainsong-55854"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Rainsong-56377"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 21677.89182
-  tps: 108569.98305
-  hps: 5312.923
+  dps: 21873.67515
+  tps: 110045.99068
+  hps: 5302.76001
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReflectionoftheLight-77986"
  value: {
-  dps: 21677.89182
-  tps: 108569.98305
-  hps: 5312.923
+  dps: 21873.67515
+  tps: 110045.99068
+  hps: 5302.76001
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReflectionoftheLight-78006"
  value: {
-  dps: 21677.89182
-  tps: 108569.98305
-  hps: 5312.923
+  dps: 21873.67515
+  tps: 110045.99068
+  hps: 5302.76001
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5951.89331
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5935.7523
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 21679.33153
-  tps: 108458.88604
-  hps: 5951.89331
+  dps: 21871.17886
+  tps: 110003.48361
+  hps: 5935.7523
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 22343.90593
-  tps: 112008.57966
-  hps: 5331.68922
+  dps: 22538.98669
+  tps: 113512.7418
+  hps: 5317.17512
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 22244.76025
-  tps: 111529.29523
-  hps: 5340.31221
+  dps: 22078.47599
+  tps: 110865.94248
+  hps: 5354.80978
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 22353.17449
-  tps: 112112.62747
-  hps: 5321.85302
+  dps: 22191.20767
+  tps: 111307.24528
+  hps: 5349.10514
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RosaryofLight-72901"
  value: {
-  dps: 22923.22068
-  tps: 115087.83973
-  hps: 5328.52493
+  dps: 23103.76261
+  tps: 116613.93246
+  hps: 5318.22989
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RottingSkull-77116"
  value: {
-  dps: 23141.01762
-  tps: 115918.67728
-  hps: 5326.63494
+  dps: 23330.71767
+  tps: 117234.13395
+  hps: 5316.47195
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RottingSkull-77987"
  value: {
-  dps: 22972.6495
-  tps: 115100.99813
-  hps: 5326.63494
+  dps: 23173.13005
+  tps: 116494.65838
+  hps: 5316.47195
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RottingSkull-78007"
  value: {
-  dps: 23351.02641
-  tps: 116971.37229
-  hps: 5328.74447
+  dps: 23534.34878
+  tps: 118233.55006
+  hps: 5318.58147
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuneofZeth-68998"
  value: {
-  dps: 22104.56807
-  tps: 110899.67717
-  hps: 5325.58018
+  dps: 22301.06282
+  tps: 112326.68337
+  hps: 5312.95606
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuthlessGladiator'sBadgeofConquest-70399"
  value: {
-  dps: 22025.49296
-  tps: 110241.87238
-  hps: 5314.81299
+  dps: 22218.7452
+  tps: 111801.99194
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuthlessGladiator'sBadgeofConquest-72304"
  value: {
-  dps: 22039.90004
-  tps: 110312.24819
-  hps: 5314.81299
+  dps: 22231.58494
+  tps: 111854.5316
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuthlessGladiator'sBadgeofDominance-70401"
  value: {
-  dps: 21735.85069
-  tps: 108775.77583
-  hps: 5314.81299
+  dps: 21929.14491
+  tps: 110331.68873
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuthlessGladiator'sBadgeofDominance-72448"
  value: {
-  dps: 21735.85069
-  tps: 108775.77583
-  hps: 5314.81299
+  dps: 21929.14491
+  tps: 110331.68873
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuthlessGladiator'sBadgeofVictory-70400"
  value: {
-  dps: 22562.91054
-  tps: 112993.49119
-  hps: 5314.81299
+  dps: 22748.65941
+  tps: 114557.08121
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuthlessGladiator'sBadgeofVictory-72450"
  value: {
-  dps: 22609.78677
-  tps: 113232.54356
-  hps: 5314.81299
+  dps: 22795.10799
+  tps: 114796.5687
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuthlessGladiator'sInsigniaofConquest-70404"
  value: {
-  dps: 22101.48009
-  tps: 110712.74217
-  hps: 5314.81299
+  dps: 22275.83208
+  tps: 112223.33823
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuthlessGladiator'sInsigniaofConquest-72309"
  value: {
-  dps: 22076.31336
-  tps: 110492.17134
-  hps: 5314.81299
+  dps: 22224.54951
+  tps: 111800.02186
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuthlessGladiator'sInsigniaofDominance-70402"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuthlessGladiator'sInsigniaofDominance-72449"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuthlessGladiator'sInsigniaofVictory-70403"
  value: {
-  dps: 22524.71179
-  tps: 113014.80346
-  hps: 5314.81299
+  dps: 22726.06484
+  tps: 114589.76083
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-RuthlessGladiator'sInsigniaofVictory-72455"
  value: {
-  dps: 22582.90227
-  tps: 113302.83059
-  hps: 5314.81299
+  dps: 22798.12856
+  tps: 114939.65617
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ScalesofLife-68915"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5878.66518
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5862.83023
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 21960.98905
-  tps: 109990.07212
-  hps: 5314.81299
+  dps: 22142.65038
+  tps: 111479.4207
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SeaStar-55256"
  value: {
-  dps: 21735.85069
-  tps: 108775.77583
-  hps: 5314.81299
+  dps: 21929.14491
+  tps: 110331.68873
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SeaStar-56290"
  value: {
-  dps: 21735.85069
-  tps: 108775.77583
-  hps: 5314.81299
+  dps: 21929.14491
+  tps: 110331.68873
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Shadowmourne-49623"
  value: {
-  dps: 23665.62284
-  tps: 118098.77266
-  hps: 6258.79956
+  dps: 23267.3197
+  tps: 116773.08859
+  hps: 6211.40889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ShardofWoe-60233"
  value: {
-  dps: 22045.41747
-  tps: 110522.83229
-  hps: 5410.20225
+  dps: 21884.69168
+  tps: 109958.2446
+  hps: 5392.25311
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 22424.25568
-  tps: 111976.1326
-  hps: 5405.42033
+  dps: 22401.03176
+  tps: 113134.63623
+  hps: 5387.98788
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5435.18967
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5420.28294
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 21932.45995
-  tps: 109850.00221
-  hps: 5314.81299
+  dps: 22125.89317
+  tps: 111436.19
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 21943.81783
-  tps: 109903.88141
-  hps: 5314.81299
+  dps: 22142.38345
+  tps: 111512.89479
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Sorrowsong-55879"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Sorrowsong-56400"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 22030.37627
-  tps: 110292.95448
-  hps: 5340.31221
+  dps: 21872.95782
+  tps: 109627.84935
+  hps: 5354.80978
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SoulCasket-58183"
  value: {
-  dps: 21735.85069
-  tps: 108775.77583
-  hps: 5314.81299
+  dps: 21929.14491
+  tps: 110331.68873
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5635.3509
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5619.79131
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5598.95795
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5583.51706
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5676.40961
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5660.7161
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 22633.40707
-  tps: 113521.30331
-  hps: 5482.00869
+  dps: 22688.3364
+  tps: 114185.61905
+  hps: 5476.02182
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 22604.3569
-  tps: 113210.40868
-  hps: 5444.40368
+  dps: 22397.17129
+  tps: 112183.87211
+  hps: 5436.28409
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 22864.729
-  tps: 114986.83658
-  hps: 5525.8169
+  dps: 22708.43542
+  tps: 114237.81571
+  hps: 5459.18691
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StayofExecution-68996"
  value: {
-  dps: 21733.33174
-  tps: 108763.38501
-  hps: 5314.81299
+  dps: 21929.14491
+  tps: 110331.68873
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 21958.28579
-  tps: 109986.29457
-  hps: 5322.19634
+  dps: 22154.21738
+  tps: 111565.96943
+  hps: 5307.68224
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StumpofTime-62465"
  value: {
-  dps: 21943.91213
-  tps: 110019.81956
-  hps: 5311.64708
+  dps: 21806.9986
+  tps: 109233.2884
+  hps: 5339.4538
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-StumpofTime-62470"
  value: {
-  dps: 21943.91213
-  tps: 110019.81956
-  hps: 5311.64708
+  dps: 21806.9986
+  tps: 109233.2884
+  hps: 5339.4538
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5539.70276
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5524.45514
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5568.63049
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5553.28852
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 22383.23479
-  tps: 112054.63201
-  hps: 5390.4869
+  dps: 22341.99293
+  tps: 112211.51144
+  hps: 5448.78603
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TearofBlood-55819"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TearofBlood-56351"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheHungerer-68927"
  value: {
-  dps: 22247.37549
-  tps: 112288.73603
-  hps: 5426.18379
+  dps: 22340.09582
+  tps: 112667.92337
+  hps: 5462.41048
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TheHungerer-69112"
  value: {
-  dps: 22360.62906
-  tps: 112607.40195
-  hps: 5437.98095
+  dps: 22348.52869
+  tps: 112489.47041
+  hps: 5464.34341
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 21990.67931
-  tps: 110175.9991
-  hps: 5314.81299
+  dps: 22187.72179
+  tps: 111758.00456
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 22020.7309
-  tps: 110389.33705
-  hps: 5314.81299
+  dps: 22215.19914
+  tps: 111899.43754
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 22442.33299
-  tps: 112593.44553
-  hps: 5425.46085
+  dps: 22165.68218
+  tps: 111316.05361
+  hps: 5444.55387
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 21628.78826
-  tps: 108245.47811
-  hps: 5314.81299
+  dps: 21822.93446
+  tps: 109783.92053
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-UnheededWarning-59520"
  value: {
-  dps: 22263.07884
-  tps: 111720.61805
-  hps: 5314.81299
+  dps: 22462.63782
+  tps: 113304.09304
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 21735.85069
-  tps: 108775.77583
-  hps: 5314.81299
+  dps: 21929.14491
+  tps: 110331.68873
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 21971.81288
-  tps: 109948.61479
-  hps: 5314.81299
+  dps: 22170.67469
+  tps: 111575.03172
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 21971.81288
-  tps: 109948.61479
-  hps: 5314.81299
+  dps: 22170.67469
+  tps: 111575.03172
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 21971.81288
-  tps: 109948.61479
-  hps: 5314.81299
+  dps: 22170.67469
+  tps: 111575.03172
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 22023.54651
-  tps: 110305.40898
-  hps: 5314.81299
+  dps: 22213.22435
+  tps: 111827.14553
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 22051.71549
-  tps: 110465.34577
-  hps: 5314.81299
+  dps: 22252.15978
+  tps: 112054.69057
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 22483.20474
-  tps: 112765.16196
-  hps: 5314.81299
+  dps: 22680.99196
+  tps: 114369.33891
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-VeilofLies-72900"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5583.09436
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5567.70521
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 22878.96692
-  tps: 115040.24176
-  hps: 5326.4154
+  dps: 23087.65199
+  tps: 116610.72041
+  hps: 5312.95606
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 23010.24219
-  tps: 115744.50526
-  hps: 5327.47017
+  dps: 23215.53053
+  tps: 117297.08186
+  hps: 5314.01083
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-VialofShadows-77207"
  value: {
-  dps: 22488.31283
-  tps: 112836.83903
-  hps: 5314.81299
+  dps: 22511.25277
+  tps: 113457.28617
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-VialofShadows-77979"
  value: {
-  dps: 22393.69249
-  tps: 112048.84451
-  hps: 5314.81299
+  dps: 22457.44814
+  tps: 113101.43254
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-VialofShadows-77999"
  value: {
-  dps: 22512.69887
-  tps: 112884.87054
-  hps: 5314.81299
+  dps: 22572.89795
+  tps: 113802.40503
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5539.70276
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5524.45514
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5568.63049
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5553.28852
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 21971.81288
-  tps: 109948.61479
-  hps: 5314.81299
+  dps: 22170.67469
+  tps: 111575.03172
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sBadgeofConquest-70517"
  value: {
-  dps: 21988.47894
-  tps: 110039.12889
-  hps: 5314.81299
+  dps: 22188.82836
+  tps: 111648.99771
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 21735.85069
-  tps: 108775.77583
-  hps: 5314.81299
+  dps: 21929.14491
+  tps: 110331.68873
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sBadgeofDominance-70518"
  value: {
-  dps: 21735.85069
-  tps: 108775.77583
-  hps: 5314.81299
+  dps: 21929.14491
+  tps: 110331.68873
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 22390.07989
-  tps: 112112.11548
-  hps: 5314.81299
+  dps: 22577.40552
+  tps: 113674.10121
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sBadgeofVictory-70519"
  value: {
-  dps: 22467.11997
-  tps: 112504.99286
-  hps: 5314.81299
+  dps: 22653.74275
+  tps: 114067.69371
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 21939.63217
-  tps: 110129.89121
-  hps: 5411.14451
+  dps: 21770.95753
+  tps: 109060.03619
+  hps: 5441.71354
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 22051.68653
-  tps: 110359.86855
-  hps: 5567.30178
+  dps: 21867.37387
+  tps: 109918.82309
+  hps: 5533.03577
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 22132.84018
-  tps: 110944.59335
-  hps: 5425.15297
+  dps: 22332.07157
+  tps: 112492.08978
+  hps: 5410.8818
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 22237.97493
-  tps: 111453.87188
-  hps: 5460.99991
+  dps: 22037.95997
+  tps: 111016.06675
+  hps: 5463.68731
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5415.49813
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5401.22696
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5415.49813
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5401.22696
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 22025.01247
-  tps: 110240.29971
-  hps: 5314.81299
+  dps: 22229.29643
+  tps: 111855.85046
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sInsigniaofConquest-70577"
  value: {
-  dps: 22075.89426
-  tps: 110433.3783
-  hps: 5314.81299
+  dps: 22225.43767
+  tps: 111834.43187
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sInsigniaofDominance-70578"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 22375.10835
-  tps: 112187.02403
-  hps: 5314.81299
+  dps: 22575.55979
+  tps: 113765.97058
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-ViciousGladiator'sInsigniaofVictory-70579"
  value: {
-  dps: 22453.62065
-  tps: 112600.38862
-  hps: 5314.81299
+  dps: 22650.67873
+  tps: 114186.37523
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WillofUnbinding-77995"
  value: {
-  dps: 21778.66598
-  tps: 108991.01167
-  hps: 5314.81299
+  dps: 21971.2473
+  tps: 110542.97145
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 21797.14422
-  tps: 109305.73649
-  hps: 5368.82049
+  dps: 21901.58158
+  tps: 110072.37715
+  hps: 5337.72892
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 21845.99345
-  tps: 109632.6946
-  hps: 5388.44672
+  dps: 21903.65781
+  tps: 109944.54987
+  hps: 5423.01123
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 21735.85069
-  tps: 108775.77583
-  hps: 5314.81299
+  dps: 21929.14491
+  tps: 110331.68873
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 22361.55427
-  tps: 112278.43069
-  hps: 5314.81299
+  dps: 22536.00911
+  tps: 113700.04021
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 22296.02369
-  tps: 111908.46113
-  hps: 5314.81299
+  dps: 22479.21654
+  tps: 113340.18305
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 22440.56739
-  tps: 112631.48176
-  hps: 5314.81299
+  dps: 22606.33334
+  tps: 114057.76883
+  hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 21677.89182
-  tps: 108569.98305
-  hps: 5466.3652
+  dps: 21873.67515
+  tps: 110045.99068
+  hps: 5455.83267
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 21677.89182
-  tps: 108569.98305
-  hps: 5466.3652
+  dps: 21873.67515
+  tps: 110045.99068
+  hps: 5455.83267
  }
 }
 dps_results: {
  key: "TestBlood-Average-Default"
  value: {
-  dps: 32516.48578
-  tps: 176448.20178
-  dtps: 24903.81759
-  hps: 19412.53132
+  dps: 32489.03862
+  tps: 176564.60085
+  dtps: 24916.32792
+  hps: 19418.12351
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p1-Basic-simple-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 24709.85344
-  tps: 120732.4258
-  hps: 5680.01012
+  dps: 24669.85523
+  tps: 120643.56874
+  hps: 5716.6257
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p1-Basic-simple-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 19548.268
-  tps: 95798.89581
-  hps: 5304.48204
+  dps: 19505.877
+  tps: 95924.98705
+  hps: 5231.25088
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p1-Basic-simple-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 25943.09584
-  tps: 116690.84679
-  hps: 8532.88465
+  dps: 26132.02139
+  tps: 118365.59295
+  hps: 8531.1072
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p1-Basic-simple-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 19219.61241
-  tps: 93321.20288
-  hps: 4595.69759
+  dps: 19154.14953
+  tps: 93195.9648
+  hps: 4591.49554
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p1-Basic-simple-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 15093.48213
-  tps: 73661.88604
-  hps: 4263.20064
+  dps: 15069.29914
+  tps: 73750.28449
+  hps: 4273.10546
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p1-Basic-simple-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 18824.51821
-  tps: 83172.83656
-  hps: 6421.34394
+  dps: 18672.63407
+  tps: 82987.33494
+  hps: 6371.81983
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3-balanced-Basic-simple-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 28937.6094
-  tps: 141784.56362
-  hps: 6776.332
+  dps: 28660.19622
+  tps: 140958.48133
+  hps: 6759.83941
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3-balanced-Basic-simple-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 23201.57206
-  tps: 114965.11486
-  hps: 6301.09036
+  dps: 23217.93007
+  tps: 115632.32683
+  hps: 6319.99651
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3-balanced-Basic-simple-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 29848.91939
-  tps: 138753.2559
-  hps: 10044.1793
+  dps: 29683.00038
+  tps: 139281.23777
+  hps: 10050.21318
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3-balanced-Basic-simple-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 22549.58477
-  tps: 110164.83083
-  hps: 5623.55612
+  dps: 22478.78068
+  tps: 109939.54051
+  hps: 5579.43625
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3-balanced-Basic-simple-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 18054.10857
-  tps: 89062.29876
-  hps: 5230.04763
+  dps: 17966.08172
+  tps: 88880.86551
+  hps: 5216.26017
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Orc-p3-balanced-Basic-simple-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 21536.96339
-  tps: 98827.66263
-  hps: 7911.22062
+  dps: 21208.05933
+  tps: 97602.19451
+  hps: 7935.34868
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Worgen-p1-Basic-simple-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 24592.66941
-  tps: 121213.70847
-  hps: 5686.47817
+  dps: 24547.23525
+  tps: 120980.30688
+  hps: 5723.08991
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Worgen-p1-Basic-simple-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 19423.35409
-  tps: 95930.17418
-  hps: 5308.98621
+  dps: 19379.42536
+  tps: 96063.81141
+  hps: 5235.76274
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Worgen-p1-Basic-simple-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 25555.3618
-  tps: 115728.35384
-  hps: 8532.09537
+  dps: 25750.72802
+  tps: 117377.23303
+  hps: 8530.3181
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Worgen-p1-Basic-simple-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 19107.77567
-  tps: 93546.52376
-  hps: 4601.28043
+  dps: 19043.36736
+  tps: 93479.17461
+  hps: 4597.07888
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Worgen-p1-Basic-simple-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 14989.56045
-  tps: 73747.28615
-  hps: 4267.9537
+  dps: 14973.94396
+  tps: 73871.71197
+  hps: 4277.85735
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Worgen-p1-Basic-simple-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 18514.99054
-  tps: 82379.70994
-  hps: 6429.34284
+  dps: 18370.65141
+  tps: 82020.75562
+  hps: 6379.8246
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Worgen-p3-balanced-Basic-simple-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 28811.57957
-  tps: 142354.33859
-  hps: 6783.11201
+  dps: 28559.46187
+  tps: 141535.1594
+  hps: 6766.62094
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Worgen-p3-balanced-Basic-simple-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 23099.43066
-  tps: 115448.96096
-  hps: 6303.9333
+  dps: 23105.86989
+  tps: 116023.44281
+  hps: 6322.8377
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Worgen-p3-balanced-Basic-simple-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 29632.04915
-  tps: 138960.10313
-  hps: 10043.37513
+  dps: 29366.16779
+  tps: 138656.3931
+  hps: 10049.40845
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Worgen-p3-balanced-Basic-simple-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 22459.38936
-  tps: 110688.34884
-  hps: 5632.4171
+  dps: 22348.36641
+  tps: 110172.54885
+  hps: 5588.30178
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Worgen-p3-balanced-Basic-simple-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 17946.16778
-  tps: 89293.92316
-  hps: 5236.99843
+  dps: 17875.78122
+  tps: 89159.12178
+  hps: 5223.21239
  }
 }
 dps_results: {
  key: "TestBlood-Settings-Worgen-p3-balanced-Basic-simple-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 21249.1187
-  tps: 98085.15377
-  hps: 7924.16297
+  dps: 20955.23537
+  tps: 97032.37878
+  hps: 7948.28854
  }
 }
 dps_results: {
  key: "TestBlood-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 34386.36236
-  tps: 184622.24126
-  dtps: 24784.4277
-  hps: 19828.98039
+  dps: 34376.23376
+  tps: 185072.41288
+  dtps: 24780.28901
+  hps: 19800.47438
  }
 }

--- a/sim/death_knight/frost/TestFrost.results
+++ b/sim/death_knight/frost/TestFrost.results
@@ -38,2696 +38,2696 @@ character_stats_results: {
 dps_results: {
  key: "TestFrost-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 40479.79054
-  tps: 37753.19823
+  dps: 40212.30504
+  tps: 37649.11662
   hps: 517.70632
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 606.11809
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 608.86783
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 38777.98861
-  tps: 36515.27197
-  hps: 509.20666
+  dps: 38640.40771
+  tps: 36524.75221
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 38263.07224
-  tps: 35988.54982
-  hps: 516.16093
+  dps: 38189.50594
+  tps: 36021.72181
+  hps: 515.38823
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 38332.4058
-  tps: 36048.22353
-  hps: 518.47902
+  dps: 38134.93404
+  tps: 35961.97951
+  hps: 516.93362
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 40090.21311
-  tps: 37755.68717
-  hps: 509.20666
+  dps: 39911.70172
+  tps: 37729.03915
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ArrowofTime-72897"
  value: {
-  dps: 38868.3902
-  tps: 36400.41524
-  hps: 523.88789
+  dps: 38872.90332
+  tps: 36555.2965
+  hps: 523.11519
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 39935.59771
-  tps: 37225.2653
-  hps: 521.69516
+  dps: 39667.41252
+  tps: 37108.42614
+  hps: 520.13787
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 38109.97941
-  tps: 35847.26277
-  hps: 509.20666
+  dps: 37972.30621
+  tps: 35856.65071
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 38535.77968
-  tps: 36239.18096
-  hps: 516.16093
+  dps: 38304.58705
+  tps: 36151.20054
+  hps: 520.02441
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 38582.97778
-  tps: 36284.08138
-  hps: 516.16093
+  dps: 38348.3969
+  tps: 36190.44824
+  hps: 520.02441
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BindingPromise-67037"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 38468.02102
-  tps: 36205.30438
-  hps: 509.20666
+  dps: 38330.3958
+  tps: 36214.7403
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 38530.39255
-  tps: 36267.67591
-  hps: 509.20666
+  dps: 38392.77625
+  tps: 36277.12075
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 38592.76408
-  tps: 36330.04744
-  hps: 509.20666
+  dps: 38455.15669
+  tps: 36339.50119
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 38491.44692
-  tps: 36197.45481
-  hps: 516.16093
+  dps: 38269.46797
+  tps: 36118.12007
+  hps: 520.02441
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 38313.6419
-  tps: 36032.43926
-  hps: 508.43397
+  dps: 38119.23116
+  tps: 35980.51961
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 39271.47519
-  tps: 36962.58159
-  hps: 509.20666
+  dps: 39124.61931
+  tps: 36966.79581
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 40499.45095
-  tps: 38143.29284
-  hps: 509.20666
+  dps: 40381.72505
+  tps: 38196.08863
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 40211.17789
-  tps: 37872.6602
-  hps: 509.20666
+  dps: 40111.34594
+  tps: 37933.49871
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 40846.75945
-  tps: 38478.98328
-  hps: 509.20666
+  dps: 40726.31206
+  tps: 38529.81927
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BottledLightning-66879"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BottledWishes-77114"
  value: {
-  dps: 38451.73771
-  tps: 36054.61359
-  hps: 533.16024
+  dps: 38148.67505
+  tps: 35898.53719
+  hps: 530.84215
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BottledWishes-77985"
  value: {
-  dps: 38343.75641
-  tps: 36054.57453
-  hps: 515.38823
+  dps: 38415.75017
+  tps: 36245.30152
+  hps: 519.25171
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BottledWishes-78005"
  value: {
-  dps: 38450.95052
-  tps: 35959.94593
-  hps: 532.38754
+  dps: 38496.84487
+  tps: 36155.30114
+  hps: 533.93294
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 39916.27127
-  tps: 36461.82009
-  hps: 517.70632
+  dps: 39648.13783
+  tps: 36347.36842
+  hps: 516.16093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 40630.61652
-  tps: 37909.40966
-  hps: 517.70632
+  dps: 40355.14227
+  tps: 37785.9888
+  hps: 516.16093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 40425.48135
-  tps: 37715.14894
-  hps: 517.70632
+  dps: 40151.25884
+  tps: 37592.27246
+  hps: 516.16093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CataclysmicGladiator'sBadgeofConquest-73648"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CataclysmicGladiator'sBadgeofDominance-73498"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CataclysmicGladiator'sBadgeofVictory-73496"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CataclysmicGladiator'sInsigniaofConquest-73643"
  value: {
-  dps: 38507.73851
-  tps: 36202.42938
-  hps: 509.20666
+  dps: 38270.62497
+  tps: 36122.34033
+  hps: 511.52475
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CataclysmicGladiator'sInsigniaofDominance-73497"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CataclysmicGladiator'sInsigniaofVictory-73491"
  value: {
-  dps: 39992.1942
-  tps: 37683.58369
-  hps: 509.20666
+  dps: 39840.0563
+  tps: 37684.58202
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 40515.24779
-  tps: 37786.6988
+  dps: 40246.58848
+  tps: 37682.13184
   hps: 517.70632
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 39196.90335
-  tps: 36902.23977
-  hps: 516.16093
+  dps: 38980.88928
+  tps: 36828.85919
+  hps: 520.02441
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 40369.69808
-  tps: 37847.16713
-  hps: 540.8872
+  dps: 40220.74387
+  tps: 37839.72114
+  hps: 543.97798
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 40174.5346
-  tps: 37715.30361
+  dps: 40012.12828
+  tps: 37703.44569
   hps: 537.79642
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 40768.67906
-  tps: 38212.54877
-  hps: 544.75068
+  dps: 40564.48162
+  tps: 38146.37149
+  hps: 540.1145
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CrushingWeight-59506"
  value: {
-  dps: 39666.38748
-  tps: 37099.71456
-  hps: 524.66058
+  dps: 39762.90509
+  tps: 37356.03649
+  hps: 528.52406
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CrushingWeight-65118"
  value: {
-  dps: 40060.69979
-  tps: 37549.27383
-  hps: 525.43328
+  dps: 39783.54709
+  tps: 37420.9616
+  hps: 521.5698
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 38483.03077
-  tps: 36220.31413
-  hps: 509.20666
+  dps: 38323.64568
+  tps: 36207.99019
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 38440.32056
-  tps: 36177.60392
-  hps: 509.20666
+  dps: 38305.65174
+  tps: 36189.99624
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-CunningoftheCruel-78000"
  value: {
-  dps: 38569.84012
-  tps: 36307.12348
-  hps: 509.20666
+  dps: 38363.04753
+  tps: 36247.39204
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 39791.33913
-  tps: 37486.89295
-  hps: 504.57049
+  dps: 39724.60124
+  tps: 37530.26393
+  hps: 499.93431
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 38800.8492
-  tps: 36525.27279
-  hps: 504.57049
+  dps: 38748.59475
+  tps: 36585.95249
+  hps: 499.93431
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 38699.52028
-  tps: 36436.80364
-  hps: 509.20666
+  dps: 38580.05581
+  tps: 36464.40031
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 38651.05374
-  tps: 36245.19611
+  dps: 38678.58162
+  tps: 36414.26576
   hps: 522.3425
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 40002.68929
-  tps: 37274.1403
+  dps: 39738.99616
+  tps: 37174.53952
   hps: 517.70632
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 38045.52166
-  tps: 35912.13047
-  hps: 513.07014
+  dps: 37906.89376
+  tps: 35882.99682
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 40015.8176
-  tps: 37629.13602
-  hps: 519.25171
+  dps: 39762.98726
+  tps: 37534.53556
+  hps: 520.7971
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 39916.27127
-  tps: 37205.93887
-  hps: 521.69516
+  dps: 39648.13783
+  tps: 37089.15145
+  hps: 520.13787
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ElementiumDeathplateBattlearmor"
  value: {
-  dps: 33976.06886
-  tps: 31600.66436
-  hps: 470.54546
+  dps: 33764.19836
+  tps: 31537.6995
+  hps: 469.77534
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ElementiumDeathplateBattlegear"
  value: {
-  dps: 36744.46997
-  tps: 34127.59601
-  hps: 519.06324
+  dps: 36682.64755
+  tps: 34191.3396
+  hps: 525.99435
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 39916.27127
-  tps: 37205.93887
-  hps: 517.70632
+  dps: 39648.13783
+  tps: 37089.15145
+  hps: 516.16093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 40002.68929
-  tps: 37274.1403
+  dps: 39738.99616
+  tps: 37174.53952
   hps: 517.70632
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 38672.06267
-  tps: 36318.2565
-  hps: 520.02441
+  dps: 38577.16549
+  tps: 36361.96006
+  hps: 523.88789
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 38825.03109
-  tps: 36473.19452
-  hps: 522.3425
+  dps: 38671.67522
+  tps: 36442.91533
+  hps: 525.43328
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 39946.51635
-  tps: 37645.20785
-  hps: 507.66127
+  dps: 39784.00205
+  tps: 37630.01061
+  hps: 513.07014
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 39916.27127
-  tps: 37205.93887
-  hps: 521.69516
+  dps: 39648.13783
+  tps: 37089.15145
+  hps: 520.13787
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 41323.27259
-  tps: 38891.51033
-  hps: 509.20666
+  dps: 41173.79022
+  tps: 38902.78836
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 40951.77581
-  tps: 38539.22328
-  hps: 509.20666
+  dps: 40803.63411
+  tps: 38550.28525
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 41731.91906
-  tps: 39279.02609
-  hps: 509.20666
+  dps: 41580.96193
+  tps: 39290.54178
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FallofMortality-59500"
  value: {
-  dps: 38007.45724
-  tps: 35743.74972
-  hps: 512.29745
+  dps: 37889.63314
+  tps: 35775.332
+  hps: 509.97936
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FallofMortality-65124"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 38332.4058
-  tps: 36048.22353
-  hps: 518.47902
+  dps: 38134.93404
+  tps: 35961.97951
+  hps: 516.93362
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 529.88905
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 533.10537
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 38592.76408
-  tps: 36330.04744
-  hps: 509.20666
+  dps: 38455.15669
+  tps: 36339.50119
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 38919.74208
-  tps: 36657.02544
-  hps: 509.20666
+  dps: 38782.18145
+  tps: 36666.52595
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FireoftheDeep-77988"
  value: {
-  dps: 38821.45967
-  tps: 36558.74304
-  hps: 509.20666
+  dps: 38683.88499
+  tps: 36568.22949
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FireoftheDeep-78008"
  value: {
-  dps: 39031.25481
-  tps: 36768.53817
-  hps: 509.20666
+  dps: 38893.71012
+  tps: 36778.05463
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 40021.35827
-  tps: 37311.02586
-  hps: 517.70632
+  dps: 39753.77937
+  tps: 37194.79299
+  hps: 516.16093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FluidDeath-58181"
  value: {
-  dps: 38594.47436
-  tps: 36283.93513
-  hps: 518.47902
+  dps: 38495.21613
+  tps: 36325.02705
+  hps: 520.02441
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 39916.27127
-  tps: 37205.93887
-  hps: 517.70632
+  dps: 39648.13783
+  tps: 37089.15145
+  hps: 516.16093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 38910.97593
-  tps: 36648.25929
-  hps: 509.20666
+  dps: 38769.62452
+  tps: 36653.96902
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 38535.77968
-  tps: 36239.18096
-  hps: 516.16093
+  dps: 38304.58705
+  tps: 36151.20054
+  hps: 520.02441
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GaleofShadows-56138"
  value: {
-  dps: 38304.01604
-  tps: 35981.88407
-  hps: 509.97936
+  dps: 38186.23133
+  tps: 35988.31441
+  hps: 515.38823
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GaleofShadows-56462"
  value: {
-  dps: 38294.14722
-  tps: 36009.10901
-  hps: 516.16093
+  dps: 38202.41666
+  tps: 36047.46459
+  hps: 510.75206
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GearDetector-61462"
  value: {
-  dps: 38402.99888
-  tps: 36002.98872
-  hps: 519.25171
+  dps: 38373.67508
+  tps: 36105.71312
+  hps: 529.29676
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 38367.70264
-  tps: 36068.92283
-  hps: 509.97936
+  dps: 38154.79228
+  tps: 35999.19646
+  hps: 516.16093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 38513.86647
-  tps: 36158.2995
-  hps: 515.38823
+  dps: 38252.10813
+  tps: 36060.406
+  hps: 520.02441
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Gurthalak,VoiceoftheDeeps-77191"
  value: {
-  dps: 40630.61652
-  tps: 37909.40966
-  hps: 517.70632
+  dps: 40355.14227
+  tps: 37785.9888
+  hps: 516.16093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Gurthalak,VoiceoftheDeeps-78478"
  value: {
-  dps: 40630.61652
-  tps: 37909.40966
-  hps: 517.70632
+  dps: 40355.14227
+  tps: 37785.9888
+  hps: 516.16093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Gurthalak,VoiceoftheDeeps-78487"
  value: {
-  dps: 40630.61652
-  tps: 37909.40966
-  hps: 517.70632
+  dps: 40355.14227
+  tps: 37785.9888
+  hps: 516.16093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HarmlightToken-63839"
  value: {
-  dps: 38169.74567
-  tps: 35907.02903
-  hps: 509.20666
+  dps: 38022.18266
+  tps: 35906.52717
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 39309.29847
-  tps: 37001.22397
-  hps: 509.20666
+  dps: 39167.28091
+  tps: 37009.9098
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartofRage-59224"
  value: {
-  dps: 40251.789
-  tps: 37535.9124
+  dps: 39969.8335
+  tps: 37442.015
   hps: 509.97936
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartofSolace-55868"
  value: {
-  dps: 39969.18481
-  tps: 37325.23921
-  hps: 515.38823
+  dps: 39710.38242
+  tps: 37209.67741
+  hps: 508.43397
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartofSolace-56393"
  value: {
-  dps: 40048.70252
-  tps: 37400.75987
-  hps: 516.16093
+  dps: 39983.04454
+  tps: 37475.48824
+  hps: 506.11588
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartofThunder-55845"
  value: {
-  dps: 38091.54168
-  tps: 35828.82504
-  hps: 509.20666
+  dps: 37953.86478
+  tps: 35838.20928
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartofThunder-56370"
  value: {
-  dps: 38103.63057
-  tps: 35840.91393
-  hps: 509.20666
+  dps: 37965.95609
+  tps: 35850.3006
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 38360.25355
-  tps: 36056.71046
-  hps: 512.29745
+  dps: 38201.82103
+  tps: 36047.98604
+  hps: 516.16093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 40002.68929
-  tps: 37274.1403
+  dps: 39738.99616
+  tps: 37174.53952
   hps: 517.70632
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 39797.55995
-  tps: 37401.68877
-  hps: 509.20666
+  dps: 39552.96185
+  tps: 37307.77058
+  hps: 513.07014
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 39797.55995
-  tps: 37401.68877
-  hps: 509.20666
+  dps: 39552.96185
+  tps: 37307.77058
+  hps: 513.07014
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 38530.39255
-  tps: 36267.67591
-  hps: 509.20666
+  dps: 38392.77625
+  tps: 36277.12075
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 38592.76408
-  tps: 36330.04744
-  hps: 509.20666
+  dps: 38455.15669
+  tps: 36339.50119
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IndomitablePride-77211"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 542.48254
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 545.7753
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IndomitablePride-77983"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 538.70449
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 541.97432
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-IndomitablePride-78003"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 546.74495
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 550.06359
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 38589.2054
-  tps: 36237.51541
-  hps: 536.25102
+  dps: 38299.47305
+  tps: 36081.2314
+  hps: 532.38754
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 38505.42908
-  tps: 36189.48101
-  hps: 530.84215
+  dps: 38395.18488
+  tps: 36172.09395
+  hps: 540.1145
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 38648.51006
-  tps: 36261.16775
-  hps: 543.97798
+  dps: 38463.9139
+  tps: 36213.22325
+  hps: 536.25102
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 38420.76987
-  tps: 36158.05323
-  hps: 509.20666
+  dps: 38283.13789
+  tps: 36167.48239
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 38468.02102
-  tps: 36205.30438
-  hps: 509.20666
+  dps: 38330.3958
+  tps: 36214.7403
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 38319.80599
-  tps: 36022.74265
-  hps: 514.61554
+  dps: 38276.07178
+  tps: 36098.5299
+  hps: 513.84284
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 38549.33697
-  tps: 36253.368
+  dps: 38380.2686
+  tps: 36195.1915
   hps: 516.93362
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 38451.73771
-  tps: 36054.61359
-  hps: 533.16024
+  dps: 38148.67505
+  tps: 35898.53719
+  hps: 530.84215
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KiroptyricSigil-77984"
  value: {
-  dps: 38343.75641
-  tps: 36054.57453
-  hps: 515.38823
+  dps: 38415.75017
+  tps: 36245.30152
+  hps: 519.25171
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KiroptyricSigil-78004"
  value: {
-  dps: 38450.95052
-  tps: 35959.94593
-  hps: 532.38754
+  dps: 38496.84487
+  tps: 36155.30114
+  hps: 533.93294
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 38120.12389
-  tps: 35893.6134
-  hps: 509.20666
+  dps: 37936.07921
+  tps: 35831.47235
+  hps: 514.61554
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 38120.12389
-  tps: 35893.6134
-  hps: 509.20666
+  dps: 37936.07921
+  tps: 35831.47235
+  hps: 514.61554
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LastWord-50708"
  value: {
-  dps: 40630.61652
-  tps: 37909.40966
-  hps: 517.70632
+  dps: 40355.14227
+  tps: 37785.9888
+  hps: 516.16093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LeadenDespair-55816"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 524.85165
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 528.0374
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LeadenDespair-56347"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 529.88905
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 533.10537
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 38482.37728
-  tps: 36195.36968
-  hps: 512.29745
+  dps: 38400.80387
+  tps: 36234.55942
+  hps: 507.66127
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 38591.18159
-  tps: 36293.06196
-  hps: 513.07014
+  dps: 38334.85435
+  tps: 36170.85717
+  hps: 509.97936
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 39771.53664
-  tps: 37416.34756
-  hps: 518.47902
+  dps: 39684.78004
+  tps: 37470.05819
+  hps: 520.02441
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MagmaPlatedBattlearmor"
  value: {
-  dps: 31983.33803
-  tps: 29619.17609
-  hps: 446.5797
+  dps: 31836.62001
+  tps: 29592.8523
+  hps: 448.7796
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MagmaPlatedBattlegear"
  value: {
-  dps: 34962.58219
-  tps: 32350.61718
-  hps: 496.4441
+  dps: 34784.5074
+  tps: 32324.75169
+  hps: 498.644
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 38220.28904
-  tps: 35971.66174
-  hps: 509.20666
+  dps: 38086.16974
+  tps: 35938.75175
+  hps: 511.52475
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 38307.80295
-  tps: 36055.03195
-  hps: 516.16093
+  dps: 38161.63462
+  tps: 36004.01883
+  hps: 510.75206
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 38996.61688
-  tps: 36685.05332
-  hps: 509.20666
+  dps: 38855.55452
+  tps: 36694.97451
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 39120.04159
-  tps: 36802.08141
-  hps: 509.20666
+  dps: 38978.53688
+  tps: 36812.0739
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 39384.32455
-  tps: 37088.4368
-  hps: 508.43397
+  dps: 39144.86461
+  tps: 36992.22839
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 39531.96206
-  tps: 37233.79995
-  hps: 508.43397
+  dps: 39295.85183
+  tps: 37138.56852
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 38084.82012
-  tps: 35796.89376
-  hps: 514.61554
+  dps: 37981.71184
+  tps: 35823.20228
+  hps: 513.84284
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 38332.4058
-  tps: 36048.22353
-  hps: 518.47902
+  dps: 38134.93404
+  tps: 35961.97951
+  hps: 516.93362
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 38660.80574
-  tps: 36398.0891
-  hps: 509.20666
+  dps: 38523.20809
+  tps: 36407.55259
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 38660.80574
-  tps: 36398.0891
-  hps: 509.20666
+  dps: 38523.20809
+  tps: 36407.55259
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 38498.88502
-  tps: 36204.22144
-  hps: 516.16093
+  dps: 38276.22512
+  tps: 36124.19503
+  hps: 520.02441
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 533.90928
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 537.15
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 38768.65492
-  tps: 36505.93828
-  hps: 509.20666
+  dps: 38631.07591
+  tps: 36515.42041
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 38860.26441
-  tps: 36597.54777
-  hps: 509.20666
+  dps: 38722.69891
+  tps: 36607.04342
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-NecroticBoneplateBattlegear"
  value: {
-  dps: 35570.84218
-  tps: 32995.81199
-  hps: 502.60102
+  dps: 35626.25102
+  tps: 33196.53647
+  hps: 509.40313
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-No'Kaled,theElementsofDeath-77188"
  value: {
-  dps: 40630.61652
-  tps: 37909.40966
-  hps: 517.70632
+  dps: 40355.14227
+  tps: 37785.9888
+  hps: 516.16093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-No'Kaled,theElementsofDeath-78472"
  value: {
-  dps: 40630.61652
-  tps: 37909.40966
-  hps: 517.70632
+  dps: 40355.14227
+  tps: 37785.9888
+  hps: 516.16093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-No'Kaled,theElementsofDeath-78481"
  value: {
-  dps: 40630.61652
-  tps: 37909.40966
-  hps: 517.70632
+  dps: 40355.14227
+  tps: 37785.9888
+  hps: 516.16093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 38779.6886
-  tps: 36479.36758
-  hps: 509.20666
+  dps: 38639.4037
+  tps: 36489.16346
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 38036.02249
-  tps: 35738.2504
-  hps: 507.66127
+  dps: 38046.05311
+  tps: 35865.89001
+  hps: 509.97936
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 38086.10602
-  tps: 35823.38938
-  hps: 509.20666
+  dps: 37948.42803
+  tps: 35832.77253
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 38294.63984
-  tps: 36014.37072
-  hps: 513.84284
+  dps: 38142.01377
+  tps: 36005.99779
+  hps: 516.93362
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 38436.80514
-  tps: 36174.0885
-  hps: 509.20666
+  dps: 38287.07361
+  tps: 36171.41812
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 38755.11367
-  tps: 36492.39703
-  hps: 509.20666
+  dps: 38616.02772
+  tps: 36500.37222
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 39916.27127
-  tps: 37205.93887
-  hps: 521.69516
+  dps: 39648.13783
+  tps: 37089.15145
+  hps: 520.13787
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 38547.35728
-  tps: 36281.6432
-  hps: 532.38754
+  dps: 38371.67341
+  tps: 36213.58884
+  hps: 526.20598
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 38748.53123
-  tps: 36419.06649
-  hps: 531.61485
+  dps: 38512.69172
+  tps: 36312.03536
+  hps: 528.52406
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Rainsong-55854"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Rainsong-56377"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReflectionoftheLight-77986"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReflectionoftheLight-78006"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 40630.61652
-  tps: 37909.40966
-  hps: 517.70632
+  dps: 40355.14227
+  tps: 37785.9888
+  hps: 516.16093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 40425.48135
-  tps: 37715.14894
-  hps: 517.70632
+  dps: 40151.25884
+  tps: 37592.27246
+  hps: 516.16093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 38276.06186
-  tps: 35983.98596
-  hps: 509.20666
+  dps: 38124.73927
+  tps: 35977.87102
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 39322.57617
-  tps: 36978.57482
-  hps: 516.16093
+  dps: 39251.45592
+  tps: 37009.24925
+  hps: 515.38823
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 39537.66624
-  tps: 37196.99226
-  hps: 518.47902
+  dps: 39304.8039
+  tps: 37078.1152
+  hps: 516.93362
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RosaryofLight-72901"
  value: {
-  dps: 40241.59176
-  tps: 37845.89322
-  hps: 521.5698
+  dps: 40048.67183
+  tps: 37806.34521
+  hps: 524.66058
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RottingSkull-77116"
  value: {
-  dps: 38694.28199
-  tps: 36380.69727
-  hps: 517.70632
+  dps: 38464.2845
+  tps: 36292.57472
+  hps: 522.3425
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RottingSkull-77987"
  value: {
-  dps: 38639.63163
-  tps: 36334.65778
-  hps: 516.93362
+  dps: 38399.61303
+  tps: 36236.98586
+  hps: 521.5698
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RottingSkull-78007"
  value: {
-  dps: 38775.86063
-  tps: 36454.90731
-  hps: 519.25171
+  dps: 38553.1706
+  tps: 36375.2581
+  hps: 523.88789
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuneofZeth-68998"
  value: {
-  dps: 38604.74465
-  tps: 36302.27435
-  hps: 516.93362
+  dps: 38367.04912
+  tps: 36207.5428
+  hps: 520.7971
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuthlessGladiator'sBadgeofConquest-70399"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuthlessGladiator'sBadgeofConquest-72304"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuthlessGladiator'sBadgeofDominance-70401"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuthlessGladiator'sBadgeofDominance-72448"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuthlessGladiator'sBadgeofVictory-70400"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuthlessGladiator'sBadgeofVictory-72450"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuthlessGladiator'sInsigniaofConquest-70404"
  value: {
-  dps: 38453.32716
-  tps: 36164.37711
-  hps: 509.20666
+  dps: 38229.84479
+  tps: 36091.97549
+  hps: 511.52475
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuthlessGladiator'sInsigniaofConquest-72309"
  value: {
-  dps: 38432.12185
-  tps: 36147.11337
-  hps: 509.20666
+  dps: 38213.5054
+  tps: 36074.80339
+  hps: 511.52475
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuthlessGladiator'sInsigniaofDominance-70402"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuthlessGladiator'sInsigniaofDominance-72449"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuthlessGladiator'sInsigniaofVictory-70403"
  value: {
-  dps: 39682.92359
-  tps: 37361.21037
-  hps: 509.20666
+  dps: 39537.37175
+  tps: 37364.99394
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-RuthlessGladiator'sInsigniaofVictory-72455"
  value: {
-  dps: 39787.52469
-  tps: 37476.71491
-  hps: 509.20666
+  dps: 39654.17647
+  tps: 37495.93427
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScalesofLife-68915"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 537.05765
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 540.31749
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ScalesofLife-69109"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 540.69039
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 543.97227
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 38592.33786
-  tps: 36311.3424
-  hps: 509.20666
+  dps: 38439.13735
+  tps: 36301.77348
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SeaStar-55256"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SeaStar-56290"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Shadowmourne-49623"
  value: {
-  dps: 40630.61652
-  tps: 37909.40966
-  hps: 517.70632
+  dps: 40355.14227
+  tps: 37785.9888
+  hps: 516.16093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ShardofWoe-60233"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 38946.85026
-  tps: 36549.0392
-  hps: 516.93362
+  dps: 39114.71133
+  tps: 36844.22983
+  hps: 520.02441
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 521.70328
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 524.86992
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 38234.35116
-  tps: 35952.01145
-  hps: 509.20666
+  dps: 38079.31284
+  tps: 35941.11392
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 38245.0738
-  tps: 35959.87649
-  hps: 509.20666
+  dps: 38096.03675
+  tps: 35954.47912
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sorrowsong-55879"
  value: {
-  dps: 38530.39255
-  tps: 36267.67591
-  hps: 509.20666
+  dps: 38392.77625
+  tps: 36277.12075
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Sorrowsong-56400"
  value: {
-  dps: 38592.76408
-  tps: 36330.04744
-  hps: 509.20666
+  dps: 38455.15669
+  tps: 36339.50119
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 38263.07224
-  tps: 35988.54982
-  hps: 516.16093
+  dps: 38189.50594
+  tps: 36021.72181
+  hps: 515.38823
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SoulCasket-58183"
  value: {
-  dps: 38660.80574
-  tps: 36398.0891
-  hps: 509.20666
+  dps: 38523.20809
+  tps: 36407.55259
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Souldrinker-77193"
  value: {
-  dps: 40630.61652
-  tps: 37909.40966
-  hps: 517.70632
+  dps: 40355.14227
+  tps: 37785.9888
+  hps: 516.16093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Souldrinker-78479"
  value: {
-  dps: 40630.61652
-  tps: 37909.40966
-  hps: 517.70632
+  dps: 40355.14227
+  tps: 37785.9888
+  hps: 516.16093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Souldrinker-78488"
  value: {
-  dps: 40630.61652
-  tps: 37909.40966
-  hps: 517.70632
+  dps: 40355.14227
+  tps: 37785.9888
+  hps: 516.16093
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 39219.70823
-  tps: 36956.99159
-  hps: 542.48254
+  dps: 39061.66849
+  tps: 36946.013
+  hps: 545.7753
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 39103.21247
-  tps: 36840.49583
-  hps: 538.70449
+  dps: 38963.07626
+  tps: 36847.42076
+  hps: 541.97432
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 39377.88596
-  tps: 37115.16932
-  hps: 546.74495
+  dps: 39210.62173
+  tps: 37094.96623
+  hps: 550.06359
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 38777.98861
-  tps: 36515.27197
-  hps: 509.20666
+  dps: 38640.40771
+  tps: 36524.75221
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 38872.49092
-  tps: 36609.77428
-  hps: 509.20666
+  dps: 38734.92354
+  tps: 36619.26804
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 38761.16214
-  tps: 36445.51507
-  hps: 538.56911
+  dps: 38614.88507
+  tps: 36403.90534
+  hps: 537.02372
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 38620.64884
-  tps: 36300.77233
-  hps: 531.61485
+  dps: 38573.76874
+  tps: 36342.37347
+  hps: 539.34181
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 38999.54633
-  tps: 36578.58014
-  hps: 534.70563
+  dps: 38839.24751
+  tps: 36556.39718
+  hps: 533.93294
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-StayofExecution-68996"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 38390.00621
-  tps: 36082.76556
-  hps: 510.75206
+  dps: 38239.0973
+  tps: 36084.55915
+  hps: 514.61554
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-StumpofTime-62465"
  value: {
-  dps: 38347.5807
-  tps: 36066.02053
-  hps: 518.47902
+  dps: 38263.44879
+  tps: 36116.98012
+  hps: 520.02441
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-StumpofTime-62470"
  value: {
-  dps: 38347.5807
-  tps: 36066.02053
-  hps: 518.47902
+  dps: 38263.44879
+  tps: 36116.98012
+  hps: 520.02441
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 532.55306
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 535.78555
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 535.55612
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 538.80684
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 38433.4535
-  tps: 36170.73686
-  hps: 509.20666
+  dps: 38297.61407
+  tps: 36181.95857
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 38901.53309
-  tps: 36514.45961
-  hps: 524.66058
+  dps: 39010.36897
+  tps: 36765.15559
+  hps: 522.3425
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TearofBlood-55819"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TearofBlood-56351"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 38460.46084
-  tps: 36197.7442
-  hps: 509.20666
+  dps: 38322.83454
+  tps: 36207.17904
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 38592.76408
-  tps: 36330.04744
-  hps: 509.20666
+  dps: 38455.15669
+  tps: 36339.50119
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheHungerer-68927"
  value: {
-  dps: 38644.31042
-  tps: 36217.97712
-  hps: 532.38754
+  dps: 38503.03348
+  tps: 36214.71698
+  hps: 530.06946
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TheHungerer-69112"
  value: {
-  dps: 38782.27353
-  tps: 36410.57756
-  hps: 533.93294
+  dps: 38452.58605
+  tps: 36195.22658
+  hps: 531.61485
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 38679.37918
-  tps: 36416.66254
-  hps: 509.20666
+  dps: 38558.29263
+  tps: 36442.63713
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 38770.31592
-  tps: 36507.59928
-  hps: 509.20666
+  dps: 38640.42304
+  tps: 36524.76754
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 38724.82727
-  tps: 36443.05355
-  hps: 509.20666
+  dps: 38573.82134
+  tps: 36437.20227
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 38809.49534
-  tps: 36523.8698
-  hps: 509.20666
+  dps: 38658.44886
+  tps: 36517.78342
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 38351.40022
-  tps: 36088.03448
-  hps: 543.20529
+  dps: 38390.22385
+  tps: 36263.31764
+  hps: 559.4319
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UnheededWarning-59520"
  value: {
-  dps: 38753.74316
-  tps: 36464.83667
-  hps: 509.20666
+  dps: 38593.03482
+  tps: 36450.055
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 38660.80574
-  tps: 36398.0891
-  hps: 509.20666
+  dps: 38523.20809
+  tps: 36407.55259
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 38660.80574
-  tps: 36398.0891
-  hps: 509.20666
+  dps: 38523.20809
+  tps: 36407.55259
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 38660.80574
-  tps: 36398.0891
-  hps: 509.20666
+  dps: 38523.20809
+  tps: 36407.55259
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 34075.17798
-  tps: 31436.37948
-  hps: 511.71448
+  dps: 33937.1854
+  tps: 31444.23154
+  hps: 510.15924
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 38309.51762
-  tps: 36046.65091
-  hps: 509.20666
+  dps: 38178.45814
+  tps: 36062.72053
+  hps: 510.75206
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 38372.28518
-  tps: 36109.56854
-  hps: 509.20666
+  dps: 38224.42451
+  tps: 36108.76902
+  hps: 511.52475
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 40380.20057
-  tps: 38043.24436
-  hps: 509.20666
+  dps: 40236.05701
+  tps: 38052.1234
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-VeilofLies-72900"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 537.05765
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 540.31749
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 40103.99525
-  tps: 37725.11674
-  hps: 517.70632
+  dps: 39925.80119
+  tps: 37697.31795
+  hps: 521.5698
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 40355.93374
-  tps: 37959.43922
-  hps: 518.47902
+  dps: 40185.40569
+  tps: 37938.90537
+  hps: 522.3425
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-VialofShadows-77207"
  value: {
-  dps: 38728.26515
-  tps: 36442.28521
-  hps: 508.43397
+  dps: 38590.5785
+  tps: 36427.98632
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-VialofShadows-77979"
  value: {
-  dps: 38651.66944
-  tps: 36364.5631
-  hps: 508.43397
+  dps: 38523.23377
+  tps: 36364.7618
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-VialofShadows-77999"
  value: {
-  dps: 38826.77041
-  tps: 36526.36534
-  hps: 508.43397
+  dps: 38678.1591
+  tps: 36517.35024
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 532.55306
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 535.78555
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 535.55612
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 538.80684
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sBadgeofConquest-70517"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sBadgeofDominance-70518"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sBadgeofVictory-70519"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 38333.78744
-  tps: 36049.49912
-  hps: 519.25171
+  dps: 38238.05834
+  tps: 36092.91125
+  hps: 520.02441
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 38442.24435
-  tps: 36175.2644
-  hps: 518.47902
+  dps: 38202.13376
+  tps: 36054.79129
+  hps: 515.38823
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 38545.06104
-  tps: 36248.00395
-  hps: 516.16093
+  dps: 38318.58486
+  tps: 36162.51352
+  hps: 520.02441
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 38412.6433
-  tps: 36157.00719
-  hps: 511.52475
+  dps: 38089.69076
+  tps: 35952.08621
+  hps: 505.34318
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 38696.71662
-  tps: 36433.99998
-  hps: 509.20666
+  dps: 38559.1241
+  tps: 36443.4686
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 38335.46688
-  tps: 36049.95974
-  hps: 508.43397
+  dps: 38136.64458
+  tps: 35996.62336
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sInsigniaofConquest-70577"
  value: {
-  dps: 38384.93436
-  tps: 36106.20375
-  hps: 508.43397
+  dps: 38179.65263
+  tps: 36043.26276
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sInsigniaofDominance-70578"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 39342.95558
-  tps: 37040.28153
-  hps: 509.20666
+  dps: 39192.35406
+  tps: 37039.85786
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sInsigniaofVictory-70579"
  value: {
-  dps: 39495.86867
-  tps: 37192.81065
-  hps: 509.20666
+  dps: 39349.32909
+  tps: 37193.92511
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WillofUnbinding-77995"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 509.20666
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 38124.51595
-  tps: 35790.37487
-  hps: 520.02441
+  dps: 37928.53025
+  tps: 35701.49767
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 38256.15308
-  tps: 35931.53642
-  hps: 522.3425
+  dps: 38121.48446
+  tps: 35925.09164
+  hps: 516.93362
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 38468.02102
-  tps: 36205.30438
-  hps: 509.20666
+  dps: 38330.3958
+  tps: 36214.7403
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 38661.85422
-  tps: 36339.95708
-  hps: 508.43397
+  dps: 38440.59641
+  tps: 36259.95528
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 38575.79137
-  tps: 36264.63528
-  hps: 508.43397
+  dps: 38370.0372
+  tps: 36197.90687
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 38752.32807
-  tps: 36418.18006
-  hps: 508.43397
+  dps: 38528.79475
+  tps: 36338.30845
+  hps: 512.29745
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 525.14227
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 528.32978
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 38054.10089
-  tps: 35791.38425
-  hps: 525.14227
+  dps: 37916.41649
+  tps: 35800.76099
+  hps: 528.32978
  }
 }
 dps_results: {
  key: "TestFrost-Average-Default"
  value: {
-  dps: 40890.97934
-  tps: 38165.52051
-  hps: 483.40518
+  dps: 40736.48102
+  tps: 38169.5985
+  hps: 483.01836
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3.masterfrost-DefaultTalents-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 135932.85398
-  tps: 133193.27512
+  dps: 134365.76565
+  tps: 131777.73116
   hps: 562.52269
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3.masterfrost-DefaultTalents-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 40630.61652
-  tps: 37909.40966
-  hps: 517.70632
+  dps: 40355.14227
+  tps: 37785.9888
+  hps: 516.16093
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3.masterfrost-DefaultTalents-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 50820.42154
-  tps: 44348.81205
-  hps: 610.42984
+  dps: 50020.15198
+  tps: 43864.95602
+  hps: 614.29332
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3.masterfrost-DefaultTalents-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 89510.53987
-  tps: 87626.71129
-  hps: 461.96959
+  dps: 89917.39336
+  tps: 88125.73298
+  hps: 459.87291
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3.masterfrost-DefaultTalents-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 27074.12998
-  tps: 25207.8102
+  dps: 26929.8742
+  tps: 25171.11754
   hps: 412.34805
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3.masterfrost-DefaultTalents-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 31547.99954
-  tps: 26813.54228
-  hps: 461.2707
+  dps: 31565.61491
+  tps: 27060.26295
+  hps: 457.77623
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3.masterfrost-DualWield-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 128996.51574
-  tps: 126262.21492
-  hps: 562.52269
+  dps: 129172.39443
+  tps: 126598.01237
+  hps: 559.4319
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3.masterfrost-DualWield-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 40159.44963
-  tps: 37438.17562
-  hps: 506.88858
+  dps: 40113.22152
+  tps: 37569.50772
+  hps: 511.52475
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3.masterfrost-DualWield-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 50549.3532
-  tps: 44083.85575
+  dps: 49873.25464
+  tps: 43731.45551
   hps: 614.29332
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3.masterfrost-DualWield-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 85264.65067
-  tps: 83373.30593
-  hps: 462.66849
+  dps: 85037.05627
+  tps: 83251.18711
+  hps: 459.87291
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3.masterfrost-DualWield-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 27055.96653
-  tps: 25180.82161
-  hps: 412.34805
+  dps: 26833.64323
+  tps: 25061.14887
+  hps: 415.84252
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3.masterfrost-DualWield-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 31455.93416
-  tps: 26704.19461
-  hps: 457.77622
+  dps: 31378.60392
+  tps: 26869.94886
+  hps: 468.25965
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3.masterfrost-TwoHand-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 130843.16336
-  tps: 128233.13287
-  hps: 244.94463
+  dps: 132670.66225
+  tps: 130231.46922
+  hps: 241.08115
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3.masterfrost-TwoHand-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 30481.68826
-  tps: 27888.92371
-  hps: 248.80811
+  dps: 30184.40001
+  tps: 27744.34791
+  hps: 247.26272
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3.masterfrost-TwoHand-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 39416.74877
-  tps: 32916.54626
+  dps: 38420.6873
+  tps: 32276.88694
   hps: 266.58012
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3.masterfrost-TwoHand-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 85014.22171
-  tps: 83142.82757
-  hps: 190.09944
+  dps: 85207.88473
+  tps: 83488.90075
+  hps: 190.79833
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3.masterfrost-TwoHand-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 20222.66644
-  tps: 18441.02178
-  hps: 192.89502
+  dps: 20096.33109
+  tps: 18377.70518
+  hps: 188.70165
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Orc-p3.masterfrost-TwoHand-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 24086.8647
-  tps: 19321.15834
+  dps: 24169.47202
+  tps: 19643.08229
   hps: 157.25138
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Worgen-p3.masterfrost-DefaultTalents-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 134767.10071
-  tps: 132091.04837
-  hps: 565.55967
+  dps: 133876.45541
+  tps: 131369.28177
+  hps: 566.33229
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Worgen-p3.masterfrost-DefaultTalents-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 40381.37048
-  tps: 37731.21699
-  hps: 515.33921
+  dps: 40064.51586
+  tps: 37568.63823
+  hps: 512.24872
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Worgen-p3.masterfrost-DefaultTalents-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 50449.91205
-  tps: 44114.37286
-  hps: 621.96111
+  dps: 49614.78626
+  tps: 43565.20867
+  hps: 618.098
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Worgen-p3.masterfrost-DefaultTalents-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 89614.66773
-  tps: 87772.98113
-  hps: 460.52568
+  dps: 88945.74878
+  tps: 87189.95261
+  hps: 465.41745
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Worgen-p3.masterfrost-DefaultTalents-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 27046.19304
-  tps: 25231.21487
-  hps: 417.89735
+  dps: 26907.31973
+  tps: 25201.99117
+  hps: 416.4997
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Worgen-p3.masterfrost-DefaultTalents-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 31266.85902
-  tps: 26594.3189
-  hps: 457.73038
+  dps: 31371.32541
+  tps: 26921.5163
+  hps: 461.2245
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Worgen-p3.masterfrost-DualWield-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 129126.06307
-  tps: 126469.33399
-  hps: 564.78705
+  dps: 127760.25418
+  tps: 125255.86039
+  hps: 564.01442
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Worgen-p3.masterfrost-DualWield-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 39994.95282
-  tps: 37350.24462
-  hps: 513.79396
+  dps: 39979.51536
+  tps: 37497.80724
+  hps: 513.02134
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Worgen-p3.masterfrost-DualWield-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 50044.32144
-  tps: 43714.46185
-  hps: 621.96111
+  dps: 48813.50611
+  tps: 42743.16019
+  hps: 610.37177
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Worgen-p3.masterfrost-DualWield-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 85372.28618
-  tps: 83542.07812
-  hps: 464.0198
+  dps: 85278.48467
+  tps: 83544.8393
+  hps: 462.62215
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Worgen-p3.masterfrost-DualWield-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26752.96072
-  tps: 24944.2399
-  hps: 415.10205
+  dps: 26842.30442
+  tps: 25122.38858
+  hps: 419.295
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Worgen-p3.masterfrost-DualWield-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 31083.66964
-  tps: 26392.85802
-  hps: 464.71863
+  dps: 31190.37924
+  tps: 26744.05102
+  hps: 468.21275
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Worgen-p3.masterfrost-TwoHand-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 131250.2157
-  tps: 128719.66146
-  hps: 248.01182
+  dps: 131499.70087
+  tps: 129103.96179
+  hps: 244.92133
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Worgen-p3.masterfrost-TwoHand-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 30406.90718
-  tps: 27875.43019
-  hps: 249.55707
+  dps: 29934.72378
+  tps: 27557.05472
+  hps: 246.46658
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Worgen-p3.masterfrost-TwoHand-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 38922.56032
-  tps: 32546.35839
-  hps: 262.69165
+  dps: 38043.82801
+  tps: 31976.51161
+  hps: 247.2392
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Worgen-p3.masterfrost-TwoHand-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 85266.06685
-  tps: 83494.87419
-  hps: 192.8757
+  dps: 84673.30738
+  tps: 83000.34004
+  hps: 197.06865
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Worgen-p3.masterfrost-TwoHand-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 20072.34289
-  tps: 18310.39327
-  hps: 193.57452
+  dps: 20011.90422
+  tps: 18343.2873
+  hps: 192.17687
  }
 }
 dps_results: {
  key: "TestFrost-Settings-Worgen-p3.masterfrost-TwoHand-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 23871.5202
-  tps: 19187.85284
-  hps: 164.22388
+  dps: 23977.44897
+  tps: 19539.5093
+  hps: 160.72975
  }
 }
 dps_results: {
  key: "TestFrost-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 38038.47065
-  tps: 35560.55474
-  hps: 486.79848
+  dps: 38213.36745
+  tps: 35883.42009
+  hps: 490.66196
  }
 }

--- a/sim/death_knight/ghoul_pet.go
+++ b/sim/death_knight/ghoul_pet.go
@@ -201,6 +201,16 @@ func (ghoulPet *GhoulPet) registerClaw() *core.Spell {
 	})
 }
 
+func (ghoulPet *GhoulPet) Enable(sim *core.Simulation, petAgent core.PetAgent) {
+	if ghoulPet.IsGuardian() {
+		// The ghoul takes around 4.5s - 5s to from summon to first hit, depending on your distance from the target.
+		randomDelay := core.DurationFromSeconds(sim.RollWithLabel(4.5, 5, "Raise Dead Delay"))
+		ghoulPet.Pet.EnableWithStartAttackDelay(sim, petAgent, randomDelay)
+	} else {
+		ghoulPet.Pet.Enable(sim, petAgent)
+	}
+}
+
 const (
 	GhoulSpellNone int64 = 0
 	GhoulSpellClaw int64 = 1 << iota

--- a/sim/death_knight/raise_dead.go
+++ b/sim/death_knight/raise_dead.go
@@ -18,7 +18,7 @@ func (dk *DeathKnight) registerRaiseDeadSpell() {
 		ActionID: core.ActionID{SpellID: 46584},
 		Duration: time.Minute * 1,
 		OnGain: func(aura *core.Aura, sim *core.Simulation) {
-			dk.Ghoul.Pet.Enable(sim, dk.Ghoul)
+			dk.Ghoul.Enable(sim, dk.Ghoul)
 		},
 		OnExpire: func(aura *core.Aura, sim *core.Simulation) {
 			dk.Ghoul.Pet.Disable(sim)


### PR DESCRIPTION
Emulate the DK Raise Dead doing its RP "climbing out of the ground" thing.
The lowest I saw on logs was 4.5s and the longest around 5s, all depending on how far the Ghoul had to walk after summon.