### PR TITLE
Suggest Reforges timeout fix for Firefox

### DIFF
--- a/ui/core/components/suggest_reforges_action.tsx
+++ b/ui/core/components/suggest_reforges_action.tsx
@@ -911,8 +911,8 @@ export class ReforgeOptimizer {
 			binaries: true,
 		};
 		const options: Options = {
-			timeout: 10000,
-			maxIterations: Infinity,
+			timeout: Infinity,
+			maxIterations: 100000,
 			tolerance: 0.01,
 		};
 		const solution = solve(model, options);


### PR DESCRIPTION
Changed timeout condition for Suggest Reforges LP solver from time-based (10s) to iteration-based (100k). This allows a partially converged solution to still be found even on low performance browsers (Firefox) - the solve will just take a lot longer compared to better browsers.

 On branch auto_reforge
 Changes to be committed:
	modified:   ui/core/components/suggest_reforges_action.tsx