### PR TITLE
[UI] Feature/improve detailed results performance

### DIFF
--- a/proto/api.proto
+++ b/proto/api.proto
@@ -360,6 +360,7 @@ message ErrorOutcome {
 
 // RPC RaidSim
 message RaidSimRequest {
+	string request_id = 5;
 	Raid raid = 1;
 	Encounter encounter = 2;
 	SimOptions sim_options = 3;

--- a/ui/core/cache_handler.ts
+++ b/ui/core/cache_handler.ts
@@ -24,9 +24,9 @@ export class CacheHandler<T> {
 	}
 
 	private keepMostRecent() {
-		if (this.data.size > 2) {
+		if (this.keysToKeep && this.data.size > this.keysToKeep) {
 			const keys = [...this.data.keys()];
-			const keysToRemove = keys.slice(0, keys.length - 2);
+			const keysToRemove = keys.slice(0, keys.length - this.keysToKeep);
 			keysToRemove.forEach(key => this.data.delete(key));
 		}
 	}

--- a/ui/core/cache_handler.ts
+++ b/ui/core/cache_handler.ts
@@ -1,0 +1,33 @@
+export type CacheHandlerOptions = {
+	keysToKeep?: number;
+};
+
+export class CacheHandler<T> {
+	keysToKeep: CacheHandlerOptions['keysToKeep'];
+	private data = new Map<string, T>();
+
+	constructor(options: CacheHandlerOptions = {}) {
+		this.keysToKeep = options.keysToKeep;
+	}
+
+	has(id: string): boolean {
+		return this.data.has(id);
+	}
+
+	get(id: string): T | undefined {
+		return this.data.get(id);
+	}
+
+	set(id: string, result: T) {
+		this.data.set(id, result);
+		if (this.keysToKeep) this.keepMostRecent();
+	}
+
+	private keepMostRecent() {
+		if (this.data.size > 2) {
+			const keys = [...this.data.keys()];
+			const keysToRemove = keys.slice(0, keys.length - 2);
+			keysToRemove.forEach(key => this.data.delete(key));
+		}
+	}
+}

--- a/ui/core/components/detailed_results.tsx
+++ b/ui/core/components/detailed_results.tsx
@@ -408,8 +408,7 @@ export class EmbeddedDetailedResults extends DetailedResults {
 				this.tabWindow = window.open(url.href, 'Detailed Results');
 				this.tabWindow!.addEventListener('load', async () => {
 					if (this.latestRun) {
-						await this.updateSettings();
-						await this.setSimRunData(this.latestRun);
+						await Promise.all([this.updateSettings(), this.setSimRunData(this.latestRun)]);
 					}
 				});
 			} else {
@@ -425,8 +424,7 @@ export class EmbeddedDetailedResults extends DetailedResults {
 		simResultsManager.currentChangeEmitter.on(async () => {
 			const runData = simResultsManager.getRunData();
 			if (runData) {
-				await this.updateSettings();
-				await this.setSimRunData(runData);
+				await Promise.all([this.updateSettings(), this.setSimRunData(runData)]);
 			}
 		});
 	}

--- a/ui/core/components/detailed_results/player_damage.tsx
+++ b/ui/core/components/detailed_results/player_damage.tsx
@@ -88,7 +88,7 @@ export class PlayerDamageMetricsTable extends MetricsTable<UnitMetrics> {
 
 	customizeRowElem(player: UnitMetrics, rowElem: HTMLElement) {
 		rowElem.classList.add('player-damage-row');
-		rowElem.addEventListener('click', event => {
+		rowElem.addEventListener('click', () => {
 			this.resultsFilter.setPlayer(this.getLastSimResult().eventID, player.index);
 		});
 	}

--- a/ui/core/components/detailed_results/player_damage_taken.tsx
+++ b/ui/core/components/detailed_results/player_damage_taken.tsx
@@ -90,7 +90,7 @@ export class PlayerDamageTakenMetricsTable extends MetricsTable<UnitMetrics> {
 
 	customizeRowElem(player: UnitMetrics, rowElem: HTMLElement) {
 		rowElem.classList.add('player-damage-row');
-		rowElem.addEventListener('click', event => {
+		rowElem.addEventListener('click', () => {
 			this.resultsFilter.setPlayer(this.getLastSimResult().eventID, player.index);
 		});
 	}

--- a/ui/core/components/detailed_results/resource_metrics.tsx
+++ b/ui/core/components/detailed_results/resource_metrics.tsx
@@ -1,4 +1,3 @@
-import { TOOLTIP_METRIC_LABELS } from '../../constants/tooltips';
 import { ResourceType } from '../../proto/api';
 import { resourceNames } from '../../proto_utils/names';
 import { ResourceMetrics } from '../../proto_utils/sim_result';
@@ -12,14 +11,14 @@ export class ResourceMetricsTable extends ResultComponent {
 		super(config);
 
 		orderedResourceTypes.forEach(resourceType => {
-			const containerElem = document.createElement('div');
-			containerElem.classList.add('resource-metrics-table-container', 'hide');
-			containerElem.innerHTML = `<span class="resource-metrics-table-title">${resourceNames.get(resourceType)}</span>`;
+			const containerElem = (
+				<div className="resource-metrics-table-container hide">
+					<span className="resource-metrics-table-title">{resourceNames.get(resourceType)}</span>
+				</div>
+			) as HTMLElement;
 			this.rootElem.appendChild(containerElem);
 
-			const childConfig = config;
-			childConfig.parent = containerElem;
-			const table = new TypedResourceMetricsTable(childConfig, resourceType);
+			const table = new TypedResourceMetricsTable({ ...config, parent: containerElem }, resourceType);
 			table.onUpdate.on(() => {
 				if (table.rootElem.classList.contains('hide')) {
 					containerElem.classList.add('hide');

--- a/ui/core/components/detailed_results/result_component.ts
+++ b/ui/core/components/detailed_results/result_component.ts
@@ -3,28 +3,28 @@ import { SimResult, SimResultFilter } from '../../proto_utils/sim_result.js';
 import { EventID, TypedEvent } from '../../typed_event.js';
 
 export interface SimResultData {
-	eventID: EventID,
-	result: SimResult,
-	filter: SimResultFilter,
-};
+	eventID: EventID;
+	result: SimResult;
+	filter: SimResultFilter;
+}
 
 export interface ResultComponentConfig {
-	parent: HTMLElement,
-	rootCssClass?: string,
-	cssScheme?: string | null,
-	resultsEmitter: TypedEvent<SimResultData | null>,
-};
+	parent: HTMLElement;
+	rootCssClass?: string;
+	cssScheme?: string | null;
+	resultsEmitter: TypedEvent<SimResultData | null>;
+}
 
 export abstract class ResultComponent extends Component {
 	lastSimResult: SimResultData | null;
+	private resetCallbacks: (() => void)[] = [];
 
 	constructor(config: ResultComponentConfig) {
 		super(config.parent, config.rootCssClass || 'result-component');
 		this.lastSimResult = null;
 
 		config.resultsEmitter.on((_, resultData) => {
-			if (!resultData)
-				return;
+			if (!resultData) return;
 
 			this.lastSimResult = resultData;
 			this.onSimResult(resultData);
@@ -32,7 +32,7 @@ export abstract class ResultComponent extends Component {
 	}
 
 	hasLastSimResult(): boolean {
-		return this.lastSimResult != null;
+		return !!this.lastSimResult;
 	}
 
 	getLastSimResult(): SimResultData {
@@ -44,4 +44,13 @@ export abstract class ResultComponent extends Component {
 	}
 
 	abstract onSimResult(resultData: SimResultData): void;
+
+	addOnResetCallback(callback: () => void) {
+		this.resetCallbacks.push(callback);
+	}
+
+	reset() {
+		this.resetCallbacks.forEach(callback => callback());
+		this.resetCallbacks = [];
+	}
 }

--- a/ui/core/components/detailed_results/results_filter.ts
+++ b/ui/core/components/detailed_results/results_filter.ts
@@ -1,8 +1,8 @@
-import { UnitPicker, UnitValue, UnitValueConfig } from '../pickers/unit_picker.jsx';
-import { UnitReference, UnitReference_Type as UnitType } from '../../proto/common.js';
-import { SimResult, SimResultFilter } from '../../proto_utils/sim_result.js';
-import { EventID, TypedEvent } from '../../typed_event.js';
-import { ResultComponent, ResultComponentConfig, SimResultData } from './result_component.js';
+import { UnitReference, UnitReference_Type as UnitType } from '../../proto/common';
+import { SimResult, SimResultFilter } from '../../proto_utils/sim_result';
+import { EventID, TypedEvent } from '../../typed_event';
+import { UnitPicker, UnitValue, UnitValueConfig } from '../pickers/unit_picker';
+import { ResultComponent, ResultComponentConfig, SimResultData } from './result_component';
 
 const ALL_UNITS = -1;
 

--- a/ui/core/components/detailed_results/timeline.tsx
+++ b/ui/core/components/detailed_results/timeline.tsx
@@ -1,17 +1,18 @@
 import tippy from 'tippy.js';
 import { ref } from 'tsx-vanilla';
 
-import { ResourceType } from '../../proto/api.js';
-import { OtherAction } from '../../proto/common.js';
-import { ActionId, buffAuraToSpellIdMap, resourceTypeToIcon } from '../../proto_utils/action_id.js';
-import { AuraUptimeLog, CastLog, DpsLog, ResourceChangedLogGroup, SimLog, ThreatLogGroup } from '../../proto_utils/logs_parser.js';
-import { resourceNames } from '../../proto_utils/names.js';
-import { UnitMetrics } from '../../proto_utils/sim_result.js';
-import { orderedResourceTypes } from '../../proto_utils/utils.js';
-import { TypedEvent } from '../../typed_event.js';
-import { bucket, distinct, maxIndex, stringComparator } from '../../utils.js';
-import { actionColors } from './color_settings.js';
-import { ResultComponent, ResultComponentConfig, SimResultData } from './result_component.js';
+import { CacheHandler } from '../../cache_handler';
+import { ResourceType } from '../../proto/api';
+import { OtherAction } from '../../proto/common';
+import { ActionId, buffAuraToSpellIdMap, resourceTypeToIcon } from '../../proto_utils/action_id';
+import { AuraUptimeLog, CastLog, DpsLog, ResourceChangedLogGroup, SimLog, ThreatLogGroup } from '../../proto_utils/logs_parser';
+import { resourceNames } from '../../proto_utils/names';
+import { UnitMetrics } from '../../proto_utils/sim_result';
+import { orderedResourceTypes } from '../../proto_utils/utils';
+import { TypedEvent } from '../../typed_event';
+import { bucket, distinct, fragmentToString, maxIndex, stringComparator } from '../../utils';
+import { actionColors } from './color_settings';
+import { ResultComponent, ResultComponentConfig, SimResultData } from './result_component';
 
 declare let ApexCharts: any;
 
@@ -21,6 +22,8 @@ const dpsColor = '#ed5653';
 const manaColor = '#2E93fA';
 const threatColor = '#b56d07';
 
+const cachedSpellCastIcon = new CacheHandler<HTMLAnchorElement>();
+
 export class Timeline extends ResultComponent {
 	private readonly dpsResourcesPlotElem: HTMLElement;
 	private dpsResourcesPlot: any;
@@ -28,21 +31,32 @@ export class Timeline extends ResultComponent {
 	private readonly rotationPlotElem: HTMLElement;
 	private readonly rotationLabels: HTMLElement;
 	private readonly rotationTimeline: HTMLElement;
+	private rotationTimelineTimeRulerElem: HTMLCanvasElement | null = null;
 	private readonly rotationHiddenIdsContainer: HTMLElement;
 	private readonly chartPicker: HTMLSelectElement;
 
+	private prevResultData: SimResultData | null;
 	private resultData: SimResultData | null;
-	private rendered: boolean;
+	rendered: boolean;
 
 	private hiddenIds: Array<ActionId>;
 	private hiddenIdsChangeEmitter;
-
-	private resetCallbacks: (() => void)[] = [];
+	private cacheHandler = new CacheHandler<{
+		dpsResourcesPlotOptions: any;
+		rotationLabels: Timeline['rotationLabels'];
+		rotationTimeline: Timeline['rotationTimeline'];
+		rotationHiddenIdsContainer: Timeline['rotationHiddenIdsContainer'];
+		rotationTimelineTimeRulerElem: Timeline['rotationTimelineTimeRulerElem'];
+		rotationTimelineTimeRulerImage: ImageData | undefined;
+	}>({
+		keysToKeep: 2,
+	});
 
 	constructor(config: ResultComponentConfig) {
 		config.rootCssClass = 'timeline-root';
 		super(config);
 		this.resultData = null;
+		this.prevResultData = null;
 		this.rendered = false;
 		this.hiddenIds = [];
 		this.hiddenIdsChangeEmitter = new TypedEvent<void>();
@@ -86,16 +100,7 @@ export class Timeline extends ResultComponent {
 		);
 
 		this.chartPicker = this.rootElem.querySelector('.timeline-chart-picker')!;
-		this.chartPicker.addEventListener('change', () => {
-			if (this.chartPicker.value == 'rotation') {
-				this.dpsResourcesPlotElem.classList.add('hide');
-				this.rotationPlotElem.classList.remove('hide');
-			} else {
-				this.dpsResourcesPlotElem.classList.remove('hide');
-				this.rotationPlotElem.classList.add('hide');
-			}
-			this.updatePlot();
-		});
+		this.chartPicker.addEventListener('change', () => this.onChartPickerSelectHandler());
 
 		this.dpsResourcesPlotElem = this.rootElem.querySelector('.dps-resources-plot')!;
 		this.dpsResourcesPlot = new ApexCharts(this.dpsResourcesPlotElem, {
@@ -155,12 +160,20 @@ export class Timeline extends ResultComponent {
 		});
 	}
 
-	onSimResult(resultData: SimResultData) {
-		this.resultData = resultData;
-
-		if (this.rendered) {
-			this.updatePlot();
+	onChartPickerSelectHandler() {
+		if (this.chartPicker.value === 'rotation') {
+			this.dpsResourcesPlotElem.classList.add('hide');
+			this.rotationPlotElem.classList.remove('hide');
+		} else {
+			this.dpsResourcesPlotElem.classList.remove('hide');
+			this.rotationPlotElem.classList.add('hide');
 		}
+	}
+
+	onSimResult(resultData: SimResultData) {
+		this.prevResultData = this.resultData;
+		this.resultData = resultData;
+		this.update();
 	}
 
 	private updatePlot() {
@@ -168,8 +181,29 @@ export class Timeline extends ResultComponent {
 			return;
 		}
 
+		const cachedData = this.cacheHandler.get(this.resultData.result.request.requestId);
+		if (cachedData) {
+			const { dpsResourcesPlotOptions, rotationLabels, rotationTimeline, rotationHiddenIdsContainer, rotationTimelineTimeRulerImage } = cachedData;
+			this.rotationLabels.replaceChildren(...rotationLabels.cloneNode(true).childNodes);
+			this.rotationTimeline.replaceChildren(...rotationTimeline.cloneNode(true).childNodes);
+			this.rotationHiddenIdsContainer.replaceChildren(...rotationHiddenIdsContainer.cloneNode(true).childNodes);
+			this.dpsResourcesPlot.updateOptions(dpsResourcesPlotOptions);
+
+			if (rotationTimelineTimeRulerImage)
+				this.rotationTimeline
+					.querySelector<HTMLCanvasElement>('.rotation-timeline-canvas')
+					?.getContext('2d')
+					?.putImageData(rotationTimelineTimeRulerImage, 0, 0);
+
+			this.onChartPickerSelectHandler();
+			return;
+		}
+
 		const duration = this.resultData!.result.result.firstIterationDuration || 1;
 		const options: any = {
+			theme: {
+				mode: 'dark',
+			},
 			series: [],
 			colors: [],
 			xaxis: {
@@ -207,7 +241,7 @@ export class Timeline extends ResultComponent {
 			enabled: true,
 			custom: (data: { series: any; seriesIndex: number; dataPointIndex: number; w: any }) => {
 				if (tooltipHandlers[data.seriesIndex]) {
-					return tooltipHandlers[data.seriesIndex]!(data.dataPointIndex);
+					return fragmentToString(tooltipHandlers[data.seriesIndex]!(data.dataPointIndex));
 				} else {
 					throw new Error('No tooltip handler for series ' + data.seriesIndex);
 				}
@@ -234,7 +268,7 @@ export class Timeline extends ResultComponent {
 			tooltipHandlers.push(dpsData.tooltipHandler);
 			tooltipHandlers.push(this.addManaSeries(player, options));
 			tooltipHandlers.push(this.addThreatSeries(player, options, ''));
-			tooltipHandlers = tooltipHandlers.filter(handler => handler != null);
+			tooltipHandlers = tooltipHandlers.filter(handler => !!handler);
 
 			this.addMajorCooldownAnnotations(player, options);
 		} else {
@@ -269,6 +303,19 @@ export class Timeline extends ResultComponent {
 		}
 
 		this.dpsResourcesPlot.updateOptions(options);
+
+		this.rotationTimelineTimeRulerElem?.toBlob(blob => {
+			this.cacheHandler.set(this.resultData!.result.request.requestId, {
+				dpsResourcesPlotOptions: options,
+				rotationLabels: this.rotationLabels.cloneNode(true) as HTMLElement,
+				rotationTimeline: this.rotationTimeline.cloneNode(true) as HTMLElement,
+				rotationHiddenIdsContainer: this.rotationHiddenIdsContainer.cloneNode(true) as HTMLElement,
+				rotationTimelineTimeRulerElem: this.rotationTimelineTimeRulerElem?.cloneNode(true) as HTMLCanvasElement,
+				rotationTimelineTimeRulerImage: this.rotationTimelineTimeRulerElem
+					?.getContext('2d')
+					?.getImageData(0, 0, this.rotationTimelineTimeRulerElem.width, this.rotationTimelineTimeRulerElem.height),
+			});
+		});
 	}
 
 	private addDpsYAxis(maxDps: number, options: any) {
@@ -479,16 +526,15 @@ export class Timeline extends ResultComponent {
 	}
 
 	private clearRotationChart() {
-		this.rotationLabels.innerText = '';
-		this.rotationLabels.appendChild(<div className="rotation-label-header"></div>);
-
-		this.rotationTimeline.innerText = '';
-		this.rotationTimeline.appendChild(
+		this.rotationLabels.replaceChildren(<div className="rotation-label-header"></div>);
+		const canvasRef = ref<HTMLCanvasElement>();
+		this.rotationTimeline.replaceChildren(
 			<div className="rotation-timeline-header">
-				<canvas className="rotation-timeline-canvas"></canvas>
+				<canvas ref={canvasRef} className="rotation-timeline-canvas" />
 			</div>,
 		);
-		this.rotationHiddenIdsContainer.innerText = '';
+		this.rotationTimelineTimeRulerElem = canvasRef.value || null;
+		this.rotationHiddenIdsContainer.replaceChildren();
 		this.hiddenIdsChangeEmitter = new TypedEvent<void>();
 	}
 
@@ -825,8 +871,14 @@ export class Timeline extends ResultComponent {
 				}
 			}
 
-			const iconElem = (<a className="rotation-timeline-cast-icon" />) as HTMLAnchorElement;
-			actionId.setBackground(iconElem);
+			const actionIdAsString = actionId.toString();
+			const cachedIconElem = cachedSpellCastIcon.get(actionIdAsString)?.cloneNode() as HTMLAnchorElement | undefined;
+			let iconElem = cachedIconElem;
+			if (!iconElem) {
+				iconElem = (<a className="rotation-timeline-cast-icon" />) as HTMLAnchorElement;
+				actionId.setBackground(iconElem);
+				cachedSpellCastIcon.set(actionIdAsString, iconElem);
+			}
 			castElem.appendChild(iconElem);
 
 			const travelTimeStr = castLog.travelTime == 0 ? '' : ` + ${castLog.travelTime.toFixed(2)}s travel time`;
@@ -859,10 +911,11 @@ export class Timeline extends ResultComponent {
 				</div>
 			);
 
-			tippy(castElem, {
+			const tooltip = tippy(castElem, {
 				placement: 'bottom',
 				content: tt,
 			});
+			this.addOnResetCallback(() => tooltip.destroy());
 
 			castLog.damageDealtLogs
 				.filter(ddl => ddl.tick)
@@ -886,10 +939,11 @@ export class Timeline extends ResultComponent {
 						</div>
 					);
 
-					tippy(tickElem, {
+					const tooltip = tippy(tickElem, {
 						placement: 'bottom',
 						content: tt,
 					});
+					this.addOnResetCallback(() => tooltip.destroy());
 				});
 		});
 
@@ -1030,7 +1084,7 @@ export class Timeline extends ResultComponent {
 					<span className="bold">{log.timestamp.toFixed(2)}s</span>
 				</div>
 				<div className="timeline-tooltip-body">
-					<ul className="timeline-dps-events">{log.damageLogs.map(damageLog => this.tooltipLogItem(damageLog, damageLog.result())).join('')}</ul>
+					<ul className="timeline-dps-events">{log.damageLogs.map(damageLog => this.tooltipLogItem(damageLog, damageLog.result()))}</ul>
 					<div className="timeline-tooltip-body-row">
 						<span className="series-color">DPS: {log.dps.toFixed(2)}</span>
 					</div>
@@ -1060,7 +1114,7 @@ export class Timeline extends ResultComponent {
 					<div className="timeline-tooltip-body-row">
 						<span className="series-color">Before: {log.threatBefore.toFixed(1)}</span>
 					</div>
-					<ul className="timeline-threat-events">{log.logs.map(log => this.tooltipLogItem(log, <>{log.threat.toFixed(1)} Threat</>)).join('')}</ul>
+					<ul className="timeline-threat-events">{log.logs.map(log => this.tooltipLogItem(log, <>{log.threat.toFixed(1)} Threat</>))}</ul>
 					<div className="timeline-tooltip-body-row">
 						<span className="series-color">After: {log.threatAfter.toFixed(1)}</span>
 					</div>
@@ -1143,20 +1197,22 @@ export class Timeline extends ResultComponent {
 		);
 	}
 
-	render() {
+	update() {
 		this.reset();
-		this.dpsResourcesPlot.render();
-		this.rendered = true;
+		if (!this.rendered) this.dpsResourcesPlot.render();
 		this.updatePlot();
+		this.rendered = true;
 	}
 
-	addOnResetCallback(callback: () => void) {
-		this.resetCallbacks.push(callback);
+	render() {
+		if (this.rendered) return;
+		this.update();
 	}
 
 	reset() {
-		this.resetCallbacks.forEach(callback => callback());
-		this.resetCallbacks = [];
+		const previousResultRequestId = this.prevResultData?.result.request.requestId;
+		if (previousResultRequestId && !this.cacheHandler.get(previousResultRequestId)) return;
+		super.reset();
 	}
 }
 
@@ -1388,16 +1444,16 @@ const idToCategoryMap: Record<number, number> = {
 	[40536]: SPELL_ACTION_CATEGORY + 0.942, // Explosive Decoy
 	[41119]: SPELL_ACTION_CATEGORY + 0.943, // Saronite Bomb
 	[40771]: SPELL_ACTION_CATEGORY + 0.944, // Cobalt Frag Bomb
-	
+
 	// Souldrinker - to pair up the damage part with the healing
 	[109828]: SPELL_ACTION_CATEGORY + 0.945, // Drain Life - LFR
 	[108022]: SPELL_ACTION_CATEGORY + 0.946, // Drain Life - Normal
 	[109831]: SPELL_ACTION_CATEGORY + 0.947, // Drain Life - Heroic
-	
+
 	// No'Kaled - to pair up the different spells it can proc
 	[109871]: SPELL_ACTION_CATEGORY + 0.948, // Flameblast - LFR
 	[109869]: SPELL_ACTION_CATEGORY + 0.949, // Iceblast - LFR
-	[109867]: SPELL_ACTION_CATEGORY + 0.950, // Shadowblast - LFR
+	[109867]: SPELL_ACTION_CATEGORY + 0.95, // Shadowblast - LFR
 	[107785]: SPELL_ACTION_CATEGORY + 0.951, // Flameblast - Normal
 	[107789]: SPELL_ACTION_CATEGORY + 0.952, // Iceblast - Normal
 	[107787]: SPELL_ACTION_CATEGORY + 0.953, // Shadowblast - Normal

--- a/ui/core/components/results_viewer.tsx
+++ b/ui/core/components/results_viewer.tsx
@@ -126,8 +126,7 @@ export class ResultsViewer extends Component {
 		if (typeof html === 'string') {
 			this.contentElem.innerHTML = html;
 		} else {
-			this.contentElem.innerHTML = '';
-			this.contentElem.appendChild(html);
+			this.contentElem.replaceChildren(html);
 		}
 		this.contentElem.style.display = 'block';
 		this.pendingElem.style.display = 'none';

--- a/ui/core/constants/lang.ts
+++ b/ui/core/constants/lang.ts
@@ -34,5 +34,5 @@ export function setLanguageCode(newLang: string) {
 	cachedWowheadLanguagePrefix_ = cachedLanguageCode_ ? cachedLanguageCode_ + '/' : '';
 }
 
-let cachedLanguageCode_: string = '';
-let cachedWowheadLanguagePrefix_: string = '';
+let cachedLanguageCode_ = '';
+let cachedWowheadLanguagePrefix_ = '';

--- a/ui/core/sim.ts
+++ b/ui/core/sim.ts
@@ -1,4 +1,5 @@
 import { hasTouch } from '../shared/bootstrap_overrides';
+import { SimRequest } from '../worker/types';
 import { getBrowserLanguageCode, setLanguageCode } from './constants/lang';
 import * as OtherConstants from './constants/other';
 import { Encounter } from './encounter';
@@ -41,7 +42,7 @@ import { runConcurrentSim, runConcurrentStatWeights } from './sim_concurrent';
 import { RequestTypes, SimSignalManager } from './sim_signal_manager';
 import { EventID, TypedEvent } from './typed_event.js';
 import { getEnumValues, noop } from './utils.js';
-import { WorkerPool, WorkerProgressCallback } from './worker_pool.js';
+import { generateRequestId, WorkerPool, WorkerProgressCallback } from './worker_pool.js';
 
 export type RaidSimData = {
 	request: RaidSimRequest;
@@ -266,6 +267,7 @@ export class Sim {
 		// TODO: remove any replenishment from sim request here? probably makes more sense to do it inside the sim to protect against accidents
 
 		return RaidSimRequest.create({
+			requestId: generateRequestId(SimRequest.raidSimAsync),
 			type: this.type,
 			raid: raid,
 			encounter: encounter,

--- a/ui/core/utils.ts
+++ b/ui/core/utils.ts
@@ -13,6 +13,12 @@ export const existsInDOM = (element: HTMLElement | null) => document.body.contai
 
 export const cloneChildren = (element: HTMLElement) => [...(element.childNodes || [])].map(child => child.cloneNode(true));
 
+export const fragmentToString = (element: Node | Element) => {
+	const div = document.createElement('div');
+	div.appendChild(element.cloneNode(true));
+	return div.innerHTML;
+};
+
 export const sanitizeId = (id: string) => id.split(' ').join('');
 
 export const omitDeep = <T>(collection: T, excludeKeys: string[]): T => {

--- a/ui/core/worker_pool.ts
+++ b/ui/core/worker_pool.ts
@@ -31,7 +31,7 @@ export type WorkerProgressCallback = (progressMetrics: ProgressMetrics) => void;
  * @param type The request type to prepend.
  * @returns Random id in the format type-randomhex
  */
-const generateRequestId = (type: SimRequest) => {
+export const generateRequestId = (type: SimRequest) => {
 	const chars = Array.from(Array(4)).map(() => Math.floor(Math.random() * 0x10000).toString(16));
 	return type + '-' + chars.join('');
 };
@@ -149,7 +149,7 @@ export class WorkerPool {
 	async raidSimAsync(request: RaidSimRequest, onProgress: WorkerProgressCallback, signals: SimSignals): Promise<RaidSimResult> {
 		const worker = this.getLeastBusyWorker();
 		worker.log('Raid sim request: ' + RaidSimRequest.toJsonString(request));
-		const id = generateRequestId(SimRequest.raidSimAsync);
+		const id = request.requestId;
 
 		signals.abort.onTrigger(async () => {
 			await worker.sendAbortById(id);

--- a/ui/scss/core/components/detailed_results/_timeline.scss
+++ b/ui/scss/core/components/detailed_results/_timeline.scss
@@ -48,7 +48,6 @@
 	color: var(--bs-holy-power);
 }
 
-
 .timeline-root {
 	display: flex;
 	height: 100%;
@@ -92,9 +91,47 @@
 	}
 }
 
+.timeline-plot {
+	.apexcharts-tooltip.apexcharts-theme-dark {
+		box-shadow: none;
+		border-radius: 0;
+		background-color: var(--bs-tooltip-bg);
+		border: var(--bs-tooltip-border) 1px solid;
+		color: var(--bs-tooltip-body-color);
+		padding: var(--bs-tooltip-body-padding-y) var(--bs-tooltip-body-padding-x);
+	}
+}
+
+.timeline-tooltip {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacer-3);
+
+	ul {
+		display: flex;
+		flex-direction: column;
+		gap: var(--spacer-1);
+		padding-left: 0;
+		list-style: none;
+		margin-bottom: 0;
+	}
+
+	li {
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: var(--spacer-2);
+	}
+}
+
 .timeline-tooltip-header {
 	border-bottom: 1px solid var(--bs-white);
-	margin-bottom: 5px;
+}
+
+.timeline-tooltip-body {
+	display: flex;
+	flex-direction: column;
+	gap: var(--spacer-3);
 }
 
 .timeline-tooltip-body-row {
@@ -113,7 +150,6 @@
 
 .timeline-tooltip-auras {
 	border-top: 1px solid var(--bs-white);
-	margin-top: 5px;
 }
 
 .rotation-container {
@@ -210,7 +246,6 @@
 		background-color: var(--bs-holy-power);
 		width: 24px;
 	}
-
 }
 .rotation-timeline-cast {
 	position: absolute;


### PR DESCRIPTION
- Added the request ID to the raid sim request to have a unique value to build cache keys with
- Added a generic CacheHandler to allow for caching of elements that do not change and can be reused.
- Added caching to diverse "enriched" HTML Nodes that are dependent on async calls like wowhead datasets
- Added caching (max 2 entries) to SimResults to make toggling between 2 (reference) datasets much quicker
- Added caching to the Timeline content
- Fixed DPS graph Timeline tooltips

**After & Before**
 ~ 3x performance increase when swapping/toggling between 2 results
Overall GC improvement
![image](https://github.com/user-attachments/assets/35221512-8555-484e-9d89-1d4a76bcdaf1)
