### PR TITLE
[Unholy] Change prepull Death Coil to its own spell to avoid dmg procs

### DIFF
--- a/sim/death_knight/death_coil.go
+++ b/sim/death_knight/death_coil.go
@@ -8,12 +8,43 @@ import (
 var DeathCoilActionID = core.ActionID{SpellID: 47541}
 
 func (dk *DeathKnight) registerDeathCoilSpell() {
-	rpMetrics := dk.NewRunicPowerMetrics(DeathCoilActionID)
+	rpMetrics := dk.NewRunicPowerMetrics(core.ActionID{SpellID: 58679})
 	hasGlyphOfDeathsEmbrace := dk.HasMinorGlyph(proto.DeathKnightMinorGlyph_GlyphOfDeathSEmbrace)
+
+	// Death Coil Heal
+	dk.RegisterSpell(core.SpellConfig{
+		ActionID:       DeathCoilActionID.WithTag(2),
+		SpellSchool:    core.SpellSchoolShadow,
+		ProcMask:       core.ProcMaskSpellHealing,
+		ClassSpellMask: DeathKnightSpellDeathCoilHeal,
+		Flags:          core.SpellFlagAPL | core.SpellFlagPrepullOnly | core.SpellFlagNoMetrics,
+
+		RuneCost: core.RuneCostOptions{
+			RunicPowerCost: 40,
+		},
+		Cast: core.CastConfig{
+			DefaultCast: core.Cast{
+				GCD: core.GCDDefault,
+			},
+		},
+
+		DamageMultiplier: 3.5,
+		CritMultiplier:   dk.DefaultMeleeCritMultiplier(),
+		ThreatMultiplier: 1.0,
+
+		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
+			baseHealing := dk.ClassSpellScaling*0.87599998713 + spell.MeleeAttackPower()*0.23
+			spell.CalcAndDealHealing(sim, target, baseHealing, spell.OutcomeHealingCrit)
+
+			if hasGlyphOfDeathsEmbrace {
+				dk.AddRunicPower(sim, 20, rpMetrics)
+			}
+		},
+	})
 
 	dk.RegisterSpell(core.SpellConfig{
 		ActionID:       DeathCoilActionID,
-		Flags:          core.SpellFlagAPL,
+		Flags:          core.SpellFlagAPL | core.SpellFlagEncounterOnly,
 		SpellSchool:    core.SpellSchoolShadow,
 		ProcMask:       core.ProcMaskSpellDamage,
 		ClassSpellMask: DeathKnightSpellDeathCoil,
@@ -32,21 +63,8 @@ func (dk *DeathKnight) registerDeathCoilSpell() {
 		ThreatMultiplier: 1.0,
 
 		ApplyEffects: func(sim *core.Simulation, target *core.Unit, spell *core.Spell) {
-			var baseDamage float64
-			if hasGlyphOfDeathsEmbrace && sim.CurrentTime < 0 {
-				baseDamage = 0
-			} else {
-				baseDamage = dk.ClassSpellScaling*0.87599998713 + spell.MeleeAttackPower()*0.23
-			}
-
+			baseDamage := dk.ClassSpellScaling*0.87599998713 + spell.MeleeAttackPower()*0.23
 			spell.CalcAndDealDamage(sim, target, baseDamage, spell.OutcomeMagicHitAndCrit)
-
-			// Instead of actually healing the ghoul, we just add the runic power
-			// to not have to deal with healing metrics and other weird stuff.
-			// Damage doesn't count before 0 anyway.
-			if hasGlyphOfDeathsEmbrace && sim.CurrentTime < 0 {
-				dk.AddRunicPower(sim, 20, rpMetrics)
-			}
 		},
 	})
 }

--- a/sim/death_knight/death_knight.go
+++ b/sim/death_knight/death_knight.go
@@ -317,6 +317,7 @@ const (
 	DeathKnightSpellFlagNone int64 = 0
 	DeathKnightSpellIcyTouch int64 = 1 << iota
 	DeathKnightSpellDeathCoil
+	DeathKnightSpellDeathCoilHeal
 	DeathKnightSpellDeathAndDecay
 	DeathKnightSpellOutbreak
 	DeathKnightSpellEmpowerRuneWeapon

--- a/sim/death_knight/glyphs.go
+++ b/sim/death_knight/glyphs.go
@@ -17,7 +17,7 @@ func (dk *DeathKnight) ApplyGlyphs() {
 	if dk.HasPrimeGlyph(proto.DeathKnightPrimeGlyph_GlyphOfDeathCoil) {
 		dk.AddStaticMod(core.SpellModConfig{
 			Kind:       core.SpellMod_DamageDone_Flat,
-			ClassMask:  DeathKnightSpellDeathCoil,
+			ClassMask:  DeathKnightSpellDeathCoil | DeathKnightSpellDeathCoilHeal,
 			FloatValue: 0.15,
 		})
 	}

--- a/sim/death_knight/items.go
+++ b/sim/death_knight/items.go
@@ -18,7 +18,7 @@ var ItemSetMagmaPlatedBattlegear = core.NewItemSet(core.ItemSet{
 			// Increases the critical strike chance of your Death Coil and Frost Strike abilities by 5%.
 			agent.GetCharacter().AddStaticMod(core.SpellModConfig{
 				Kind:       core.SpellMod_BonusCrit_Percent,
-				ClassMask:  DeathKnightSpellDeathCoil | DeathKnightSpellFrostStrike,
+				ClassMask:  DeathKnightSpellDeathCoil | DeathKnightSpellDeathCoilHeal | DeathKnightSpellFrostStrike,
 				FloatValue: 5,
 			})
 		},

--- a/sim/death_knight/talents_unholy.go
+++ b/sim/death_knight/talents_unholy.go
@@ -30,7 +30,7 @@ func (dk *DeathKnight) ApplyUnholyTalents() {
 	if dk.Talents.Morbidity > 0 {
 		dk.AddStaticMod(core.SpellModConfig{
 			Kind:       core.SpellMod_DamageDone_Flat,
-			ClassMask:  DeathKnightSpellDeathCoil,
+			ClassMask:  DeathKnightSpellDeathCoil | DeathKnightSpellDeathCoilHeal,
 			FloatValue: 0.05 * float64(dk.Talents.Morbidity),
 		})
 
@@ -111,7 +111,7 @@ func (dk *DeathKnight) applyRunicEmpowerementCorruption() {
 	if dk.Talents.RunicCorruption > 0 {
 		dk.AddStaticMod(core.SpellModConfig{
 			Kind:       core.SpellMod_RunicPowerCost_Flat,
-			ClassMask:  DeathKnightSpellDeathCoil,
+			ClassMask:  DeathKnightSpellDeathCoil | DeathKnightSpellDeathCoilHeal,
 			FloatValue: -3.0 * float64(dk.Talents.RunicCorruption),
 		})
 
@@ -279,7 +279,7 @@ func (dk *DeathKnight) applySuddenDoom() {
 
 	mod := dk.AddDynamicMod(core.SpellModConfig{
 		Kind:       core.SpellMod_PowerCost_Pct,
-		ClassMask:  DeathKnightSpellDeathCoil,
+		ClassMask:  DeathKnightSpellDeathCoil | DeathKnightSpellDeathCoilHeal,
 		FloatValue: -1,
 	})
 
@@ -374,8 +374,8 @@ func (dk *DeathKnight) applyShadowInfusion() *core.Aura {
 
 	core.MakeProcTriggerAura(&dk.Unit, core.ProcTrigger{
 		Name:           "Shadow Infusion",
-		Callback:       core.CallbackOnSpellHitDealt,
-		ClassSpellMask: DeathKnightSpellDeathCoil,
+		Callback:       core.CallbackOnSpellHitDealt | core.CallbackOnHealDealt,
+		ClassSpellMask: DeathKnightSpellDeathCoil | DeathKnightSpellDeathCoilHeal,
 		Outcome:        core.OutcomeLanded,
 		ProcChance:     []float64{0.0, 0.33, 0.66, 1.0}[dk.Talents.ShadowInfusion],
 

--- a/sim/death_knight/unholy/TestUnholy.results
+++ b/sim/death_knight/unholy/TestUnholy.results
@@ -38,2440 +38,2440 @@ character_stats_results: {
 dps_results: {
  key: "TestUnholy-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 41903.39025
-  tps: 31047.4118
-  hps: 667.66767
+  dps: 41842.59314
+  tps: 30973.10433
+  hps: 662.96579
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 763.07597
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 779.66947
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 40046.99189
-  tps: 29919.30302
-  hps: 650.42743
+  dps: 39967.47978
+  tps: 29836.69919
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 40922.83739
-  tps: 30316.33891
-  hps: 650.42743
+  dps: 40845.18225
+  tps: 30235.89063
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 41118.91133
-  tps: 30457.18
-  hps: 650.42743
+  dps: 41041.17456
+  tps: 30376.74073
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ArrowofTime-72897"
  value: {
-  dps: 40479.96292
-  tps: 29928.36405
+  dps: 40545.32596
+  tps: 30004.78615
   hps: 662.18214
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 41556.89048
-  tps: 30713.02253
-  hps: 672.74005
+  dps: 41499.92786
+  tps: 30643.12837
+  hps: 668.00245
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 39460.20846
-  tps: 29276.57495
-  hps: 650.42743
+  dps: 39383.12802
+  tps: 29196.07204
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 40118.13693
-  tps: 29766.70763
-  hps: 662.18214
+  dps: 40024.75875
+  tps: 29665.68094
+  hps: 659.04755
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 40195.35118
-  tps: 29833.96867
-  hps: 664.53308
+  dps: 40090.96611
+  tps: 29715.39639
+  hps: 661.39849
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BindingPromise-67037"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 39778.64767
-  tps: 29627.09699
-  hps: 650.42743
+  dps: 39700.19963
+  tps: 29545.38785
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 39832.61279
-  tps: 29685.86357
-  hps: 650.42743
+  dps: 39753.95078
+  tps: 29603.97454
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 39886.59351
-  tps: 29744.64576
-  hps: 650.42743
+  dps: 39807.71746
+  tps: 29662.57677
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 40064.37684
-  tps: 29723.55644
-  hps: 662.18214
+  dps: 39987.78603
+  tps: 29638.60067
+  hps: 659.04755
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 39812.22673
-  tps: 29488.69282
-  hps: 650.42743
+  dps: 39708.96905
+  tps: 29400.19554
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39344.02407
+  tps: 29157.25051
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 40256.0788
-  tps: 29843.25804
+  dps: 40324.69834
+  tps: 29943.67256
   hps: 644.94189
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 42135.37047
-  tps: 31444.26928
-  hps: 650.42743
+  dps: 42014.10509
+  tps: 31310.58217
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 41780.67333
-  tps: 31157.86626
-  hps: 650.42743
+  dps: 41652.14198
+  tps: 31011.56907
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 42477.23589
-  tps: 31700.43138
-  hps: 650.42743
+  dps: 42396.87595
+  tps: 31641.06832
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BottledLightning-66879"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BottledWishes-77114"
  value: {
-  dps: 40229.94524
-  tps: 29909.90271
-  hps: 668.45132
+  dps: 40307.50705
+  tps: 29906.99442
+  hps: 662.96579
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BottledWishes-77985"
  value: {
-  dps: 40054.00634
-  tps: 29676.61215
+  dps: 40146.36334
+  tps: 29739.83105
   hps: 662.96579
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BottledWishes-78005"
  value: {
-  dps: 40259.85006
-  tps: 29818.59628
+  dps: 40310.34545
+  tps: 29850.31794
   hps: 666.10038
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 41543.15465
-  tps: 30085.37646
-  hps: 667.66767
+  dps: 41486.19765
+  tps: 30016.87203
+  hps: 662.96579
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 43236.52248
-  tps: 32106.98283
-  hps: 602.84679
+  dps: 43146.93172
+  tps: 31975.25213
+  hps: 598.86498
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 41833.33566
-  tps: 31005.03438
-  hps: 667.66767
+  dps: 41774.22761
+  tps: 30933.75971
+  hps: 662.96579
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CataclysmicGladiator'sBadgeofConquest-73648"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CataclysmicGladiator'sBadgeofDominance-73498"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CataclysmicGladiator'sBadgeofVictory-73496"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CataclysmicGladiator'sInsigniaofConquest-73643"
  value: {
-  dps: 39923.34788
-  tps: 29552.92901
-  hps: 650.42743
+  dps: 39900.4626
+  tps: 29529.12958
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CataclysmicGladiator'sInsigniaofDominance-73497"
  value: {
-  dps: 39420.94767
-  tps: 29237.56574
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CataclysmicGladiator'sInsigniaofVictory-73491"
  value: {
-  dps: 40882.3928
-  tps: 30225.27581
-  hps: 644.15825
+  dps: 41322.42915
+  tps: 30565.65175
+  hps: 648.07648
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 41952.86035
-  tps: 31093.24159
-  hps: 669.23497
+  dps: 41894.09618
+  tps: 31021.95466
+  hps: 663.74943
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 40372.61727
-  tps: 30014.81664
-  hps: 662.18214
+  dps: 40283.10944
+  tps: 29926.59574
+  hps: 659.04755
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 42738.08864
-  tps: 31580.13568
-  hps: 671.58591
+  dps: 42720.15034
+  tps: 31560.58871
+  hps: 659.04755
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 42515.37019
-  tps: 31410.69192
-  hps: 660.61484
+  dps: 42474.89827
+  tps: 31402.33576
+  hps: 659.8312
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 43406.10386
-  tps: 32008.42273
-  hps: 670.80226
+  dps: 43298.76532
+  tps: 31998.7925
+  hps: 665.31673
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CrushingWeight-59506"
  value: {
-  dps: 41289.85353
-  tps: 30595.39074
+  dps: 41414.67371
+  tps: 30616.04128
   hps: 662.18214
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CrushingWeight-65118"
  value: {
-  dps: 41532.70001
-  tps: 30652.15557
-  hps: 665.31673
+  dps: 41639.30792
+  tps: 30711.24682
+  hps: 662.96579
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 39957.62305
-  tps: 29805.23649
-  hps: 650.42743
+  dps: 39915.03259
+  tps: 29705.33059
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 39920.06533
-  tps: 29735.44388
-  hps: 650.42743
+  dps: 39820.63697
+  tps: 29658.14837
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-CunningoftheCruel-78000"
  value: {
-  dps: 40051.37181
-  tps: 29871.12099
-  hps: 650.42743
+  dps: 40009.93005
+  tps: 29816.29577
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 41137.52927
-  tps: 30625.20375
-  hps: 641.8073
+  dps: 41091.09189
+  tps: 30562.66609
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 40228.24408
-  tps: 29938.41748
-  hps: 641.8073
+  dps: 40188.81955
+  tps: 29901.99332
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 40013.42816
-  tps: 29889.87559
-  hps: 650.42743
+  dps: 39932.37657
+  tps: 29779.00875
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 40371.75608
-  tps: 29887.83677
-  hps: 654.34566
+  dps: 40362.23932
+  tps: 29850.97583
+  hps: 659.04755
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 41657.98627
-  tps: 30782.57809
-  hps: 669.23497
+  dps: 41601.25627
+  tps: 30712.66404
+  hps: 663.74943
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 39728.73297
-  tps: 29522.98228
+  dps: 39682.02531
+  tps: 29439.98122
   hps: 652.77837
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 41304.53041
-  tps: 30729.92157
-  hps: 662.96579
+  dps: 41530.5634
+  tps: 30823.24101
+  hps: 655.91296
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 41543.15465
-  tps: 30699.36374
-  hps: 672.74005
+  dps: 41486.19765
+  tps: 30629.46126
+  hps: 668.00245
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ElementiumDeathplateBattlearmor"
  value: {
-  dps: 34163.91927
-  tps: 25472.14917
-  hps: 581.15788
+  dps: 34214.96895
+  tps: 25474.80615
+  hps: 574.11829
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ElementiumDeathplateBattlegear"
  value: {
-  dps: 38367.96399
-  tps: 28544.48394
-  hps: 650.77168
+  dps: 38398.7013
+  tps: 28625.0129
+  hps: 643.73208
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 41543.15465
-  tps: 30699.36374
-  hps: 667.66767
+  dps: 41486.19765
+  tps: 30629.46126
+  hps: 662.96579
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 41657.98627
-  tps: 30782.57809
-  hps: 669.23497
+  dps: 41601.25627
+  tps: 30712.66404
+  hps: 663.74943
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 40366.61347
-  tps: 29911.05601
-  hps: 657.48025
+  dps: 40399.34872
+  tps: 29948.19761
+  hps: 659.04755
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 40431.06917
-  tps: 30040.43521
-  hps: 661.39849
+  dps: 40500.66281
+  tps: 30029.92127
+  hps: 664.53308
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 40046.99189
-  tps: 29919.30302
-  hps: 650.42743
+  dps: 39967.47978
+  tps: 29836.69919
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 41543.15465
-  tps: 30699.36374
-  hps: 672.74005
+  dps: 41486.19765
+  tps: 30629.46126
+  hps: 668.00245
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 42758.25231
-  tps: 31594.67859
-  hps: 649.64378
+  dps: 42728.48393
+  tps: 31590.87326
+  hps: 644.94189
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 42373.65593
-  tps: 31319.05195
-  hps: 649.64378
+  dps: 42343.63079
+  tps: 31314.61988
+  hps: 644.94189
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 43181.30833
-  tps: 31897.86789
-  hps: 649.64378
+  dps: 43151.82238
+  tps: 31894.75197
+  hps: 644.94189
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FallofMortality-59500"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FallofMortality-65124"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 676.47656
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 673.21643
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 39886.59351
-  tps: 29744.64576
-  hps: 650.42743
+  dps: 39807.71746
+  tps: 29662.57677
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 40169.83873
-  tps: 30053.06228
-  hps: 650.42743
+  dps: 40089.8394
+  tps: 29970.04869
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FireoftheDeep-77988"
  value: {
-  dps: 40084.65635
-  tps: 29960.31396
-  hps: 650.42743
+  dps: 40004.99486
+  tps: 29877.5845
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FireoftheDeep-78008"
  value: {
-  dps: 40266.53489
-  tps: 30158.34287
-  hps: 650.42743
+  dps: 40186.15204
+  tps: 30075.00669
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 41635.89834
-  tps: 30800.45013
-  hps: 667.66767
+  dps: 41578.51281
+  tps: 30730.1878
+  hps: 662.96579
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FluidDeath-58181"
  value: {
-  dps: 39852.17692
-  tps: 29526.65557
-  hps: 650.42743
+  dps: 39771.32513
+  tps: 29450.9014
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 41543.15465
-  tps: 30699.36374
-  hps: 667.66767
+  dps: 41486.19765
+  tps: 30629.46126
+  hps: 662.96579
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 40087.80239
-  tps: 29967.2576
-  hps: 650.42743
+  dps: 39995.99444
+  tps: 29872.53431
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 40118.10876
-  tps: 29766.65411
-  hps: 662.18214
+  dps: 40024.75875
+  tps: 29665.68094
+  hps: 659.04755
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GaleofShadows-56138"
  value: {
-  dps: 39861.77513
-  tps: 29501.26658
-  hps: 652.77837
+  dps: 39892.5605
+  tps: 29583.37939
+  hps: 658.2639
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GaleofShadows-56462"
  value: {
-  dps: 39986.02039
-  tps: 29612.41237
-  hps: 659.8312
+  dps: 39995.79104
+  tps: 29610.44576
+  hps: 662.18214
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GearDetector-61462"
  value: {
-  dps: 39718.74393
-  tps: 29372.37845
-  hps: 651.99472
+  dps: 39882.67392
+  tps: 29483.77959
+  hps: 650.42743
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 39690.72561
-  tps: 29393.97688
-  hps: 647.29284
+  dps: 39724.78391
+  tps: 29483.82442
+  hps: 644.15825
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 39876.8303
-  tps: 29544.57919
-  hps: 654.34566
+  dps: 39847.60216
+  tps: 29472.00728
+  hps: 653.56202
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Gurthalak,VoiceoftheDeeps-77191"
  value: {
-  dps: 44813.59589
-  tps: 33307.79919
-  hps: 638.69602
+  dps: 44731.3338
+  tps: 33111.06662
+  hps: 632.81329
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Gurthalak,VoiceoftheDeeps-78478"
  value: {
-  dps: 45149.68266
-  tps: 33568.72219
-  hps: 644.22616
+  dps: 45067.2754
+  tps: 33371.00781
+  hps: 638.2925
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Gurthalak,VoiceoftheDeeps-78487"
  value: {
-  dps: 44517.4794
-  tps: 33077.87169
-  hps: 633.72448
+  dps: 44435.34556
+  tps: 32882.00411
+  hps: 627.88754
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HarmlightToken-63839"
  value: {
-  dps: 39530.75046
-  tps: 29347.33553
-  hps: 650.42743
+  dps: 39474.66709
+  tps: 29287.7134
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 40742.45766
-  tps: 30326.99791
-  hps: 650.42743
+  dps: 40648.62197
+  tps: 30231.97523
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HeartofRage-59224"
  value: {
-  dps: 41599.97118
-  tps: 30809.57106
+  dps: 41645.23523
+  tps: 30872.15073
   hps: 655.91296
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HeartofSolace-55868"
  value: {
-  dps: 41557.53402
-  tps: 30694.07661
-  hps: 655.12931
+  dps: 41629.97705
+  tps: 30739.83533
+  hps: 655.91296
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HeartofSolace-56393"
  value: {
-  dps: 41696.95417
-  tps: 30768.8966
-  hps: 655.12931
+  dps: 41903.04458
+  tps: 30868.26653
+  hps: 659.8312
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HeartofThunder-55845"
  value: {
-  dps: 39447.24183
-  tps: 29263.68044
-  hps: 650.42743
+  dps: 39370.17807
+  tps: 29183.17283
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HeartofThunder-56370"
  value: {
-  dps: 39455.74354
-  tps: 29272.13486
-  hps: 650.42743
+  dps: 39378.66884
+  tps: 29191.63033
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 39958.71587
-  tps: 29667.35053
-  hps: 651.99472
+  dps: 39820.62916
+  tps: 29408.15639
+  hps: 643.3746
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 41657.98627
-  tps: 30782.57809
-  hps: 669.23497
+  dps: 41601.25627
+  tps: 30712.66404
+  hps: 663.74943
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 39945.49937
-  tps: 29808.78957
-  hps: 650.42743
+  dps: 39866.38974
+  tps: 29726.52419
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 39945.49937
-  tps: 29808.78957
-  hps: 650.42743
+  dps: 39866.38974
+  tps: 29726.52419
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 39832.61279
-  tps: 29685.86357
-  hps: 650.42743
+  dps: 39753.95078
+  tps: 29603.97454
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 39886.59351
-  tps: 29744.64576
-  hps: 650.42743
+  dps: 39807.71746
+  tps: 29662.57677
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IndomitablePride-77211"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 692.33786
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 689.00129
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IndomitablePride-77983"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 687.57947
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 684.26583
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-IndomitablePride-78003"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 697.7063
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 694.34386
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 40251.81751
-  tps: 29676.46084
-  hps: 664.53308
+  dps: 40483.49292
+  tps: 29873.16323
+  hps: 668.45132
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 40393.96998
-  tps: 29917.89664
-  hps: 663.74943
+  dps: 40295.91758
+  tps: 29662.18572
+  hps: 661.39849
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 40607.6574
-  tps: 30022.35426
-  hps: 665.31673
+  dps: 40502.75264
+  tps: 29970.2142
+  hps: 669.23497
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 39737.7754
-  tps: 29582.58725
-  hps: 650.42743
+  dps: 39659.48941
+  tps: 29501.01434
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 39420.97562
-  tps: 29237.61883
-  hps: 650.42743
+  dps: 39343.94573
+  tps: 29157.10167
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 39420.97562
-  tps: 29237.61883
-  hps: 650.42743
+  dps: 39343.94573
+  tps: 29157.10167
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 39778.64767
-  tps: 29627.09699
-  hps: 650.42743
+  dps: 39700.19963
+  tps: 29545.38785
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 39698.32756
-  tps: 29414.53702
-  hps: 650.42743
+  dps: 39600.84406
+  tps: 29310.35991
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 39791.14196
-  tps: 29465.60809
-  hps: 650.42743
+  dps: 39751.61384
+  tps: 29422.60573
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 40229.94524
-  tps: 29909.90271
-  hps: 668.45132
+  dps: 40307.50705
+  tps: 29906.99442
+  hps: 662.96579
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-KiroptyricSigil-77984"
  value: {
-  dps: 40054.00634
-  tps: 29676.61215
+  dps: 40146.36334
+  tps: 29739.83105
   hps: 662.96579
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-KiroptyricSigil-78004"
  value: {
-  dps: 40259.85006
-  tps: 29818.59628
+  dps: 40310.34545
+  tps: 29850.31794
   hps: 666.10038
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 39737.42249
-  tps: 29528.30539
+  dps: 39803.28637
+  tps: 29541.36453
   hps: 651.99472
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 39737.42249
-  tps: 29528.30539
+  dps: 39803.28637
+  tps: 29541.36453
   hps: 651.99472
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LeadenDespair-55816"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 670.13204
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 666.90249
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LeadenDespair-56347"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 676.47656
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 673.21643
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 39809.87201
-  tps: 29535.47766
-  hps: 655.12931
+  dps: 39902.31641
+  tps: 29683.13475
+  hps: 653.56202
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 39866.9208
-  tps: 29578.86419
+  dps: 39869.32696
+  tps: 29639.41581
   hps: 655.91296
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 40835.48677
-  tps: 30216.72173
-  hps: 649.64378
+  dps: 40804.41943
+  tps: 30209.75557
+  hps: 644.94189
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MagmaPlatedBattlearmor"
  value: {
-  dps: 32624.85644
-  tps: 23949.94923
-  hps: 552.30731
+  dps: 32693.80699
+  tps: 23918.98195
+  hps: 544.85377
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MagmaPlatedBattlegear"
  value: {
-  dps: 36021.64623
-  tps: 26725.72112
-  hps: 603.73674
+  dps: 35934.33204
+  tps: 26616.60911
+  hps: 602.24603
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 39469.76609
-  tps: 29312.79516
-  hps: 653.56202
+  dps: 39622.8868
+  tps: 29500.32685
+  hps: 655.12931
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 39583.53296
-  tps: 29411.9106
+  dps: 39592.38885
+  tps: 29459.81308
   hps: 655.91296
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 40409.12367
-  tps: 29947.33522
-  hps: 650.42743
+  dps: 40331.68239
+  tps: 29866.86339
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 40538.53247
-  tps: 30040.29035
-  hps: 650.42743
+  dps: 40461.03731
+  tps: 29959.82445
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 41090.55694
-  tps: 30420.67663
+  dps: 41049.31302
+  tps: 30342.66886
   hps: 664.53308
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 41431.25943
-  tps: 30655.34289
-  hps: 668.45132
+  dps: 41337.31503
+  tps: 30518.44486
+  hps: 666.10038
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 39945.49937
-  tps: 29808.78957
-  hps: 650.42743
+  dps: 39866.38974
+  tps: 29726.52419
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 39945.49937
-  tps: 29808.78957
-  hps: 650.42743
+  dps: 39866.38974
+  tps: 29726.52419
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 40071.59657
-  tps: 29728.06046
-  hps: 662.18214
+  dps: 39993.33126
+  tps: 29642.32051
+  hps: 659.04755
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 681.53998
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 678.25545
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 40032.83764
-  tps: 29902.23542
-  hps: 650.42743
+  dps: 39953.02862
+  tps: 29819.36253
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 40111.44298
-  tps: 29987.61162
-  hps: 650.42743
+  dps: 40031.27657
+  tps: 29904.43562
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-NecroticBoneplateBattlegear"
  value: {
-  dps: 36670.05092
-  tps: 27347.52972
-  hps: 633.47213
+  dps: 36846.79853
+  tps: 27473.48437
+  hps: 635.77566
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 40181.6779
-  tps: 29783.95955
-  hps: 650.42743
+  dps: 40104.3313
+  tps: 29703.47728
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 39553.70626
-  tps: 29310.86701
-  hps: 647.29284
+  dps: 39588.14707
+  tps: 29376.41105
+  hps: 652.77837
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 39443.41912
-  tps: 29259.879
-  hps: 650.42743
+  dps: 39366.36028
+  tps: 29179.37
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 39794.97822
-  tps: 29524.527
-  hps: 655.91296
+  dps: 39727.33806
+  tps: 29443.48629
+  hps: 651.99472
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 39801.23419
-  tps: 29649.12745
-  hps: 650.42743
+  dps: 39721.16299
+  tps: 29564.65796
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 40111.70416
-  tps: 29975.76012
-  hps: 650.42743
+  dps: 40031.72333
+  tps: 29896.92519
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 41543.15465
-  tps: 30699.36374
-  hps: 672.74005
+  dps: 41486.19765
+  tps: 30629.46126
+  hps: 668.00245
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 40480.03046
-  tps: 29976.93597
-  hps: 662.96579
+  dps: 40408.4658
+  tps: 29869.21917
+  hps: 659.8312
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 40408.36039
-  tps: 29952.05005
-  hps: 661.39849
+  dps: 40538.25206
+  tps: 30100.21171
+  hps: 657.48025
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Rainsong-55854"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Rainsong-56377"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReflectionoftheLight-77986"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReflectionoftheLight-78006"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 42049.41037
-  tps: 31160.27061
-  hps: 667.66767
+  dps: 41990.28016
+  tps: 31089.03373
+  hps: 662.96579
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 41833.33566
-  tps: 31005.03438
-  hps: 667.66767
+  dps: 41774.22761
+  tps: 30933.75971
+  hps: 662.96579
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 39828.47528
-  tps: 29510.97716
-  hps: 650.42743
+  dps: 39745.79527
+  tps: 29427.92858
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 40420.24396
-  tps: 29917.45473
-  hps: 646.50919
+  dps: 40305.52913
+  tps: 29761.56238
+  hps: 644.15825
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 40219.54032
-  tps: 29738.35947
-  hps: 645.72554
+  dps: 40356.67343
+  tps: 29856.13876
+  hps: 642.59095
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RosaryofLight-72901"
  value: {
-  dps: 41585.48562
-  tps: 30801.69645
-  hps: 668.45132
+  dps: 41502.10113
+  tps: 30806.08832
+  hps: 652.77837
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RottingSkull-77116"
  value: {
-  dps: 40413.25589
-  tps: 29987.71004
-  hps: 668.45132
+  dps: 40290.95156
+  tps: 29850.38829
+  hps: 666.10038
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RottingSkull-77987"
  value: {
-  dps: 40301.37367
-  tps: 29906.81071
-  hps: 666.10038
+  dps: 40200.90744
+  tps: 29791.8695
+  hps: 662.96579
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RottingSkull-78007"
  value: {
-  dps: 40556.77109
-  tps: 30091.22914
-  hps: 670.01861
+  dps: 40438.12977
+  tps: 29967.85402
+  hps: 666.88402
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuneofZeth-68998"
  value: {
-  dps: 40239.69583
-  tps: 29863.89052
-  hps: 665.31673
+  dps: 40138.39682
+  tps: 29747.59223
+  hps: 662.18214
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuthlessGladiator'sBadgeofConquest-70399"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuthlessGladiator'sBadgeofConquest-72304"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuthlessGladiator'sBadgeofDominance-70401"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuthlessGladiator'sBadgeofDominance-72448"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuthlessGladiator'sBadgeofVictory-70400"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuthlessGladiator'sBadgeofVictory-72450"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuthlessGladiator'sInsigniaofConquest-70404"
  value: {
-  dps: 39885.03248
-  tps: 29534.08945
-  hps: 650.42743
+  dps: 39817.78533
+  tps: 29462.76348
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuthlessGladiator'sInsigniaofConquest-72309"
  value: {
-  dps: 39869.08369
-  tps: 29516.65212
-  hps: 650.42743
+  dps: 39818.33884
+  tps: 29473.1588
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuthlessGladiator'sInsigniaofDominance-70402"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuthlessGladiator'sInsigniaofDominance-72449"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39344.02407
+  tps: 29157.25051
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuthlessGladiator'sInsigniaofVictory-70403"
  value: {
-  dps: 40506.61388
-  tps: 30007.66142
-  hps: 648.07648
+  dps: 40853.63222
+  tps: 30309.55209
+  hps: 645.72554
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-RuthlessGladiator'sInsigniaofVictory-72455"
  value: {
-  dps: 40821.28271
-  tps: 30180.52704
-  hps: 644.94189
+  dps: 40971.66037
+  tps: 30299.58312
+  hps: 641.8073
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ScalesofLife-68915"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 685.5053
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 682.20166
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ScalesofLife-69109"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 690.08068
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 686.75499
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 40084.94355
-  tps: 29840.26315
-  hps: 650.42743
+  dps: 40004.53609
+  tps: 29751.50661
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SeaStar-55256"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SeaStar-56290"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Shadowmourne-49623"
  value: {
-  dps: 44699.42642
-  tps: 33194.63452
-  hps: 616.96934
+  dps: 44561.77242
+  tps: 33099.09046
+  hps: 610.54258
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ShardofWoe-60233"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 40700.40219
-  tps: 30137.86925
-  hps: 656.69661
+  dps: 40537.06506
+  tps: 30042.85943
+  hps: 655.91296
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 666.16672
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 662.95627
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 39705.33066
-  tps: 29426.17124
-  hps: 650.42743
+  dps: 39635.99983
+  tps: 29351.59697
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 39748.10426
-  tps: 29456.64374
-  hps: 650.42743
+  dps: 39671.43926
+  tps: 29373.79107
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Sorrowsong-55879"
  value: {
-  dps: 39832.61279
-  tps: 29685.86357
-  hps: 650.42743
+  dps: 39753.95078
+  tps: 29603.97454
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Sorrowsong-56400"
  value: {
-  dps: 39886.59351
-  tps: 29744.64576
-  hps: 650.42743
+  dps: 39807.71746
+  tps: 29662.57677
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SoulCasket-58183"
  value: {
-  dps: 39945.49937
-  tps: 29808.78957
-  hps: 650.42743
+  dps: 39866.38974
+  tps: 29726.52419
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 40416.8329
-  tps: 30325.63913
-  hps: 692.33786
+  dps: 40587.5957
+  tps: 30515.17444
+  hps: 689.00129
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 40296.80648
-  tps: 30189.90447
-  hps: 687.57947
+  dps: 40448.88718
+  tps: 30359.56805
+  hps: 684.26583
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 40652.50182
-  tps: 30574.43468
-  hps: 697.7063
+  dps: 40661.30039
+  tps: 30585.12348
+  hps: 694.34386
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 40046.99189
-  tps: 29919.30302
-  hps: 650.42743
+  dps: 39967.47978
+  tps: 29836.69919
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 40128.88083
-  tps: 30008.4669
-  hps: 650.42743
+  dps: 40049.04395
+  tps: 29925.58994
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 40842.38369
-  tps: 30213.09015
-  hps: 662.96579
+  dps: 40977.95381
+  tps: 30254.89908
+  hps: 667.66767
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 40581.38265
-  tps: 29894.89383
-  hps: 661.39849
+  dps: 40883.59485
+  tps: 30253.51741
+  hps: 667.66767
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 41219.31477
-  tps: 30444.54734
-  hps: 667.66767
+  dps: 41150.26722
+  tps: 30352.13985
+  hps: 670.80226
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-StayofExecution-68996"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 39699.19217
-  tps: 29454.48339
-  hps: 655.91296
+  dps: 39695.07885
+  tps: 29429.80542
+  hps: 652.77837
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-StumpofTime-62465"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.94573
+  tps: 29157.10167
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-StumpofTime-62470"
  value: {
-  dps: 39420.93918
-  tps: 29237.5496
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 679.83183
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 676.55554
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 683.61414
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 680.31962
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 39758.75644
-  tps: 29603.18096
-  hps: 650.42743
+  dps: 39676.78541
+  tps: 29517.36787
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 40689.79593
-  tps: 30152.95109
-  hps: 653.56202
+  dps: 40619.63639
+  tps: 30036.36794
+  hps: 656.69661
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TearofBlood-55819"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TearofBlood-56351"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 39772.1736
-  tps: 29620.10041
-  hps: 650.42743
+  dps: 39693.6854
+  tps: 29538.28749
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 39886.59351
-  tps: 29744.64576
-  hps: 650.42743
+  dps: 39807.71746
+  tps: 29662.57677
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TheHungerer-68927"
  value: {
-  dps: 40508.8819
-  tps: 29960.20484
-  hps: 662.18214
+  dps: 40535.19008
+  tps: 30017.30366
+  hps: 659.8312
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TheHungerer-69112"
  value: {
-  dps: 40702.23557
-  tps: 30148.45832
+  dps: 40707.77449
+  tps: 30155.95587
   hps: 665.31673
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 39958.63383
-  tps: 29826.54891
-  hps: 650.42743
+  dps: 39862.20743
+  tps: 29721.15945
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 40030.59823
-  tps: 29899.27115
-  hps: 650.42743
+  dps: 39958.36206
+  tps: 29822.87764
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 40165.22205
-  tps: 29911.38698
-  hps: 650.42743
+  dps: 40095.3799
+  tps: 29834.53617
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 40288.46005
-  tps: 30019.50357
-  hps: 650.42743
+  dps: 40202.07439
+  tps: 29933.01055
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 39872.33495
-  tps: 29553.87669
-  hps: 680.98968
+  dps: 39820.38828
+  tps: 29595.3174
+  hps: 678.63874
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-UnheededWarning-59520"
  value: {
-  dps: 40154.65433
-  tps: 29826.73864
-  hps: 650.42743
+  dps: 40062.1456
+  tps: 29740.07505
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 39945.49937
-  tps: 29808.78957
-  hps: 650.42743
+  dps: 39866.38974
+  tps: 29726.52419
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 39945.49937
-  tps: 29808.78957
-  hps: 650.42743
+  dps: 39866.38974
+  tps: 29726.52419
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 39945.49937
-  tps: 29808.78957
-  hps: 650.42743
+  dps: 39866.38974
+  tps: 29726.52419
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 39832.09347
-  tps: 29775.06908
-  hps: 646.50919
+  dps: 39843.7124
+  tps: 29693.10862
+  hps: 644.94189
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 39950.63947
-  tps: 29841.89936
-  hps: 646.50919
+  dps: 39889.27722
+  tps: 29705.33839
+  hps: 645.72554
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 41733.7151
-  tps: 31199.02699
-  hps: 650.42743
+  dps: 41645.52887
+  tps: 31107.09147
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-VeilofLies-72900"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 685.5053
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 682.20166
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 41742.46907
-  tps: 30939.39535
-  hps: 665.31673
+  dps: 41703.29146
+  tps: 30879.4027
+  hps: 660.61484
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-VialofShadows-77207"
  value: {
-  dps: 40416.42203
-  tps: 30061.89626
-  hps: 650.42743
+  dps: 40271.60572
+  tps: 29891.23147
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-VialofShadows-77979"
  value: {
-  dps: 40345.57385
-  tps: 30008.98626
-  hps: 650.42743
+  dps: 40283.20801
+  tps: 29938.05318
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-VialofShadows-77999"
  value: {
-  dps: 40542.09525
-  tps: 30159.54046
-  hps: 650.42743
+  dps: 40518.21562
+  tps: 30147.66036
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 679.83183
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 676.55554
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 683.61414
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 680.31962
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sBadgeofConquest-70517"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sBadgeofDominance-70518"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sBadgeofVictory-70519"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 40053.07895
-  tps: 29688.91787
-  hps: 663.74943
+  dps: 40103.78842
+  tps: 29733.45344
+  hps: 660.61484
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 40137.33908
-  tps: 29785.07724
-  hps: 662.96579
+  dps: 40045.76246
+  tps: 29681.34382
+  hps: 659.8312
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 39714.76557
-  tps: 29517.20906
-  hps: 659.8312
+  dps: 39738.33578
+  tps: 29560.76715
+  hps: 658.2639
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 39976.59606
-  tps: 29842.65074
-  hps: 650.42743
+  dps: 39897.36311
+  tps: 29760.28167
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 39809.68109
-  tps: 29487.1847
-  hps: 650.42743
+  dps: 39711.18449
+  tps: 29395.27905
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sInsigniaofConquest-70577"
  value: {
-  dps: 39817.00473
-  tps: 29476.10194
-  hps: 650.42743
+  dps: 39767.7441
+  tps: 29417.87382
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39344.02407
+  tps: 29157.25051
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sInsigniaofDominance-70578"
  value: {
-  dps: 39420.94767
-  tps: 29237.56574
-  hps: 650.42743
+  dps: 39344.02407
+  tps: 29157.25051
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 40139.71883
-  tps: 29786.63072
-  hps: 648.07648
+  dps: 40432.19347
+  tps: 30026.88625
+  hps: 644.15825
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-ViciousGladiator'sInsigniaofVictory-70579"
  value: {
-  dps: 40625.17469
-  tps: 30109.18937
-  hps: 648.86013
+  dps: 40653.00979
+  tps: 30035.57728
+  hps: 642.59095
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WillofUnbinding-77995"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 650.42743
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 39847.04961
-  tps: 29583.30827
-  hps: 652.77837
+  dps: 39600.42785
+  tps: 29358.88267
+  hps: 651.21107
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 39756.35125
-  tps: 29466.75498
+  dps: 39859.54766
+  tps: 29576.07928
   hps: 655.91296
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 39778.64767
-  tps: 29627.09699
-  hps: 650.42743
+  dps: 39700.19963
+  tps: 29545.38785
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 40403.31207
-  tps: 29895.23519
-  hps: 650.42743
+  dps: 40300.19442
+  tps: 29798.41886
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 40299.77128
-  tps: 29833.04191
-  hps: 650.42743
+  dps: 40190.49354
+  tps: 29723.07823
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 40508.91656
-  tps: 29947.17493
-  hps: 650.42743
+  dps: 40409.64137
+  tps: 29860.98251
+  hps: 647.29284
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 670.49807
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 667.26675
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 39420.91101
-  tps: 29237.49608
-  hps: 670.49807
+  dps: 39343.88113
+  tps: 29156.97892
+  hps: 667.26675
  }
 }
 dps_results: {
  key: "TestUnholy-Average-Default"
  value: {
-  dps: 41940.4705
-  tps: 31014.45508
-  hps: 626.90267
+  dps: 41909.95078
+  tps: 30977.73313
+  hps: 626.91936
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3.bis-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 73772.17761
-  tps: 87609.2757
-  hps: 659.8312
+  dps: 74035.16721
+  tps: 87874.24514
+  hps: 651.99472
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3.bis-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 42049.41037
-  tps: 31160.27061
-  hps: 667.66767
+  dps: 41990.28016
+  tps: 31089.03373
+  hps: 662.96579
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3.bis-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 55288.5948
-  tps: 35598.39456
-  hps: 811.07516
+  dps: 55640.47206
+  tps: 35904.9679
+  hps: 799.32045
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3.bis-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 46938.0626
-  tps: 55552.76445
-  hps: 516.3886
+  dps: 46595.18703
+  tps: 54911.89668
+  hps: 515.67928
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3.bis-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26455.06416
-  tps: 19838.34444
-  hps: 517.80725
+  dps: 26483.9072
+  tps: 19885.78259
+  hps: 512.84198
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Orc-p3.bis-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 31894.17505
-  tps: 21751.03571
-  hps: 588.73975
+  dps: 31744.6364
+  tps: 21728.58676
+  hps: 546.18025
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Worgen-p3.bis-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 73336.63978
-  tps: 87790.50354
-  hps: 666.0379
+  dps: 73535.41172
+  tps: 88030.82865
+  hps: 658.20216
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Worgen-p3.bis-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 41663.22987
-  tps: 31257.94758
-  hps: 673.87364
+  dps: 41522.62171
+  tps: 31135.32816
+  hps: 669.95577
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Worgen-p3.bis-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 54463.12054
-  tps: 35672.14595
-  hps: 814.91696
+  dps: 54551.02594
+  tps: 35755.76361
+  hps: 799.24548
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Worgen-p3.bis-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 46839.4055
-  tps: 55871.56558
-  hps: 522.72093
+  dps: 46436.09726
+  tps: 55172.74269
+  hps: 519.88392
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Worgen-p3.bis-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26309.65455
-  tps: 19969.07315
-  hps: 524.13944
+  dps: 26337.53565
+  tps: 20010.13259
+  hps: 518.4654
  }
 }
 dps_results: {
  key: "TestUnholy-Settings-Worgen-p3.bis-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 31579.44748
-  tps: 21802.07022
-  hps: 599.32047
+  dps: 31341.86161
+  tps: 21694.39875
+  hps: 549.67262
  }
 }
 dps_results: {
  key: "TestUnholy-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 39609.71374
-  tps: 29354.30138
-  hps: 605.75952
+  dps: 39765.52069
+  tps: 29535.17632
+  hps: 607.32681
  }
 }

--- a/ui/core/proto_utils/action_id.ts
+++ b/ui/core/proto_utils/action_id.ts
@@ -623,7 +623,7 @@ export class ActionId {
 					name += ' 1.7%';
 				}
 
-				if (this.tag === 2) {
+				if (tag === 2) {
 					name += ' (Heal)';
 				}
 				break;
@@ -637,6 +637,11 @@ export class ActionId {
 					name += ' (Normal)';
 				} else if (this.spellId === 109872 || this.spellId === 109870 || this.spellId === 109868) {
 					name += ' (Heroic)';
+				}
+				break;
+			case 'Death Coil':
+				if (tag === 2) {
+					name += ' (Heal)';
 				}
 				break;
 			default:

--- a/ui/death_knight/unholy/apls/default.apl.json
+++ b/ui/death_knight/unholy/apls/default.apl.json
@@ -3,12 +3,12 @@
       "prepullActions": [
         {"action":{"castSpell":{"spellId":{"spellId":48265}}},"doAtValue":{"const":{"val":"-20s"}}},
         {"action":{"castSpell":{"spellId":{"spellId":57330}}},"doAtValue":{"const":{"val":"-12s"}}},
-        {"action":{"castSpell":{"spellId":{"spellId":47541}}},"doAtValue":{"const":{"val":"-11s"}}},
-        {"action":{"castSpell":{"spellId":{"spellId":47541}}},"doAtValue":{"const":{"val":"-10s"}}},
-        {"action":{"castSpell":{"spellId":{"spellId":47541}}},"doAtValue":{"const":{"val":"-9s"}}},
-        {"action":{"castSpell":{"spellId":{"spellId":47541}}},"doAtValue":{"const":{"val":"-8s"}}},
+        {"action":{"castSpell":{"spellId":{"spellId":47541,"tag":2}}},"doAtValue":{"const":{"val":"-11s"}}},
+        {"action":{"castSpell":{"spellId":{"spellId":47541,"tag":2}}},"doAtValue":{"const":{"val":"-10s"}}},
+        {"action":{"castSpell":{"spellId":{"spellId":47541,"tag":2}}},"doAtValue":{"const":{"val":"-9s"}}},
+        {"action":{"castSpell":{"spellId":{"spellId":47541,"tag":2}}},"doAtValue":{"const":{"val":"-8s"}}},
         {"action":{"castSpell":{"spellId":{"spellId":42650}}},"doAtValue":{"const":{"val":"-7s"}}},
-        {"action":{"castSpell":{"spellId":{"spellId":47541}}},"doAtValue":{"const":{"val":"-1s"}}},
+        {"action":{"castSpell":{"spellId":{"spellId":47541,"tag":2}}},"doAtValue":{"const":{"val":"-1s"}}},
         {"action":{"castSpell":{"spellId":{"otherId":"OtherActionPotion"}}},"doAtValue":{"const":{"val":"-1s"}}}
       ],
       "priorityList": [


### PR DESCRIPTION
The issue with just casting the regular coil during prepull was that it could proc trinkets and Runic Corruption which would influence dps (this also pretty much reverts the Unholy Blight change I pushed earlier).
Using the same spell for both damage and healing is weird with the damage breakdown so I just made a clone which only does healing instead, only available during prepull.
Set the regular DC to only be usable during encounter.