### PR TITLE
Various survival fixes and T12 fix

### DIFF
--- a/sim/hunter/beast_mastery/TestBM.results
+++ b/sim/hunter/beast_mastery/TestBM.results
@@ -641,8 +641,8 @@ dps_results: {
 dps_results: {
  key: "TestBM-AllItems-Flamewaker'sBattlegear"
  value: {
-  dps: 22782.96715
-  tps: 19168.04784
+  dps: 22850.13117
+  tps: 19266.89187
  }
 }
 dps_results: {

--- a/sim/hunter/beast_mastery/TestBM.results
+++ b/sim/hunter/beast_mastery/TestBM.results
@@ -38,2330 +38,2330 @@ character_stats_results: {
 dps_results: {
  key: "TestBM-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 22279.4006
-  tps: 18781.13274
+  dps: 22285.33063
+  tps: 18787.06277
  }
 }
 dps_results: {
  key: "TestBM-AllItems-AgonyandTorment"
  value: {
-  dps: 21582.77655
-  tps: 18236.78154
+  dps: 21588.97347
+  tps: 18242.97846
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
-  dps: 19152.48048
-  tps: 16265.04926
+  dps: 19158.09361
+  tps: 16270.66239
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 21977.73808
-  tps: 18476.69556
+  dps: 21977.934
+  tps: 18476.89148
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 21131.30017
-  tps: 17825.70474
+  dps: 21137.03713
+  tps: 17831.44171
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 21131.30017
-  tps: 17825.70474
+  dps: 21137.03713
+  tps: 17831.44171
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 21097.03318
-  tps: 17811.53822
+  dps: 21105.83296
+  tps: 17820.338
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 21145.32226
-  tps: 17859.07559
+  dps: 21154.12032
+  tps: 17867.87365
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ArrowofTime-72897"
  value: {
-  dps: 22301.14457
-  tps: 18827.17927
+  dps: 22309.23203
+  tps: 18835.26673
  }
 }
 dps_results: {
  key: "TestBM-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 21841.61792
-  tps: 18367.10286
+  dps: 21846.61625
+  tps: 18372.10119
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 20882.1586
-  tps: 17632.35153
+  dps: 20890.90149
+  tps: 17641.09441
   hps: 105.41457
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 21123.68032
-  tps: 17850.86089
+  dps: 21130.19637
+  tps: 17857.37694
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 21136.72762
-  tps: 17869.38628
+  dps: 21144.44885
+  tps: 17877.10751
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BindingPromise-67037"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BlackBruise-50692"
  value: {
-  dps: 20831.96184
-  tps: 17610.6085
+  dps: 20837.57641
+  tps: 17616.22306
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 21594.99132
-  tps: 18195.99455
+  dps: 21599.42432
+  tps: 18200.42755
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 20999.40017
-  tps: 17686.45515
+  dps: 21008.14305
+  tps: 17695.19803
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 21014.72206
-  tps: 17693.54014
+  dps: 21023.46494
+  tps: 17702.28303
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 21875.61457
-  tps: 18464.43788
+  dps: 21876.0893
+  tps: 18464.91262
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 21119.45324
-  tps: 17844.62759
+  dps: 21126.43683
+  tps: 17851.61119
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 21705.47628
-  tps: 18316.74012
+  dps: 21710.25397
+  tps: 18321.51781
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 21715.29456
-  tps: 18477.6717
+  dps: 21725.92622
+  tps: 18488.30336
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 21674.95829
-  tps: 18432.80316
+  dps: 21679.96343
+  tps: 18437.8083
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 22048.12244
-  tps: 18786.29877
+  dps: 22056.46884
+  tps: 18794.64517
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BottledLightning-66879"
  value: {
-  dps: 20946.90972
-  tps: 17683.95697
+  dps: 20955.21312
+  tps: 17692.26037
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BottledWishes-77114"
  value: {
-  dps: 21318.24842
-  tps: 17988.51849
+  dps: 21328.82004
+  tps: 17999.09011
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 21841.61792
-  tps: 17999.7608
+  dps: 21846.61625
+  tps: 18004.65917
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 22340.68061
-  tps: 18842.72601
+  dps: 22346.61063
+  tps: 18848.65604
  }
 }
 dps_results: {
  key: "TestBM-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 22109.86054
-  tps: 18635.34548
+  dps: 22114.84364
+  tps: 18640.32859
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CataclysmicGladiator'sBadgeofConquest-73648"
  value: {
-  dps: 22258.21796
-  tps: 18779.80225
+  dps: 22253.76942
+  tps: 18775.35371
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CataclysmicGladiator'sBadgeofDominance-73498"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CataclysmicGladiator'sBadgeofVictory-73496"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CataclysmicGladiator'sInsigniaofConquest-73643"
  value: {
-  dps: 22327.23666
-  tps: 18858.20132
+  dps: 22331.36126
+  tps: 18862.32592
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CataclysmicGladiator'sInsigniaofDominance-73497"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CataclysmicGladiator'sInsigniaofVictory-73491"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 22247.38649
-  tps: 18771.70481
+  dps: 22252.91132
+  tps: 18777.22964
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 21600.0087
-  tps: 18236.49441
+  dps: 21604.69556
+  tps: 18241.18126
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 21606.54953
-  tps: 18265.66859
+  dps: 21614.10718
+  tps: 18273.22624
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 21440.43951
-  tps: 18100.93983
+  dps: 21446.75251
+  tps: 18107.25283
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 21647.86724
-  tps: 18304.53651
+  dps: 21655.14282
+  tps: 18311.81209
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CrushingWeight-59506"
  value: {
-  dps: 20983.59985
-  tps: 17708.19631
+  dps: 20989.54116
+  tps: 17714.13762
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CrushingWeight-65118"
  value: {
-  dps: 20948.84102
-  tps: 17665.02231
+  dps: 20957.4338
+  tps: 17673.61509
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 21287.65557
-  tps: 18037.79792
+  dps: 21296.39846
+  tps: 18046.5408
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 21223.91023
-  tps: 17973.9861
+  dps: 21232.65312
+  tps: 17982.72899
  }
 }
 dps_results: {
  key: "TestBM-AllItems-CunningoftheCruel-78000"
  value: {
-  dps: 21336.75786
-  tps: 18086.91593
+  dps: 21345.50075
+  tps: 18095.65882
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 21297.34424
-  tps: 18040.27916
+  dps: 21306.25247
+  tps: 18049.18739
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 22309.77139
-  tps: 18909.97124
+  dps: 22317.89554
+  tps: 18918.09539
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 21031.43685
-  tps: 17701.26923
+  dps: 21040.17973
+  tps: 17710.01212
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 21465.97352
-  tps: 18142.45818
+  dps: 21474.76541
+  tps: 18151.25007
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 21972.89618
-  tps: 18497.21451
+  dps: 21978.4263
+  tps: 18502.74462
  }
 }
 dps_results: {
  key: "TestBM-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 21017.51581
-  tps: 17746.84838
+  dps: 21021.63879
+  tps: 17750.97136
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Dragonwrath,Tarecgosa'sRest-71086"
  value: {
-  dps: 22561.37065
-  tps: 19018.0046
+  dps: 22567.90399
+  tps: 19024.53794
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 21356.51197
-  tps: 18061.45835
+  dps: 21362.43497
+  tps: 18067.38135
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 21841.61792
-  tps: 18367.10286
+  dps: 21846.61625
+  tps: 18372.10119
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 21841.61792
-  tps: 18367.10286
+  dps: 21846.61625
+  tps: 18372.10119
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 21972.89618
-  tps: 18497.21451
+  dps: 21978.4263
+  tps: 18502.74462
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 22056.74988
-  tps: 18640.90234
+  dps: 22063.65594
+  tps: 18647.8084
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 22234.01562
-  tps: 18791.76515
+  dps: 22242.1013
+  tps: 18799.85082
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 21060.22343
-  tps: 17714.58044
+  dps: 21068.96632
+  tps: 17723.32333
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 21841.61792
-  tps: 18367.10286
+  dps: 21846.61625
+  tps: 18372.10119
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FallofMortality-59500"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FallofMortality-65124"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 20953.95302
-  tps: 17697.35234
+  dps: 20956.87057
+  tps: 17700.2699
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 21974.9278
-  tps: 18544.58804
+  dps: 21974.23607
+  tps: 18543.89631
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 21014.72206
-  tps: 17693.54014
+  dps: 21023.46494
+  tps: 17702.28303
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 21095.04591
-  tps: 17730.68271
+  dps: 21103.7888
+  tps: 17739.42559
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Flamewaker'sBattlegear"
  value: {
-  dps: 22850.13117
-  tps: 19266.89187
+  dps: 22854.3142
+  tps: 19271.0749
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 21868.0655
-  tps: 18379.14097
+  dps: 21873.06383
+  tps: 18384.1393
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FluidDeath-58181"
  value: {
-  dps: 22147.6968
-  tps: 18685.54185
+  dps: 22154.63852
+  tps: 18692.48357
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 21841.61792
-  tps: 18367.10286
+  dps: 21846.61625
+  tps: 18372.10119
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 21064.16077
-  tps: 17716.69742
+  dps: 21072.90365
+  tps: 17725.4403
  }
 }
 dps_results: {
  key: "TestBM-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 21136.54754
-  tps: 17863.74665
+  dps: 21142.75705
+  tps: 17869.95617
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GaleofShadows-56138"
  value: {
-  dps: 21172.47788
-  tps: 17905.30957
+  dps: 21180.28634
+  tps: 17913.11802
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GaleofShadows-56462"
  value: {
-  dps: 21054.23256
-  tps: 17742.84741
+  dps: 21061.09095
+  tps: 17749.7058
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GearDetector-61462"
  value: {
-  dps: 21510.91335
-  tps: 18189.38753
+  dps: 21517.86918
+  tps: 18196.34336
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 19617.27614
-  tps: 16522.49408
+  dps: 19622.02013
+  tps: 16527.23808
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 21525.51607
-  tps: 18164.54317
+  dps: 21532.9399
+  tps: 18171.967
  }
 }
 dps_results: {
  key: "TestBM-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 21801.99768
-  tps: 18405.58627
+  dps: 21810.84613
+  tps: 18414.43472
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Gurthalak,VoiceoftheDeeps-77191"
  value: {
-  dps: 22279.4006
-  tps: 18781.13274
+  dps: 22285.33063
+  tps: 18787.06277
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Gurthalak,VoiceoftheDeeps-78478"
  value: {
-  dps: 22279.4006
-  tps: 18781.13274
+  dps: 22285.33063
+  tps: 18787.06277
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Gurthalak,VoiceoftheDeeps-78487"
  value: {
-  dps: 22279.4006
-  tps: 18781.13274
+  dps: 22285.33063
+  tps: 18787.06277
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HarmlightToken-63839"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 20947.40436
-  tps: 17660.83884
+  dps: 20956.14725
+  tps: 17669.58173
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HeartofRage-59224"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HeartofRage-65072"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HeartofSolace-55868"
  value: {
-  dps: 21172.47788
-  tps: 17905.30957
+  dps: 21180.28634
+  tps: 17913.11802
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HeartofSolace-56393"
  value: {
-  dps: 21054.23256
-  tps: 17742.84741
+  dps: 21061.09095
+  tps: 17749.7058
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HeartofThunder-55845"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HeartofThunder-56370"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 21591.13988
-  tps: 18209.71857
+  dps: 21598.58977
+  tps: 18217.16846
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Heartpierce-50641"
  value: {
-  dps: 22470.21674
-  tps: 18956.13196
+  dps: 22475.74878
+  tps: 18961.664
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 21972.89618
-  tps: 18497.21451
+  dps: 21978.4263
+  tps: 18502.74462
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 21031.43685
-  tps: 17701.26923
+  dps: 21040.17973
+  tps: 17710.01212
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 21031.43685
-  tps: 17701.26923
+  dps: 21040.17973
+  tps: 17710.01212
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 20999.40017
-  tps: 17686.45515
+  dps: 21008.14305
+  tps: 17695.19803
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 21014.72206
-  tps: 17693.54014
+  dps: 21023.46494
+  tps: 17702.28303
  }
 }
 dps_results: {
  key: "TestBM-AllItems-IndomitablePride-77211"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-IndomitablePride-77983"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-IndomitablePride-78003"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 21332.24707
-  tps: 17983.67378
+  dps: 21340.29837
+  tps: 17991.72508
  }
 }
 dps_results: {
  key: "TestBM-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 21315.75088
-  tps: 17936.90861
+  dps: 21319.54853
+  tps: 17940.70626
  }
 }
 dps_results: {
  key: "TestBM-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 21522.37622
-  tps: 18141.57922
+  dps: 21527.14555
+  tps: 18146.34854
  }
 }
 dps_results: {
  key: "TestBM-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 21059.36194
-  tps: 17762.67696
+  dps: 21068.92722
+  tps: 17772.24223
  }
 }
 dps_results: {
  key: "TestBM-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 21594.99132
-  tps: 18195.99455
+  dps: 21599.42432
+  tps: 18200.42755
  }
 }
 dps_results: {
  key: "TestBM-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 21872.19306
-  tps: 18445.54564
+  dps: 21875.77055
+  tps: 18449.12314
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Kiril,FuryofBeasts-77194"
  value: {
-  dps: 24487.19816
-  tps: 20669.30392
+  dps: 24494.82915
+  tps: 20676.93492
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Kiril,FuryofBeasts-78473"
  value: {
-  dps: 24841.66714
-  tps: 20976.70289
+  dps: 24851.14586
+  tps: 20986.18161
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Kiril,FuryofBeasts-78482"
  value: {
-  dps: 24298.53658
-  tps: 20516.14068
+  dps: 24306.44457
+  tps: 20524.04867
  }
 }
 dps_results: {
  key: "TestBM-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 22374.98968
-  tps: 18881.60014
+  dps: 22378.35329
+  tps: 18884.96374
  }
 }
 dps_results: {
  key: "TestBM-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 21142.10401
-  tps: 17853.59123
+  dps: 21147.66627
+  tps: 17859.15349
  }
 }
 dps_results: {
  key: "TestBM-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 21142.10401
-  tps: 17853.59123
+  dps: 21147.66627
+  tps: 17859.15349
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 20995.94549
-  tps: 17734.30218
+  dps: 21001.18298
+  tps: 17739.53968
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LastWord-50708"
  value: {
-  dps: 22279.4006
-  tps: 18781.13274
+  dps: 22285.33063
+  tps: 18787.06277
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LeadenDespair-55816"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LeadenDespair-56347"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 21614.94738
-  tps: 18240.77198
+  dps: 21616.32619
+  tps: 18242.15079
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 21842.89905
-  tps: 18430.14789
+  dps: 21845.12179
+  tps: 18432.37063
  }
 }
 dps_results: {
  key: "TestBM-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 21131.30017
-  tps: 17825.70474
+  dps: 21137.03713
+  tps: 17831.44171
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Lightning-ChargedBattlegear"
  value: {
-  dps: 21279.79442
-  tps: 17906.56354
+  dps: 21283.27738
+  tps: 17910.0465
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 20968.92938
-  tps: 17720.64117
+  dps: 20978.49465
+  tps: 17730.20644
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 20968.92938
-  tps: 17720.64117
+  dps: 20978.49465
+  tps: 17730.20644
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 21066.20062
-  tps: 17763.11233
+  dps: 21075.76589
+  tps: 17772.6776
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 21078.93852
-  tps: 17768.67403
+  dps: 21088.5038
+  tps: 17778.2393
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 22436.5236
-  tps: 18945.63121
+  dps: 22441.79523
+  tps: 18950.90284
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 22697.7764
-  tps: 19168.58044
+  dps: 22704.91757
+  tps: 19175.72161
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 21203.55296
-  tps: 17891.6018
+  dps: 21209.10037
+  tps: 17897.1492
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 21203.55296
-  tps: 17891.6018
+  dps: 21209.10037
+  tps: 17897.1492
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 21031.43685
-  tps: 17701.26923
+  dps: 21040.17973
+  tps: 17710.01212
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 21031.43685
-  tps: 17701.26923
+  dps: 21040.17973
+  tps: 17710.01212
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 21120.06643
-  tps: 17844.62759
+  dps: 21127.05003
+  tps: 17851.61119
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 21030.04817
-  tps: 17695.97401
+  dps: 21038.79106
+  tps: 17704.71689
  }
 }
 dps_results: {
  key: "TestBM-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-No'Kaled,theElementsofDeath-77188"
  value: {
-  dps: 23107.01712
-  tps: 19519.43084
+  dps: 23114.93659
+  tps: 19527.35031
  }
 }
 dps_results: {
  key: "TestBM-AllItems-No'Kaled,theElementsofDeath-78472"
  value: {
-  dps: 23201.59947
-  tps: 19605.15852
+  dps: 23208.86889
+  tps: 19612.42793
  }
 }
 dps_results: {
  key: "TestBM-AllItems-No'Kaled,theElementsofDeath-78481"
  value: {
-  dps: 23020.58118
-  tps: 19444.9551
+  dps: 23028.42824
+  tps: 19452.80216
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 21060.79553
-  tps: 17785.99254
+  dps: 21068.82984
+  tps: 17794.02685
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 21045.46695
-  tps: 17778.04781
+  dps: 21054.85332
+  tps: 17787.43417
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 20938.49112
-  tps: 17655.7508
+  dps: 20947.23401
+  tps: 17664.49369
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 20983.40443
-  tps: 17675.5032
+  dps: 20992.14731
+  tps: 17684.24608
  }
 }
 dps_results: {
  key: "TestBM-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 21841.61792
-  tps: 18367.10286
+  dps: 21846.61625
+  tps: 18372.10119
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 22067.05235
-  tps: 18621.06456
+  dps: 22072.21785
+  tps: 18626.23006
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 22137.23814
-  tps: 18668.34944
+  dps: 22141.33289
+  tps: 18672.44419
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Rainsong-55854"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Rainsong-56377"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Rathrak,thePoisonousMind-77195"
  value: {
-  dps: 20759.5687
-  tps: 17549.86426
+  dps: 20765.18984
+  tps: 17555.48539
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Rathrak,thePoisonousMind-78475"
  value: {
-  dps: 20770.31363
-  tps: 17560.60919
+  dps: 20775.93477
+  tps: 17566.23032
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Rathrak,thePoisonousMind-78484"
  value: {
-  dps: 20761.08245
-  tps: 17551.37801
+  dps: 20766.70358
+  tps: 17556.99914
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 20968.92938
-  tps: 17720.64117
+  dps: 20978.49465
+  tps: 17730.20644
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 22109.86054
-  tps: 18635.34548
+  dps: 22114.84364
+  tps: 18640.32859
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 22109.86054
-  tps: 18635.34548
+  dps: 22114.84364
+  tps: 18640.32859
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 22109.14625
-  tps: 18667.30394
+  dps: 22112.71009
+  tps: 18670.86778
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 21131.30017
-  tps: 17825.70474
+  dps: 21137.03713
+  tps: 17831.44171
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 21131.30017
-  tps: 17825.70474
+  dps: 21137.03713
+  tps: 17831.44171
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RosaryofLight-72901"
  value: {
-  dps: 21339.40915
-  tps: 18046.59809
+  dps: 21346.10028
+  tps: 18053.28922
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RottingSkull-77116"
  value: {
-  dps: 21310.21283
-  tps: 18003.1852
+  dps: 21317.21412
+  tps: 18010.18649
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RuneofZeth-68998"
  value: {
-  dps: 21139.38129
-  tps: 17863.87554
+  dps: 21145.99639
+  tps: 17870.49063
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RuthlessGladiator'sBadgeofConquest-70399"
  value: {
-  dps: 22003.00364
-  tps: 18560.29098
+  dps: 22001.67708
+  tps: 18558.96442
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RuthlessGladiator'sBadgeofConquest-72304"
  value: {
-  dps: 22055.09046
-  tps: 18602.84931
+  dps: 22053.37249
+  tps: 18601.13134
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RuthlessGladiator'sBadgeofDominance-70401"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RuthlessGladiator'sBadgeofDominance-72448"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RuthlessGladiator'sBadgeofVictory-70400"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RuthlessGladiator'sBadgeofVictory-72450"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RuthlessGladiator'sInsigniaofConquest-70404"
  value: {
-  dps: 22071.13161
-  tps: 18631.92637
+  dps: 22076.81985
+  tps: 18637.61461
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RuthlessGladiator'sInsigniaofConquest-72309"
  value: {
-  dps: 22257.38278
-  tps: 18790.48744
+  dps: 22264.01352
+  tps: 18797.11818
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RuthlessGladiator'sInsigniaofDominance-70402"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RuthlessGladiator'sInsigniaofDominance-72449"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RuthlessGladiator'sInsigniaofVictory-70403"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-RuthlessGladiator'sInsigniaofVictory-72455"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ScalesofLife-68915"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
   hps: 344.15369
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ScalesofLife-69109"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
   hps: 388.20214
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 21567.03803
-  tps: 18180.32511
+  dps: 21576.36162
+  tps: 18189.6487
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SeaStar-55256"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SeaStar-56290"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Shadowmourne-49623"
  value: {
-  dps: 22496.2595
-  tps: 18980.16715
+  dps: 22502.54771
+  tps: 18986.45536
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ShardofWoe-60233"
  value: {
-  dps: 21170.32174
-  tps: 17878.74679
+  dps: 21180.20887
+  tps: 17888.63393
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 20980.17082
-  tps: 17737.91041
+  dps: 20986.90362
+  tps: 17744.64321
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 21658.92836
-  tps: 18238.34518
+  dps: 21668.26708
+  tps: 18247.6839
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 21763.2311
-  tps: 18320.24645
+  dps: 21772.62291
+  tps: 18329.63826
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Sorrowsong-55879"
  value: {
-  dps: 20999.40017
-  tps: 17686.45515
+  dps: 21008.14305
+  tps: 17695.19803
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Sorrowsong-56400"
  value: {
-  dps: 21014.72206
-  tps: 17693.54014
+  dps: 21023.46494
+  tps: 17702.28303
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 21203.55296
-  tps: 17891.6018
+  dps: 21209.10037
+  tps: 17897.1492
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SoulCasket-58183"
  value: {
-  dps: 21031.43685
-  tps: 17701.26923
+  dps: 21040.17973
+  tps: 17710.01212
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Souldrinker-77193"
  value: {
-  dps: 22346.52525
-  tps: 18848.2574
+  dps: 22352.45528
+  tps: 18854.18743
   hps: 147.67423
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Souldrinker-78479"
  value: {
-  dps: 22355.84887
-  tps: 18857.58101
+  dps: 22361.7789
+  tps: 18863.51104
   hps: 168.18619
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Souldrinker-78488"
  value: {
-  dps: 22337.31677
-  tps: 18839.04892
+  dps: 22343.2468
+  tps: 18844.97894
   hps: 127.41558
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 21244.8299
-  tps: 17802.28813
+  dps: 21253.57279
+  tps: 17811.03101
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 21192.28941
-  tps: 17773.62582
+  dps: 21201.03229
+  tps: 17782.3687
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 21270.07839
-  tps: 17808.08237
+  dps: 21278.82128
+  tps: 17816.82525
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 21060.22343
-  tps: 17714.58044
+  dps: 21068.96632
+  tps: 17723.32333
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 21083.43842
-  tps: 17725.31529
+  dps: 21092.18131
+  tps: 17734.05817
  }
 }
 dps_results: {
  key: "TestBM-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 22576.31331
-  tps: 19017.64896
+  dps: 22581.15944
+  tps: 19022.49509
  }
 }
 dps_results: {
  key: "TestBM-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 22337.34552
-  tps: 18805.79191
+  dps: 22338.61677
+  tps: 18807.06317
  }
 }
 dps_results: {
  key: "TestBM-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 22854.15448
-  tps: 19273.49383
+  dps: 22859.69427
+  tps: 19279.03363
  }
 }
 dps_results: {
  key: "TestBM-AllItems-StayofExecution-68996"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-StumpofTime-62465"
  value: {
-  dps: 21131.30017
-  tps: 17825.70474
+  dps: 21137.03713
+  tps: 17831.44171
  }
 }
 dps_results: {
  key: "TestBM-AllItems-StumpofTime-62470"
  value: {
-  dps: 21131.30017
-  tps: 17825.70474
+  dps: 21137.03713
+  tps: 17831.44171
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 20841.23743
-  tps: 17584.52908
+  dps: 20846.30886
+  tps: 17589.60051
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TearofBlood-55819"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TearofBlood-56351"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 20982.22108
-  tps: 17678.51136
+  dps: 20990.96396
+  tps: 17687.25425
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 21014.72206
-  tps: 17693.54014
+  dps: 21023.46494
+  tps: 17702.28303
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TheHungerer-68927"
  value: {
-  dps: 22154.24419
-  tps: 18662.64489
+  dps: 22162.0828
+  tps: 18670.48349
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TheHungerer-69112"
  value: {
-  dps: 22404.62822
-  tps: 18871.36263
+  dps: 22412.9138
+  tps: 18879.64821
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Ti'tahk,theStepsofTime-77190"
  value: {
-  dps: 22251.87534
-  tps: 18753.68663
+  dps: 22257.92348
+  tps: 18759.73477
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Ti'tahk,theStepsofTime-78477"
  value: {
-  dps: 22249.57188
-  tps: 18749.81951
+  dps: 22254.91041
+  tps: 18755.15803
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Ti'tahk,theStepsofTime-78486"
  value: {
-  dps: 22260.99402
-  tps: 18762.43598
+  dps: 22266.93809
+  tps: 18768.38005
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 21781.60557
-  tps: 18342.29042
+  dps: 21790.2477
+  tps: 18350.93254
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 21896.78976
-  tps: 18434.64221
+  dps: 21904.37922
+  tps: 18442.23168
  }
 }
 dps_results: {
  key: "TestBM-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 20978.07373
-  tps: 17692.15386
+  dps: 20985.76217
+  tps: 17699.8423
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 20333.48068
-  tps: 17181.47471
+  dps: 20337.11905
+  tps: 17185.11308
  }
 }
 dps_results: {
  key: "TestBM-AllItems-UnheededWarning-59520"
  value: {
-  dps: 21856.37677
-  tps: 18442.52302
+  dps: 21862.6767
+  tps: 18448.82294
  }
 }
 dps_results: {
  key: "TestBM-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 21926.31529
-  tps: 18443.33843
+  dps: 21926.84328
+  tps: 18443.86641
  }
 }
 dps_results: {
  key: "TestBM-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 21926.31529
-  tps: 18443.33843
+  dps: 21926.84328
+  tps: 18443.86641
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 20775.50519
-  tps: 17550.46167
+  dps: 20782.61613
+  tps: 17557.57262
  }
 }
 dps_results: {
  key: "TestBM-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 21219.93426
-  tps: 17970.20005
+  dps: 21228.67715
+  tps: 17978.94294
  }
 }
 dps_results: {
  key: "TestBM-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 21250.388
-  tps: 18000.45117
+  dps: 21259.13089
+  tps: 18009.19406
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 21113.32865
-  tps: 17739.47363
+  dps: 21122.07154
+  tps: 17748.21651
  }
 }
 dps_results: {
  key: "TestBM-AllItems-VeilofLies-72900"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 20988.8969
-  tps: 17725.20354
+  dps: 20996.12001
+  tps: 17732.42665
  }
 }
 dps_results: {
  key: "TestBM-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 20968.63033
-  tps: 17705.07417
+  dps: 20975.2885
+  tps: 17711.73235
  }
 }
 dps_results: {
  key: "TestBM-AllItems-VialofShadows-77207"
  value: {
-  dps: 22914.20207
-  tps: 19464.43273
+  dps: 22922.71016
+  tps: 19472.94082
  }
 }
 dps_results: {
  key: "TestBM-AllItems-VialofShadows-77979"
  value: {
-  dps: 22475.45083
-  tps: 19042.30272
+  dps: 22479.1465
+  tps: 19045.99839
  }
 }
 dps_results: {
  key: "TestBM-AllItems-VialofShadows-77999"
  value: {
-  dps: 22848.58254
-  tps: 19363.12081
+  dps: 22854.77865
+  tps: 19369.31691
  }
 }
 dps_results: {
  key: "TestBM-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 21771.0872
-  tps: 18371.90937
+  dps: 21771.61518
+  tps: 18372.43736
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sBadgeofConquest-70517"
  value: {
-  dps: 21871.20616
-  tps: 18451.42186
+  dps: 21870.90838
+  tps: 18451.12408
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sBadgeofDominance-70518"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sBadgeofVictory-70519"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 21131.30017
-  tps: 17825.70474
+  dps: 21137.03713
+  tps: 17831.44171
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 21059.54288
-  tps: 17773.67755
+  dps: 21067.96112
+  tps: 17782.09579
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 21092.97732
-  tps: 17825.84556
+  dps: 21100.10008
+  tps: 17832.96832
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 21040.25854
-  tps: 17705.34847
+  dps: 21049.00143
+  tps: 17714.09136
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 21885.48942
-  tps: 18470.24065
+  dps: 21893.49169
+  tps: 18478.24293
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sInsigniaofConquest-70577"
  value: {
-  dps: 22002.18705
-  tps: 18576.67928
+  dps: 22012.24601
+  tps: 18586.73825
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sInsigniaofDominance-70578"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-ViciousGladiator'sInsigniaofVictory-70579"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Vishanka,JawsoftheEarth-78359"
  value: {
-  dps: 24761.0033
-  tps: 21327.07242
+  dps: 24762.60419
+  tps: 21328.67331
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Vishanka,JawsoftheEarth-78471"
  value: {
-  dps: 25508.13354
-  tps: 22066.85452
+  dps: 25510.7994
+  tps: 22069.52038
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Vishanka,JawsoftheEarth-78480"
  value: {
-  dps: 24122.91619
-  tps: 20689.79059
+  dps: 24124.90034
+  tps: 20691.77474
  }
 }
 dps_results: {
  key: "TestBM-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-WillofUnbinding-77995"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 20882.39663
-  tps: 17632.35153
+  dps: 20891.13952
+  tps: 17641.09441
  }
 }
 dps_results: {
  key: "TestBM-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 20984.07828
-  tps: 17679.37015
+  dps: 20992.82116
+  tps: 17688.11303
  }
 }
 dps_results: {
  key: "TestBM-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 23151.50037
-  tps: 19534.02638
+  dps: 23156.22853
+  tps: 19538.75455
  }
 }
 dps_results: {
  key: "TestBM-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 22933.18976
-  tps: 19350.46474
+  dps: 22937.61685
+  tps: 19354.89183
  }
 }
 dps_results: {
  key: "TestBM-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 23509.52708
-  tps: 19835.45803
+  dps: 23515.99491
+  tps: 19841.92585
  }
 }
 dps_results: {
  key: "TestBM-AllItems-WyrmstalkerBattlegear"
  value: {
-  dps: 22604.90031
-  tps: 19097.24913
+  dps: 22608.14509
+  tps: 19100.49391
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 21053.46272
-  tps: 17757.55063
+  dps: 21063.02799
+  tps: 17767.1159
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 21053.46272
-  tps: 17757.55063
+  dps: 21063.02799
+  tps: 17767.1159
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 20788.59978
-  tps: 17436.3372
+  dps: 20796.44394
+  tps: 17444.18136
  }
 }
 dps_results: {
  key: "TestBM-Average-Default"
  value: {
-  dps: 22208.80392
-  tps: 18757.49046
+  dps: 22214.13656
+  tps: 18762.8231
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm-FullBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 22006.79924
-  tps: 18707.7215
+  dps: 22011.02354
+  tps: 18711.9458
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm-FullBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 22006.79924
-  tps: 18707.7215
+  dps: 22011.02354
+  tps: 18711.9458
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 26846.64664
-  tps: 22653.16134
+  dps: 26856.81593
+  tps: 22663.33063
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm-NoBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 15170.23417
-  tps: 12966.6438
+  dps: 15169.06191
+  tps: 12965.47154
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm-NoBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 15170.23417
-  tps: 12966.6438
+  dps: 15169.06191
+  tps: 12965.47154
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm-NoBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 16640.44719
-  tps: 14173.57228
+  dps: 16643.22664
+  tps: 14176.35173
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm_advanced-FullBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 22006.79924
-  tps: 18707.7215
+  dps: 22011.02354
+  tps: 18711.9458
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm_advanced-FullBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 22006.79924
-  tps: 18707.7215
+  dps: 22011.02354
+  tps: 18711.9458
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm_advanced-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 26846.64664
-  tps: 22653.16134
+  dps: 26856.81593
+  tps: 22663.33063
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm_advanced-NoBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 15170.23417
-  tps: 12966.6438
+  dps: 15169.06191
+  tps: 12965.47154
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm_advanced-NoBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 15170.23417
-  tps: 12966.6438
+  dps: 15169.06191
+  tps: 12965.47154
  }
 }
 dps_results: {
  key: "TestBM-Settings-Dwarf-preraid_bm-Basic-bm_advanced-NoBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 16640.44719
-  tps: 14173.57228
+  dps: 16643.22664
+  tps: 14176.35173
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm-FullBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 22279.4006
-  tps: 18781.13274
+  dps: 22285.33063
+  tps: 18787.06277
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm-FullBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 22279.4006
-  tps: 18781.13274
+  dps: 22285.33063
+  tps: 18787.06277
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 27376.33649
-  tps: 22894.29174
+  dps: 27390.06376
+  tps: 22908.01901
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm-NoBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 15380.9973
-  tps: 13046.34169
+  dps: 15381.38194
+  tps: 13046.72633
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm-NoBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 15380.9973
-  tps: 13046.34169
+  dps: 15381.38194
+  tps: 13046.72633
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm-NoBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 17030.48078
-  tps: 14387.51886
+  dps: 17036.5005
+  tps: 14393.53858
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm_advanced-FullBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 22279.4006
-  tps: 18781.13274
+  dps: 22285.33063
+  tps: 18787.06277
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm_advanced-FullBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 22279.4006
-  tps: 18781.13274
+  dps: 22285.33063
+  tps: 18787.06277
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm_advanced-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 27376.33649
-  tps: 22894.29174
+  dps: 27390.06376
+  tps: 22908.01901
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm_advanced-NoBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 15380.9973
-  tps: 13046.34169
+  dps: 15381.38194
+  tps: 13046.72633
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm_advanced-NoBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 15380.9973
-  tps: 13046.34169
+  dps: 15381.38194
+  tps: 13046.72633
  }
 }
 dps_results: {
  key: "TestBM-Settings-Orc-preraid_bm-Basic-bm_advanced-NoBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 17030.48078
-  tps: 14387.51886
+  dps: 17036.5005
+  tps: 14393.53858
  }
 }
 dps_results: {
  key: "TestBM-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 21954.76632
-  tps: 18517.64202
+  dps: 21960.69635
+  tps: 18523.57205
  }
 }

--- a/sim/hunter/cata_items.go
+++ b/sim/hunter/cata_items.go
@@ -73,16 +73,20 @@ var ItemSetFlameWakersBattleGear = core.NewItemSet(core.ItemSet{
 				OnGain: func(aura *core.Aura, sim *core.Simulation) {
 					baMod.Activate()
 				},
-				OnCastComplete: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell) {
-					if spell.ClassSpellMask&^HunterSpellsTierTwelve != 0 || spell.ActionID.SpellID == 0 {
+				OnApplyEffects: func(aura *core.Aura, sim *core.Simulation, _ *core.Unit, spell *core.Spell) {
+					if spell.ClassSpellMask&HunterSpellsTierTwelve == 0 || spell.ActionID.SpellID == 0 {
 						return
 					}
-					if hunter.HasActiveAura("Lock and Load Proc") && (spell.ClassSpellMask == HunterSpellExplosiveShot || spell.ClassSpellMask == HunterSpellArcaneShot) {
+
+					// Arcane Shot is free if Lock and Load is up
+					if hunter.HasActiveAura("Lock and Load Proc") && (spell.ClassSpellMask == HunterSpellArcaneShot || spell.ClassSpellMask == HunterSpellExplosiveShot) {
 						return
 					}
+
 					if hunter.HasActiveAura("Ready, Set, Aim...") && spell.ClassSpellMask == HunterSpellAimedShot {
 						return
 					}
+
 					baMod.Deactivate()
 					aura.Deactivate(sim)
 				},

--- a/sim/hunter/marksmanship/TestMM.results
+++ b/sim/hunter/marksmanship/TestMM.results
@@ -641,8 +641,8 @@ dps_results: {
 dps_results: {
  key: "TestMM-AllItems-Flamewaker'sBattlegear"
  value: {
-  dps: 23392.8437
-  tps: 21026.16747
+  dps: 23386.63986
+  tps: 21027.98042
  }
 }
 dps_results: {

--- a/sim/hunter/marksmanship/TestMM.results
+++ b/sim/hunter/marksmanship/TestMM.results
@@ -38,2246 +38,2246 @@ character_stats_results: {
 dps_results: {
  key: "TestMM-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 22594.33236
-  tps: 20258.79679
+  dps: 22594.34381
+  tps: 20258.80824
  }
 }
 dps_results: {
  key: "TestMM-AllItems-AgonyandTorment"
  value: {
-  dps: 22194.33466
-  tps: 19912.47535
+  dps: 22193.8521
+  tps: 19911.9928
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
-  dps: 19276.38546
-  tps: 17311.10381
+  dps: 19278.71476
+  tps: 17313.4331
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 22256.45262
-  tps: 19994.74841
+  dps: 22261.74739
+  tps: 20000.04318
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 21427.17584
-  tps: 19216.21721
+  dps: 21426.37752
+  tps: 19215.41888
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 21427.17584
-  tps: 19216.21721
+  dps: 21426.37752
+  tps: 19215.41888
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ArrowofTime-72897"
  value: {
-  dps: 22896.24477
-  tps: 20560.59726
+  dps: 22896.34132
+  tps: 20560.6938
  }
 }
 dps_results: {
  key: "TestMM-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 22095.75077
-  tps: 19777.83661
+  dps: 22095.78704
+  tps: 19777.87289
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 21171.6838
-  tps: 18990.10515
+  dps: 21171.26616
+  tps: 18989.68751
   hps: 94.98927
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 21730.64923
-  tps: 19520.51372
+  dps: 21730.28764
+  tps: 19520.15214
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 21785.24107
-  tps: 19572.53546
+  dps: 21784.90313
+  tps: 19572.19753
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BindingPromise-67037"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BlackBruise-50692"
  value: {
-  dps: 20888.1554
-  tps: 18693.86386
+  dps: 20888.1108
+  tps: 18693.81925
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 21772.97835
-  tps: 19527.98643
+  dps: 21779.29556
+  tps: 19534.30365
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 21378.04103
-  tps: 19195.33647
+  dps: 21377.71681
+  tps: 19195.01226
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 21395.65446
-  tps: 19223.84444
+  dps: 21395.51918
+  tps: 19223.70916
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 22021.33251
-  tps: 19748.09308
+  dps: 22022.95758
+  tps: 19749.71815
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 21299.82397
-  tps: 19118.61017
+  dps: 21299.40633
+  tps: 19118.19253
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 21524.78106
-  tps: 19317.21151
+  dps: 21524.41382
+  tps: 19316.84428
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 22025.86598
-  tps: 19753.13263
+  dps: 22025.00061
+  tps: 19752.26726
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 21189.73763
-  tps: 19008.52382
+  dps: 21189.31999
+  tps: 19008.10618
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 21732.13705
-  tps: 19555.79285
+  dps: 21731.42446
+  tps: 19555.08027
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 21711.53265
-  tps: 19536.66067
+  dps: 21710.80776
+  tps: 19535.93577
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 21986.84741
-  tps: 19820.44848
+  dps: 21986.12701
+  tps: 19819.72808
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BottledLightning-66879"
  value: {
-  dps: 21259.93946
-  tps: 19070.49279
+  dps: 21259.51753
+  tps: 19070.07086
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BottledWishes-77114"
  value: {
-  dps: 21697.78138
-  tps: 19468.20931
+  dps: 21699.52046
+  tps: 19469.94838
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 22095.75077
-  tps: 19382.27988
+  dps: 22095.78704
+  tps: 19382.31543
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 22594.33236
-  tps: 20258.79679
+  dps: 22594.34381
+  tps: 20258.80824
  }
 }
 dps_results: {
  key: "TestMM-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 22432.89999
-  tps: 20114.98583
+  dps: 22432.92411
+  tps: 20115.00996
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CataclysmicGladiator'sBadgeofConquest-73648"
  value: {
-  dps: 22450.18801
-  tps: 20139.14553
+  dps: 22455.01513
+  tps: 20143.97266
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CataclysmicGladiator'sBadgeofDominance-73498"
  value: {
-  dps: 21375.74777
-  tps: 19194.53397
+  dps: 21375.33013
+  tps: 19194.11633
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CataclysmicGladiator'sBadgeofVictory-73496"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CataclysmicGladiator'sInsigniaofConquest-73643"
  value: {
-  dps: 22618.13017
-  tps: 20271.61126
+  dps: 22617.55987
+  tps: 20271.04096
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CataclysmicGladiator'sInsigniaofDominance-73497"
  value: {
-  dps: 21427.7862
-  tps: 19246.57239
+  dps: 21427.36856
+  tps: 19246.15475
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CataclysmicGladiator'sInsigniaofVictory-73491"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 22514.0582
-  tps: 20190.04521
+  dps: 22514.07171
+  tps: 20190.05872
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 22037.18575
-  tps: 19768.15632
+  dps: 22034.49011
+  tps: 19765.46068
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 21784.30625
-  tps: 19536.42896
+  dps: 21783.65231
+  tps: 19535.77502
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 21772.85241
-  tps: 19529.11797
+  dps: 21772.16363
+  tps: 19528.42919
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 21865.91783
-  tps: 19612.2299
+  dps: 21865.45352
+  tps: 19611.76559
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CrushingWeight-59506"
  value: {
-  dps: 21203.94544
-  tps: 19018.01774
+  dps: 21203.82349
+  tps: 19017.89579
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CrushingWeight-65118"
  value: {
-  dps: 21180.66121
-  tps: 18996.93008
+  dps: 21180.29079
+  tps: 18996.55966
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 21515.69471
-  tps: 19334.0763
+  dps: 21515.27707
+  tps: 19333.65866
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 21464.86103
-  tps: 19283.38995
+  dps: 21464.44339
+  tps: 19282.97231
  }
 }
 dps_results: {
  key: "TestMM-AllItems-CunningoftheCruel-78000"
  value: {
-  dps: 21559.27865
-  tps: 19377.85708
+  dps: 21558.86101
+  tps: 19377.43944
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 21485.5652
-  tps: 19308.79763
+  dps: 21484.80411
+  tps: 19308.03654
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 22369.92977
-  tps: 20096.42217
+  dps: 22369.35226
+  tps: 20095.84466
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 21459.0411
-  tps: 19283.10686
+  dps: 21459.18073
+  tps: 19283.2465
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 21802.26715
-  tps: 19558.04679
+  dps: 21802.43984
+  tps: 19558.21948
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 22173.35436
-  tps: 19849.34137
+  dps: 22173.38085
+  tps: 19849.36786
  }
 }
 dps_results: {
  key: "TestMM-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 21152.38508
-  tps: 18964.63436
+  dps: 21153.75313
+  tps: 18966.00242
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Dragonwrath,Tarecgosa'sRest-71086"
  value: {
-  dps: 24109.58928
-  tps: 21746.53515
+  dps: 24109.62565
+  tps: 21746.57152
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 21625.90724
-  tps: 19408.48089
+  dps: 21625.34575
+  tps: 19407.91941
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 22095.75077
-  tps: 19777.83661
+  dps: 22095.78704
+  tps: 19777.87289
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 22095.75077
-  tps: 19777.83661
+  dps: 22095.78704
+  tps: 19777.87289
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 22173.35436
-  tps: 19849.34137
+  dps: 22173.38085
+  tps: 19849.36786
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 22489.86001
-  tps: 20170.32744
+  dps: 22489.34059
+  tps: 20169.80802
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 22600.94176
-  tps: 20268.867
+  dps: 22600.51914
+  tps: 20268.44438
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 21410.42468
-  tps: 19237.25042
+  dps: 21410.38413
+  tps: 19237.20987
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 22095.75077
-  tps: 19777.83661
+  dps: 22095.78704
+  tps: 19777.87289
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FallofMortality-59500"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FallofMortality-65124"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 21134.40045
-  tps: 18964.7565
+  dps: 21135.93129
+  tps: 18966.28734
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 22251.82164
-  tps: 19962.12761
+  dps: 22253.78085
+  tps: 19964.08681
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 21291.80088
-  tps: 19110.58708
+  dps: 21291.38324
+  tps: 19110.16944
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 21395.65446
-  tps: 19223.84444
+  dps: 21395.51918
+  tps: 19223.70916
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 21506.63794
-  tps: 19325.47137
+  dps: 21507.33508
+  tps: 19326.16851
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Flamewaker'sBattlegear"
  value: {
-  dps: 23386.63986
-  tps: 21027.98042
+  dps: 23387.09468
+  tps: 21028.43523
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 22215.34354
-  tps: 19884.55556
+  dps: 22215.52365
+  tps: 19884.73568
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FluidDeath-58181"
  value: {
-  dps: 22468.65589
-  tps: 20145.0954
+  dps: 22467.97235
+  tps: 20144.41186
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 22095.75077
-  tps: 19777.83661
+  dps: 22095.78704
+  tps: 19777.87289
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 21577.41234
-  tps: 19373.77599
+  dps: 21576.61494
+  tps: 19372.97859
  }
 }
 dps_results: {
  key: "TestMM-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 21555.77158
-  tps: 19345.63608
+  dps: 21555.40999
+  tps: 19345.27449
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GaleofShadows-56138"
  value: {
-  dps: 21347.2102
-  tps: 19127.99738
+  dps: 21349.41801
+  tps: 19130.2052
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GaleofShadows-56462"
  value: {
-  dps: 21394.6996
-  tps: 19192.00336
+  dps: 21395.85817
+  tps: 19193.16193
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GearDetector-61462"
  value: {
-  dps: 22012.3203
-  tps: 19759.90192
+  dps: 22013.88273
+  tps: 19761.46435
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 19888.12941
-  tps: 17816.61023
+  dps: 19890.00573
+  tps: 17818.48656
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 21821.99472
-  tps: 19570.83273
+  dps: 21821.58978
+  tps: 19570.42779
  }
 }
 dps_results: {
  key: "TestMM-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 22124.42735
-  tps: 19843.1685
+  dps: 22124.01606
+  tps: 19842.75721
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Gurthalak,VoiceoftheDeeps-77191"
  value: {
-  dps: 22594.33236
-  tps: 20258.79679
+  dps: 22594.34381
+  tps: 20258.80824
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Gurthalak,VoiceoftheDeeps-78478"
  value: {
-  dps: 22594.33236
-  tps: 20258.79679
+  dps: 22594.34381
+  tps: 20258.80824
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Gurthalak,VoiceoftheDeeps-78487"
  value: {
-  dps: 22594.33236
-  tps: 20258.79679
+  dps: 22594.34381
+  tps: 20258.80824
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HarmlightToken-63839"
  value: {
-  dps: 21177.49948
-  tps: 18996.24697
+  dps: 21177.08184
+  tps: 18995.82933
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 21172.84998
-  tps: 18991.63618
+  dps: 21172.43234
+  tps: 18991.21854
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 21173.03122
-  tps: 18991.81741
+  dps: 21172.61357
+  tps: 18991.39977
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofRage-59224"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofRage-65072"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofSolace-55868"
  value: {
-  dps: 21342.74092
-  tps: 19123.5281
+  dps: 21344.94873
+  tps: 19125.73591
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofSolace-56393"
  value: {
-  dps: 21389.69207
-  tps: 19186.99583
+  dps: 21390.85064
+  tps: 19188.15441
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofThunder-55845"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartofThunder-56370"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 21905.80325
-  tps: 19641.28057
+  dps: 21905.3617
+  tps: 19640.83902
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Heartpierce-50641"
  value: {
-  dps: 22743.79719
-  tps: 20393.23326
+  dps: 22743.86652
+  tps: 20393.30258
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 22173.35436
-  tps: 19849.34137
+  dps: 22173.38085
+  tps: 19849.36786
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 21454.5
-  tps: 19278.75933
+  dps: 21454.63964
+  tps: 19278.89896
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 21454.5
-  tps: 19278.75933
+  dps: 21454.63964
+  tps: 19278.89896
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 21378.04103
-  tps: 19195.33647
+  dps: 21377.71681
+  tps: 19195.01226
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 21395.65446
-  tps: 19223.84444
+  dps: 21395.51918
+  tps: 19223.70916
  }
 }
 dps_results: {
  key: "TestMM-AllItems-IndomitablePride-77211"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-IndomitablePride-77983"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-IndomitablePride-78003"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 21949.96591
-  tps: 19685.06125
+  dps: 21950.1578
+  tps: 19685.25314
  }
 }
 dps_results: {
  key: "TestMM-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 21823.11261
-  tps: 19556.77983
+  dps: 21822.67517
+  tps: 19556.34239
  }
 }
 dps_results: {
  key: "TestMM-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 22067.37253
-  tps: 19785.74083
+  dps: 22066.57765
+  tps: 19784.94595
  }
 }
 dps_results: {
  key: "TestMM-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 21364.62107
-  tps: 19162.46501
+  dps: 21367.00861
+  tps: 19164.85254
  }
 }
 dps_results: {
  key: "TestMM-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 21772.97835
-  tps: 19527.98643
+  dps: 21779.29556
+  tps: 19534.30365
  }
 }
 dps_results: {
  key: "TestMM-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 22194.36679
-  tps: 19900.64405
+  dps: 22193.30164
+  tps: 19899.5789
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Kiril,FuryofBeasts-77194"
  value: {
-  dps: 24881.00903
-  tps: 22294.17538
+  dps: 24880.84406
+  tps: 22294.01042
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Kiril,FuryofBeasts-78473"
  value: {
-  dps: 25209.63438
-  tps: 22585.37911
+  dps: 25208.92533
+  tps: 22584.67006
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Kiril,FuryofBeasts-78482"
  value: {
-  dps: 24664.60115
-  tps: 22103.07381
+  dps: 24664.52471
+  tps: 22102.99738
  }
 }
 dps_results: {
  key: "TestMM-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 22675.77358
-  tps: 20332.14838
+  dps: 22681.65724
+  tps: 20338.03205
  }
 }
 dps_results: {
  key: "TestMM-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 21158.77411
-  tps: 18966.95375
+  dps: 21160.14318
+  tps: 18968.32282
  }
 }
 dps_results: {
  key: "TestMM-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 21158.77411
-  tps: 18966.95375
+  dps: 21160.14318
+  tps: 18968.32282
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 21202.52055
-  tps: 19018.64421
+  dps: 21202.17913
+  tps: 19018.30278
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LastWord-50708"
  value: {
-  dps: 22594.33236
-  tps: 20258.79679
+  dps: 22594.34381
+  tps: 20258.80824
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LeadenDespair-55816"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LeadenDespair-56347"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 22074.41434
-  tps: 19798.44845
+  dps: 22073.59636
+  tps: 19797.63047
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 22185.16145
-  tps: 19896.42818
+  dps: 22183.33307
+  tps: 19894.5998
  }
 }
 dps_results: {
  key: "TestMM-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 21427.17584
-  tps: 19216.21721
+  dps: 21426.37752
+  tps: 19215.41888
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Lightning-ChargedBattlegear"
  value: {
-  dps: 21859.65266
-  tps: 19671.87021
+  dps: 21861.65968
+  tps: 19673.87723
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 21131.13372
-  tps: 18951.92822
+  dps: 21132.70368
+  tps: 18953.49819
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 21131.13372
-  tps: 18951.92822
+  dps: 21132.70368
+  tps: 18953.49819
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 21203.95929
-  tps: 19015.06107
+  dps: 21206.01276
+  tps: 19017.11454
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 21394.11044
-  tps: 19216.5363
+  dps: 21396.07608
+  tps: 19218.50193
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 22834.94016
-  tps: 20480.97773
+  dps: 22834.52065
+  tps: 20480.55821
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 23009.25543
-  tps: 20635.66304
+  dps: 23008.9042
+  tps: 20635.31181
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 21481.75645
-  tps: 19272.8005
+  dps: 21483.61738
+  tps: 19274.66143
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 21481.75645
-  tps: 19272.8005
+  dps: 21483.61738
+  tps: 19274.66143
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 21454.5
-  tps: 19278.75933
+  dps: 21454.63964
+  tps: 19278.89896
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 21454.5
-  tps: 19278.75933
+  dps: 21454.63964
+  tps: 19278.89896
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 21539.37127
-  tps: 19331.80172
+  dps: 21539.00403
+  tps: 19331.43448
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 21318.1947
-  tps: 19127.47195
+  dps: 21317.40053
+  tps: 19126.67778
  }
 }
 dps_results: {
  key: "TestMM-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 21121.33851
-  tps: 18962.99069
+  dps: 21121.16479
+  tps: 18962.81696
  }
 }
 dps_results: {
  key: "TestMM-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 21133.09557
-  tps: 18964.80642
+  dps: 21133.26386
+  tps: 18964.97472
  }
 }
 dps_results: {
  key: "TestMM-AllItems-No'Kaled,theElementsofDeath-77188"
  value: {
-  dps: 23237.48924
-  tps: 20834.28599
+  dps: 23237.6594
+  tps: 20834.45615
  }
 }
 dps_results: {
  key: "TestMM-AllItems-No'Kaled,theElementsofDeath-78472"
  value: {
-  dps: 23320.26141
-  tps: 20907.99536
+  dps: 23320.43101
+  tps: 20908.16497
  }
 }
 dps_results: {
  key: "TestMM-AllItems-No'Kaled,theElementsofDeath-78481"
  value: {
-  dps: 23172.18518
-  tps: 20776.44701
+  dps: 23172.29852
+  tps: 20776.56035
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 21338.0816
-  tps: 19143.51839
+  dps: 21337.71074
+  tps: 19143.14752
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 21405.17712
-  tps: 19208.96863
+  dps: 21404.81721
+  tps: 19208.60872
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 22095.75077
-  tps: 19777.83661
+  dps: 22095.78704
+  tps: 19777.87289
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 22697.68528
-  tps: 20366.58119
+  dps: 22697.43233
+  tps: 20366.32823
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 22560.65787
-  tps: 20203.51605
+  dps: 22560.78922
+  tps: 20203.64741
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Rainsong-55854"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Rainsong-56377"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Rathrak,thePoisonousMind-77195"
  value: {
-  dps: 22089.38824
-  tps: 19902.95992
+  dps: 22089.34219
+  tps: 19902.91387
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Rathrak,thePoisonousMind-78475"
  value: {
-  dps: 22260.79643
-  tps: 20074.36812
+  dps: 22260.75038
+  tps: 20074.32207
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Rathrak,thePoisonousMind-78484"
  value: {
-  dps: 21947.44868
-  tps: 19761.02037
+  dps: 21947.40263
+  tps: 19760.97432
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 21302.70444
-  tps: 19123.49895
+  dps: 21304.27441
+  tps: 19125.06892
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 22432.89999
-  tps: 20114.98583
+  dps: 22432.92411
+  tps: 20115.00996
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 22432.89999
-  tps: 20114.98583
+  dps: 22432.92411
+  tps: 20115.00996
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 22450.75747
-  tps: 20142.60921
+  dps: 22450.51835
+  tps: 20142.37008
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 21427.17584
-  tps: 19216.21721
+  dps: 21426.37752
+  tps: 19215.41888
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 21427.17584
-  tps: 19216.21721
+  dps: 21426.37752
+  tps: 19215.41888
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RosaryofLight-72901"
  value: {
-  dps: 21722.1854
-  tps: 19503.63704
+  dps: 21721.7576
+  tps: 19503.20924
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RottingSkull-77116"
  value: {
-  dps: 21658.59547
-  tps: 19433.51243
+  dps: 21660.13055
+  tps: 19435.04751
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RuneofZeth-68998"
  value: {
-  dps: 21623.66896
-  tps: 19408.02218
+  dps: 21623.3145
+  tps: 19407.66773
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RuthlessGladiator'sBadgeofConquest-70399"
  value: {
-  dps: 22226.58304
-  tps: 19937.8503
+  dps: 22230.62361
+  tps: 19941.89087
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RuthlessGladiator'sBadgeofConquest-72304"
  value: {
-  dps: 22290.72786
-  tps: 19995.82346
+  dps: 22295.01515
+  tps: 20000.11075
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RuthlessGladiator'sBadgeofDominance-70401"
  value: {
-  dps: 21342.81086
-  tps: 19161.59706
+  dps: 21342.39322
+  tps: 19161.17942
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RuthlessGladiator'sBadgeofDominance-72448"
  value: {
-  dps: 21352.52303
-  tps: 19171.30922
+  dps: 21352.10539
+  tps: 19170.89158
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RuthlessGladiator'sBadgeofVictory-70400"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RuthlessGladiator'sBadgeofVictory-72450"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RuthlessGladiator'sInsigniaofConquest-70404"
  value: {
-  dps: 22446.92866
-  tps: 20124.44877
+  dps: 22442.21641
+  tps: 20119.73652
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RuthlessGladiator'sInsigniaofConquest-72309"
  value: {
-  dps: 22453.41324
-  tps: 20127.05014
+  dps: 22450.84098
+  tps: 20124.47787
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RuthlessGladiator'sInsigniaofDominance-70402"
  value: {
-  dps: 21380.54907
-  tps: 19199.33526
+  dps: 21380.13143
+  tps: 19198.91762
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RuthlessGladiator'sInsigniaofDominance-72449"
  value: {
-  dps: 21391.77359
-  tps: 19210.55979
+  dps: 21391.35595
+  tps: 19210.14215
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RuthlessGladiator'sInsigniaofVictory-70403"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-RuthlessGladiator'sInsigniaofVictory-72455"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ScalesofLife-68915"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
   hps: 312.86699
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ScalesofLife-69109"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
   hps: 352.91104
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 21794.04178
-  tps: 19543.57555
+  dps: 21793.62147
+  tps: 19543.15524
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SeaStar-55256"
  value: {
-  dps: 21236.0615
-  tps: 19054.8477
+  dps: 21235.64386
+  tps: 19054.43006
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SeaStar-56290"
  value: {
-  dps: 21291.80088
-  tps: 19110.58708
+  dps: 21291.38324
+  tps: 19110.16944
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Shadowmourne-49623"
  value: {
-  dps: 22750.57609
-  tps: 20403.8488
+  dps: 22750.46159
+  tps: 20403.73429
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ShardofWoe-60233"
  value: {
-  dps: 21613.26058
-  tps: 19405.06409
+  dps: 21614.7382
+  tps: 19406.54171
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 21944.74839
-  tps: 19693.00992
+  dps: 21944.84871
+  tps: 19693.11024
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 22137.7802
-  tps: 19872.39784
+  dps: 22137.6894
+  tps: 19872.30705
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Sorrowsong-55879"
  value: {
-  dps: 21378.04103
-  tps: 19195.33647
+  dps: 21377.71681
+  tps: 19195.01226
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Sorrowsong-56400"
  value: {
-  dps: 21395.65446
-  tps: 19223.84444
+  dps: 21395.51918
+  tps: 19223.70916
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 21481.75645
-  tps: 19272.8005
+  dps: 21483.61738
+  tps: 19274.66143
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SoulCasket-58183"
  value: {
-  dps: 21638.99091
-  tps: 19463.25024
+  dps: 21639.13055
+  tps: 19463.38987
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Souldrinker-77193"
  value: {
-  dps: 22596.47171
-  tps: 20260.93613
+  dps: 22596.48316
+  tps: 20260.94758
   hps: 4.27869
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Souldrinker-78479"
  value: {
-  dps: 22596.76886
-  tps: 20261.23329
+  dps: 22596.78032
+  tps: 20261.24474
   hps: 4.873
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Souldrinker-78488"
  value: {
-  dps: 22596.17822
-  tps: 20260.64265
+  dps: 22596.18967
+  tps: 20260.6541
   hps: 3.69172
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 21780.9889
-  tps: 19589.76584
+  dps: 21781.29888
+  tps: 19590.07582
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 21850.65967
-  tps: 19655.39337
+  dps: 21850.21607
+  tps: 19654.94977
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 21882.68486
-  tps: 19689.29821
+  dps: 21882.21049
+  tps: 19688.82384
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 21410.42468
-  tps: 19237.25042
+  dps: 21410.38413
+  tps: 19237.20987
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 21497.73214
-  tps: 19319.86307
+  dps: 21498.22606
+  tps: 19320.35699
  }
 }
 dps_results: {
  key: "TestMM-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 23163.16895
-  tps: 20764.65777
+  dps: 23164.55054
+  tps: 20766.03936
  }
 }
 dps_results: {
  key: "TestMM-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 22940.46919
-  tps: 20565.34205
+  dps: 22940.26252
+  tps: 20565.13538
  }
 }
 dps_results: {
  key: "TestMM-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 23535.99318
-  tps: 21095.38383
+  dps: 23536.86096
+  tps: 21096.25161
  }
 }
 dps_results: {
  key: "TestMM-AllItems-StayofExecution-68996"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 21198.45432
-  tps: 19016.8744
+  dps: 21198.03668
+  tps: 19016.45676
  }
 }
 dps_results: {
  key: "TestMM-AllItems-StumpofTime-62465"
  value: {
-  dps: 21443.5352
-  tps: 19232.57656
+  dps: 21442.73687
+  tps: 19231.77824
  }
 }
 dps_results: {
  key: "TestMM-AllItems-StumpofTime-62470"
  value: {
-  dps: 21453.36144
-  tps: 19242.40281
+  dps: 21452.56312
+  tps: 19241.60449
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 21170.14748
-  tps: 18998.72736
+  dps: 21169.77511
+  tps: 18998.35499
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TearofBlood-55819"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TearofBlood-56351"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 21306.5192
-  tps: 19115.15558
+  dps: 21306.66517
+  tps: 19115.30154
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 21401.23498
-  tps: 19229.42496
+  dps: 21401.09971
+  tps: 19229.28968
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TheHungerer-68927"
  value: {
-  dps: 22796.12214
-  tps: 20473.56261
+  dps: 22797.23434
+  tps: 20474.67481
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TheHungerer-69112"
  value: {
-  dps: 22979.25554
-  tps: 20619.55013
+  dps: 22978.09957
+  tps: 20618.39416
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 21193.33523
-  tps: 19012.26131
+  dps: 21193.36552
+  tps: 19012.29159
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Ti'tahk,theStepsofTime-77190"
  value: {
-  dps: 23878.99337
-  tps: 21532.53268
+  dps: 23878.44184
+  tps: 21531.98114
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Ti'tahk,theStepsofTime-78477"
  value: {
-  dps: 24113.87442
-  tps: 21772.82828
+  dps: 24114.75223
+  tps: 21773.7061
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Ti'tahk,theStepsofTime-78486"
  value: {
-  dps: 23767.89758
-  tps: 21431.32747
+  dps: 23768.00002
+  tps: 21431.4299
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 22184.08053
-  tps: 19913.26173
+  dps: 22183.80167
+  tps: 19912.98287
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 22290.53851
-  tps: 20022.39566
+  dps: 22290.49367
+  tps: 20022.35082
  }
 }
 dps_results: {
  key: "TestMM-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 21182.78651
-  tps: 18990.11268
+  dps: 21182.61861
+  tps: 18989.94477
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 20595.9467
-  tps: 18481.53536
+  dps: 20596.46456
+  tps: 18482.05321
  }
 }
 dps_results: {
  key: "TestMM-AllItems-UnheededWarning-59520"
  value: {
-  dps: 22070.54149
-  tps: 19794.03653
+  dps: 22070.20091
+  tps: 19793.69596
  }
 }
 dps_results: {
  key: "TestMM-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 22306.95525
-  tps: 20045.26534
+  dps: 22309.92938
+  tps: 20048.23946
  }
 }
 dps_results: {
  key: "TestMM-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 22306.95525
-  tps: 20045.26534
+  dps: 22309.92938
+  tps: 20048.23946
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 21333.48053
-  tps: 19156.38634
+  dps: 21335.49209
+  tps: 19158.3979
  }
 }
 dps_results: {
  key: "TestMM-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 21471.79033
-  tps: 19290.64456
+  dps: 21471.37269
+  tps: 19290.22692
  }
 }
 dps_results: {
  key: "TestMM-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 21502.35776
-  tps: 19320.85396
+  dps: 21501.94012
+  tps: 19320.43632
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 21574.52712
-  tps: 19375.60858
+  dps: 21573.71233
+  tps: 19374.79379
  }
 }
 dps_results: {
  key: "TestMM-AllItems-VeilofLies-72900"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-VialofShadows-77207"
  value: {
-  dps: 23029.87118
-  tps: 20714.02471
+  dps: 23029.14891
+  tps: 20713.30244
  }
 }
 dps_results: {
  key: "TestMM-AllItems-VialofShadows-77979"
  value: {
-  dps: 22699.52559
-  tps: 20402.36771
+  dps: 22698.41184
+  tps: 20401.25395
  }
 }
 dps_results: {
  key: "TestMM-AllItems-VialofShadows-77999"
  value: {
-  dps: 23095.39226
-  tps: 20758.198
+  dps: 23094.83381
+  tps: 20757.63955
  }
 }
 dps_results: {
  key: "TestMM-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 21999.95508
-  tps: 19734.12922
+  dps: 22003.01692
+  tps: 19737.19106
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sBadgeofConquest-70517"
  value: {
-  dps: 22100.11167
-  tps: 19823.39816
+  dps: 22103.66842
+  tps: 19826.9549
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 21307.00253
-  tps: 19125.78873
+  dps: 21306.58489
+  tps: 19125.37109
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sBadgeofDominance-70518"
  value: {
-  dps: 21322.96426
-  tps: 19141.75046
+  dps: 21322.54662
+  tps: 19141.33282
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sBadgeofVictory-70519"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 21427.17584
-  tps: 19216.21721
+  dps: 21426.37752
+  tps: 19215.41888
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 21380.12213
-  tps: 19176.22861
+  dps: 21380.49847
+  tps: 19176.60495
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 21580.4996
-  tps: 19369.39898
+  dps: 21580.14162
+  tps: 19369.041
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 21340.24289
-  tps: 19154.33996
+  dps: 21340.45888
+  tps: 19154.55595
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 22141.39503
-  tps: 19850.97043
+  dps: 22139.64154
+  tps: 19849.21694
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sInsigniaofConquest-70577"
  value: {
-  dps: 22284.97384
-  tps: 19980.87464
+  dps: 22282.45014
+  tps: 19978.35094
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 21337.8952
-  tps: 19156.68139
+  dps: 21337.47755
+  tps: 19156.26375
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sInsigniaofDominance-70578"
  value: {
-  dps: 21354.3623
-  tps: 19173.14849
+  dps: 21353.94465
+  tps: 19172.73085
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-ViciousGladiator'sInsigniaofVictory-70579"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Vishanka,JawsoftheEarth-78359"
  value: {
-  dps: 25704.00865
-  tps: 23387.63202
+  dps: 25703.21582
+  tps: 23386.83919
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Vishanka,JawsoftheEarth-78471"
  value: {
-  dps: 26694.05974
-  tps: 24365.92137
+  dps: 26693.17743
+  tps: 24365.03906
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Vishanka,JawsoftheEarth-78480"
  value: {
-  dps: 24846.89146
-  tps: 22533.99302
+  dps: 24845.93572
+  tps: 22533.03728
  }
 }
 dps_results: {
  key: "TestMM-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-WillofUnbinding-77995"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 21171.45449
-  tps: 18990.24068
+  dps: 21171.03685
+  tps: 18989.82304
  }
 }
 dps_results: {
  key: "TestMM-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 21271.26085
-  tps: 19079.05574
+  dps: 21271.57128
+  tps: 19079.36617
  }
 }
 dps_results: {
  key: "TestMM-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 23539.55477
-  tps: 21098.55261
+  dps: 23539.11675
+  tps: 21098.1146
  }
 }
 dps_results: {
  key: "TestMM-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 23290.15113
-  tps: 20878.41696
+  dps: 23289.74993
+  tps: 20878.01576
  }
 }
 dps_results: {
  key: "TestMM-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 23826.35849
-  tps: 21355.57471
+  dps: 23825.9082
+  tps: 21355.12442
  }
 }
 dps_results: {
  key: "TestMM-AllItems-WyrmstalkerBattlegear"
  value: {
-  dps: 22643.2169
-  tps: 20336.62862
+  dps: 22644.83085
+  tps: 20338.24256
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 21200.83686
-  tps: 18989.71246
+  dps: 21203.11764
+  tps: 18991.99324
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 21200.83686
-  tps: 18989.71246
+  dps: 21203.11764
+  tps: 18991.99324
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 20826.01966
-  tps: 18548.60504
+  dps: 20824.7558
+  tps: 18547.34118
  }
 }
 dps_results: {
  key: "TestMM-Average-Default"
  value: {
-  dps: 22508.3096
-  tps: 20168.40753
+  dps: 22508.62214
+  tps: 20168.72006
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-FullBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 23747.19985
-  tps: 21563.33944
+  dps: 23746.8931
+  tps: 21563.03269
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-FullBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 22429.1987
-  tps: 20228.47273
+  dps: 22428.71202
+  tps: 20227.98606
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 28893.69572
-  tps: 26005.91889
+  dps: 28929.63511
+  tps: 26041.85827
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-NoBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 16192.31755
-  tps: 14608.0956
+  dps: 16192.6563
+  tps: 14608.43435
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-NoBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 15286.73368
-  tps: 13720.30856
+  dps: 15286.53106
+  tps: 13720.10595
  }
 }
 dps_results: {
  key: "TestMM-Settings-Dwarf-preraid_mm-Basic-mm-NoBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 17604.70799
-  tps: 15850.90628
+  dps: 17623.21597
+  tps: 15869.41426
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-FullBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 23999.47476
-  tps: 21682.23542
+  dps: 23999.57516
+  tps: 21682.33581
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-FullBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 22594.33236
-  tps: 20258.79679
+  dps: 22594.34381
+  tps: 20258.80824
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 29413.36829
-  tps: 26329.94735
+  dps: 29454.44504
+  tps: 26371.0241
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-NoBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 16389.68441
-  tps: 14706.58312
+  dps: 16389.24449
+  tps: 14706.14321
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-NoBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 15448.59606
-  tps: 13785.12867
+  dps: 15447.55178
+  tps: 13784.08439
  }
 }
 dps_results: {
  key: "TestMM-Settings-Orc-preraid_mm-Basic-mm-NoBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 17875.54118
-  tps: 15998.79674
+  dps: 17900.38114
+  tps: 16023.63671
  }
 }
 dps_results: {
  key: "TestMM-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 22290.73926
-  tps: 19988.27718
+  dps: 22290.75071
+  tps: 19988.28863
  }
 }

--- a/sim/hunter/serpent_sting.go
+++ b/sim/hunter/serpent_sting.go
@@ -76,9 +76,12 @@ func (hunter *Hunter) registerSerpentStingSpell() {
 
 			NumberOfTicks: 5,
 			TickLength:    time.Second * 3,
-			OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
+			OnSnapshot: func(sim *core.Simulation, target *core.Unit, dot *core.Dot, isRollover bool) {
 				baseDmg := 460 + 0.08*dot.Spell.RangedAttackPower(target)
-				dot.Spell.CalcAndDealPeriodicDamage(sim, target, baseDmg, dot.OutcomeTickPhysicalCrit)
+				dot.Snapshot(target, baseDmg)
+			},
+			OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
+				dot.CalcAndDealPeriodicSnapshotDamage(sim, target, dot.OutcomeTickPhysicalCrit)
 			},
 		},
 

--- a/sim/hunter/survival/TestSV.results
+++ b/sim/hunter/survival/TestSV.results
@@ -38,2330 +38,2330 @@ character_stats_results: {
 dps_results: {
  key: "TestSV-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 30004.63797
-  tps: 27230.09504
+  dps: 30012.17458
+  tps: 27237.63164
  }
 }
 dps_results: {
  key: "TestSV-AllItems-AgonyandTorment"
  value: {
-  dps: 28697.1928
-  tps: 26054.20686
+  dps: 28699.07779
+  tps: 26056.09185
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
-  dps: 24105.27286
-  tps: 21859.35611
+  dps: 24103.48146
+  tps: 21857.56471
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 28184.57757
-  tps: 25589.13393
+  dps: 28194.30935
+  tps: 25598.86572
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 28186.39854
-  tps: 25590.71544
+  dps: 28196.13033
+  tps: 25600.44722
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ArrowofTime-72897"
  value: {
-  dps: 30248.3606
-  tps: 27505.43965
+  dps: 30259.16286
+  tps: 27516.24191
  }
 }
 dps_results: {
  key: "TestSV-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 29211.63463
-  tps: 26458.74497
+  dps: 29219.16169
+  tps: 26466.27203
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 28168.29164
-  tps: 25574.9581
+  dps: 28178.06504
+  tps: 25584.7315
   hps: 96.72062
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 28558.32045
-  tps: 25930.25034
+  dps: 28567.96024
+  tps: 25939.89014
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 28609.47056
-  tps: 25977.77599
+  dps: 28619.29659
+  tps: 25987.60202
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BindingPromise-67037"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlackBruise-50692"
  value: {
-  dps: 27701.63202
-  tps: 25156.86406
+  dps: 27703.0269
+  tps: 25158.25894
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 29098.79823
-  tps: 26439.51883
+  dps: 29092.76714
+  tps: 26433.48774
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 28425.38854
-  tps: 25831.20986
+  dps: 28435.2822
+  tps: 25841.10352
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 28459.21382
-  tps: 25864.97503
+  dps: 28469.12323
+  tps: 25874.88444
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 29430.01978
-  tps: 26717.82404
+  dps: 29416.44827
+  tps: 26704.25253
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 28537.74191
-  tps: 25911.61094
+  dps: 28547.50025
+  tps: 25921.36928
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 29441.59103
-  tps: 26716.71368
+  dps: 29445.90174
+  tps: 26721.02439
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 29147.14727
-  tps: 26561.80831
+  dps: 29153.60393
+  tps: 26568.26497
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 29022.1259
-  tps: 26435.50915
+  dps: 29027.5165
+  tps: 26440.89975
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 29243.58511
-  tps: 26657.54479
+  dps: 29247.12561
+  tps: 26661.08529
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BottledLightning-66879"
  value: {
-  dps: 28276.90495
-  tps: 25674.58352
+  dps: 28287.09859
+  tps: 25684.77715
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BottledWishes-77114"
  value: {
-  dps: 28721.37979
-  tps: 26095.48705
+  dps: 28729.69796
+  tps: 26103.80521
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 29211.63463
-  tps: 25929.57007
+  dps: 29219.16169
+  tps: 25936.94658
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 30005.23573
-  tps: 27230.6072
+  dps: 30012.77233
+  tps: 27238.14381
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 29811.27744
-  tps: 27056.99107
+  dps: 29818.91135
+  tps: 27064.62497
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CataclysmicGladiator'sBadgeofConquest-73648"
  value: {
-  dps: 30039.96048
-  tps: 27275.46877
+  dps: 30062.13113
+  tps: 27297.63942
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CataclysmicGladiator'sBadgeofDominance-73498"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CataclysmicGladiator'sBadgeofVictory-73496"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CataclysmicGladiator'sInsigniaofConquest-73643"
  value: {
-  dps: 30168.01978
-  tps: 27370.65783
+  dps: 30179.07283
+  tps: 27381.71088
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CataclysmicGladiator'sInsigniaofDominance-73497"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CataclysmicGladiator'sInsigniaofVictory-73491"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 29869.91654
-  tps: 27110.05518
+  dps: 29877.50747
+  tps: 27117.64611
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 29111.64443
-  tps: 26426.46397
+  dps: 29122.75061
+  tps: 26437.57015
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 29007.13506
-  tps: 26332.79861
+  dps: 29013.14709
+  tps: 26338.81064
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 28947.339
-  tps: 26276.87892
+  dps: 28953.3071
+  tps: 26282.84702
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 29100.00472
-  tps: 26411.26965
+  dps: 29105.61176
+  tps: 26416.87669
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CrushingWeight-59506"
  value: {
-  dps: 28168.44196
-  tps: 25580.04096
+  dps: 28176.29456
+  tps: 25587.89356
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CrushingWeight-65118"
  value: {
-  dps: 28135.89504
-  tps: 25542.49881
+  dps: 28145.21956
+  tps: 25551.82334
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 28631.26411
-  tps: 26037.81787
+  dps: 28641.03751
+  tps: 26047.59127
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 28560.36554
-  tps: 25967.06432
+  dps: 28570.13894
+  tps: 25976.83772
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CunningoftheCruel-78000"
  value: {
-  dps: 28691.00103
-  tps: 26097.49431
+  dps: 28700.77443
+  tps: 26107.26771
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 28572.07766
-  tps: 25989.89523
+  dps: 28581.85106
+  tps: 25999.66863
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 29761.48216
-  tps: 27066.05302
+  dps: 29770.78195
+  tps: 27075.35281
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 28503.38562
-  tps: 25909.38897
+  dps: 28513.31222
+  tps: 25919.31556
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 28875.03637
-  tps: 26208.18871
+  dps: 28883.92886
+  tps: 26217.0812
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 29266.55314
-  tps: 26508.08848
+  dps: 29274.03533
+  tps: 26515.57067
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 28257.27619
-  tps: 25647.74505
+  dps: 28262.18843
+  tps: 25652.6573
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Dragonwrath,Tarecgosa'sRest-71086"
  value: {
-  dps: 30221.24934
-  tps: 27438.53007
+  dps: 30221.46347
+  tps: 27438.7442
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 28633.28799
-  tps: 25998.93928
+  dps: 28642.91454
+  tps: 26008.56582
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 29211.63463
-  tps: 26458.74497
+  dps: 29219.16169
+  tps: 26466.27203
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 29211.63463
-  tps: 26458.74497
+  dps: 29219.16169
+  tps: 26466.27203
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 29266.55314
-  tps: 26508.08848
+  dps: 29274.03533
+  tps: 26515.57067
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 29829.5938
-  tps: 27076.62848
+  dps: 29837.50302
+  tps: 27084.5377
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 28559.66465
-  tps: 25965.24734
+  dps: 28569.62083
+  tps: 25975.20352
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 29211.63463
-  tps: 26458.74497
+  dps: 29219.16169
+  tps: 26466.27203
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FallofMortality-59500"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FallofMortality-65124"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 28202.0655
-  tps: 25609.7469
+  dps: 28188.24585
+  tps: 25595.92725
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 29261.30444
-  tps: 26571.52208
+  dps: 29279.44363
+  tps: 26589.66126
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 28459.21382
-  tps: 25864.97503
+  dps: 28469.12323
+  tps: 25874.88444
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 28636.54028
-  tps: 26041.98635
+  dps: 28646.53225
+  tps: 26051.97832
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Flamewaker'sBattlegear"
  value: {
-  dps: 29215.8687
-  tps: 26475.73291
+  dps: 29211.80126
+  tps: 26471.66547
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 29268.90469
-  tps: 26515.91283
+  dps: 29276.4516
+  tps: 26523.45973
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FluidDeath-58181"
  value: {
-  dps: 29564.16219
-  tps: 26834.71985
+  dps: 29570.68821
+  tps: 26841.24587
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 29211.63463
-  tps: 26458.74497
+  dps: 29219.16169
+  tps: 26466.27203
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 28565.52905
-  tps: 25971.19496
+  dps: 28577.1098
+  tps: 25982.77571
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 28558.32045
-  tps: 25930.25034
+  dps: 28567.96024
+  tps: 25939.89014
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GaleofShadows-56138"
  value: {
-  dps: 28448.11296
-  tps: 25834.30819
+  dps: 28450.66563
+  tps: 25836.86087
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GaleofShadows-56462"
  value: {
-  dps: 28447.6025
-  tps: 25837.81536
+  dps: 28448.55358
+  tps: 25838.76645
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GearDetector-61462"
  value: {
-  dps: 28961.30899
-  tps: 26295.48965
+  dps: 28963.87568
+  tps: 26298.05634
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 25224.94898
-  tps: 22848.19931
+  dps: 25206.55313
+  tps: 22829.80346
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 29020.15479
-  tps: 26338.64993
+  dps: 29028.82519
+  tps: 26347.32033
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 29471.97446
-  tps: 26744.96767
+  dps: 29480.02884
+  tps: 26753.02205
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Gurthalak,VoiceoftheDeeps-77191"
  value: {
-  dps: 30004.63797
-  tps: 27230.09504
+  dps: 30012.17458
+  tps: 27237.63164
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Gurthalak,VoiceoftheDeeps-78478"
  value: {
-  dps: 30004.63797
-  tps: 27230.09504
+  dps: 30012.17458
+  tps: 27237.63164
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Gurthalak,VoiceoftheDeeps-78487"
  value: {
-  dps: 30004.63797
-  tps: 27230.09504
+  dps: 30012.17458
+  tps: 27237.63164
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HarmlightToken-63839"
  value: {
-  dps: 28174.83
-  tps: 25581.23025
+  dps: 28184.6034
+  tps: 25591.00365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 28181.22562
-  tps: 25587.506
+  dps: 28190.78282
+  tps: 25597.06319
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofRage-59224"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofRage-65072"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofSolace-55868"
  value: {
-  dps: 28448.11296
-  tps: 25834.30819
+  dps: 28450.66563
+  tps: 25836.86087
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofSolace-56393"
  value: {
-  dps: 28447.6025
-  tps: 25837.81536
+  dps: 28448.55358
+  tps: 25838.76645
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofThunder-55845"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofThunder-56370"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 29165.31275
-  tps: 26471.60503
+  dps: 29174.63404
+  tps: 26480.92632
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Heartpierce-50641"
  value: {
-  dps: 30196.26605
-  tps: 27405.38664
+  dps: 30203.75437
+  tps: 27412.87496
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 29266.55314
-  tps: 26508.08848
+  dps: 29274.03533
+  tps: 26515.57067
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 28496.11412
-  tps: 25901.80975
+  dps: 28506.04071
+  tps: 25911.73634
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 28496.11412
-  tps: 25901.80975
+  dps: 28506.04071
+  tps: 25911.73634
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 28425.38854
-  tps: 25831.20986
+  dps: 28435.2822
+  tps: 25841.10352
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 28459.21382
-  tps: 25864.97503
+  dps: 28469.12323
+  tps: 25874.88444
  }
 }
 dps_results: {
  key: "TestSV-AllItems-IndomitablePride-77211"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-IndomitablePride-77983"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-IndomitablePride-78003"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 28731.93447
-  tps: 26068.5922
+  dps: 28733.01986
+  tps: 26069.67759
  }
 }
 dps_results: {
  key: "TestSV-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 28676.54119
-  tps: 26013.10965
+  dps: 28678.81767
+  tps: 26015.38613
  }
 }
 dps_results: {
  key: "TestSV-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 28770.54897
-  tps: 26097.31448
+  dps: 28765.41526
+  tps: 26092.18077
  }
 }
 dps_results: {
  key: "TestSV-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 28363.28148
-  tps: 25770.26064
+  dps: 28370.82755
+  tps: 25777.80672
  }
 }
 dps_results: {
  key: "TestSV-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 29098.79823
-  tps: 26439.51883
+  dps: 29092.76714
+  tps: 26433.48774
  }
 }
 dps_results: {
  key: "TestSV-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 29208.88307
-  tps: 26503.95929
+  dps: 29212.95859
+  tps: 26508.03481
  }
 }
 dps_results: {
  key: "TestSV-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 29549.00139
-  tps: 26819.43344
+  dps: 29565.00402
+  tps: 26835.43607
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Kiril,FuryofBeasts-77194"
  value: {
-  dps: 33077.54581
-  tps: 30002.16836
+  dps: 33082.39376
+  tps: 30007.01631
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Kiril,FuryofBeasts-78473"
  value: {
-  dps: 33507.83212
-  tps: 30394.43636
+  dps: 33505.46874
+  tps: 30392.07299
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Kiril,FuryofBeasts-78482"
  value: {
-  dps: 32710.52001
-  tps: 29667.25656
+  dps: 32713.85453
+  tps: 29670.59109
  }
 }
 dps_results: {
  key: "TestSV-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 30356.84741
-  tps: 27577.08381
+  dps: 30335.07349
+  tps: 27555.30988
  }
 }
 dps_results: {
  key: "TestSV-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 28301.67428
-  tps: 25697.37832
+  dps: 28303.66621
+  tps: 25699.37024
  }
 }
 dps_results: {
  key: "TestSV-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 28301.67428
-  tps: 25697.37832
+  dps: 28303.66621
+  tps: 25699.37024
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 28331.06913
-  tps: 25731.92994
+  dps: 28326.83875
+  tps: 25727.69956
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LastWord-50708"
  value: {
-  dps: 30004.63797
-  tps: 27230.09504
+  dps: 30012.17458
+  tps: 27237.63164
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LeadenDespair-55816"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LeadenDespair-56347"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 29313.78671
-  tps: 26612.33566
+  dps: 29323.19137
+  tps: 26621.74031
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 29476.37479
-  tps: 26759.82868
+  dps: 29493.87076
+  tps: 26777.32466
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Lightning-ChargedBattlegear"
  value: {
-  dps: 27385.30454
-  tps: 24845.31525
+  dps: 27383.77977
+  tps: 24843.79048
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 28164.44947
-  tps: 25571.78204
+  dps: 28171.92474
+  tps: 25579.2573
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 28164.44947
-  tps: 25571.78204
+  dps: 28171.92474
+  tps: 25579.2573
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 28381.67862
-  tps: 25789.01119
+  dps: 28382.40916
+  tps: 25789.74173
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 28410.1253
-  tps: 25817.45786
+  dps: 28409.9726
+  tps: 25817.30516
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 30359.22622
-  tps: 27552.98767
+  dps: 30365.61612
+  tps: 27559.37757
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 30667.07255
-  tps: 27824.19979
+  dps: 30673.23034
+  tps: 27830.35759
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 28164.44947
-  tps: 25571.78204
+  dps: 28171.92474
+  tps: 25579.2573
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 28164.44947
-  tps: 25571.78204
+  dps: 28171.92474
+  tps: 25579.2573
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 28496.11412
-  tps: 25901.80975
+  dps: 28506.04071
+  tps: 25911.73634
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 28496.11412
-  tps: 25901.80975
+  dps: 28506.04071
+  tps: 25911.73634
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 28539.90708
-  tps: 25913.22799
+  dps: 28549.57507
+  tps: 25922.89598
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 28494.81934
-  tps: 25901.09972
+  dps: 28508.77362
+  tps: 25915.054
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 28199.80459
-  tps: 25606.08497
+  dps: 28209.96125
+  tps: 25616.24162
  }
 }
 dps_results: {
  key: "TestSV-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 28203.99923
-  tps: 25610.27961
+  dps: 28214.20502
+  tps: 25620.4854
  }
 }
 dps_results: {
  key: "TestSV-AllItems-No'Kaled,theElementsofDeath-77188"
  value: {
-  dps: 30849.4028
-  tps: 27996.79747
+  dps: 30857.16728
+  tps: 28004.56195
  }
 }
 dps_results: {
  key: "TestSV-AllItems-No'Kaled,theElementsofDeath-78472"
  value: {
-  dps: 30960.19773
-  tps: 28096.89214
+  dps: 30968.00588
+  tps: 28104.70029
  }
 }
 dps_results: {
  key: "TestSV-AllItems-No'Kaled,theElementsofDeath-78481"
  value: {
-  dps: 30752.58474
-  tps: 27909.2584
+  dps: 30760.31277
+  tps: 27916.98643
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 28399.40427
-  tps: 25788.99565
+  dps: 28410.68086
+  tps: 25800.27224
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 28379.91361
-  tps: 25764.72791
+  dps: 28389.52949
+  tps: 25774.3438
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 28172.16451
-  tps: 25578.44489
+  dps: 28182.16685
+  tps: 25588.44723
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 28174.86272
-  tps: 25581.14309
+  dps: 28184.51727
+  tps: 25590.79765
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 29211.63463
-  tps: 26458.74497
+  dps: 29219.16169
+  tps: 26466.27203
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 29731.8119
-  tps: 27013.11919
+  dps: 29736.19721
+  tps: 27017.5045
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 30016.96004
-  tps: 27259.97408
+  dps: 30020.28225
+  tps: 27263.29629
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Rainsong-55854"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Rainsong-56377"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Rathrak,thePoisonousMind-77195"
  value: {
-  dps: 27638.15204
-  tps: 25101.66472
+  dps: 27639.58123
+  tps: 25103.09391
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Rathrak,thePoisonousMind-78475"
  value: {
-  dps: 27641.28096
-  tps: 25104.79365
+  dps: 27642.71016
+  tps: 25106.22284
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Rathrak,thePoisonousMind-78484"
  value: {
-  dps: 27632.02493
-  tps: 25095.53761
+  dps: 27633.45412
+  tps: 25096.96681
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 28164.44947
-  tps: 25571.78204
+  dps: 28171.92474
+  tps: 25579.2573
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 29811.27744
-  tps: 27056.99107
+  dps: 29818.91135
+  tps: 27064.62497
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 29811.27744
-  tps: 27056.99107
+  dps: 29818.91135
+  tps: 27064.62497
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 29848.00789
-  tps: 27097.27845
+  dps: 29860.28615
+  tps: 27109.55671
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RosaryofLight-72901"
  value: {
-  dps: 28705.03943
-  tps: 26062.75445
+  dps: 28713.09946
+  tps: 26070.81448
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RottingSkull-77116"
  value: {
-  dps: 28717.0617
-  tps: 26078.38495
+  dps: 28724.8628
+  tps: 26086.18605
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RuneofZeth-68998"
  value: {
-  dps: 28628.99402
-  tps: 25996.07892
+  dps: 28639.00755
+  tps: 26006.09244
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RuthlessGladiator'sBadgeofConquest-70399"
  value: {
-  dps: 29719.52755
-  tps: 26984.84002
+  dps: 29740.13095
+  tps: 27005.44343
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RuthlessGladiator'sBadgeofConquest-72304"
  value: {
-  dps: 29813.62515
-  tps: 27070.6177
+  dps: 29834.706
+  tps: 27091.69854
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RuthlessGladiator'sBadgeofDominance-70401"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RuthlessGladiator'sBadgeofDominance-72448"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RuthlessGladiator'sBadgeofVictory-70400"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RuthlessGladiator'sBadgeofVictory-72450"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RuthlessGladiator'sInsigniaofConquest-70404"
  value: {
-  dps: 29880.35333
-  tps: 27114.48403
+  dps: 29890.79503
+  tps: 27124.92573
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RuthlessGladiator'sInsigniaofConquest-72309"
  value: {
-  dps: 29940.06256
-  tps: 27170.37246
+  dps: 29941.22706
+  tps: 27171.53697
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RuthlessGladiator'sInsigniaofDominance-70402"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RuthlessGladiator'sInsigniaofDominance-72449"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RuthlessGladiator'sInsigniaofVictory-70403"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RuthlessGladiator'sInsigniaofVictory-72455"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ScalesofLife-68915"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
   hps: 315.97258
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ScalesofLife-69109"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
   hps: 356.41412
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 29051.61721
-  tps: 26369.65399
+  dps: 29060.80698
+  tps: 26378.84376
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SeaStar-55256"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SeaStar-56290"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Shadowmourne-49623"
  value: {
-  dps: 30278.40389
-  tps: 27512.03127
+  dps: 30283.09456
+  tps: 27516.72194
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ShardofWoe-60233"
  value: {
-  dps: 28553.45062
-  tps: 25936.51728
+  dps: 28553.61317
+  tps: 25936.67983
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 28264.39908
-  tps: 25667.71238
+  dps: 28273.75655
+  tps: 25677.06985
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 29354.64681
-  tps: 26666.60609
+  dps: 29367.44095
+  tps: 26679.40023
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 29512.48342
-  tps: 26813.38356
+  dps: 29525.66021
+  tps: 26826.56035
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Sorrowsong-55879"
  value: {
-  dps: 28425.38854
-  tps: 25831.20986
+  dps: 28435.2822
+  tps: 25841.10352
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Sorrowsong-56400"
  value: {
-  dps: 28459.21382
-  tps: 25864.97503
+  dps: 28469.12323
+  tps: 25874.88444
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 28164.44947
-  tps: 25571.78204
+  dps: 28171.92474
+  tps: 25579.2573
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SoulCasket-58183"
  value: {
-  dps: 28496.11412
-  tps: 25901.80975
+  dps: 28506.04071
+  tps: 25911.73634
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Souldrinker-77193"
  value: {
-  dps: 30009.30515
-  tps: 27234.76221
+  dps: 30016.84175
+  tps: 27242.29882
   hps: 9.33435
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Souldrinker-78479"
  value: {
-  dps: 30009.95205
-  tps: 27235.40911
+  dps: 30017.48865
+  tps: 27242.94572
   hps: 10.62815
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Souldrinker-78488"
  value: {
-  dps: 30008.66583
-  tps: 27234.1229
+  dps: 30016.20244
+  tps: 27241.6595
   hps: 8.05572
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 28888.59417
-  tps: 26291.90726
+  dps: 28901.71941
+  tps: 26305.0325
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 28795.37353
-  tps: 26199.61104
+  dps: 28808.77919
+  tps: 26213.0167
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 28983.13616
-  tps: 26386.93596
+  dps: 28989.99953
+  tps: 26393.79934
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 28559.66465
-  tps: 25965.24734
+  dps: 28569.62083
+  tps: 25975.20352
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 28610.91507
-  tps: 26016.40668
+  dps: 28620.89511
+  tps: 26026.38672
  }
 }
 dps_results: {
  key: "TestSV-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 30412.7043
-  tps: 27572.42896
+  dps: 30412.96795
+  tps: 27572.69261
  }
 }
 dps_results: {
  key: "TestSV-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 30267.31668
-  tps: 27475.08424
+  dps: 30265.53062
+  tps: 27473.29818
  }
 }
 dps_results: {
  key: "TestSV-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 30681.52352
-  tps: 27816.76794
+  dps: 30680.92387
+  tps: 27816.16829
  }
 }
 dps_results: {
  key: "TestSV-AllItems-StayofExecution-68996"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 28171.88687
-  tps: 25577.4526
+  dps: 28181.47868
+  tps: 25587.04442
  }
 }
 dps_results: {
  key: "TestSV-AllItems-StumpofTime-62465"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-StumpofTime-62470"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 28238.29879
-  tps: 25644.37212
+  dps: 28247.48832
+  tps: 25653.56166
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 28194.62196
-  tps: 25599.82454
+  dps: 28203.62925
+  tps: 25608.83183
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TearofBlood-55819"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TearofBlood-56351"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 28387.46322
-  tps: 25793.35195
+  dps: 28397.33923
+  tps: 25803.22795
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 28459.21382
-  tps: 25864.97503
+  dps: 28469.12323
+  tps: 25874.88444
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TheHungerer-68927"
  value: {
-  dps: 30043.35719
-  tps: 27275.66696
+  dps: 30046.28623
+  tps: 27278.59601
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TheHungerer-69112"
  value: {
-  dps: 30206.52236
-  tps: 27408.49219
+  dps: 30206.47851
+  tps: 27408.44834
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 28177.0692
-  tps: 25583.34958
+  dps: 28186.87397
+  tps: 25593.15434
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 28212.52025
-  tps: 25618.21359
+  dps: 28223.22831
+  tps: 25628.92166
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Ti'tahk,theStepsofTime-77190"
  value: {
-  dps: 30004.38883
-  tps: 27223.94286
+  dps: 30012.15378
+  tps: 27231.70781
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Ti'tahk,theStepsofTime-78477"
  value: {
-  dps: 30065.51825
-  tps: 27303.67578
+  dps: 30074.55753
+  tps: 27312.71506
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Ti'tahk,theStepsofTime-78486"
  value: {
-  dps: 30056.86905
-  tps: 27275.84948
+  dps: 30062.16689
+  tps: 27281.14733
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 29533.61659
-  tps: 26831.34059
+  dps: 29540.80056
+  tps: 26838.52456
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 29721.21302
-  tps: 27004.84265
+  dps: 29728.25129
+  tps: 27011.88092
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 27248.17726
-  tps: 24756.58437
+  dps: 27240.10561
+  tps: 24748.51272
  }
 }
 dps_results: {
  key: "TestSV-AllItems-UnheededWarning-59520"
  value: {
-  dps: 29388.98974
-  tps: 26674.14307
+  dps: 29400.78299
+  tps: 26685.93632
  }
 }
 dps_results: {
  key: "TestSV-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 29745.34754
-  tps: 27041.72151
+  dps: 29764.60634
+  tps: 27060.9803
  }
 }
 dps_results: {
  key: "TestSV-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 29745.34754
-  tps: 27041.72151
+  dps: 29764.60634
+  tps: 27060.9803
  }
 }
 dps_results: {
  key: "TestSV-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 29745.34754
-  tps: 27041.72151
+  dps: 29764.60634
+  tps: 27060.9803
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 27716.86813
-  tps: 25172.21185
+  dps: 27723.17837
+  tps: 25178.52208
  }
 }
 dps_results: {
  key: "TestSV-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 28990.62302
-  tps: 26397.2009
+  dps: 29000.39642
+  tps: 26406.9743
  }
 }
 dps_results: {
  key: "TestSV-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 29053.95922
-  tps: 26460.44171
+  dps: 29063.73262
+  tps: 26470.21511
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 28644.71012
-  tps: 26050.03422
+  dps: 28652.87876
+  tps: 26058.20285
  }
 }
 dps_results: {
  key: "TestSV-AllItems-VeilofLies-72900"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 28174.69293
-  tps: 25580.60248
+  dps: 28184.46633
+  tps: 25590.37588
  }
 }
 dps_results: {
  key: "TestSV-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 28174.69293
-  tps: 25580.60248
+  dps: 28184.46633
+  tps: 25590.37588
  }
 }
 dps_results: {
  key: "TestSV-AllItems-VialofShadows-77207"
  value: {
-  dps: 30418.76488
-  tps: 27659.80515
+  dps: 30422.67048
+  tps: 27663.71075
  }
 }
 dps_results: {
  key: "TestSV-AllItems-VialofShadows-77979"
  value: {
-  dps: 30183.20959
-  tps: 27450.85767
+  dps: 30191.01955
+  tps: 27458.66763
  }
 }
 dps_results: {
  key: "TestSV-AllItems-VialofShadows-77999"
  value: {
-  dps: 30713.93965
-  tps: 27934.68925
+  dps: 30717.47629
+  tps: 27938.22588
  }
 }
 dps_results: {
  key: "TestSV-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 29402.02616
-  tps: 26698.98487
+  dps: 29420.98774
+  tps: 26717.94645
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sBadgeofConquest-70517"
  value: {
-  dps: 29539.96235
-  tps: 26824.38169
+  dps: 29559.68455
+  tps: 26844.10389
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sBadgeofDominance-70518"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sBadgeofVictory-70519"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 28517.91318
-  tps: 25906.92091
+  dps: 28519.28397
+  tps: 25908.2917
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 28577.9865
-  tps: 25948.57614
+  dps: 28587.81252
+  tps: 25958.40216
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 28515.58928
-  tps: 25921.2503
+  dps: 28525.52494
+  tps: 25931.18596
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 29461.0917
-  tps: 26737.38665
+  dps: 29468.76728
+  tps: 26745.06223
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sInsigniaofConquest-70577"
  value: {
-  dps: 29638.27672
-  tps: 26894.16149
+  dps: 29642.75847
+  tps: 26898.64324
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sInsigniaofDominance-70578"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sInsigniaofVictory-70579"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Vishanka,JawsoftheEarth-78359"
  value: {
-  dps: 31817.97696
-  tps: 29087.46913
+  dps: 31822.19871
+  tps: 29091.69087
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Vishanka,JawsoftheEarth-78471"
  value: {
-  dps: 32621.94509
-  tps: 29878.07479
+  dps: 32629.97884
+  tps: 29886.10854
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Vishanka,JawsoftheEarth-78480"
  value: {
-  dps: 31098.98978
-  tps: 28367.06209
+  dps: 31106.60752
+  tps: 28374.67983
  }
 }
 dps_results: {
  key: "TestSV-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-WillofUnbinding-77995"
  value: {
-  dps: 28167.0864
-  tps: 25573.36678
+  dps: 28176.8598
+  tps: 25583.14018
  }
 }
 dps_results: {
  key: "TestSV-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 28164.06795
-  tps: 25574.92666
+  dps: 28174.4131
+  tps: 25585.27182
  }
 }
 dps_results: {
  key: "TestSV-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 28143.82376
-  tps: 25557.70065
+  dps: 28153.00241
+  tps: 25566.8793
  }
 }
 dps_results: {
  key: "TestSV-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 28391.56326
-  tps: 25797.44469
+  dps: 28401.44117
+  tps: 25807.32261
  }
 }
 dps_results: {
  key: "TestSV-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 31415.97461
-  tps: 28507.44899
+  dps: 31418.93908
+  tps: 28510.41345
  }
 }
 dps_results: {
  key: "TestSV-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 31030.42571
-  tps: 28155.94341
+  dps: 31034.32181
+  tps: 28159.8395
  }
 }
 dps_results: {
  key: "TestSV-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 31814.39101
-  tps: 28865.65301
+  dps: 31816.3877
+  tps: 28867.6497
  }
 }
 dps_results: {
  key: "TestSV-AllItems-WyrmstalkerBattlegear"
  value: {
-  dps: 28498.53202
-  tps: 25879.51489
+  dps: 28500.12561
+  tps: 25881.10849
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 28353.23195
-  tps: 25760.56451
+  dps: 28354.84572
+  tps: 25762.17829
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 28353.23195
-  tps: 25760.56451
+  dps: 28354.84572
+  tps: 25762.17829
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 27961.75538
-  tps: 25266.36469
+  dps: 27965.85992
+  tps: 25270.46923
  }
 }
 dps_results: {
  key: "TestSV-Average-Default"
  value: {
-  dps: 30093.48662
-  tps: 27347.86787
+  dps: 30092.45717
+  tps: 27346.83842
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-FullBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 141215.31282
-  tps: 114530.62632
+  dps: 141217.44156
+  tps: 114532.75506
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-FullBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 23704.72931
-  tps: 21098.62038
+  dps: 23708.31656
+  tps: 21102.20763
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 28420.36696
-  tps: 25053.94714
+  dps: 28427.42698
+  tps: 25061.00716
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-NoBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 101328.11475
-  tps: 82027.31457
+  dps: 101342.4327
+  tps: 82041.63252
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-NoBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 16879.24382
-  tps: 15069.09819
+  dps: 16879.2579
+  tps: 15069.11228
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-NoBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 18017.13842
-  tps: 16013.10621
+  dps: 18008.4073
+  tps: 16004.37509
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-FullBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 32544.99012
-  tps: 29914.92019
+  dps: 32561.13015
+  tps: 29931.06022
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-FullBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 29812.7064
-  tps: 27193.86892
+  dps: 29816.79394
+  tps: 27197.95645
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 35952.01069
-  tps: 32684.6371
+  dps: 35785.3128
+  tps: 32517.93922
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-NoBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 22794.42433
-  tps: 20960.41691
+  dps: 22799.76528
+  tps: 20965.75785
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-NoBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 21046.83986
-  tps: 19220.1156
+  dps: 21048.69581
+  tps: 19221.97155
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-NoBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 23108.41649
-  tps: 21059.0257
+  dps: 23036.78947
+  tps: 20987.39868
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-FullBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 141858.71803
-  tps: 115074.15993
+  dps: 141847.00934
+  tps: 115062.45123
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-FullBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 23906.76394
-  tps: 21145.28994
+  dps: 23910.47589
+  tps: 21149.0019
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 28792.82771
-  tps: 25210.06552
+  dps: 28801.01461
+  tps: 25218.25242
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-NoBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 101829.56307
-  tps: 82473.64362
+  dps: 101833.80321
+  tps: 82477.88376
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-NoBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 17018.32973
-  tps: 15095.5162
+  dps: 17018.19245
+  tps: 15095.37893
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-NoBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 18315.04712
-  tps: 16178.65312
+  dps: 18304.53023
+  tps: 16168.13623
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-FullBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 32861.15034
-  tps: 30074.56854
+  dps: 32888.61262
+  tps: 30102.03081
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-FullBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 30004.63797
-  tps: 27230.09504
+  dps: 30012.17458
+  tps: 27237.63164
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 36432.91467
-  tps: 32954.16357
+  dps: 36250.64413
+  tps: 32771.89303
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-NoBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 23010.32308
-  tps: 21065.48507
+  dps: 23023.98637
+  tps: 21079.14836
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-NoBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 21177.34375
-  tps: 19240.73526
+  dps: 21181.19201
+  tps: 19244.58352
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-NoBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 23428.44556
-  tps: 21244.38372
+  dps: 23343.51902
+  tps: 21159.45718
  }
 }
 dps_results: {
  key: "TestSV-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 29782.81506
-  tps: 27034.17028
+  dps: 29790.35166
+  tps: 27041.70689
  }
 }

--- a/sim/hunter/survival/TestSV.results
+++ b/sim/hunter/survival/TestSV.results
@@ -1,2367 +1,2367 @@
 character_stats_results: {
  key: "TestSV-CharacterStats-Default"
  value: {
-  final_stats: 679.35
-  final_stats: 6254.29728
-  final_stats: 6447.21
-  final_stats: 122.85
-  final_stats: 114
-  final_stats: 962
-  final_stats: 1904
-  final_stats: 802
+  final_stats: 684.6
+  final_stats: 7135.04484
+  final_stats: 7274.19
+  final_stats: 128.1
+  final_stats: 119
+  final_stats: 966
+  final_stats: 2302
+  final_stats: 916
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 847
-  final_stats: 15418.31347
-  final_stats: 14144.45402
-  final_stats: 0
-  final_stats: 0
-  final_stats: 316
-  final_stats: 0
+  final_stats: 1117
+  final_stats: 17532.10762
+  final_stats: 16082.09865
   final_stats: 0
   final_stats: 0
   final_stats: 0
   final_stats: 0
-  final_stats: 14342
   final_stats: 0
-  final_stats: 129037.94
+  final_stats: 0
+  final_stats: 0
+  final_stats: 0
+  final_stats: 15003
+  final_stats: 0
+  final_stats: 140615.66
   final_stats: 0
   final_stats: 326
-  final_stats: 8.0094
-  final_stats: 9.39034
-  final_stats: 33.47658
-  final_stats: 15.62026
+  final_stats: 8.04271
+  final_stats: 9.42938
+  final_stats: 38.42689
+  final_stats: 17.84025
   final_stats: 5
  }
 }
 dps_results: {
  key: "TestSV-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 26535.60808
-  tps: 24009.68268
+  dps: 30004.63797
+  tps: 27230.09504
  }
 }
 dps_results: {
  key: "TestSV-AllItems-AgonyandTorment"
  value: {
-  dps: 25502.74324
-  tps: 23054.38592
+  dps: 28697.1928
+  tps: 26054.20686
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Ahn'KaharBloodHunter'sBattlegear"
  value: {
-  dps: 22282.06665
-  tps: 20167.88271
+  dps: 24105.27286
+  tps: 21859.35611
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
- }
-}
-dps_results: {
- key: "TestSV-AllItems-AncientPetrifiedSeed-69001"
- value: {
-  dps: 26194.56653
-  tps: 23768.67646
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 25082.02721
-  tps: 22703.50693
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 25082.02721
-  tps: 22703.50693
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 24784.45812
-  tps: 22449.46323
+  dps: 28184.57757
+  tps: 25589.13393
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 24786.82335
-  tps: 22451.82846
+  dps: 28186.39854
+  tps: 25590.71544
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ArrowofTime-72897"
  value: {
-  dps: 26489.17276
-  tps: 23959.4661
+  dps: 30248.3606
+  tps: 27505.43965
  }
 }
 dps_results: {
  key: "TestSV-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 25940.41458
-  tps: 23436.34139
+  dps: 29211.63463
+  tps: 26458.74497
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 24767.11009
-  tps: 22434.55279
-  hps: 95.75904
+  dps: 28168.29164
+  tps: 25574.9581
+  hps: 96.72062
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 25099.97676
-  tps: 22734.21652
+  dps: 28558.32045
+  tps: 25930.25034
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 25136.89383
-  tps: 22767.11514
+  dps: 28609.47056
+  tps: 25977.77599
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BindingPromise-67037"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BlackBruise-50692"
  value: {
-  dps: 24686.51713
-  tps: 22338.92111
+  dps: 27701.63202
+  tps: 25156.86406
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 25532.52886
-  tps: 23144.99488
+  dps: 29098.79823
+  tps: 26439.51883
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 24995.33013
-  tps: 22662.62379
+  dps: 28425.38854
+  tps: 25831.20986
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 25025.26919
-  tps: 22692.51466
+  dps: 28459.21382
+  tps: 25864.97503
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 25818.66871
-  tps: 23389.28753
+  dps: 29430.01978
+  tps: 26717.82404
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 25088.12516
-  tps: 22723.54191
+  dps: 28537.74191
+  tps: 25911.61094
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 25965.27841
-  tps: 23515.79518
+  dps: 29441.59103
+  tps: 26716.71368
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 25551.70331
-  tps: 23208.92534
+  dps: 29147.14727
+  tps: 26561.80831
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 25479.74658
-  tps: 23131.18191
+  dps: 29022.1259
+  tps: 26435.50915
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 25734.84419
-  tps: 23383.53247
+  dps: 29243.58511
+  tps: 26657.54479
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BottledLightning-66879"
  value: {
-  dps: 24881.0391
-  tps: 22543.27367
+  dps: 28276.90495
+  tps: 25674.58352
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BottledWishes-77114"
  value: {
-  dps: 25235.93589
-  tps: 22845.6617
+  dps: 28721.37979
+  tps: 26095.48705
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 25940.41458
-  tps: 22967.61456
+  dps: 29211.63463
+  tps: 25929.57007
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 26536.72588
-  tps: 24010.58084
+  dps: 30005.23573
+  tps: 27230.6072
  }
 }
 dps_results: {
  key: "TestSV-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 26345.63831
-  tps: 23840.47919
+  dps: 29811.27744
+  tps: 27056.99107
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CataclysmicGladiator'sBadgeofConquest-73648"
  value: {
-  dps: 26454.26047
-  tps: 23987.77628
+  dps: 30039.96048
+  tps: 27275.46877
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CataclysmicGladiator'sBadgeofDominance-73498"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CataclysmicGladiator'sBadgeofVictory-73496"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CataclysmicGladiator'sInsigniaofConquest-73643"
  value: {
-  dps: 26570.73583
-  tps: 24051.01093
+  dps: 30168.01978
+  tps: 27370.65783
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CataclysmicGladiator'sInsigniaofDominance-73497"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CataclysmicGladiator'sInsigniaofVictory-73491"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 26414.42611
-  tps: 23902.52439
+  dps: 29869.91654
+  tps: 27110.05518
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 25558.58477
-  tps: 23144.1391
+  dps: 29111.64443
+  tps: 26426.46397
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 25618.55204
-  tps: 23207.16061
+  dps: 29007.13506
+  tps: 26332.79861
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 25540.92932
-  tps: 23138.41596
+  dps: 28947.339
+  tps: 26276.87892
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 25675.39693
-  tps: 23255.46982
+  dps: 29100.00472
+  tps: 26411.26965
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CrushingWeight-59506"
  value: {
-  dps: 24800.6075
-  tps: 22458.66896
+  dps: 28168.44196
+  tps: 25580.04096
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CrushingWeight-65118"
  value: {
-  dps: 24755.21907
-  tps: 22415.61671
+  dps: 28135.89504
+  tps: 25542.49881
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 25215.58197
-  tps: 22883.05446
+  dps: 28631.26411
+  tps: 26037.81787
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 25144.24116
-  tps: 22811.69282
+  dps: 28560.36554
+  tps: 25967.06432
  }
 }
 dps_results: {
  key: "TestSV-AllItems-CunningoftheCruel-78000"
  value: {
-  dps: 25268.49288
-  tps: 22935.82806
+  dps: 28691.00103
+  tps: 26097.49431
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 25167.59115
-  tps: 22806.30059
+  dps: 28572.07766
+  tps: 25989.89523
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 26228.53392
-  tps: 23761.32751
+  dps: 29761.48216
+  tps: 27066.05302
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 25063.96346
-  tps: 22731.13249
+  dps: 28503.38562
+  tps: 25909.38897
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 25447.7238
-  tps: 23038.43181
+  dps: 28875.03637
+  tps: 26208.18871
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 26005.38938
-  tps: 23494.57359
+  dps: 29266.55314
+  tps: 26508.08848
  }
 }
 dps_results: {
  key: "TestSV-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 24938.84344
-  tps: 22553.96484
+  dps: 28257.27619
+  tps: 25647.74505
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Dragonwrath,Tarecgosa'sRest-71086"
  value: {
-  dps: 26853.82115
-  tps: 24284.3534
+  dps: 30221.24934
+  tps: 27438.53007
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 25238.60256
-  tps: 22863.28721
+  dps: 28633.28799
+  tps: 25998.93928
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 25940.41458
-  tps: 23436.34139
+  dps: 29211.63463
+  tps: 26458.74497
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 25940.41458
-  tps: 23436.34139
+  dps: 29211.63463
+  tps: 26458.74497
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 26005.38938
-  tps: 23494.57359
+  dps: 29266.55314
+  tps: 26508.08848
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 26291.99621
-  tps: 23805.02164
- }
-}
-dps_results: {
- key: "TestSV-AllItems-EssenceoftheCyclone-65140"
- value: {
-  dps: 26458.30145
-  tps: 23960.96335
+  dps: 29829.5938
+  tps: 27076.62848
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 25114.17912
-  tps: 22781.28149
+  dps: 28559.66465
+  tps: 25965.24734
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 25940.41458
-  tps: 23436.34139
+  dps: 29211.63463
+  tps: 26458.74497
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FallofMortality-59500"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FallofMortality-65124"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 24732.49253
-  tps: 22426.10571
+  dps: 28202.0655
+  tps: 25609.7469
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 26038.11693
-  tps: 23576.56313
+  dps: 29261.30444
+  tps: 26571.52208
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 25025.26919
-  tps: 22692.51466
+  dps: 28459.21382
+  tps: 25864.97503
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 25182.22243
-  tps: 22849.21528
+  dps: 28636.54028
+  tps: 26041.98635
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Flamewaker'sBattlegear"
  value: {
-  dps: 26727.86356
-  tps: 24188.46227
+  dps: 29215.8687
+  tps: 26475.73291
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 25991.47541
-  tps: 23487.31378
+  dps: 29268.90469
+  tps: 26515.91283
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FluidDeath-58181"
  value: {
-  dps: 26391.2674
-  tps: 23884.04533
+  dps: 29564.16219
+  tps: 26834.71985
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 25940.41458
-  tps: 23436.34139
+  dps: 29211.63463
+  tps: 26458.74497
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 25124.0943
-  tps: 22791.33837
+  dps: 28565.52905
+  tps: 25971.19496
  }
 }
 dps_results: {
  key: "TestSV-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 25099.97676
-  tps: 22734.21652
+  dps: 28558.32045
+  tps: 25930.25034
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GaleofShadows-56138"
  value: {
-  dps: 25007.14207
-  tps: 22630.9427
+  dps: 28448.11296
+  tps: 25834.30819
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GaleofShadows-56462"
  value: {
-  dps: 25034.85725
-  tps: 22654.55086
+  dps: 28447.6025
+  tps: 25837.81536
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GearDetector-61462"
  value: {
-  dps: 25361.6459
-  tps: 22929.36872
+  dps: 28961.30899
+  tps: 26295.48965
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Gladiator'sPursuit"
  value: {
-  dps: 23156.58292
-  tps: 20923.52019
+  dps: 25224.94898
+  tps: 22848.19931
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 25574.336
-  tps: 23156.37849
+  dps: 29020.15479
+  tps: 26338.64993
  }
 }
 dps_results: {
  key: "TestSV-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 25980.51925
-  tps: 23520.00397
+  dps: 29471.97446
+  tps: 26744.96767
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Gurthalak,VoiceoftheDeeps-77191"
  value: {
-  dps: 26535.60808
-  tps: 24009.68268
+  dps: 30004.63797
+  tps: 27230.09504
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Gurthalak,VoiceoftheDeeps-78478"
  value: {
-  dps: 26535.60808
-  tps: 24009.68268
+  dps: 30004.63797
+  tps: 27230.09504
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Gurthalak,VoiceoftheDeeps-78487"
  value: {
-  dps: 26535.60808
-  tps: 24009.68268
+  dps: 30004.63797
+  tps: 27230.09504
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HarmlightToken-63839"
  value: {
-  dps: 24774.11333
-  tps: 22441.72959
+  dps: 28174.83
+  tps: 25581.23025
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 24779.942
-  tps: 22447.60364
+  dps: 28181.22562
+  tps: 25587.506
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofRage-59224"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofRage-65072"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofSolace-55868"
  value: {
-  dps: 25007.14207
-  tps: 22630.9427
+  dps: 28448.11296
+  tps: 25834.30819
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofSolace-56393"
  value: {
-  dps: 25034.85725
-  tps: 22654.55086
+  dps: 28447.6025
+  tps: 25837.81536
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofThunder-55845"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartofThunder-56370"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 25720.35461
-  tps: 23289.2823
+  dps: 29165.31275
+  tps: 26471.60503
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Heartpierce-50641"
  value: {
-  dps: 26712.74679
-  tps: 24170.35202
+  dps: 30196.26605
+  tps: 27405.38664
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 26005.38938
-  tps: 23494.57359
+  dps: 29266.55314
+  tps: 26508.08848
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 25057.92998
-  tps: 22725.12288
+  dps: 28496.11412
+  tps: 25901.80975
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 25057.92998
-  tps: 22725.12288
+  dps: 28496.11412
+  tps: 25901.80975
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 24995.33013
-  tps: 22662.62379
+  dps: 28425.38854
+  tps: 25831.20986
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 25025.26919
-  tps: 22692.51466
+  dps: 28459.21382
+  tps: 25864.97503
  }
 }
 dps_results: {
  key: "TestSV-AllItems-IndomitablePride-77211"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-IndomitablePride-77983"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-IndomitablePride-78003"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 25305.95986
-  tps: 22855.51717
+  dps: 28731.93447
+  tps: 26068.5922
  }
 }
 dps_results: {
  key: "TestSV-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 25157.82554
-  tps: 22740.91685
+  dps: 28676.54119
+  tps: 26013.10965
  }
 }
 dps_results: {
  key: "TestSV-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 25310.83671
-  tps: 22861.07515
+  dps: 28770.54897
+  tps: 26097.31448
  }
 }
 dps_results: {
  key: "TestSV-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 24933.01138
-  tps: 22605.52985
+  dps: 28363.28148
+  tps: 25770.26064
  }
 }
 dps_results: {
  key: "TestSV-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 25532.52886
-  tps: 23144.99488
+  dps: 29098.79823
+  tps: 26439.51883
  }
 }
 dps_results: {
  key: "TestSV-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 26078.75171
-  tps: 23599.84521
+  dps: 29208.88307
+  tps: 26503.95929
+ }
+}
+dps_results: {
+ key: "TestSV-AllItems-KeytotheEndlessChamber-56328"
+ value: {
+  dps: 29549.00139
+  tps: 26819.43344
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Kiril,FuryofBeasts-77194"
  value: {
-  dps: 29409.37305
-  tps: 26603.42735
+  dps: 33077.54581
+  tps: 30002.16836
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Kiril,FuryofBeasts-78473"
  value: {
-  dps: 29826.13433
-  tps: 26983.61908
+  dps: 33507.83212
+  tps: 30394.43636
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Kiril,FuryofBeasts-78482"
  value: {
-  dps: 29097.89673
-  tps: 26322.71745
+  dps: 32710.52001
+  tps: 29667.25656
  }
 }
 dps_results: {
  key: "TestSV-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 26506.85712
-  tps: 23987.65343
+  dps: 30356.84741
+  tps: 27577.08381
  }
 }
 dps_results: {
  key: "TestSV-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 24946.91861
-  tps: 22568.24696
+  dps: 28301.67428
+  tps: 25697.37832
  }
 }
 dps_results: {
  key: "TestSV-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 24946.91861
-  tps: 22568.24696
+  dps: 28301.67428
+  tps: 25697.37832
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 24961.29525
-  tps: 22585.72527
+  dps: 28331.06913
+  tps: 25731.92994
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LastWord-50708"
  value: {
-  dps: 26535.60808
-  tps: 24009.68268
+  dps: 30004.63797
+  tps: 27230.09504
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LeadenDespair-55816"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LeadenDespair-56347"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 25807.23976
-  tps: 23369.3799
+  dps: 29313.78671
+  tps: 26612.33566
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 25966.28176
-  tps: 23511.09793
+  dps: 29476.37479
+  tps: 26759.82868
  }
 }
 dps_results: {
  key: "TestSV-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 25082.02721
-  tps: 22703.50693
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Lightning-ChargedBattlegear"
  value: {
-  dps: 25245.68399
-  tps: 22881.71101
+  dps: 27385.30454
+  tps: 24845.31525
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 24757.1849
-  tps: 22429.98665
+  dps: 28164.44947
+  tps: 25571.78204
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 24757.1849
-  tps: 22429.98665
+  dps: 28164.44947
+  tps: 25571.78204
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 24924.84571
-  tps: 22597.64746
+  dps: 28381.67862
+  tps: 25789.01119
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 24946.80129
-  tps: 22619.60304
+  dps: 28410.1253
+  tps: 25817.45786
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 26837.03373
-  tps: 24296.70539
+  dps: 30359.22622
+  tps: 27552.98767
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 27084.36191
-  tps: 24519.70715
+  dps: 30667.07255
+  tps: 27824.19979
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 25087.14981
-  tps: 22709.95297
+  dps: 28164.44947
+  tps: 25571.78204
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 25087.14981
-  tps: 22709.95297
+  dps: 28164.44947
+  tps: 25571.78204
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 25057.92998
-  tps: 22725.12288
+  dps: 28496.11412
+  tps: 25901.80975
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 25057.92998
-  tps: 22725.12288
+  dps: 28496.11412
+  tps: 25901.80975
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 25089.02453
-  tps: 22724.06326
+  dps: 28539.90708
+  tps: 25913.22799
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 25049.5314
-  tps: 22717.19304
+  dps: 28494.81934
+  tps: 25901.09972
  }
 }
 dps_results: {
  key: "TestSV-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 24798.58277
-  tps: 22466.24441
+  dps: 28199.80459
+  tps: 25606.08497
  }
 }
 dps_results: {
  key: "TestSV-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 24802.66971
-  tps: 22470.33135
+  dps: 28203.99923
+  tps: 25610.27961
  }
 }
 dps_results: {
  key: "TestSV-AllItems-No'Kaled,theElementsofDeath-77188"
  value: {
-  dps: 27332.60666
-  tps: 24731.51507
+  dps: 30849.4028
+  tps: 27996.79747
  }
 }
 dps_results: {
  key: "TestSV-AllItems-No'Kaled,theElementsofDeath-78472"
  value: {
-  dps: 27444.54335
-  tps: 24834.65796
+  dps: 30960.19773
+  tps: 28096.89214
  }
 }
 dps_results: {
  key: "TestSV-AllItems-No'Kaled,theElementsofDeath-78481"
  value: {
-  dps: 27231.29956
-  tps: 24639.85652
+  dps: 30752.58474
+  tps: 27909.2584
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 24974.63626
-  tps: 22630.47715
+  dps: 28399.40427
+  tps: 25788.99565
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 24966.85491
-  tps: 22611.79592
+  dps: 28379.91361
+  tps: 25764.72791
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 24771.44769
-  tps: 22439.10932
+  dps: 28172.16451
+  tps: 25578.44489
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 24774.10915
-  tps: 22441.77079
+  dps: 28174.86272
+  tps: 25581.14309
  }
 }
 dps_results: {
  key: "TestSV-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 25940.41458
-  tps: 23436.34139
+  dps: 29211.63463
+  tps: 26458.74497
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 26102.66059
-  tps: 23591.53338
+  dps: 29731.8119
+  tps: 27013.11919
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 26389.49213
-  tps: 23875.95914
+  dps: 30016.96004
+  tps: 27259.97408
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Rainsong-55854"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Rainsong-56377"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Rathrak,thePoisonousMind-77195"
  value: {
-  dps: 24627.41637
-  tps: 22287.67446
+  dps: 27638.15204
+  tps: 25101.66472
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Rathrak,thePoisonousMind-78475"
  value: {
-  dps: 24630.66037
-  tps: 22290.91847
+  dps: 27641.28096
+  tps: 25104.79365
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Rathrak,thePoisonousMind-78484"
  value: {
-  dps: 24622.07252
-  tps: 22282.33062
+  dps: 27632.02493
+  tps: 25095.53761
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 24757.1849
-  tps: 22429.98665
+  dps: 28164.44947
+  tps: 25571.78204
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 26345.63831
-  tps: 23840.47919
+  dps: 29811.27744
+  tps: 27056.99107
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 26345.63831
-  tps: 23840.47919
+  dps: 29811.27744
+  tps: 27056.99107
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 26277.80936
-  tps: 23799.07442
+  dps: 29848.00789
+  tps: 27097.27845
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 25082.02721
-  tps: 22703.50693
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 25082.02721
-  tps: 22703.50693
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RosaryofLight-72901"
  value: {
-  dps: 25273.89723
-  tps: 22888.18774
+  dps: 28705.03943
+  tps: 26062.75445
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RottingSkull-77116"
  value: {
-  dps: 25224.59945
-  tps: 22849.35454
+  dps: 28717.0617
+  tps: 26078.38495
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RuneofZeth-68998"
  value: {
-  dps: 25162.32471
-  tps: 22788.0061
+  dps: 28628.99402
+  tps: 25996.07892
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RuthlessGladiator'sBadgeofConquest-70399"
  value: {
-  dps: 26175.73501
-  tps: 23731.74613
+  dps: 29719.52755
+  tps: 26984.84002
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RuthlessGladiator'sBadgeofConquest-72304"
  value: {
-  dps: 26260.41764
-  tps: 23809.85719
+  dps: 29813.62515
+  tps: 27070.6177
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RuthlessGladiator'sBadgeofDominance-70401"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RuthlessGladiator'sBadgeofDominance-72448"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RuthlessGladiator'sBadgeofVictory-70400"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RuthlessGladiator'sBadgeofVictory-72450"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RuthlessGladiator'sInsigniaofConquest-70404"
  value: {
-  dps: 26359.98526
-  tps: 23866.43436
+  dps: 29880.35333
+  tps: 27114.48403
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RuthlessGladiator'sInsigniaofConquest-72309"
  value: {
-  dps: 26414.32982
-  tps: 23917.65081
+  dps: 29940.06256
+  tps: 27170.37246
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RuthlessGladiator'sInsigniaofDominance-70402"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RuthlessGladiator'sInsigniaofDominance-72449"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RuthlessGladiator'sInsigniaofVictory-70403"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-RuthlessGladiator'sInsigniaofVictory-72455"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ScalesofLife-68915"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
-  hps: 312.86699
+  dps: 28167.0864
+  tps: 25573.36678
+  hps: 315.97258
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ScalesofLife-69109"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
-  hps: 352.91104
+  dps: 28167.0864
+  tps: 25573.36678
+  hps: 356.41412
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 25588.59334
-  tps: 23171.85962
+  dps: 29051.61721
+  tps: 26369.65399
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SeaStar-55256"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SeaStar-56290"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Shadowmourne-49623"
  value: {
-  dps: 26734.69502
-  tps: 24182.3811
+  dps: 30278.40389
+  tps: 27512.03127
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ShardofWoe-60233"
  value: {
-  dps: 24990.2668
-  tps: 22596.97445
+  dps: 28553.45062
+  tps: 25936.51728
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 24759.18233
-  tps: 22421.26804
+  dps: 28264.39908
+  tps: 25667.71238
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 25855.08327
-  tps: 23431.509
+  dps: 29354.64681
+  tps: 26666.60609
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 25990.99279
-  tps: 23557.2955
+  dps: 29512.48342
+  tps: 26813.38356
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Sorrowsong-55879"
  value: {
-  dps: 24995.33013
-  tps: 22662.62379
+  dps: 28425.38854
+  tps: 25831.20986
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Sorrowsong-56400"
  value: {
-  dps: 25025.26919
-  tps: 22692.51466
+  dps: 28459.21382
+  tps: 25864.97503
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 25087.14981
-  tps: 22709.95297
+  dps: 28164.44947
+  tps: 25571.78204
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SoulCasket-58183"
  value: {
-  dps: 25057.92998
-  tps: 22725.12288
+  dps: 28496.11412
+  tps: 25901.80975
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Souldrinker-77193"
  value: {
-  dps: 26539.84842
-  tps: 24013.92301
-  hps: 8.48068
+  dps: 30009.30515
+  tps: 27234.76221
+  hps: 9.33435
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Souldrinker-78479"
  value: {
-  dps: 26540.43808
-  tps: 24014.51268
-  hps: 9.66001
+  dps: 30009.95205
+  tps: 27235.40911
+  hps: 10.62815
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Souldrinker-78488"
  value: {
-  dps: 26539.26624
-  tps: 24013.34083
-  hps: 7.31631
+  dps: 30008.66583
+  tps: 27234.1229
+  hps: 8.05572
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 25458.6803
-  tps: 23124.12109
+  dps: 28888.59417
+  tps: 26291.90726
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 25371.65458
-  tps: 23037.72361
+  dps: 28795.37353
+  tps: 26199.61104
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 25515.19597
-  tps: 23180.93769
+  dps: 28983.13616
+  tps: 26386.93596
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 25114.17912
-  tps: 22781.28149
+  dps: 28559.66465
+  tps: 25965.24734
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 25159.54132
-  tps: 22826.57069
+  dps: 28610.91507
+  tps: 26016.40668
  }
 }
 dps_results: {
  key: "TestSV-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 26804.13387
-  tps: 24205.06178
+  dps: 30412.7043
+  tps: 27572.42896
  }
 }
 dps_results: {
  key: "TestSV-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 26582.1399
-  tps: 24002.36333
+  dps: 30267.31668
+  tps: 27475.08424
  }
 }
 dps_results: {
  key: "TestSV-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 27145.10889
-  tps: 24520.4757
+  dps: 30681.52352
+  tps: 27816.76794
  }
 }
 dps_results: {
  key: "TestSV-AllItems-StayofExecution-68996"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 24784.48983
-  tps: 22448.35509
+  dps: 28171.88687
+  tps: 25577.4526
  }
 }
 dps_results: {
  key: "TestSV-AllItems-StumpofTime-62465"
  value: {
-  dps: 25082.02721
-  tps: 22703.50693
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-StumpofTime-62470"
  value: {
-  dps: 25082.02721
-  tps: 22703.50693
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 24836.20937
-  tps: 22503.73921
+  dps: 28238.29879
+  tps: 25644.37212
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 24772.93463
-  tps: 22449.1096
+  dps: 28194.62196
+  tps: 25599.82454
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TearofBlood-55819"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TearofBlood-56351"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 24961.7621
-  tps: 22629.10978
+  dps: 28387.46322
+  tps: 25793.35195
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 25025.26919
-  tps: 22692.51466
+  dps: 28459.21382
+  tps: 25864.97503
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TheHungerer-68927"
  value: {
-  dps: 26411.08144
-  tps: 23901.98355
+  dps: 30043.35719
+  tps: 27275.66696
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TheHungerer-69112"
  value: {
-  dps: 26612.22381
-  tps: 24043.77746
+  dps: 30206.52236
+  tps: 27408.49219
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 24776.34223
-  tps: 22444.00387
+  dps: 28177.0692
+  tps: 25583.34958
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 24808.95285
-  tps: 22476.04011
+  dps: 28212.52025
+  tps: 25618.21359
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Ti'tahk,theStepsofTime-77190"
  value: {
-  dps: 26483.57818
-  tps: 23960.24398
+  dps: 30004.38883
+  tps: 27223.94286
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Ti'tahk,theStepsofTime-78477"
  value: {
-  dps: 26628.91987
-  tps: 24098.37101
+  dps: 30065.51825
+  tps: 27303.67578
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Ti'tahk,theStepsofTime-78486"
  value: {
-  dps: 26516.47442
-  tps: 23991.92483
+  dps: 30056.86905
+  tps: 27275.84948
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 26023.86211
-  tps: 23586.95861
+  dps: 29533.61659
+  tps: 26831.34059
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 26184.98289
-  tps: 23735.48876
+  dps: 29721.21302
+  tps: 27004.84265
  }
 }
 dps_results: {
  key: "TestSV-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 24948.99876
-  tps: 22586.1776
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 24000.42032
-  tps: 21745.81893
+  dps: 27248.17726
+  tps: 24756.58437
  }
 }
 dps_results: {
  key: "TestSV-AllItems-UnheededWarning-59520"
  value: {
-  dps: 25893.10251
-  tps: 23445.47403
+  dps: 29388.98974
+  tps: 26674.14307
  }
 }
 dps_results: {
  key: "TestSV-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 26178.27304
-  tps: 23758.02149
+  dps: 29745.34754
+  tps: 27041.72151
  }
 }
 dps_results: {
  key: "TestSV-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 26178.27304
-  tps: 23758.02149
+  dps: 29745.34754
+  tps: 27041.72151
+ }
+}
+dps_results: {
+ key: "TestSV-AllItems-UnsolvableRiddle-68709"
+ value: {
+  dps: 29745.34754
+  tps: 27041.72151
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 24660.29063
-  tps: 22318.64195
+  dps: 27716.86813
+  tps: 25172.21185
  }
 }
 dps_results: {
  key: "TestSV-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 25432.39612
-  tps: 23100.17452
+  dps: 28990.62302
+  tps: 26397.2009
  }
 }
 dps_results: {
  key: "TestSV-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 25505.7159
-  tps: 23173.12848
+  dps: 29053.95922
+  tps: 26460.44171
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 25191.77016
-  tps: 22858.67958
+  dps: 28644.71012
+  tps: 26050.03422
  }
 }
 dps_results: {
  key: "TestSV-AllItems-VeilofLies-72900"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 24768.17049
-  tps: 22435.83212
+  dps: 28174.69293
+  tps: 25580.60248
  }
 }
 dps_results: {
  key: "TestSV-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 24768.17049
-  tps: 22435.83212
+  dps: 28174.69293
+  tps: 25580.60248
  }
 }
 dps_results: {
  key: "TestSV-AllItems-VialofShadows-77207"
  value: {
-  dps: 26839.44135
-  tps: 24355.24868
+  dps: 30418.76488
+  tps: 27659.80515
  }
 }
 dps_results: {
  key: "TestSV-AllItems-VialofShadows-77979"
  value: {
-  dps: 26622.97222
-  tps: 24161.18405
+  dps: 30183.20959
+  tps: 27450.85767
  }
 }
 dps_results: {
  key: "TestSV-AllItems-VialofShadows-77999"
  value: {
-  dps: 27089.2287
-  tps: 24577.946
+  dps: 30713.93965
+  tps: 27934.68925
  }
 }
 dps_results: {
  key: "TestSV-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 25874.05095
-  tps: 23454.26813
+  dps: 29402.02616
+  tps: 26698.98487
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sBadgeofConquest-70517"
  value: {
-  dps: 26003.75181
-  tps: 23572.80358
+  dps: 29539.96235
+  tps: 26824.38169
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sBadgeofDominance-70518"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sBadgeofVictory-70519"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 25082.02721
-  tps: 22703.50693
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 24923.34628
-  tps: 22538.53617
+  dps: 28517.91318
+  tps: 25906.92091
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 25118.21004
-  tps: 22750.23022
+  dps: 28577.9865
+  tps: 25948.57614
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 25075.16762
-  tps: 22742.33278
+  dps: 28515.58928
+  tps: 25921.2503
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 25964.85506
-  tps: 23507.08452
+  dps: 29461.0917
+  tps: 26737.38665
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sInsigniaofConquest-70577"
  value: {
-  dps: 26141.87879
-  tps: 23670.81788
+  dps: 29638.27672
+  tps: 26894.16149
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sInsigniaofDominance-70578"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-ViciousGladiator'sInsigniaofVictory-70579"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Vishanka,JawsoftheEarth-78359"
  value: {
-  dps: 28585.58725
-  tps: 26094.74143
+  dps: 31817.97696
+  tps: 29087.46913
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Vishanka,JawsoftheEarth-78471"
  value: {
-  dps: 29237.30856
-  tps: 26752.95921
+  dps: 32621.94509
+  tps: 29878.07479
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Vishanka,JawsoftheEarth-78480"
  value: {
-  dps: 28035.27264
-  tps: 25559.45648
+  dps: 31098.98978
+  tps: 28367.06209
  }
 }
 dps_results: {
  key: "TestSV-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-WillofUnbinding-77995"
  value: {
-  dps: 24766.7046
-  tps: 22434.36624
+  dps: 28167.0864
+  tps: 25573.36678
  }
 }
 dps_results: {
  key: "TestSV-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 24759.0393
-  tps: 22420.11695
+  dps: 28164.06795
+  tps: 25574.92666
  }
 }
 dps_results: {
  key: "TestSV-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 24761.90774
-  tps: 22424.08977
+  dps: 28143.82376
+  tps: 25557.70065
  }
 }
 dps_results: {
  key: "TestSV-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 24965.39107
-  tps: 22632.73292
+  dps: 28391.56326
+  tps: 25797.44469
  }
 }
 dps_results: {
  key: "TestSV-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 27784.85104
-  tps: 25157.35965
+  dps: 31415.97461
+  tps: 28507.44899
  }
 }
 dps_results: {
  key: "TestSV-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 27427.20316
-  tps: 24834.161
+  dps: 31030.42571
+  tps: 28155.94341
  }
 }
 dps_results: {
  key: "TestSV-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 28195.6342
-  tps: 25533.03116
+  dps: 31814.39101
+  tps: 28865.65301
  }
 }
 dps_results: {
  key: "TestSV-AllItems-WyrmstalkerBattlegear"
  value: {
-  dps: 26557.83258
-  tps: 24067.48316
+  dps: 28498.53202
+  tps: 25879.51489
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 24902.89012
-  tps: 22575.69188
+  dps: 28353.23195
+  tps: 25760.56451
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 24902.89012
-  tps: 22575.69188
+  dps: 28353.23195
+  tps: 25760.56451
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Zod'sRepeatingLongbow-50638"
  value: {
-  dps: 25118.36152
-  tps: 22640.0427
+  dps: 27961.75538
+  tps: 25266.36469
  }
 }
 dps_results: {
  key: "TestSV-Average-Default"
  value: {
-  dps: 26528.18847
-  tps: 24004.01219
+  dps: 30093.48662
+  tps: 27347.86787
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-FullBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 125568.60001
-  tps: 102492.63255
+  dps: 141215.31282
+  tps: 114530.62632
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-FullBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 20929.53806
-  tps: 18509.71977
+  dps: 23704.72931
+  tps: 21098.62038
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 26212.55082
-  tps: 22876.31507
+  dps: 28420.36696
+  tps: 25053.94714
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-NoBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 88938.32315
-  tps: 72345.20961
+  dps: 101328.11475
+  tps: 82027.31457
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-NoBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 14566.55738
-  tps: 12900.63094
+  dps: 16879.24382
+  tps: 15069.09819
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-aoe-NoBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 16032.87544
-  tps: 14086.86897
+  dps: 18017.13842
+  tps: 16013.10621
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-FullBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 28966.88741
-  tps: 26592.79333
+  dps: 32544.99012
+  tps: 29914.92019
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-FullBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 26366.2922
-  tps: 23982.53539
+  dps: 29812.7064
+  tps: 27193.86892
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 33529.486
-  tps: 30363.24515
+  dps: 35952.01069
+  tps: 32684.6371
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-NoBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 20151.60153
-  tps: 18489.48351
+  dps: 22794.42433
+  tps: 20960.41691
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-NoBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 18345.6649
-  tps: 16689.15533
+  dps: 21046.83986
+  tps: 19220.1156
  }
 }
 dps_results: {
  key: "TestSV-Settings-Dwarf-preraid_sv-Basic-sv-NoBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 21078.50189
-  tps: 19099.19582
+  dps: 23108.41649
+  tps: 21059.0257
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-FullBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 126187.40862
-  tps: 103051.14561
+  dps: 141858.71803
+  tps: 115074.15993
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-FullBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 21132.93424
-  tps: 18568.73257
+  dps: 23906.76394
+  tps: 21145.28994
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 26612.97207
-  tps: 23062.8375
+  dps: 28792.82771
+  tps: 25210.06552
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-NoBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 89419.63559
-  tps: 72769.41514
+  dps: 101829.56307
+  tps: 82473.64362
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-NoBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 14707.08116
-  tps: 12948.33252
+  dps: 17018.32973
+  tps: 15095.5162
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-aoe-NoBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 16259.41156
-  tps: 14185.34802
+  dps: 18315.04712
+  tps: 16178.65312
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-FullBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 29251.11185
-  tps: 26735.30944
+  dps: 32861.15034
+  tps: 30074.56854
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-FullBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 26535.60808
-  tps: 24009.68268
+  dps: 30004.63797
+  tps: 27230.09504
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-FullBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 34010.44944
-  tps: 30645.81608
+  dps: 36432.91467
+  tps: 32954.16357
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-NoBuffs-5.1yards-LongMultiTarget"
  value: {
-  dps: 20383.32024
-  tps: 18620.405
+  dps: 23010.32308
+  tps: 21065.48507
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-NoBuffs-5.1yards-LongSingleTarget"
  value: {
-  dps: 18471.21335
-  tps: 16714.38382
+  dps: 21177.34375
+  tps: 19240.73526
  }
 }
 dps_results: {
  key: "TestSV-Settings-Orc-preraid_sv-Basic-sv-NoBuffs-5.1yards-ShortSingleTarget"
  value: {
-  dps: 21344.75804
-  tps: 19239.88109
+  dps: 23428.44556
+  tps: 21244.38372
  }
 }
 dps_results: {
  key: "TestSV-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 26380.62433
-  tps: 23880.66436
+  dps: 29782.81506
+  tps: 27034.17028
  }
 }

--- a/sim/hunter/survival/black_arrow.go
+++ b/sim/hunter/survival/black_arrow.go
@@ -47,10 +47,13 @@ func (svHunter *SurvivalHunter) registerBlackArrowSpell(timer *core.Timer) {
 			NumberOfTicks:       10,
 			TickLength:          time.Second * 2,
 			AffectedByCastSpeed: false,
-			OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
+			OnSnapshot: func(sim *core.Simulation, target *core.Unit, dot *core.Dot, isRollover bool) {
 				rap := dot.Spell.RangedAttackPower(target)
 				baseDmg := 285.245 + (0.0665 * rap)
-				dot.Spell.CalcAndDealPeriodicDamage(sim, target, baseDmg, dot.OutcomeTickPhysicalCrit)
+				dot.Snapshot(target, baseDmg)
+			},
+			OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
+				dot.CalcAndDealPeriodicSnapshotDamage(sim, target, dot.OutcomeTickPhysicalCrit)
 			},
 		},
 

--- a/sim/hunter/survival/explosive_shot.go
+++ b/sim/hunter/survival/explosive_shot.go
@@ -19,7 +19,7 @@ func (svHunter *SurvivalHunter) registerExplosiveShotSpell() {
 		ProcMask:         core.ProcMaskRangedSpecial,
 		DamageMultiplier: 1,
 		ClassSpellMask:   hunter.HunterSpellExplosiveShot,
-		CritMultiplier:   svHunter.CritMultiplier(true, false, false),
+		CritMultiplier:   svHunter.SpellCritMultiplier(1, 1),
 		ThreatMultiplier: 1,
 		Flags:            core.SpellFlagMeleeMetrics,
 		Dot: core.DotConfig{
@@ -32,11 +32,19 @@ func (svHunter *SurvivalHunter) registerExplosiveShotSpell() {
 			},
 			NumberOfTicks: 2,
 			TickLength:    time.Second * 1,
-			OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
+			OnSnapshot: func(sim *core.Simulation, target *core.Unit, dot *core.Dot, isRollover bool) {
 				rap := dot.Spell.RangedAttackPower(target)
 				baseDmg := sim.Roll(minFlatDamage, maxFlatDamage) + (0.273 * rap)
-				dot.Spell.CalcAndDealPeriodicDamage(sim, target, baseDmg, dot.OutcomeTickPhysicalCrit)
+				dot.Snapshot(target, baseDmg)
 			},
+			OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
+				dot.CalcAndDealPeriodicSnapshotDamage(sim, target, dot.OutcomeTickPhysicalCrit)
+			},
+			// OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
+			// 	rap := dot.Spell.RangedAttackPower(target)
+			// 	baseDmg := sim.Roll(minFlatDamage, maxFlatDamage) + (0.273 * rap)
+			// 	dot.Spell.CalcAndDealPeriodicDamage(sim, target, baseDmg, dot.OutcomeTickPhysicalCrit)
+			// },
 		},
 	})
 	svHunter.Hunter.ExplosiveShot = svHunter.Hunter.RegisterSpell(core.SpellConfig{
@@ -62,7 +70,7 @@ func (svHunter *SurvivalHunter) registerExplosiveShotSpell() {
 			},
 		},
 		DamageMultiplier: 1,
-		CritMultiplier:   svHunter.CritMultiplier(true, false, false),
+		CritMultiplier:   svHunter.SpellCritMultiplier(1, 1),
 		ThreatMultiplier: 1,
 
 		Dot: core.DotConfig{
@@ -71,10 +79,13 @@ func (svHunter *SurvivalHunter) registerExplosiveShotSpell() {
 			},
 			NumberOfTicks: 2,
 			TickLength:    time.Second * 1,
-			OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
+			OnSnapshot: func(sim *core.Simulation, target *core.Unit, dot *core.Dot, isRollover bool) {
 				rap := dot.Spell.RangedAttackPower(target)
 				baseDmg := sim.Roll(minFlatDamage, maxFlatDamage) + (0.273 * rap)
-				dot.Spell.CalcAndDealPeriodicDamage(sim, target, baseDmg, dot.OutcomeTickPhysicalCrit)
+				dot.Snapshot(target, baseDmg)
+			},
+			OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
+				dot.CalcAndDealPeriodicSnapshotDamage(sim, target, dot.OutcomeTickPhysicalCrit)
 			},
 		},
 

--- a/ui/core/components/detailed_results/timeline.tsx
+++ b/ui/core/components/detailed_results/timeline.tsx
@@ -1193,7 +1193,8 @@ const idToCategoryMap: Record<number, number> = {
 	[53217]: 0.6, // Wild Quiver
 	[53209]: MELEE_ACTION_CATEGORY + 0.1, // Chimera Shot
 	[53353]: MELEE_ACTION_CATEGORY + 0.11, // Chimera Shot Serpent
-	[60053]: MELEE_ACTION_CATEGORY + 0.1, // Explosive Shot
+	[53301]: MELEE_ACTION_CATEGORY + 0.1, // Explosive Shot
+	[1215485]: MELEE_ACTION_CATEGORY + 0.12, // Explosive Shot
 	[49050]: MELEE_ACTION_CATEGORY + 0.2, // Aimed Shot
 	[49048]: MELEE_ACTION_CATEGORY + 0.21, // Multi Shot
 	[3044]: MELEE_ACTION_CATEGORY + 0.22, // Arcane Shot

--- a/ui/core/proto_utils/action_id.ts
+++ b/ui/core/proto_utils/action_id.ts
@@ -264,10 +264,10 @@ export class ActionId {
 
 		switch (baseName) {
 			case 'Explosive Shot':
-				if (this.spellId == 60053) {
-					name += ' (R4)';
-				} else if (this.spellId == 60052) {
-					name += ' (R3)';
+				if (this.spellId == 53301) {
+					name += ' (First)';
+				} else if (this.spellId == 1215485) {
+					name += ' (Second)';
 				}
 				break;
 			case 'Explosive Trap':

--- a/ui/hunter/survival/gear_sets/preraid_sv.gear.json
+++ b/ui/hunter/survival/gear_sets/preraid_sv.gear.json
@@ -1,21 +1,21 @@
 {
 	"items":  [
-		{ "id": 59456, "enchant": 4209, "gems": [68778, 59478, 59493] },
-		{ "id": 52350, "gems": [52212] },
-		{ "id": 64712, "enchant": 4204, "gems": [52212], "reforging": 152 },
-		{ "id": 56315, "enchant": 1099 },
-		{ "id": 56564, "enchant": 4063, "gems": [52258], "reforging": 152 },
-		{ "id": 63479, "enchant": 4071, "gems": [0] },
-		{ "id": 64709, "enchant": 3222, "gems": [52212, 0], "reforging": 137 },
-		{ "id": 56539, "gems": [52212, 52212], "reforging": 165 },
-		{ "id": 56386, "enchant": 4126, "gems": [52258, 52258] },
-		{ "id": 62385, "enchant": 4076, "gems": [52212], "reforging": 166 },
-		{ "id": 52348, "gems": [52212], "reforging": 167 },
-		{ "id": 62362, "reforging": 166 },
-		{ "id": 68709, "reforging": 166 },
-		{ "id": 56328, "reforging": 137 },
-		{ "id": 55066, "enchant": 4227, "reforging": 165 },
-		{},
-		{ "id": 59367, "enchant": 4175, "gems": [52212], "reforging": 151 }
+ 		{"id":60303,"enchant":4209,"gems":[68778,52209],"reforging":165},
+        {"id":69880,"randomSuffix":-135,"reforging":151},
+        {"id":60306,"enchant":4204,"gems":[52212],"reforging":166},
+        {"id":69884,"randomSuffix":-135,"enchant":4087,"reforging":151},
+        {"id":60304,"enchant":4102,"gems":[52212,52220],"reforging":166},
+        {"id":65028,"enchant":4071,"gems":[0],"reforging":138},
+        {"id":60307,"enchant":3222,"gems":[52212,0]},
+        {"id":71255,"gems":[52212,52212],"reforging":152},
+        {"id":60230,"enchant":4126,"gems":[52258,52258,52212],"reforging":165},
+        {"id":70123,"enchant":4076,"gems":[52258],"reforging":152},
+        {"id":70105},
+        {"id":65367,"randomSuffix":-135,"reforging":151},
+        {"id":69001,"reforging":166},
+        {"id":65140},
+        {"id":70165,"enchant":4227,"reforging":165},
+        {},
+        {"id":71077,"enchant":4267,"gems":[52212],"reforging":165}
 	]
 }

--- a/ui/hunter/survival/presets.ts
+++ b/ui/hunter/survival/presets.ts
@@ -1,5 +1,6 @@
 import { ConjuredHealthstone, TinkerHandsSynapseSprings } from '../../core/components/inputs/consumables';
 import * as PresetUtils from '../../core/preset_utils';
+import { APLRotation_Type as APLRotationType } from '../../core/proto/apl.js';
 import { Consumes, Flask, Food, Glyphs, Potions, Profession, PseudoStat, RotationType, Spec, Stat } from '../../core/proto/common';
 import {
 	HunterMajorGlyph as MajorGlyph,
@@ -18,23 +19,36 @@ import AoeApl from './apls/aoe.apl.json';
 import SvApl from './apls/sv.apl.json';
 import P1SVGear from './gear_sets/p1_sv.gear.json';
 import P3SVGear from './gear_sets/p3_sv.gear.json';
-import P4SVGear from './gear_sets/p3_sv.gear.json';
+import P4SVGear from './gear_sets/p4_sv_gear.json';
 import PreraidSVGear from './gear_sets/preraid_sv.gear.json';
 
 // Preset options for this spec.
 // Eventually we will import these values for the raid sim too, so its good to
 // keep them in a separate file.
 
-export const SV_PRERAID_PRESET = PresetUtils.makePresetGear('SV PreRaid Preset', PreraidSVGear);
-export const SV_P1_PRESET = PresetUtils.makePresetGear('SV T11 Preset', P1SVGear);
-export const SV_P3_PRESET = PresetUtils.makePresetGear('SV T12 Preset', P3SVGear);
-export const SV_P4_PRESET = PresetUtils.makePresetGear('SV T12 Preset', P4SVGear);
+export const SV_PRERAID_PRESET = PresetUtils.makePresetGear('Pre-raid', PreraidSVGear);
+export const SV_P1_PRESET = PresetUtils.makePresetGear('P2', P1SVGear);
+export const SV_P3_PRESET = PresetUtils.makePresetGear('P3', P3SVGear);
+export const SV_P4_PRESET = PresetUtils.makePresetGear('P4', P4SVGear);
 export const ROTATION_PRESET_SV = PresetUtils.makePresetAPLRotation('SV', SvApl);
 export const ROTATION_PRESET_AOE = PresetUtils.makePresetAPLRotation('AOE', AoeApl);
-
+export const SurvivalTalents = {
+	name: 'Survival',
+	data: SavedTalents.create({
+		talentsString: '03-2302-03203203023022121311',
+		glyphs: Glyphs.create({
+			prime1: PrimeGlyph.GlyphOfExplosiveShot,
+			prime2: PrimeGlyph.GlyphOfKillShot,
+			prime3: PrimeGlyph.GlyphOfArcaneShot,
+			major1: MajorGlyph.GlyphOfDisengage,
+			major2: MajorGlyph.GlyphOfRaptorStrike,
+			major3: MajorGlyph.GlyphOfTrapLauncher,
+		}),
+	}),
+};
 // Preset options for EP weights
 export const P1_EP_PRESET = PresetUtils.makePresetEpWeights(
-	'SV P1',
+	'P2',
 	Stats.fromMap(
 		{
 			[Stat.StatStamina]: 0.5,
@@ -52,7 +66,7 @@ export const P1_EP_PRESET = PresetUtils.makePresetEpWeights(
 );
 
 export const P3_EP_PRESET = PresetUtils.makePresetEpWeights(
-	'SV P3 (T12 4 set)',
+	'P3',
 	Stats.fromMap(
 		{
 			[Stat.StatStamina]: 0.5,
@@ -69,23 +83,48 @@ export const P3_EP_PRESET = PresetUtils.makePresetEpWeights(
 	),
 );
 
+export const P4_EP_PRESET = PresetUtils.makePresetEpWeights(
+	'P4',
+	Stats.fromMap(
+		{
+			[Stat.StatStamina]: 0.5,
+			[Stat.StatAgility]: 3.47,
+			[Stat.StatRangedAttackPower]: 1.0,
+			[Stat.StatHitRating]: 2.56,
+			[Stat.StatCritRating]: 1.45,
+			[Stat.StatHasteRating]: 1.09,
+			[Stat.StatMasteryRating]: 1.04,
+		},
+		{
+			[PseudoStat.PseudoStatRangedDps]: 4.16,
+		},
+	),
+);
+
+export const P2_PRESET = PresetUtils.makePresetBuild('P2', {
+	gear: SV_P1_PRESET,
+	epWeights: P1_EP_PRESET,
+	talents: SurvivalTalents,
+	rotationType: APLRotationType.TypeAuto,
+});
+
+export const P3_PRESET = PresetUtils.makePresetBuild('P3', {
+	gear: SV_P3_PRESET,
+	epWeights: P3_EP_PRESET,
+	talents: SurvivalTalents,
+	rotationType: APLRotationType.TypeAuto,
+});
+
+export const P4_PRESET = PresetUtils.makePresetBuild('P4', {
+	gear: SV_P4_PRESET,
+	epWeights: P4_EP_PRESET,
+	talents: SurvivalTalents,
+	rotationType: APLRotationType.TypeAuto,
+});
 // Default talents. Uses the wowhead calculator format, make the talents on
 // https://wowhead.com/wotlk/talent-calc and copy the numbers in the url.
 
-export const SurvivalTalents = {
-	name: 'Survival',
-	data: SavedTalents.create({
-		talentsString: '03-2302-03203203023022121311',
-		glyphs: Glyphs.create({
-			prime1: PrimeGlyph.GlyphOfExplosiveShot,
-			prime2: PrimeGlyph.GlyphOfKillShot,
-			prime3: PrimeGlyph.GlyphOfArcaneShot,
-			major1: MajorGlyph.GlyphOfDisengage,
-			major2: MajorGlyph.GlyphOfRaptorStrike,
-			major3: MajorGlyph.GlyphOfTrapLauncher,
-		}),
-	}),
-};
+
 
 export const SVDefaultOptions = HunterOptions.create({
 	classOptions: {

--- a/ui/hunter/survival/sim.ts
+++ b/ui/hunter/survival/sim.ts
@@ -144,13 +144,14 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecSurvivalHunter, {
 	},
 
 	presets: {
-		epWeights: [Presets.P1_EP_PRESET, Presets.P3_EP_PRESET],
+		epWeights: [Presets.P1_EP_PRESET, Presets.P3_EP_PRESET, Presets.P4_EP_PRESET],
 		// Preset talents that the user can quickly select.
 		talents: [Presets.SurvivalTalents],
 		// Preset rotations that the user can quickly select.
 		rotations: [Presets.ROTATION_PRESET_SV, Presets.ROTATION_PRESET_AOE],
 		// Preset gear configurations that the user can quickly select.
-		gear: [Presets.SV_P3_PRESET, Presets.SV_P1_PRESET, Presets.SV_PRERAID_PRESET, Presets.SV_P4_PRESET],
+		builds: [Presets.P2_PRESET, Presets.P3_PRESET, Presets.P4_PRESET],
+		gear: [Presets.SV_PRERAID_PRESET, Presets.SV_P1_PRESET, Presets.SV_P3_PRESET,  Presets.SV_P4_PRESET],
 	},
 
 	autoRotation: (player: Player<Spec.SpecSurvivalHunter>): APLRotation => {


### PR DESCRIPTION
- Fix Black Arrow, Serpent Sting and Explosive Shot snapshotting ticks
- Fix Explosive Shot having wrong crit damage multiplier (2.09 instead of 2.06)
- Fix T12 4-set being consumed by things it shouldn't be consumed by
- Clean up Survival presets