### PR TITLE
[UI] Add option to override glyph tooltip from a spell instead of item

### DIFF
--- a/ui/core/talents/glyphs_picker.tsx
+++ b/ui/core/talents/glyphs_picker.tsx
@@ -15,6 +15,7 @@ export type GlyphConfig = {
 	name: string;
 	description: string;
 	iconUrl: string;
+	spellIdOverride?: number;
 };
 
 export type GlyphsConfig = {
@@ -29,6 +30,7 @@ interface GlyphData {
 	description: string;
 	iconUrl: string;
 	quality: ItemQuality | null;
+	spellIdOverride?: number;
 }
 
 const emptyGlyphData: GlyphData = {
@@ -122,6 +124,7 @@ export class GlyphsPicker extends Component {
 			description: glyphConfig.description,
 			iconUrl: glyphConfig.iconUrl,
 			quality: ItemQuality.ItemQualityCommon,
+			spellIdOverride: glyphConfig.spellIdOverride,
 		};
 	}
 }
@@ -204,11 +207,19 @@ class GlyphPicker extends Input<Player<any>, number> {
 		this.selectedGlyph = this.glyphOptions.find(glyphData => glyphData.id == newValue);
 
 		if (this.selectedGlyph) {
-			this.anchorElem.href = ActionId.makeItemUrl(this.selectedGlyph.id);
-			ActionId.makeItemTooltipData(this.selectedGlyph.id).then(url => {
-				this.anchorElem.dataset.wowhead = url;
-				this.anchorElem.dataset.whtticon = 'false';
-			});
+			if (this.selectedGlyph.spellIdOverride) {
+				this.anchorElem.href = ActionId.makeSpellUrl(this.selectedGlyph.spellIdOverride);
+				ActionId.makeSpellTooltipData(this.selectedGlyph.spellIdOverride).then(url => {
+					this.anchorElem.dataset.wowhead = url;
+					this.anchorElem.dataset.whtticon = 'false';
+				});
+			} else {
+				this.anchorElem.href = ActionId.makeItemUrl(this.selectedGlyph.id);
+				ActionId.makeItemTooltipData(this.selectedGlyph.id).then(url => {
+					this.anchorElem.dataset.wowhead = url;
+					this.anchorElem.dataset.whtticon = 'false';
+				});
+			}
 
 			this.iconElem.src = this.selectedGlyph.iconUrl;
 			this.nameElem.textContent = this.selectedGlyph.name;

--- a/ui/core/talents/mage.ts
+++ b/ui/core/talents/mage.ts
@@ -36,6 +36,7 @@ export const mageGlyphsConfig: GlyphsConfig = {
 			name: 'Glyph of Fireball',
 			description: 'Increases the critical strike chance of your Fireball spell by 5%.',
 			iconUrl: 'https://wow.zamimg.com/images/wow/icons/large/spell_fire_flamebolt.jpg',
+			spellIdOverride: 56368,
 		},
 		[MagePrimeGlyph.GlyphOfFrostbolt]: {
 			name: 'Glyph of Frostbolt',


### PR DESCRIPTION
Fixes #1175 

Added an option to override the tooltip for a glyph from a spell id instead of using the item id. Just a QoL change since Blizzard/Wowhead doesn't seem to want to change this 😄 
![image](https://github.com/user-attachments/assets/05a01da4-a680-46a8-b4ab-e27d0028aecf)
