### PR TITLE
Feral Rotation Updates

### DIFF
--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -38,2041 +38,2041 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 32753.20322
-  tps: 44186.0023
+  dps: 32710.91126
+  tps: 44415.53096
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 30766.65324
-  tps: 41558.24042
+  dps: 30674.96338
+  tps: 41987.80057
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 32934.97397
-  tps: 44380.3835
+  dps: 32994.01328
+  tps: 45409.258
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 30755.19392
-  tps: 41558.23422
+  dps: 30688.1801
+  tps: 41921.93394
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 30739.2349
-  tps: 41658.97024
+  dps: 30677.89419
+  tps: 42006.69448
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 31732.16582
-  tps: 43754.40086
+  dps: 31725.93082
+  tps: 43567.21614
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 31914.31587
-  tps: 44212.6666
+  dps: 31839.64948
+  tps: 43687.06496
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ArrowofTime-72897"
  value: {
-  dps: 32902.57544
-  tps: 45132.58022
+  dps: 32894.30083
+  tps: 44700.78728
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 31913.28255
-  tps: 43163.74081
+  dps: 31933.80668
+  tps: 43433.68304
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 30766.65324
-  tps: 41558.36582
+  dps: 30674.96338
+  tps: 41987.93464
   hps: 96.77966
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 30766.65324
-  tps: 41558.36582
+  dps: 30674.96338
+  tps: 41987.93464
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 31199.05969
-  tps: 42187.20832
+  dps: 31159.77949
+  tps: 42845.30849
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 31288.66606
-  tps: 42169.42165
+  dps: 31205.81357
+  tps: 42740.40492
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BindingPromise-67037"
  value: {
-  dps: 30775.90736
-  tps: 41426.16014
+  dps: 30684.69329
+  tps: 41885.31903
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 32201.04757
-  tps: 42746.77942
+  dps: 32209.70415
+  tps: 43833.70022
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 31088.11293
-  tps: 42168.58841
+  dps: 30999.22114
+  tps: 42493.52532
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 31130.69137
-  tps: 42234.50711
+  dps: 31041.68346
+  tps: 42559.73363
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 32759.04581
-  tps: 43453.91287
+  dps: 32726.75927
+  tps: 44005.64221
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 30775.90736
-  tps: 41426.16014
+  dps: 30684.69329
+  tps: 41885.31903
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 31326.86411
-  tps: 42264.049
+  dps: 31214.29009
+  tps: 42811.45841
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 31199.77531
-  tps: 41969.6236
+  dps: 31132.17091
+  tps: 42547.32441
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 30775.90736
-  tps: 41426.16014
+  dps: 30684.2175
+  tps: 41855.72896
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 30775.90736
-  tps: 41426.16014
+  dps: 30684.2175
+  tps: 41855.72896
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 32196.28505
-  tps: 43255.87141
+  dps: 32077.33014
+  tps: 44015.11703
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 30763.98353
-  tps: 41588.52985
+  dps: 30674.96338
+  tps: 41987.93464
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 31321.62283
-  tps: 41952.14893
+  dps: 31287.67335
+  tps: 42360.04022
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 32397.26042
-  tps: 43873.73778
+  dps: 32523.58517
+  tps: 44301.50987
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 32230.01859
-  tps: 43738.67431
+  dps: 32137.4464
+  tps: 43591.34893
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 32768.75942
-  tps: 44769.50726
+  dps: 32740.856
+  tps: 44808.19079
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledLightning-66879"
  value: {
-  dps: 30921.79249
-  tps: 41836.11807
+  dps: 30821.68082
+  tps: 42327.49507
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledWishes-77114"
  value: {
-  dps: 31236.43032
-  tps: 42333.47532
+  dps: 31183.53969
+  tps: 41686.31109
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 31913.28255
-  tps: 42300.7039
+  dps: 31933.80668
+  tps: 42565.24863
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 30775.90736
-  tps: 41426.16014
+  dps: 30684.69329
+  tps: 41885.31903
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 32512.19531
-  tps: 43945.07439
+  dps: 32534.7867
+  tps: 44221.02403
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sBadgeofConquest-73648"
  value: {
-  dps: 33194.34594
-  tps: 43583.60165
+  dps: 33137.61832
+  tps: 43933.06671
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sBadgeofDominance-73498"
  value: {
-  dps: 30775.90736
-  tps: 41426.16014
+  dps: 30684.69329
+  tps: 41885.31903
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sBadgeofVictory-73496"
  value: {
-  dps: 31573.87869
-  tps: 42701.764
+  dps: 31493.75368
+  tps: 43111.31485
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sInsigniaofConquest-73643"
  value: {
-  dps: 32945.50399
-  tps: 43842.32771
+  dps: 32903.6244
+  tps: 44173.59476
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sInsigniaofDominance-73497"
  value: {
-  dps: 30760.08124
-  tps: 41698.02524
+  dps: 30655.30127
+  tps: 42027.77137
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sInsigniaofVictory-73491"
  value: {
-  dps: 31680.583
-  tps: 41837.8233
+  dps: 31558.04
+  tps: 43019.14817
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 32623.60547
-  tps: 44148.05853
+  dps: 32533.03825
+  tps: 44197.81384
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 32080.57909
-  tps: 42931.71022
+  dps: 32083.21558
+  tps: 42742.03208
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 30777.76359
-  tps: 41427.24618
+  dps: 30686.54952
+  tps: 41886.39212
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 30766.65324
-  tps: 41558.36582
+  dps: 30674.96338
+  tps: 41987.93464
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 32377.36936
-  tps: 44267.29606
+  dps: 32276.56956
+  tps: 43904.56441
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 32115.53684
-  tps: 43449.79466
+  dps: 32064.97892
+  tps: 43592.98475
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 32559.28857
-  tps: 43660.39871
+  dps: 32474.47881
+  tps: 44059.14702
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-59506"
  value: {
-  dps: 31526.49181
-  tps: 42359.3718
+  dps: 31554.96912
+  tps: 42819.43154
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-65118"
  value: {
-  dps: 31726.2088
-  tps: 42884.49758
+  dps: 31728.85961
+  tps: 42701.76848
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 31085.02095
-  tps: 42013.17461
+  dps: 30979.83563
+  tps: 42499.54389
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 31001.68887
-  tps: 42070.1628
+  dps: 30957.03547
+  tps: 42132.64658
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-78000"
  value: {
-  dps: 31125.3509
-  tps: 42405.46972
+  dps: 31056.22896
+  tps: 42709.47145
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 30775.90736
-  tps: 41426.16014
+  dps: 30684.2175
+  tps: 41855.72896
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 31521.41602
-  tps: 42218.92394
+  dps: 31429.42204
+  tps: 42692.21394
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 32321.65242
-  tps: 43453.9648
+  dps: 32231.59514
+  tps: 43837.48964
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 30768.50947
-  tps: 41559.4497
+  dps: 30676.8196
+  tps: 41989.00234
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 31212.40105
-  tps: 44051.19326
+  dps: 31224.48467
+  tps: 43960.73015
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 31695.56291
-  tps: 43472.35668
+  dps: 31666.49637
+  tps: 44019.27645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeepEarthRegalia"
  value: {
-  dps: 22028.80755
-  tps: 28501.15473
+  dps: 21982.84351
+  tps: 28845.26358
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 32019.03904
-  tps: 43357.50073
+  dps: 31930.71867
+  tps: 43405.24
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 30918.37581
-  tps: 42421.39999
+  dps: 31014.1368
+  tps: 43487.53675
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dragonwrath,Tarecgosa'sRest-71086"
  value: {
-  dps: 33138.40222
-  tps: 43832.9012
+  dps: 33134.07465
+  tps: 44808.38913
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 31847.78414
-  tps: 42703.57158
+  dps: 31726.64359
+  tps: 43833.86696
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 31913.28255
-  tps: 43163.74081
+  dps: 31933.80668
+  tps: 43433.68304
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 30776.83548
-  tps: 41463.58716
+  dps: 30685.62141
+  tps: 41923.28205
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 31913.28255
-  tps: 43163.67368
+  dps: 31933.80668
+  tps: 43433.62086
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 32019.03904
-  tps: 43357.50073
+  dps: 31930.71867
+  tps: 43405.24
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 32575.15248
-  tps: 43687.88491
+  dps: 32437.76808
+  tps: 43672.22415
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 31928.96626
-  tps: 44233.23782
+  dps: 31900.89556
+  tps: 44210.64271
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 31913.28255
-  tps: 43163.74081
+  dps: 31933.80668
+  tps: 43433.68304
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 32187.41412
-  tps: 43356.80684
+  dps: 32084.77872
+  tps: 43750.92629
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 32031.30898
-  tps: 43143.85345
+  dps: 31929.21089
+  tps: 43535.75411
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 32359.12978
-  tps: 43591.05557
+  dps: 32255.90333
+  tps: 43987.61568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-59500"
  value: {
-  dps: 30768.50947
-  tps: 41559.4497
+  dps: 30676.8196
+  tps: 41989.00234
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-65124"
  value: {
-  dps: 30768.50947
-  tps: 41559.41908
+  dps: 30676.8196
+  tps: 41988.96961
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 30783.39032
-  tps: 41732.30815
+  dps: 30681.09051
+  tps: 42085.62875
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 32130.90206
-  tps: 42415.20057
+  dps: 32060.78528
+  tps: 42563.36031
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 30776.83548
-  tps: 41426.61322
+  dps: 30685.62141
+  tps: 41885.76062
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 30775.90736
-  tps: 41426.16014
+  dps: 30684.69329
+  tps: 41885.31903
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 30776.83548
-  tps: 41426.61322
+  dps: 30685.62141
+  tps: 41885.76062
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 31661.53448
-  tps: 43000.84635
+  dps: 31552.97722
+  tps: 43471.45101
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 31440.74743
-  tps: 44162.8965
+  dps: 31397.73544
+  tps: 43894.76181
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 31984.25721
-  tps: 43273.42414
+  dps: 32004.58158
+  tps: 43543.05899
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FluidDeath-58181"
  value: {
-  dps: 32343.64156
-  tps: 43685.95231
+  dps: 32179.38358
+  tps: 43878.88839
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 31913.28255
-  tps: 43163.69654
+  dps: 31933.80668
+  tps: 43433.64204
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 31267.82466
-  tps: 42792.01298
+  dps: 31167.71225
+  tps: 43224.8698
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 31892.29031
-  tps: 43065.80386
+  dps: 31797.72519
+  tps: 43669.55033
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56138"
  value: {
-  dps: 31085.16805
-  tps: 42537.83233
+  dps: 31185.74234
+  tps: 42805.12774
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56462"
  value: {
-  dps: 31091.19093
-  tps: 41883.20233
+  dps: 31110.73496
+  tps: 42925.72788
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GearDetector-61462"
  value: {
-  dps: 31685.90847
-  tps: 43583.89963
+  dps: 31653.02934
+  tps: 43834.6179
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 26227.70645
-  tps: 34738.71656
+  dps: 26276.41555
+  tps: 35135.05115
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 30766.65324
-  tps: 41558.23167
+  dps: 30674.96338
+  tps: 41987.79122
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 31765.78533
-  tps: 42240.5537
+  dps: 31690.62003
+  tps: 43157.16756
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 32139.51077
-  tps: 43104.4378
+  dps: 31995.77752
+  tps: 43986.68716
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HarmlightToken-63839"
  value: {
-  dps: 30808.24724
-  tps: 41762.00978
+  dps: 30705.47938
+  tps: 42168.54751
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 31308.87948
-  tps: 42438.79316
+  dps: 31259.52202
+  tps: 42664.36237
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 30766.65324
-  tps: 41558.36582
+  dps: 30674.96338
+  tps: 41987.93464
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 30766.65324
-  tps: 41558.36582
+  dps: 30674.96338
+  tps: 41987.93464
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-59224"
  value: {
-  dps: 31481.64745
-  tps: 42519.12721
+  dps: 31422.16198
+  tps: 43097.16864
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-65072"
  value: {
-  dps: 31535.25547
-  tps: 42229.73922
+  dps: 31459.89545
+  tps: 43017.71344
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-55868"
  value: {
-  dps: 31574.85053
-  tps: 43486.96252
+  dps: 31671.09899
+  tps: 43439.18683
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-56393"
  value: {
-  dps: 31646.71748
-  tps: 42644.03341
+  dps: 31668.54862
+  tps: 44169.75664
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-55845"
  value: {
-  dps: 30766.65324
-  tps: 41558.36582
+  dps: 30674.96338
+  tps: 41987.93464
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-56370"
  value: {
-  dps: 30766.65324
-  tps: 41558.36582
+  dps: 30674.96338
+  tps: 41987.93464
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 31828.12542
-  tps: 42916.6557
+  dps: 31692.73563
+  tps: 43307.54647
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-50641"
  value: {
-  dps: 33215.7302
-  tps: 44730.41573
+  dps: 33246.7943
+  tps: 44398.2951
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 32019.03904
-  tps: 43357.50073
+  dps: 31930.71867
+  tps: 43405.24
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 31861.91614
-  tps: 44401.22381
+  dps: 31838.65144
+  tps: 44291.84798
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 31861.91614
-  tps: 44401.22381
+  dps: 31838.65144
+  tps: 44291.84798
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 31099.10029
-  tps: 42038.35886
+  dps: 31012.87724
+  tps: 42385.52927
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 31141.68034
-  tps: 42103.86303
+  dps: 31055.33123
+  tps: 42451.43557
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndomitablePride-77211"
  value: {
-  dps: 30766.65324
-  tps: 41558.36582
+  dps: 30674.96338
+  tps: 41987.93464
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndomitablePride-77983"
  value: {
-  dps: 30766.65324
-  tps: 41558.36582
+  dps: 30674.96338
+  tps: 41987.93464
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndomitablePride-78003"
  value: {
-  dps: 30766.65324
-  tps: 41558.36582
+  dps: 30674.96338
+  tps: 41987.93464
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 30766.65324
-  tps: 41558.36582
+  dps: 30674.96338
+  tps: 41987.93464
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 31462.62379
-  tps: 41645.11913
+  dps: 31342.2497
+  tps: 42071.48603
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 31287.86202
-  tps: 42032.11788
+  dps: 31398.05127
+  tps: 42342.92351
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 31408.50305
-  tps: 41378.42527
+  dps: 31499.35671
+  tps: 41988.42812
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 31031.20238
-  tps: 42018.64675
+  dps: 30927.43083
+  tps: 42375.94778
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 30766.65324
-  tps: 41558.59911
+  dps: 30674.96338
+  tps: 41988.32279
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 30766.65324
-  tps: 41558.59911
+  dps: 30674.96338
+  tps: 41988.32279
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 30768.50947
-  tps: 41559.4045
+  dps: 30676.8196
+  tps: 41988.95402
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 30768.50947
-  tps: 41559.36804
+  dps: 30676.8196
+  tps: 41988.91504
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 32201.04757
-  tps: 42746.77942
+  dps: 32209.70415
+  tps: 43833.70022
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 31929.69917
-  tps: 43276.5963
+  dps: 31912.49785
+  tps: 44071.5479
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 32344.43031
-  tps: 43563.76284
+  dps: 32220.48308
+  tps: 44352.37292
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-77194"
  value: {
-  dps: 36330.71227
-  tps: 48747.90051
+  dps: 36230.05048
+  tps: 48697.97119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-78473"
  value: {
-  dps: 36761.7145
-  tps: 49318.4179
+  dps: 36734.85189
+  tps: 49571.8748
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-78482"
  value: {
-  dps: 35943.9044
-  tps: 48873.45887
+  dps: 35822.43999
+  tps: 49003.12726
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 33847.99809
-  tps: 44129.08281
+  dps: 33874.79738
+  tps: 44721.34427
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 31210.84253
-  tps: 42199.51097
+  dps: 31161.89233
+  tps: 41830.71882
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 31210.84253
-  tps: 42199.51097
+  dps: 31161.89233
+  tps: 41830.71882
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 30867.51644
-  tps: 42469.81868
+  dps: 30844.20799
+  tps: 42392.10817
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50708"
  value: {
-  dps: 32909.44713
-  tps: 44306.41384
+  dps: 32895.03501
+  tps: 44668.60967
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-55816"
  value: {
-  dps: 30766.65324
-  tps: 41558.36582
+  dps: 30674.96338
+  tps: 41987.93464
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-56347"
  value: {
-  dps: 30766.65324
-  tps: 41558.36582
+  dps: 30674.96338
+  tps: 41987.93464
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 31957.01423
-  tps: 42252.72937
+  dps: 32005.91088
+  tps: 43044.59257
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 32216.89744
-  tps: 43308.86056
+  dps: 32190.18016
+  tps: 43144.0757
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 31337.39023
-  tps: 42459.7892
+  dps: 31268.0177
+  tps: 42826.20233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 31273.26464
-  tps: 42250.51652
+  dps: 31100.93966
+  tps: 42598.82013
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 31422.4527
-  tps: 42403.46739
+  dps: 31247.32983
+  tps: 42757.72616
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 30766.65324
-  tps: 41558.36582
+  dps: 30674.96338
+  tps: 41987.93464
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 30766.65324
-  tps: 41558.36582
+  dps: 30674.96338
+  tps: 41987.93464
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 31696.22935
-  tps: 42723.81479
+  dps: 31639.87699
+  tps: 43166.68078
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 31734.33912
-  tps: 42745.11156
+  dps: 31806.28181
+  tps: 43715.54356
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 33052.47976
-  tps: 45728.1863
+  dps: 32987.2948
+  tps: 45178.09906
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 33355.24953
-  tps: 45808.48233
+  dps: 33276.03526
+  tps: 46092.31468
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 31106.66472
-  tps: 42060.80238
+  dps: 30981.94007
+  tps: 42482.66544
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 31399.57006
-  tps: 42305.04991
+  dps: 31250.26065
+  tps: 42776.48601
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 31258.71807
-  tps: 43770.93792
+  dps: 31225.80123
+  tps: 43511.24874
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 31258.71807
-  tps: 43770.93792
+  dps: 31225.80123
+  tps: 43511.24874
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 31192.28129
-  tps: 42264.58319
+  dps: 31129.05375
+  tps: 42631.63725
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 31185.69969
-  tps: 41439.5422
+  dps: 31177.50464
+  tps: 42388.38817
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 30775.90736
-  tps: 41426.16014
+  dps: 30684.69329
+  tps: 41885.31903
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 30768.50947
-  tps: 41559.4045
+  dps: 30676.8196
+  tps: 41988.95402
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 30768.50947
-  tps: 41559.36804
+  dps: 30676.8196
+  tps: 41988.91504
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ObsidianArborweaveBattlegarb"
  value: {
-  dps: 31018.82722
-  tps: 38710.21998
+  dps: 30974.90118
+  tps: 38845.36829
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ObsidianArborweaveRegalia"
  value: {
-  dps: 22405.35
-  tps: 28873.01479
+  dps: 22451.36914
+  tps: 29513.39709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 31391.46239
-  tps: 42299.25631
+  dps: 31320.87255
+  tps: 43086.19472
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 30767.58136
-  tps: 41558.80314
+  dps: 30675.89149
+  tps: 41988.35664
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 30766.65324
-  tps: 41558.36582
+  dps: 30674.96338
+  tps: 41987.93464
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 30974.86393
-  tps: 41975.18583
+  dps: 30916.57049
+  tps: 42270.83528
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 31068.23377
-  tps: 42034.9067
+  dps: 30888.63611
+  tps: 42277.49989
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 31192.11986
-  tps: 42206.42508
+  dps: 31158.40839
+  tps: 42765.56296
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 31913.28255
-  tps: 43163.74081
+  dps: 31933.80668
+  tps: 43433.68304
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 32569.33252
-  tps: 43632.39191
+  dps: 32468.63666
+  tps: 43540.02606
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-55854"
  value: {
-  dps: 30766.65324
-  tps: 41558.36582
+  dps: 30674.96338
+  tps: 41987.93464
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-56377"
  value: {
-  dps: 30766.65324
-  tps: 41558.36582
+  dps: 30674.96338
+  tps: 41987.93464
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rathrak,thePoisonousMind-77195"
  value: {
-  dps: 29538.96705
-  tps: 39603.77005
+  dps: 29515.83604
+  tps: 39645.20948
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rathrak,thePoisonousMind-78475"
  value: {
-  dps: 30121.50435
-  tps: 40109.62362
+  dps: 30096.45223
+  tps: 40299.42122
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rathrak,thePoisonousMind-78484"
  value: {
-  dps: 29099.25501
-  tps: 39358.49037
+  dps: 28998.77444
+  tps: 38981.27143
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 30781.00166
-  tps: 41632.32709
+  dps: 30677.77374
+  tps: 41986.7945
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 30766.65324
-  tps: 41558.36582
+  dps: 30674.96338
+  tps: 41987.93464
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 30766.65324
-  tps: 41558.36582
+  dps: 30674.96338
+  tps: 41987.93464
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 30766.65324
-  tps: 41558.36582
+  dps: 30674.96338
+  tps: 41987.93464
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 32599.22293
-  tps: 44063.5671
+  dps: 32621.9049
+  tps: 44340.35894
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 32512.19531
-  tps: 43945.11866
+  dps: 32534.7867
+  tps: 44221.06503
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 32638.74742
-  tps: 44321.53624
+  dps: 32581.84686
+  tps: 44979.7798
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 31322.95621
-  tps: 42188.95499
+  dps: 31241.98419
+  tps: 42791.66019
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 31357.865
-  tps: 42205.84103
+  dps: 31281.77367
+  tps: 42866.33185
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RosaryofLight-72901"
  value: {
-  dps: 31997.44384
-  tps: 42826.57732
+  dps: 31910.53637
+  tps: 44163.53203
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RottingSkull-77116"
  value: {
-  dps: 32441.07718
-  tps: 43582.57453
+  dps: 32303.53149
+  tps: 44253.14463
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuneofZeth-68998"
  value: {
-  dps: 31221.82399
-  tps: 42606.23698
+  dps: 31243.36183
+  tps: 43181.3096
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofConquest-70399"
  value: {
-  dps: 32759.06107
-  tps: 42868.97509
+  dps: 32668.88692
+  tps: 43399.31176
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofConquest-72304"
  value: {
-  dps: 32869.31396
-  tps: 42995.35441
+  dps: 32779.36453
+  tps: 43537.30353
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofDominance-70401"
  value: {
-  dps: 30775.90736
-  tps: 41426.16014
+  dps: 30684.69329
+  tps: 41885.31903
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofDominance-72448"
  value: {
-  dps: 30775.90736
-  tps: 41426.16014
+  dps: 30684.69329
+  tps: 41885.31903
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofVictory-70400"
  value: {
-  dps: 31457.66972
-  tps: 42633.98392
+  dps: 31369.50351
+  tps: 43069.29314
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofVictory-72450"
  value: {
-  dps: 31479.933
-  tps: 42552.84525
+  dps: 31391.86034
+  tps: 42987.70922
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofConquest-70404"
  value: {
-  dps: 32587.93732
-  tps: 42970.72003
+  dps: 32582.23246
+  tps: 43646.84309
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofConquest-72309"
  value: {
-  dps: 32634.58278
-  tps: 43193.60289
+  dps: 32653.42812
+  tps: 43686.57282
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofDominance-70402"
  value: {
-  dps: 30766.65324
-  tps: 41558.36582
+  dps: 30682.02662
+  tps: 42142.2282
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofDominance-72449"
  value: {
-  dps: 30766.65324
-  tps: 41558.36582
+  dps: 30682.02662
+  tps: 42142.2282
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofVictory-70403"
  value: {
-  dps: 31522.79188
-  tps: 42002.31009
+  dps: 31445.10886
+  tps: 42607.64124
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofVictory-72455"
  value: {
-  dps: 31542.52855
-  tps: 42370.4235
+  dps: 31456.61216
+  tps: 42783.77982
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ScalesofLife-68915"
  value: {
-  dps: 30766.65324
-  tps: 41558.36582
+  dps: 30674.96338
+  tps: 41987.93464
   hps: 315.97258
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ScalesofLife-69109"
  value: {
-  dps: 30766.65324
-  tps: 41558.36582
+  dps: 30674.96338
+  tps: 41987.93464
   hps: 356.41412
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 31882.41564
-  tps: 43183.03738
+  dps: 31874.9475
+  tps: 43376.42051
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-55256"
  value: {
-  dps: 30775.90736
-  tps: 41426.16014
+  dps: 30684.69329
+  tps: 41885.31903
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-56290"
  value: {
-  dps: 30775.90736
-  tps: 41426.16014
+  dps: 30684.69329
+  tps: 41885.31903
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShardofWoe-60233"
  value: {
-  dps: 30988.86464
-  tps: 42114.13212
+  dps: 31108.67562
+  tps: 42197.87762
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 31423.54457
-  tps: 42690.93767
+  dps: 31442.29701
+  tps: 43284.34756
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 30780.37301
-  tps: 41452.67598
+  dps: 30688.68314
+  tps: 41882.2448
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 32113.07578
-  tps: 42924.63516
+  dps: 32044.25124
+  tps: 43681.18236
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 32272.06465
-  tps: 43021.61986
+  dps: 32259.42234
+  tps: 43751.9767
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-55879"
  value: {
-  dps: 31081.00868
-  tps: 42132.50019
+  dps: 31009.93101
+  tps: 42436.51077
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-56400"
  value: {
-  dps: 31123.60673
-  tps: 42198.14577
+  dps: 31052.38655
+  tps: 42502.47759
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 31106.66472
-  tps: 42060.80238
+  dps: 30981.94007
+  tps: 42482.66544
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulCasket-58183"
  value: {
-  dps: 31254.26009
-  tps: 43744.70868
+  dps: 31233.47977
+  tps: 43576.78301
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 31657.09793
-  tps: 42614.36885
+  dps: 31502.73536
+  tps: 43137.13506
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 31424.10069
-  tps: 42044.21701
+  dps: 31414.89119
+  tps: 42431.26395
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 31737.79798
-  tps: 42220.73131
+  dps: 31567.52128
+  tps: 42319.16144
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 31324.06548
-  tps: 43959.6402
+  dps: 31302.72295
+  tps: 43762.00366
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 31388.53931
-  tps: 44062.90872
+  dps: 31367.18977
+  tps: 43864.98849
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 33250.33614
-  tps: 44798.83307
+  dps: 33413.72044
+  tps: 45009.78867
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 32886.17768
-  tps: 43710.11156
+  dps: 33016.41778
+  tps: 44432.34045
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 33497.5952
-  tps: 43803.76681
+  dps: 33584.66445
+  tps: 44026.44727
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StayofExecution-68996"
  value: {
-  dps: 30766.65324
-  tps: 41558.36582
+  dps: 30674.96338
+  tps: 41987.93464
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 30806.62361
-  tps: 41649.31412
+  dps: 30720.93362
+  tps: 41979.80035
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stormrider'sBattlegarb"
  value: {
-  dps: 28460.47215
-  tps: 37007.62766
+  dps: 28430.88516
+  tps: 37206.92042
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stormrider'sRegalia"
  value: {
-  dps: 22193.14961
-  tps: 28511.48424
+  dps: 22238.19656
+  tps: 28712.45214
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62465"
  value: {
-  dps: 30745.88495
-  tps: 41647.91946
+  dps: 30677.89419
+  tps: 42006.69448
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62470"
  value: {
-  dps: 30743.21524
-  tps: 41678.08349
+  dps: 30677.15471
+  tps: 42000.80946
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 30766.65324
-  tps: 41558.36582
+  dps: 30674.96338
+  tps: 41987.93464
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 30766.65324
-  tps: 41558.36582
+  dps: 30674.96338
+  tps: 41987.93464
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 30816.43214
-  tps: 41629.73916
+  dps: 30729.32514
+  tps: 41954.93508
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 31427.54481
-  tps: 42853.34782
+  dps: 31348.88918
+  tps: 43276.05819
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-55819"
  value: {
-  dps: 30766.65324
-  tps: 41558.20907
+  dps: 30674.96338
+  tps: 41987.76705
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-56351"
  value: {
-  dps: 30767.58136
-  tps: 41558.81699
+  dps: 30675.89149
+  tps: 41988.37145
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 31040.37347
-  tps: 42094.67956
+  dps: 30951.61186
+  tps: 42419.29177
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 31130.69137
-  tps: 42234.50711
+  dps: 31044.53803
+  tps: 42558.48875
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheHungerer-68927"
  value: {
-  dps: 32735.16647
-  tps: 45225.22101
+  dps: 32748.77423
+  tps: 45179.67569
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheHungerer-69112"
  value: {
-  dps: 32945.11927
-  tps: 44762.50446
+  dps: 32910.03581
+  tps: 45170.84214
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 30802.56029
-  tps: 41567.80009
+  dps: 30707.03653
+  tps: 41951.14082
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 30832.96075
-  tps: 41492.1563
+  dps: 30732.92752
+  tps: 42099.30813
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 30766.65324
-  tps: 41558.36582
+  dps: 30674.96338
+  tps: 41987.93464
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 30766.65324
-  tps: 41558.36582
+  dps: 30674.96338
+  tps: 41987.93464
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-77190"
  value: {
-  dps: 32764.15194
-  tps: 43805.63189
+  dps: 32759.0807
+  tps: 44637.18618
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-78477"
  value: {
-  dps: 32718.84079
-  tps: 43856.19318
+  dps: 32696.86403
+  tps: 44239.50582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-78486"
  value: {
-  dps: 32814.22995
-  tps: 44020.01938
+  dps: 32681.44909
+  tps: 44299.9213
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 32379.09602
-  tps: 43860.92813
+  dps: 32275.34692
+  tps: 43981.16608
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 32498.3788
-  tps: 45515.65075
+  dps: 32503.89853
+  tps: 45793.29556
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 30940.5559
-  tps: 43049.10165
+  dps: 30911.91144
+  tps: 42716.23032
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 30697.48896
-  tps: 41961.17866
+  dps: 30725.80441
+  tps: 42173.92124
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnheededWarning-59520"
  value: {
-  dps: 32665.49089
-  tps: 43786.54664
+  dps: 32610.83428
+  tps: 44136.44339
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 30775.90736
-  tps: 41426.16014
+  dps: 30684.69329
+  tps: 41885.31903
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 32720.55083
-  tps: 44260.98776
+  dps: 32709.16795
+  tps: 44705.68306
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 32720.55083
-  tps: 44260.98776
+  dps: 32709.16795
+  tps: 44705.68306
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 32720.55083
-  tps: 44260.98776
+  dps: 32709.16795
+  tps: 44705.68306
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 26664.97333
-  tps: 37230.75552
+  dps: 26689.62152
+  tps: 37527.56412
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 30771.93429
-  tps: 41637.79654
+  dps: 30672.33276
+  tps: 42091.99839
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 30777.47543
-  tps: 41569.4617
+  dps: 30683.28167
+  tps: 42021.17008
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 31897.02284
-  tps: 43084.51034
+  dps: 31954.89349
+  tps: 43236.44375
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VeilofLies-72900"
  value: {
-  dps: 30766.65324
-  tps: 41558.36582
+  dps: 30709.5341
+  tps: 42212.09664
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 32031.60888
-  tps: 43124.61822
+  dps: 31945.05994
+  tps: 43698.72664
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 32186.8082
-  tps: 43466.15425
+  dps: 32120.22495
+  tps: 43953.0177
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77207"
  value: {
-  dps: 33328.81561
-  tps: 45945.48176
+  dps: 33237.9157
+  tps: 45756.55153
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77979"
  value: {
-  dps: 32772.7039
-  tps: 44896.97584
+  dps: 33008.1788
+  tps: 46072.56469
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77999"
  value: {
-  dps: 33549.9842
-  tps: 45768.65898
+  dps: 33453.91847
+  tps: 45850.23629
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 30775.90736
-  tps: 41426.16014
+  dps: 30684.69329
+  tps: 41885.31903
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 30775.90736
-  tps: 41426.16014
+  dps: 30684.69329
+  tps: 41885.31903
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 32310.85798
-  tps: 42513.44114
+  dps: 32274.22216
+  tps: 43302.80074
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-70517"
  value: {
-  dps: 32516.8077
-  tps: 42879.76203
+  dps: 32432.67455
+  tps: 43450.65876
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 30775.90736
-  tps: 41426.16014
+  dps: 30684.69329
+  tps: 41885.31903
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-70518"
  value: {
-  dps: 30775.90736
-  tps: 41426.16014
+  dps: 30684.69329
+  tps: 41885.31903
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 31358.0311
-  tps: 42302.11739
+  dps: 31245.58406
+  tps: 42849.45582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-70519"
  value: {
-  dps: 31415.40051
-  tps: 42435.73748
+  dps: 31315.16712
+  tps: 42933.94417
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 30755.13907
-  tps: 41515.71377
+  dps: 30687.14831
+  tps: 41874.4888
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 31077.44441
-  tps: 41923.3831
+  dps: 31190.63109
+  tps: 42445.68774
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 31241.24795
-  tps: 42019.68718
+  dps: 31175.73167
+  tps: 42601.21338
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 30775.90736
-  tps: 41426.16014
+  dps: 30684.2175
+  tps: 41855.72896
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 31278.75163
-  tps: 43783.82536
+  dps: 31257.41513
+  tps: 43586.43281
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 30775.90736
-  tps: 41426.16014
+  dps: 30684.2175
+  tps: 41855.72896
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 32243.75154
-  tps: 42240.15282
+  dps: 32234.60336
+  tps: 44123.90219
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-70577"
  value: {
-  dps: 32393.86596
-  tps: 43256.99184
+  dps: 32394.9773
+  tps: 43946.46922
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 30766.65324
-  tps: 41558.36582
+  dps: 30682.02662
+  tps: 42142.2282
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-70578"
  value: {
-  dps: 30761.43341
-  tps: 41505.02712
+  dps: 30674.96338
+  tps: 41987.93464
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 31405.91695
-  tps: 42328.83251
+  dps: 31244.16123
+  tps: 42883.62717
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-70579"
  value: {
-  dps: 31495.77994
-  tps: 42354.54187
+  dps: 31324.26868
+  tps: 43132.76033
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 30766.65324
-  tps: 41570.66326
+  dps: 30674.96338
+  tps: 42000.94626
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 30766.65324
-  tps: 41568.88492
+  dps: 30674.96338
+  tps: 41999.01881
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WillofUnbinding-77995"
  value: {
-  dps: 30766.65324
-  tps: 41572.61576
+  dps: 30674.96338
+  tps: 42003.06647
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 30830.8228
-  tps: 41363.37483
+  dps: 30725.88793
+  tps: 42020.27827
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 30747.85171
-  tps: 41284.97913
+  dps: 30676.88763
+  tps: 41953.71748
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 31045.5345
-  tps: 42102.6697
+  dps: 30956.75881
+  tps: 42427.31702
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 34438.24053
-  tps: 46471.93575
+  dps: 34389.65317
+  tps: 47099.82704
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 34056.40583
-  tps: 45905.36681
+  dps: 33954.45685
+  tps: 46280.4668
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 34898.31975
-  tps: 47048.53364
+  dps: 34873.2261
+  tps: 47849.54333
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 31237.46701
-  tps: 41990.57243
+  dps: 31142.25705
+  tps: 42437.13546
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 31237.46701
-  tps: 41990.57243
+  dps: 31142.25705
+  tps: 42437.13546
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 33064.4923
-  tps: 44254.55049
+  dps: 33073.52718
+  tps: 44460.62237
  }
 }
 dps_results: {
@@ -2120,15 +2120,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 41891.03519
-  tps: 56226.73219
+  dps: 41999.33992
+  tps: 56746.72914
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38728.16417
-  tps: 49465.33225
+  dps: 38819.13954
+  tps: 49958.80909
  }
 }
 dps_results: {
@@ -2141,15 +2141,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 26334.88808
-  tps: 35362.5747
+  dps: 26364.66525
+  tps: 35453.56346
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25042.87137
-  tps: 32773.84962
+  dps: 25027.74156
+  tps: 32913.59692
  }
 }
 dps_results: {
@@ -2162,15 +2162,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38409.47815
-  tps: 27272.99013
+  dps: 38428.58091
+  tps: 27286.55308
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38037.12528
-  tps: 27006.35895
+  dps: 38125.69787
+  tps: 27069.24549
  }
 }
 dps_results: {
@@ -2183,15 +2183,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24128.14274
-  tps: 17133.34422
+  dps: 24104.97812
+  tps: 17116.89735
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24172.85667
-  tps: 17162.9384
+  dps: 24155.88706
+  tps: 17150.88997
  }
 }
 dps_results: {
@@ -2246,15 +2246,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 40586.10789
-  tps: 54760.40356
+  dps: 40612.94465
+  tps: 54752.36207
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37825.52678
-  tps: 47220.50851
+  dps: 37707.14466
+  tps: 46823.75104
  }
 }
 dps_results: {
@@ -2267,15 +2267,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 26017.63616
-  tps: 35916.45726
+  dps: 25925.87422
+  tps: 35980.02696
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24442.7231
-  tps: 32185.43405
+  dps: 24456.04946
+  tps: 32222.90241
  }
 }
 dps_results: {
@@ -2288,15 +2288,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 37579.60651
-  tps: 26683.78126
+  dps: 37548.95478
+  tps: 26662.01853
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37030.6823
-  tps: 26291.78443
+  dps: 37112.04278
+  tps: 26349.55037
  }
 }
 dps_results: {
@@ -2309,15 +2309,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 23573.75987
-  tps: 16739.73239
+  dps: 23546.10624
+  tps: 16720.09831
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 23608.10561
-  tps: 16761.96514
+  dps: 23627.00044
+  tps: 16775.38047
  }
 }
 dps_results: {
@@ -2372,36 +2372,36 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 35921.44367
-  tps: 51178.91842
+  dps: 35992.38512
+  tps: 51880.92945
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 32723.91769
-  tps: 43584.95278
+  dps: 32791.05122
+  tps: 43852.15062
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 41149.13441
-  tps: 39983.84383
+  dps: 41239.82337
+  tps: 40790.12972
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 23269.38028
-  tps: 36282.9067
+  dps: 23398.52142
+  tps: 36471.23977
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20937.38111
-  tps: 30220.38351
+  dps: 20973.08909
+  tps: 30124.22907
  }
 }
 dps_results: {
@@ -2414,36 +2414,36 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 32290.67369
-  tps: 22928.63896
+  dps: 32356.82413
+  tps: 22975.60577
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 31734.65169
-  tps: 22531.6027
+  dps: 31709.56961
+  tps: 22513.79442
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 40431.76952
-  tps: 28706.55636
+  dps: 40418.91567
+  tps: 28697.43013
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 19861.74797
-  tps: 14104.20394
+  dps: 19846.93802
+  tps: 14093.68888
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 19972.1714
-  tps: 14180.45185
+  dps: 19975.66756
+  tps: 14182.93413
  }
 }
 dps_results: {
@@ -2498,36 +2498,36 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 35296.43981
-  tps: 51325.22568
+  dps: 35507.11659
+  tps: 51737.94836
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 32027.24529
-  tps: 41740.40951
+  dps: 31969.08233
+  tps: 41688.42265
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 40307.34724
-  tps: 37641.79053
+  dps: 40271.51722
+  tps: 38116.90423
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 22299.17756
-  tps: 32869.49386
+  dps: 22379.24424
+  tps: 33441.95821
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20272.29798
-  tps: 28615.37973
+  dps: 20253.62221
+  tps: 28515.51553
  }
 }
 dps_results: {
@@ -2540,36 +2540,36 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 31649.42277
-  tps: 22473.35081
+  dps: 31707.22307
+  tps: 22514.38902
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 31078.55962
-  tps: 22065.77733
+  dps: 31079.00701
+  tps: 22066.09498
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 39566.34632
-  tps: 28092.10589
+  dps: 39662.55548
+  tps: 28160.41439
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 19471.50471
-  tps: 13827.13122
+  dps: 19472.39808
+  tps: 13827.76552
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 19430.97779
-  tps: 13796.20439
+  dps: 19443.46678
+  tps: 13805.07157
  }
 }
 dps_results: {
@@ -2624,15 +2624,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 41334.7913
-  tps: 56749.16645
+  dps: 41317.47112
+  tps: 56550.70526
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38628.1682
-  tps: 49479.71525
+  dps: 38611.94756
+  tps: 50272.92219
  }
 }
 dps_results: {
@@ -2645,15 +2645,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 26763.99268
-  tps: 37474.98443
+  dps: 26808.34237
+  tps: 37348.06399
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24977.99174
-  tps: 32761.48232
+  dps: 24990.85323
+  tps: 32607.88449
  }
 }
 dps_results: {
@@ -2666,15 +2666,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38313.344
-  tps: 27204.73488
+  dps: 38297.41127
+  tps: 27193.42264
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37825.92962
-  tps: 26856.41003
+  dps: 37906.94021
+  tps: 26913.92755
  }
 }
 dps_results: {
@@ -2687,15 +2687,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24022.95017
-  tps: 17058.6575
+  dps: 24019.64868
+  tps: 17056.31344
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24245.96398
-  tps: 17214.84458
+  dps: 24323.70021
+  tps: 17270.03731
  }
 }
 dps_results: {
@@ -2750,15 +2750,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 40874.00861
-  tps: 56083.55957
+  dps: 40830.85343
+  tps: 55761.37711
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37752.73835
-  tps: 47813.1923
+  dps: 37830.90559
+  tps: 48740.92487
  }
 }
 dps_results: {
@@ -2771,15 +2771,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 25670.37534
-  tps: 34939.60713
+  dps: 25803.48973
+  tps: 35310.62995
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24299.65296
-  tps: 32076.58318
+  dps: 24341.5788
+  tps: 32323.7649
  }
 }
 dps_results: {
@@ -2792,15 +2792,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 37498.22369
-  tps: 26625.99946
+  dps: 37467.63643
+  tps: 26604.28251
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37008.50555
-  tps: 26276.03894
+  dps: 37004.10443
+  tps: 26272.91415
  }
 }
 dps_results: {
@@ -2813,15 +2813,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 23321.5164
-  tps: 16560.63952
+  dps: 23332.98344
+  tps: 16568.78112
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 23539.47352
-  tps: 16713.23636
+  dps: 23519.07972
+  tps: 16698.75676
  }
 }
 dps_results: {
@@ -2876,36 +2876,36 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 36082.1024
-  tps: 53192.84708
+  dps: 36045.96185
+  tps: 52033.1329
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 32753.20322
-  tps: 44186.0023
+  dps: 32710.91126
+  tps: 44415.53096
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 40651.20136
-  tps: 40039.44218
+  dps: 40798.96208
+  tps: 40674.19791
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 23066.66019
-  tps: 35471.58455
+  dps: 23107.08792
+  tps: 35720.32232
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20778.89051
-  tps: 30364.8238
+  dps: 20773.00701
+  tps: 30149.73894
  }
 }
 dps_results: {
@@ -2918,36 +2918,36 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 32355.17884
-  tps: 22974.43762
+  dps: 32299.21954
+  tps: 22934.70652
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 31761.32136
-  tps: 22550.53816
+  dps: 31701.97199
+  tps: 22508.40011
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 39996.82856
-  tps: 28397.74828
+  dps: 40065.45488
+  tps: 28446.47296
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 19937.09629
-  tps: 14157.70124
+  dps: 19876.41463
+  tps: 14114.61727
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 19977.9364
-  tps: 14184.54501
+  dps: 19996.93398
+  tps: 14198.03329
  }
 }
 dps_results: {
@@ -3002,36 +3002,36 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 35179.05063
-  tps: 50935.25267
+  dps: 35309.35779
+  tps: 51602.78186
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 31839.45474
-  tps: 42451.69213
+  dps: 31852.84613
+  tps: 42662.49483
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 39712.6521
-  tps: 38253.12066
+  dps: 39795.704
+  tps: 38758.91517
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 22480.97982
-  tps: 34086.42467
+  dps: 22491.44365
+  tps: 33968.05023
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20302.99035
-  tps: 29184.79881
+  dps: 20314.44506
+  tps: 29173.84098
  }
 }
 dps_results: {
@@ -3044,36 +3044,36 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 31536.41106
-  tps: 22393.11249
+  dps: 31534.47015
+  tps: 22391.73445
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 30932.64164
-  tps: 21962.17556
+  dps: 30991.51437
+  tps: 22003.9752
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 38854.04285
-  tps: 27586.37042
+  dps: 38918.17703
+  tps: 27631.90569
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 19351.74399
-  tps: 13742.10112
+  dps: 19336.29478
+  tps: 13731.13217
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 19465.77178
-  tps: 13820.90812
+  dps: 19465.63885
+  tps: 13820.81374
  }
 }
 dps_results: {
@@ -3086,7 +3086,7 @@ dps_results: {
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 28665.377
-  tps: 39933.2262
+  dps: 28757.09835
+  tps: 40315.80425
  }
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -1131,8 +1131,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-ObsidianArborweaveBattlegarb"
  value: {
-  dps: 30964.6234
-  tps: 38521.40057
+  dps: 31004.01992
+  tps: 38852.04751
  }
 }
 dps_results: {
@@ -2127,15 +2127,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38723.32213
-  tps: 49095.64475
+  dps: 38737.625
+  tps: 49280.64941
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 50233.98497
-  tps: 44159.0619
+  dps: 50353.51305
+  tps: 43664.7744
  }
 }
 dps_results: {
@@ -2176,8 +2176,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 50054.68352
-  tps: 35538.8253
+  dps: 50137.92159
+  tps: 35597.92433
  }
 }
 dps_results: {
@@ -2414,8 +2414,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 32358.38142
-  tps: 22976.71145
+  dps: 32378.94591
+  tps: 22991.31223
  }
 }
 dps_results: {
@@ -2631,15 +2631,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38719.56706
-  tps: 49836.13559
+  dps: 38732.20014
+  tps: 49685.56727
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 49671.97157
-  tps: 44701.91324
+  dps: 49685.54461
+  tps: 44773.32513
  }
 }
 dps_results: {
@@ -2673,15 +2673,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37892.89516
-  tps: 26903.95557
+  dps: 37851.69905
+  tps: 26874.70633
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 49576.18805
-  tps: 35199.09351
+  dps: 49599.20513
+  tps: 35215.43565
  }
 }
 dps_results: {

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -38,2041 +38,2041 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 32710.91126
-  tps: 44415.53096
+  dps: 32686.64482
+  tps: 44482.746
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 30674.96338
-  tps: 41987.80057
+  dps: 30675.77563
+  tps: 41775.61051
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 32994.01328
-  tps: 45409.258
+  dps: 32971.56585
+  tps: 45775.27594
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 30688.1801
-  tps: 41921.93394
+  dps: 30668.75688
+  tps: 41757.48782
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 30677.89419
-  tps: 42006.69448
+  dps: 30685.67504
+  tps: 41877.77641
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 31725.93082
-  tps: 43567.21614
+  dps: 31747.55439
+  tps: 43371.3271
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 31839.64948
-  tps: 43687.06496
+  dps: 31862.3121
+  tps: 43451.89821
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ArrowofTime-72897"
  value: {
-  dps: 32894.30083
-  tps: 44700.78728
+  dps: 32864.60601
+  tps: 44541.86032
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 31933.80668
-  tps: 43433.68304
+  dps: 31901.26997
+  tps: 43500.20471
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 30674.96338
-  tps: 41987.93464
+  dps: 30675.77563
+  tps: 41775.74978
   hps: 96.77966
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 30674.96338
-  tps: 41987.93464
+  dps: 30675.77563
+  tps: 41775.74978
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 31159.77949
-  tps: 42845.30849
+  dps: 31144.51724
+  tps: 42692.66972
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 31205.81357
-  tps: 42740.40492
+  dps: 31181.49243
+  tps: 42571.509
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BindingPromise-67037"
  value: {
-  dps: 30684.69329
-  tps: 41885.31903
+  dps: 30681.12285
+  tps: 41730.03995
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 32209.70415
-  tps: 43833.70022
+  dps: 32156.02307
+  tps: 43795.2129
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 30999.22114
-  tps: 42493.52532
+  dps: 31000.16342
+  tps: 42282.14098
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 31041.68346
-  tps: 42559.73363
+  dps: 31042.64278
+  tps: 42348.45411
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 32726.75927
-  tps: 44005.64221
+  dps: 32719.34444
+  tps: 43870.10314
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 30684.69329
-  tps: 41885.31903
+  dps: 30681.12285
+  tps: 41730.03995
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 31214.29009
-  tps: 42811.45841
+  dps: 31240.3181
+  tps: 42587.96233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 31132.17091
-  tps: 42547.32441
+  dps: 31102.20705
+  tps: 42397.82799
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 30684.2175
-  tps: 41855.72896
+  dps: 30677.57609
+  tps: 41672.25329
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 30684.2175
-  tps: 41855.72896
+  dps: 30677.57609
+  tps: 41672.25329
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 32077.33014
-  tps: 44015.11703
+  dps: 32115.86277
+  tps: 43968.96374
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 30674.96338
-  tps: 41987.93464
+  dps: 30675.77563
+  tps: 41775.74978
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 31287.67335
-  tps: 42360.04022
+  dps: 31273.35861
+  tps: 42609.30242
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 32523.58517
-  tps: 44301.50987
+  dps: 32502.38009
+  tps: 44382.60797
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 32137.4464
-  tps: 43591.34893
+  dps: 32164.41617
+  tps: 44039.55488
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 32740.856
-  tps: 44808.19079
+  dps: 32776.57652
+  tps: 45080.22653
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledLightning-66879"
  value: {
-  dps: 30821.68082
-  tps: 42327.49507
+  dps: 30809.86302
+  tps: 41980.54193
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledWishes-77114"
  value: {
-  dps: 31183.53969
-  tps: 41686.31109
+  dps: 31269.3257
+  tps: 42007.00214
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 31933.80668
-  tps: 42565.24863
+  dps: 31901.26997
+  tps: 42630.43613
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 30684.69329
-  tps: 41885.31903
+  dps: 30681.12285
+  tps: 41730.03995
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 32534.7867
-  tps: 44221.02403
+  dps: 32498.96482
+  tps: 44288.71688
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sBadgeofConquest-73648"
  value: {
-  dps: 33137.61832
-  tps: 43933.06671
+  dps: 33194.29612
+  tps: 43708.753
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sBadgeofDominance-73498"
  value: {
-  dps: 30684.69329
-  tps: 41885.31903
+  dps: 30681.12285
+  tps: 41730.03995
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sBadgeofVictory-73496"
  value: {
-  dps: 31493.75368
-  tps: 43111.31485
+  dps: 31563.32031
+  tps: 43108.94931
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sInsigniaofConquest-73643"
  value: {
-  dps: 32903.6244
-  tps: 44173.59476
+  dps: 32878.92285
+  tps: 44131.88559
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sInsigniaofDominance-73497"
  value: {
-  dps: 30655.30127
-  tps: 42027.77137
+  dps: 30621.15284
+  tps: 41871.0802
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sInsigniaofVictory-73491"
  value: {
-  dps: 31558.04
-  tps: 43019.14817
+  dps: 31593.78934
+  tps: 43291.19854
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 32533.03825
-  tps: 44197.81384
+  dps: 32533.53312
+  tps: 44261.82353
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 32083.21558
-  tps: 42742.03208
+  dps: 32104.81753
+  tps: 42697.93386
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 30686.54952
-  tps: 41886.39212
+  dps: 30682.97908
+  tps: 41731.11197
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 30674.96338
-  tps: 41987.93464
+  dps: 30675.77563
+  tps: 41775.74978
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 32276.56956
-  tps: 43904.56441
+  dps: 32231.27274
+  tps: 43805.61863
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 32064.97892
-  tps: 43592.98475
+  dps: 32031.33166
+  tps: 43303.97604
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 32474.47881
-  tps: 44059.14702
+  dps: 32471.57005
+  tps: 44324.15044
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-59506"
  value: {
-  dps: 31554.96912
-  tps: 42819.43154
+  dps: 31581.20508
+  tps: 42652.51348
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-65118"
  value: {
-  dps: 31728.85961
-  tps: 42701.76848
+  dps: 31770.12441
+  tps: 42429.73633
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 30979.83563
-  tps: 42499.54389
+  dps: 30997.72506
+  tps: 42248.18726
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 30957.03547
-  tps: 42132.64658
+  dps: 30952.87512
+  tps: 41806.35825
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-78000"
  value: {
-  dps: 31056.22896
-  tps: 42709.47145
+  dps: 31068.13264
+  tps: 42565.08884
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 30684.2175
-  tps: 41855.72896
+  dps: 30677.57609
+  tps: 41672.25329
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 31429.42204
-  tps: 42692.21394
+  dps: 31411.08518
+  tps: 42549.81256
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 32231.59514
-  tps: 43837.48964
+  dps: 32200.50238
+  tps: 43635.63562
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 30676.8196
-  tps: 41989.00234
+  dps: 30677.63185
+  tps: 41776.80778
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 31224.48467
-  tps: 43960.73015
+  dps: 31178.86735
+  tps: 43845.47317
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 31666.49637
-  tps: 44019.27645
+  dps: 31691.31939
+  tps: 44044.93184
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeepEarthRegalia"
  value: {
-  dps: 21982.84351
-  tps: 28845.26358
+  dps: 21987.01398
+  tps: 28747.56488
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 31930.71867
-  tps: 43405.24
+  dps: 31932.65274
+  tps: 43469.25648
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 31014.1368
-  tps: 43487.53675
+  dps: 31024.95543
+  tps: 43220.27699
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dragonwrath,Tarecgosa'sRest-71086"
  value: {
-  dps: 33134.07465
-  tps: 44808.38913
+  dps: 33154.21272
+  tps: 44372.90142
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 31726.64359
-  tps: 43833.86696
+  dps: 31747.88695
+  tps: 43972.06133
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 31933.80668
-  tps: 43433.68304
+  dps: 31901.26997
+  tps: 43500.20471
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 30685.62141
-  tps: 41923.28205
+  dps: 30682.05097
+  tps: 41768.09318
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 31933.80668
-  tps: 43433.62086
+  dps: 31901.26997
+  tps: 43500.14474
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 31930.71867
-  tps: 43405.24
+  dps: 31932.65274
+  tps: 43469.25648
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 32437.76808
-  tps: 43672.22415
+  dps: 32440.06655
+  tps: 43872.38938
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 31900.89556
-  tps: 44210.64271
+  dps: 31912.55939
+  tps: 44629.65545
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 31933.80668
-  tps: 43433.68304
+  dps: 31901.26997
+  tps: 43500.20471
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 32084.77872
-  tps: 43750.92629
+  dps: 32101.3974
+  tps: 43638.78978
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 31929.21089
-  tps: 43535.75411
+  dps: 31945.68338
+  tps: 43424.04592
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 32255.90333
-  tps: 43987.61568
+  dps: 32272.68284
+  tps: 43875.00802
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-59500"
  value: {
-  dps: 30676.8196
-  tps: 41989.00234
+  dps: 30677.63185
+  tps: 41776.80778
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-65124"
  value: {
-  dps: 30676.8196
-  tps: 41988.96961
+  dps: 30677.63185
+  tps: 41776.77377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 30681.09051
-  tps: 42085.62875
+  dps: 30711.47531
+  tps: 42215.68276
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 32060.78528
-  tps: 42563.36031
+  dps: 32130.21266
+  tps: 42785.47736
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 30685.62141
-  tps: 41885.76062
+  dps: 30682.05097
+  tps: 41730.48059
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 30684.69329
-  tps: 41885.31903
+  dps: 30681.12285
+  tps: 41730.03995
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 30685.62141
-  tps: 41885.76062
+  dps: 30682.05097
+  tps: 41730.48059
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 31552.97722
-  tps: 43471.45101
+  dps: 31576.4656
+  tps: 43122.16312
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 31397.73544
-  tps: 43894.76181
+  dps: 31408.35355
+  tps: 43995.70558
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 32004.58158
-  tps: 43543.05899
+  dps: 31972.00672
+  tps: 43609.68326
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FluidDeath-58181"
  value: {
-  dps: 32179.38358
-  tps: 43878.88839
+  dps: 32205.69184
+  tps: 43981.67656
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 31933.80668
-  tps: 43433.64204
+  dps: 31901.26997
+  tps: 43500.16516
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 31167.71225
-  tps: 43224.8698
+  dps: 31257.31317
+  tps: 43402.58399
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 31797.72519
-  tps: 43669.55033
+  dps: 31851.86509
+  tps: 43718.86491
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56138"
  value: {
-  dps: 31185.74234
-  tps: 42805.12774
+  dps: 31142.99017
+  tps: 42500.71211
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56462"
  value: {
-  dps: 31110.73496
-  tps: 42925.72788
+  dps: 31097.74107
+  tps: 42630.0814
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GearDetector-61462"
  value: {
-  dps: 31653.02934
-  tps: 43834.6179
+  dps: 31670.6347
+  tps: 44087.03191
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 26276.41555
-  tps: 35135.05115
+  dps: 26313.27593
+  tps: 35279.01318
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 30674.96338
-  tps: 41987.79122
+  dps: 30675.77563
+  tps: 41775.60079
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 31690.62003
-  tps: 43157.16756
+  dps: 31695.32336
+  tps: 43084.49948
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 31995.77752
-  tps: 43986.68716
+  dps: 31984.34776
+  tps: 44125.78367
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HarmlightToken-63839"
  value: {
-  dps: 30705.47938
-  tps: 42168.54751
+  dps: 30689.94575
+  tps: 41897.73504
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 31259.52202
-  tps: 42664.36237
+  dps: 31351.4955
+  tps: 43065.3197
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 30674.96338
-  tps: 41987.93464
+  dps: 30675.77563
+  tps: 41775.74978
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 30674.96338
-  tps: 41987.93464
+  dps: 30675.77563
+  tps: 41775.74978
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-59224"
  value: {
-  dps: 31422.16198
-  tps: 43097.16864
+  dps: 31458.83267
+  tps: 43277.91703
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-65072"
  value: {
-  dps: 31459.89545
-  tps: 43017.71344
+  dps: 31513.58777
+  tps: 43097.53614
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-55868"
  value: {
-  dps: 31671.09899
-  tps: 43439.18683
+  dps: 31645.52228
+  tps: 43100.55966
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-56393"
  value: {
-  dps: 31668.54862
-  tps: 44169.75664
+  dps: 31612.55173
+  tps: 43377.52468
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-55845"
  value: {
-  dps: 30674.96338
-  tps: 41987.93464
+  dps: 30658.38661
+  tps: 41815.34274
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-56370"
  value: {
-  dps: 30674.96338
-  tps: 41987.93464
+  dps: 30658.38661
+  tps: 41815.34274
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 31692.73563
-  tps: 43307.54647
+  dps: 31721.10357
+  tps: 43146.38869
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-50641"
  value: {
-  dps: 33246.7943
-  tps: 44398.2951
+  dps: 33329.9059
+  tps: 45290.69533
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 31930.71867
-  tps: 43405.24
+  dps: 31932.65274
+  tps: 43469.25648
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 31838.65144
-  tps: 44291.84798
+  dps: 31816.8959
+  tps: 44315.36957
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 31838.65144
-  tps: 44291.84798
+  dps: 31816.8959
+  tps: 44315.36957
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 31012.87724
-  tps: 42385.52927
+  dps: 30993.49534
+  tps: 42268.75736
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 31055.33123
-  tps: 42451.43557
+  dps: 31035.94628
+  tps: 42334.83894
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndomitablePride-77211"
  value: {
-  dps: 30674.96338
-  tps: 41987.93464
+  dps: 30675.77563
+  tps: 41775.74978
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndomitablePride-77983"
  value: {
-  dps: 30674.96338
-  tps: 41987.93464
+  dps: 30675.77563
+  tps: 41775.74978
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndomitablePride-78003"
  value: {
-  dps: 30674.96338
-  tps: 41987.93464
+  dps: 30675.77563
+  tps: 41775.74978
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 30674.96338
-  tps: 41987.93464
+  dps: 30658.38661
+  tps: 41815.34274
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 31342.2497
-  tps: 42071.48603
+  dps: 31346.65741
+  tps: 42097.12143
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 31398.05127
-  tps: 42342.92351
+  dps: 31437.77558
+  tps: 42851.41472
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 31499.35671
-  tps: 41988.42812
+  dps: 31503.95239
+  tps: 41848.14849
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 30927.43083
-  tps: 42375.94778
+  dps: 30939.07929
+  tps: 42550.40319
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 30674.96338
-  tps: 41988.32279
+  dps: 30675.77563
+  tps: 41776.09121
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 30674.96338
-  tps: 41988.32279
+  dps: 30675.77563
+  tps: 41776.09121
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 30676.8196
-  tps: 41988.95402
+  dps: 30677.63185
+  tps: 41776.75758
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 30676.8196
-  tps: 41988.91504
+  dps: 30677.63185
+  tps: 41776.71709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 32209.70415
-  tps: 43833.70022
+  dps: 32156.02307
+  tps: 43795.2129
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 31912.49785
-  tps: 44071.5479
+  dps: 31875.96751
+  tps: 44167.20346
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 32220.48308
-  tps: 44352.37292
+  dps: 32290.67163
+  tps: 43932.75658
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-77194"
  value: {
-  dps: 36230.05048
-  tps: 48697.97119
+  dps: 36236.76638
+  tps: 48851.94822
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-78473"
  value: {
-  dps: 36734.85189
-  tps: 49571.8748
+  dps: 36713.89123
+  tps: 49473.31585
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-78482"
  value: {
-  dps: 35822.43999
-  tps: 49003.12726
+  dps: 35806.07865
+  tps: 49071.19057
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 33874.79738
-  tps: 44721.34427
+  dps: 33892.29644
+  tps: 44561.83269
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 31161.89233
-  tps: 41830.71882
+  dps: 31303.11481
+  tps: 42642.77213
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 31161.89233
-  tps: 41830.71882
+  dps: 31303.11481
+  tps: 42642.77213
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 30844.20799
-  tps: 42392.10817
+  dps: 30860.23999
+  tps: 42373.69705
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50708"
  value: {
-  dps: 32895.03501
-  tps: 44668.60967
+  dps: 32870.71711
+  tps: 44736.14036
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-55816"
  value: {
-  dps: 30674.96338
-  tps: 41987.93464
+  dps: 30675.77563
+  tps: 41775.74978
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-56347"
  value: {
-  dps: 30674.96338
-  tps: 41987.93464
+  dps: 30675.77563
+  tps: 41775.74978
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 32005.91088
-  tps: 43044.59257
+  dps: 32018.87872
+  tps: 42984.99681
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 32190.18016
-  tps: 43144.0757
+  dps: 32149.59676
+  tps: 43302.82815
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 31268.0177
-  tps: 42826.20233
+  dps: 31269.04498
+  tps: 42611.08875
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 31100.93966
-  tps: 42598.82013
+  dps: 31129.13443
+  tps: 42994.90506
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 31247.32983
-  tps: 42757.72616
+  dps: 31276.15296
+  tps: 43156.73385
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 30674.96338
-  tps: 41987.93464
+  dps: 30675.77563
+  tps: 41775.74978
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 30674.96338
-  tps: 41987.93464
+  dps: 30675.77563
+  tps: 41775.74978
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 31639.87699
-  tps: 43166.68078
+  dps: 31638.08229
+  tps: 43621.13146
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 31806.28181
-  tps: 43715.54356
+  dps: 31756.11816
+  tps: 43776.97313
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 32987.2948
-  tps: 45178.09906
+  dps: 33009.38232
+  tps: 45763.05896
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 33276.03526
-  tps: 46092.31468
+  dps: 33300.68053
+  tps: 46239.09367
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 30981.94007
-  tps: 42482.66544
+  dps: 31000.44118
+  tps: 42846.03375
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 31250.26065
-  tps: 42776.48601
+  dps: 31289.2764
+  tps: 43099.93136
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 31225.80123
-  tps: 43511.24874
+  dps: 31215.06479
+  tps: 43524.3359
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 31225.80123
-  tps: 43511.24874
+  dps: 31215.06479
+  tps: 43524.3359
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 31129.05375
-  tps: 42631.63725
+  dps: 31096.59376
+  tps: 42444.35915
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 31177.50464
-  tps: 42388.38817
+  dps: 31201.9074
+  tps: 42301.7329
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 30684.69329
-  tps: 41885.31903
+  dps: 30681.12285
+  tps: 41730.03995
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 30676.8196
-  tps: 41988.95402
+  dps: 30677.63185
+  tps: 41776.75758
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 30676.8196
-  tps: 41988.91504
+  dps: 30677.63185
+  tps: 41776.71709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ObsidianArborweaveBattlegarb"
  value: {
-  dps: 30974.90118
-  tps: 38845.36829
+  dps: 30940.10479
+  tps: 38723.7898
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ObsidianArborweaveRegalia"
  value: {
-  dps: 22451.36914
-  tps: 29513.39709
+  dps: 22456.21836
+  tps: 29591.97053
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 31320.87255
-  tps: 43086.19472
+  dps: 31261.20175
+  tps: 42656.18579
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 30675.89149
-  tps: 41988.35664
+  dps: 30676.70374
+  tps: 41776.16259
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 30674.96338
-  tps: 41987.93464
+  dps: 30675.77563
+  tps: 41775.74978
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 30916.57049
-  tps: 42270.83528
+  dps: 30912.21131
+  tps: 42222.13589
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 30888.63611
-  tps: 42277.49989
+  dps: 30956.09439
+  tps: 42073.94889
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 31158.40839
-  tps: 42765.56296
+  dps: 31143.37654
+  tps: 42104.29158
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 31933.80668
-  tps: 43433.68304
+  dps: 31901.26997
+  tps: 43500.20471
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 32468.63666
-  tps: 43540.02606
+  dps: 32406.0352
+  tps: 43501.36024
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-55854"
  value: {
-  dps: 30674.96338
-  tps: 41987.93464
+  dps: 30675.77563
+  tps: 41775.74978
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-56377"
  value: {
-  dps: 30674.96338
-  tps: 41987.93464
+  dps: 30675.77563
+  tps: 41775.74978
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rathrak,thePoisonousMind-77195"
  value: {
-  dps: 29515.83604
-  tps: 39645.20948
+  dps: 29533.40137
+  tps: 39662.41228
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rathrak,thePoisonousMind-78475"
  value: {
-  dps: 30096.45223
-  tps: 40299.42122
+  dps: 30119.61979
+  tps: 40345.48442
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rathrak,thePoisonousMind-78484"
  value: {
-  dps: 28998.77444
-  tps: 38981.27143
+  dps: 29002.07752
+  tps: 39187.88052
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 30677.77374
-  tps: 41986.7945
+  dps: 30689.48304
+  tps: 42157.69712
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 30674.96338
-  tps: 41987.93464
+  dps: 30675.77563
+  tps: 41775.74978
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 30674.96338
-  tps: 41987.93464
+  dps: 30675.77563
+  tps: 41775.74978
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 30674.96338
-  tps: 41987.93464
+  dps: 30675.77563
+  tps: 41775.74978
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 32621.9049
-  tps: 44340.35894
+  dps: 32585.99081
+  tps: 44408.21533
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 32534.7867
-  tps: 44221.06503
+  dps: 32498.96482
+  tps: 44288.75644
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 32581.84686
-  tps: 44979.7798
+  dps: 32515.53695
+  tps: 44421.64154
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 31241.98419
-  tps: 42791.66019
+  dps: 31210.772
+  tps: 42847.28941
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 31281.77367
-  tps: 42866.33185
+  dps: 31290.64461
+  tps: 43196.99057
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RosaryofLight-72901"
  value: {
-  dps: 31910.53637
-  tps: 44163.53203
+  dps: 31874.61693
+  tps: 43973.21448
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RottingSkull-77116"
  value: {
-  dps: 32303.53149
-  tps: 44253.14463
+  dps: 32328.61649
+  tps: 44833.41752
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuneofZeth-68998"
  value: {
-  dps: 31243.36183
-  tps: 43181.3096
+  dps: 31205.66127
+  tps: 42962.26462
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofConquest-70399"
  value: {
-  dps: 32668.88692
-  tps: 43399.31176
+  dps: 32744.18432
+  tps: 43630.34731
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofConquest-72304"
  value: {
-  dps: 32779.36453
-  tps: 43537.30353
+  dps: 32853.85929
+  tps: 43771.06469
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofDominance-70401"
  value: {
-  dps: 30684.69329
-  tps: 41885.31903
+  dps: 30681.12285
+  tps: 41730.03995
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofDominance-72448"
  value: {
-  dps: 30684.69329
-  tps: 41885.31903
+  dps: 30681.12285
+  tps: 41730.03995
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofVictory-70400"
  value: {
-  dps: 31369.50351
-  tps: 43069.29314
+  dps: 31418.04104
+  tps: 42928.36477
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofVictory-72450"
  value: {
-  dps: 31391.86034
-  tps: 42987.70922
+  dps: 31460.8798
+  tps: 42981.61405
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofConquest-70404"
  value: {
-  dps: 32582.23246
-  tps: 43646.84309
+  dps: 32582.47663
+  tps: 44037.21753
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofConquest-72309"
  value: {
-  dps: 32653.42812
-  tps: 43686.57282
+  dps: 32708.75365
+  tps: 43620.19639
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofDominance-70402"
  value: {
-  dps: 30682.02662
-  tps: 42142.2282
+  dps: 30645.17853
+  tps: 41975.71099
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofDominance-72449"
  value: {
-  dps: 30682.02662
-  tps: 42142.2282
+  dps: 30684.41386
+  tps: 42300.42131
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofVictory-70403"
  value: {
-  dps: 31445.10886
-  tps: 42607.64124
+  dps: 31463.47406
+  tps: 42605.82444
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofVictory-72455"
  value: {
-  dps: 31456.61216
-  tps: 42783.77982
+  dps: 31474.77701
+  tps: 43157.09452
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ScalesofLife-68915"
  value: {
-  dps: 30674.96338
-  tps: 41987.93464
+  dps: 30675.77563
+  tps: 41775.74978
   hps: 315.97258
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ScalesofLife-69109"
  value: {
-  dps: 30674.96338
-  tps: 41987.93464
+  dps: 30675.77563
+  tps: 41775.74978
   hps: 356.41412
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 31874.9475
-  tps: 43376.42051
+  dps: 31947.35545
+  tps: 43919.02586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-55256"
  value: {
-  dps: 30684.69329
-  tps: 41885.31903
+  dps: 30681.12285
+  tps: 41730.03995
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-56290"
  value: {
-  dps: 30684.69329
-  tps: 41885.31903
+  dps: 30681.12285
+  tps: 41730.03995
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShardofWoe-60233"
  value: {
-  dps: 31108.67562
-  tps: 42197.87762
+  dps: 31066.03615
+  tps: 41974.83133
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 31442.29701
-  tps: 43284.34756
+  dps: 31478.9284
+  tps: 43670.11737
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 30688.68314
-  tps: 41882.2448
+  dps: 30669.3245
+  tps: 41764.13436
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 32044.25124
-  tps: 43681.18236
+  dps: 32086.45115
+  tps: 43383.12057
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 32259.42234
-  tps: 43751.9767
+  dps: 32271.99417
+  tps: 43642.31536
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-55879"
  value: {
-  dps: 31009.93101
-  tps: 42436.51077
+  dps: 31024.32326
+  tps: 42420.04587
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-56400"
  value: {
-  dps: 31052.38655
-  tps: 42502.47759
+  dps: 31066.77564
+  tps: 42486.34894
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 30981.94007
-  tps: 42482.66544
+  dps: 31000.44118
+  tps: 42846.03375
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulCasket-58183"
  value: {
-  dps: 31233.47977
-  tps: 43576.78301
+  dps: 31209.87447
+  tps: 43576.51953
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 31502.73536
-  tps: 43137.13506
+  dps: 31503.60344
+  tps: 43028.19417
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 31414.89119
-  tps: 42431.26395
+  dps: 31415.17915
+  tps: 42883.78947
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 31567.52128
-  tps: 42319.16144
+  dps: 31606.56796
+  tps: 42165.12048
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 31302.72295
-  tps: 43762.00366
+  dps: 31296.85735
+  tps: 43808.47023
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 31367.18977
-  tps: 43864.98849
+  dps: 31361.39524
+  tps: 43911.23641
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 33413.72044
-  tps: 45009.78867
+  dps: 33372.00332
+  tps: 45040.08381
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 33016.41778
-  tps: 44432.34045
+  dps: 32992.64929
+  tps: 44449.61461
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 33584.66445
-  tps: 44026.44727
+  dps: 33589.63089
+  tps: 44179.5742
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StayofExecution-68996"
  value: {
-  dps: 30674.96338
-  tps: 41987.93464
+  dps: 30675.77563
+  tps: 41775.74978
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 30720.93362
-  tps: 41979.80035
+  dps: 30726.86774
+  tps: 41784.4757
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stormrider'sBattlegarb"
  value: {
-  dps: 28430.88516
-  tps: 37206.92042
+  dps: 28370.16577
+  tps: 37227.54216
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stormrider'sRegalia"
  value: {
-  dps: 22238.19656
-  tps: 28712.45214
+  dps: 22289.88314
+  tps: 28858.82396
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62465"
  value: {
-  dps: 30677.89419
-  tps: 42006.69448
+  dps: 30678.84319
+  tps: 41795.19754
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62470"
  value: {
-  dps: 30677.15471
-  tps: 42000.80946
+  dps: 30658.84916
+  tps: 41820.89807
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 30674.96338
-  tps: 41987.93464
+  dps: 30675.77563
+  tps: 41775.74978
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 30674.96338
-  tps: 41987.93464
+  dps: 30675.77563
+  tps: 41775.74978
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 30729.32514
-  tps: 41954.93508
+  dps: 30734.47897
+  tps: 41738.39835
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 31348.88918
-  tps: 43276.05819
+  dps: 31416.1131
+  tps: 43511.47202
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-55819"
  value: {
-  dps: 30674.96338
-  tps: 41987.76705
+  dps: 30675.77563
+  tps: 41775.57569
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-56351"
  value: {
-  dps: 30675.89149
-  tps: 41988.37145
+  dps: 30676.70374
+  tps: 41776.17797
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 30951.61186
-  tps: 42419.29177
+  dps: 30951.23029
+  tps: 42200.39192
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 31044.53803
-  tps: 42558.48875
+  dps: 31033.50526
+  tps: 42404.43201
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheHungerer-68927"
  value: {
-  dps: 32748.77423
-  tps: 45179.67569
+  dps: 32833.56271
+  tps: 45522.67882
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheHungerer-69112"
  value: {
-  dps: 32910.03581
-  tps: 45170.84214
+  dps: 32892.98376
+  tps: 45530.5862
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 30707.03653
-  tps: 41951.14082
+  dps: 30712.25263
+  tps: 41714.02369
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 30732.92752
-  tps: 42099.30813
+  dps: 30771.96995
+  tps: 42126.13818
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 30674.96338
-  tps: 41987.93464
+  dps: 30675.77563
+  tps: 41775.74978
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 30674.96338
-  tps: 41987.93464
+  dps: 30675.77563
+  tps: 41775.74978
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-77190"
  value: {
-  dps: 32759.0807
-  tps: 44637.18618
+  dps: 32745.5369
+  tps: 44298.9734
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-78477"
  value: {
-  dps: 32696.86403
-  tps: 44239.50582
+  dps: 32730.67963
+  tps: 43935.94572
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-78486"
  value: {
-  dps: 32681.44909
-  tps: 44299.9213
+  dps: 32704.9586
+  tps: 44375.51683
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 32275.34692
-  tps: 43981.16608
+  dps: 32298.33715
+  tps: 44068.58502
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 32503.89853
-  tps: 45793.29556
+  dps: 32498.87169
+  tps: 45685.28167
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 30911.91144
-  tps: 42716.23032
+  dps: 30918.68851
+  tps: 42909.4279
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 30725.80441
-  tps: 42173.92124
+  dps: 30731.92031
+  tps: 41903.42594
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnheededWarning-59520"
  value: {
-  dps: 32610.83428
-  tps: 44136.44339
+  dps: 32571.17235
+  tps: 43849.9123
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 30684.69329
-  tps: 41885.31903
+  dps: 30681.12285
+  tps: 41730.03995
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 32709.16795
-  tps: 44705.68306
+  dps: 32698.90547
+  tps: 44580.49261
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 32709.16795
-  tps: 44705.68306
+  dps: 32698.90547
+  tps: 44580.49261
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 32709.16795
-  tps: 44705.68306
+  dps: 32698.90547
+  tps: 44580.49261
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 26689.62152
-  tps: 37527.56412
+  dps: 26667.09844
+  tps: 37736.17811
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 30672.33276
-  tps: 42091.99839
+  dps: 30702.43781
+  tps: 41950.16409
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 30683.28167
-  tps: 42021.17008
+  dps: 30683.61879
+  tps: 41806.59986
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 31954.89349
-  tps: 43236.44375
+  dps: 31969.75652
+  tps: 43607.60557
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VeilofLies-72900"
  value: {
-  dps: 30709.5341
-  tps: 42212.09664
+  dps: 30726.9603
+  tps: 42379.02311
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 31945.05994
-  tps: 43698.72664
+  dps: 31912.30016
+  tps: 43506.83031
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 32120.22495
-  tps: 43953.0177
+  dps: 32078.08594
+  tps: 43858.36096
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77207"
  value: {
-  dps: 33237.9157
-  tps: 45756.55153
+  dps: 33214.61189
+  tps: 45903.89396
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77979"
  value: {
-  dps: 33008.1788
-  tps: 46072.56469
+  dps: 33021.31775
+  tps: 45969.36074
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77999"
  value: {
-  dps: 33453.91847
-  tps: 45850.23629
+  dps: 33489.89602
+  tps: 46096.79422
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 30684.69329
-  tps: 41885.31903
+  dps: 30681.12285
+  tps: 41730.03995
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 30684.69329
-  tps: 41885.31903
+  dps: 30681.12285
+  tps: 41730.03995
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 32274.22216
-  tps: 43302.80074
+  dps: 32353.78429
+  tps: 43227.52811
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-70517"
  value: {
-  dps: 32432.67455
-  tps: 43450.65876
+  dps: 32507.34194
+  tps: 43351.78579
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 30684.69329
-  tps: 41885.31903
+  dps: 30681.12285
+  tps: 41730.03995
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-70518"
  value: {
-  dps: 30684.69329
-  tps: 41885.31903
+  dps: 30681.12285
+  tps: 41730.03995
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 31245.58406
-  tps: 42849.45582
+  dps: 31271.57411
+  tps: 42626.17454
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-70519"
  value: {
-  dps: 31315.16712
-  tps: 42933.94417
+  dps: 31341.07278
+  tps: 42711.14051
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 30687.14831
-  tps: 41874.4888
+  dps: 30680.64365
+  tps: 41691.70105
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 31190.63109
-  tps: 42445.68774
+  dps: 31194.35855
+  tps: 42832.0745
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 31175.73167
-  tps: 42601.21338
+  dps: 31147.1909
+  tps: 42448.21797
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 30684.2175
-  tps: 41855.72896
+  dps: 30677.57609
+  tps: 41672.25329
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 31257.41513
-  tps: 43586.43281
+  dps: 31232.35486
+  tps: 43623.46472
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 30684.2175
-  tps: 41855.72896
+  dps: 30677.57609
+  tps: 41672.25329
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 32234.60336
-  tps: 44123.90219
+  dps: 32291.64049
+  tps: 43758.94771
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-70577"
  value: {
-  dps: 32394.9773
-  tps: 43946.46922
+  dps: 32473.25873
+  tps: 43654.4546
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 30682.02662
-  tps: 42142.2282
+  dps: 30638.62456
+  tps: 41992.38847
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-70578"
  value: {
-  dps: 30674.96338
-  tps: 41987.93464
+  dps: 30688.5749
+  tps: 41723.05423
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 31244.16123
-  tps: 42883.62717
+  dps: 31302.37168
+  tps: 42805.94023
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-70579"
  value: {
-  dps: 31324.26868
-  tps: 43132.76033
+  dps: 31406.51587
+  tps: 43022.96205
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 30674.96338
-  tps: 42000.94626
+  dps: 30675.77563
+  tps: 41787.95173
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 30674.96338
-  tps: 41999.01881
+  dps: 30675.77563
+  tps: 41786.09164
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WillofUnbinding-77995"
  value: {
-  dps: 30674.96338
-  tps: 42003.06647
+  dps: 30675.77563
+  tps: 41789.99783
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 30725.88793
-  tps: 42020.27827
+  dps: 30695.85331
+  tps: 42060.65149
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 30676.88763
-  tps: 41953.71748
+  dps: 30682.54476
+  tps: 42084.83901
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 30956.75881
-  tps: 42427.31702
+  dps: 30957.68407
+  tps: 42215.82785
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 34389.65317
-  tps: 47099.82704
+  dps: 34369.8336
+  tps: 46994.15327
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 33954.45685
-  tps: 46280.4668
+  dps: 33945.56285
+  tps: 46214.31591
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 34873.2261
-  tps: 47849.54333
+  dps: 34856.89125
+  tps: 47764.48199
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 31142.25705
-  tps: 42437.13546
+  dps: 31213.13878
+  tps: 43027.9298
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 31142.25705
-  tps: 42437.13546
+  dps: 31213.13878
+  tps: 43027.9298
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 33073.52718
-  tps: 44460.62237
+  dps: 33083.4175
+  tps: 44526.03517
  }
 }
 dps_results: {
@@ -2120,85 +2120,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 41999.33992
-  tps: 56746.72914
+  dps: 41849.06211
+  tps: 56849.99366
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38819.13954
-  tps: 49958.80909
+  dps: 38936.15288
+  tps: 50479.25806
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 50143.86971
-  tps: 44367.97712
+  dps: 50364.62301
+  tps: 44163.61089
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 26364.66525
-  tps: 35453.56346
+  dps: 26359.63568
+  tps: 35528.78101
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25027.74156
-  tps: 32913.59692
+  dps: 25057.38185
+  tps: 33071.01959
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 28193.24488
-  tps: 25335.23013
+  dps: 28342.64563
+  tps: 25591.92973
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38428.58091
-  tps: 27286.55308
+  dps: 38450.20917
+  tps: 27301.90915
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38125.69787
-  tps: 27069.24549
+  dps: 38142.62761
+  tps: 27081.2656
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 49883.70748
-  tps: 35417.43231
+  dps: 50056.96654
+  tps: 35540.44625
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24104.97812
-  tps: 17116.89735
+  dps: 24105.57553
+  tps: 17117.3215
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24155.88706
-  tps: 17150.88997
+  dps: 24166.06667
+  tps: 17158.11749
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27873.82586
-  tps: 19790.98436
+  dps: 27859.9495
+  tps: 19781.13214
  }
 }
 dps_results: {
@@ -2246,15 +2246,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 40612.94465
-  tps: 54752.36207
+  dps: 40820.29345
+  tps: 55604.75785
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37707.14466
-  tps: 46823.75104
+  dps: 37847.04224
+  tps: 47806.45424
  }
 }
 dps_results: {
@@ -2267,15 +2267,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 25925.87422
-  tps: 35980.02696
+  dps: 26021.24947
+  tps: 36030.19355
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24456.04946
-  tps: 32222.90241
+  dps: 24462.3301
+  tps: 31674.24532
  }
 }
 dps_results: {
@@ -2288,15 +2288,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 37548.95478
-  tps: 26662.01853
+  dps: 37534.79209
+  tps: 26651.96303
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37112.04278
-  tps: 26349.55037
+  dps: 37114.68211
+  tps: 26351.4243
  }
 }
 dps_results: {
@@ -2309,15 +2309,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 23546.10624
-  tps: 16720.09831
+  dps: 23539.88771
+  tps: 16715.68315
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 23627.00044
-  tps: 16775.38047
+  dps: 23607.31327
+  tps: 16761.40258
  }
 }
 dps_results: {
@@ -2372,15 +2372,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 35992.38512
-  tps: 51880.92945
+  dps: 36066.97278
+  tps: 52651.32581
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 32791.05122
-  tps: 43852.15062
+  dps: 32784.98143
+  tps: 44173.36686
  }
 }
 dps_results: {
@@ -2393,15 +2393,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 23398.52142
-  tps: 36471.23977
+  dps: 23391.78804
+  tps: 36507.55667
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20973.08909
-  tps: 30124.22907
+  dps: 20982.06151
+  tps: 30156.15994
  }
 }
 dps_results: {
@@ -2414,15 +2414,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 32356.82413
-  tps: 22975.60577
+  dps: 32386.95656
+  tps: 22996.9998
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 31709.56961
-  tps: 22513.79442
+  dps: 31704.4557
+  tps: 22510.16354
  }
 }
 dps_results: {
@@ -2435,15 +2435,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 19846.93802
-  tps: 14093.68888
+  dps: 19846.87081
+  tps: 14093.64115
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 19975.66756
-  tps: 14182.93413
+  dps: 19980.40465
+  tps: 14186.29746
  }
 }
 dps_results: {
@@ -2498,15 +2498,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 35507.11659
-  tps: 51737.94836
+  dps: 35434.33193
+  tps: 51314.6001
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 31969.08233
-  tps: 41688.42265
+  dps: 31998.83569
+  tps: 41722.73557
  }
 }
 dps_results: {
@@ -2519,15 +2519,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 22379.24424
-  tps: 33441.95821
+  dps: 22450.70768
+  tps: 33654.67774
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20253.62221
-  tps: 28515.51553
+  dps: 20255.34668
+  tps: 28502.1264
  }
 }
 dps_results: {
@@ -2540,15 +2540,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 31707.22307
-  tps: 22514.38902
+  dps: 31706.80282
+  tps: 22514.09064
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 31079.00701
-  tps: 22066.09498
+  dps: 31084.31049
+  tps: 22069.86044
  }
 }
 dps_results: {
@@ -2561,15 +2561,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 19472.39808
-  tps: 13827.76552
+  dps: 19462.29858
+  tps: 13820.59487
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 19443.46678
-  tps: 13805.07157
+  dps: 19468.87988
+  tps: 13823.11488
  }
 }
 dps_results: {
@@ -2624,85 +2624,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 41317.47112
-  tps: 56550.70526
+  dps: 41381.18785
+  tps: 56417.76683
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38611.94756
-  tps: 50272.92219
+  dps: 38725.58659
+  tps: 50147.5389
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 49626.09511
-  tps: 44311.2675
+  dps: 49615.80836
+  tps: 43826.77745
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 26808.34237
-  tps: 37348.06399
+  dps: 26820.18223
+  tps: 37664.02261
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24990.85323
-  tps: 32607.88449
+  dps: 25032.68028
+  tps: 33037.21645
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27407.43625
-  tps: 24361.20948
+  dps: 27552.11081
+  tps: 25394.1767
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38297.41127
-  tps: 27193.42264
+  dps: 38322.11173
+  tps: 27210.95997
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37906.94021
-  tps: 26913.92755
+  dps: 37899.65567
+  tps: 26908.75553
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 49547.02326
-  tps: 35178.38652
+  dps: 49521.32701
+  tps: 35160.14218
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24019.64868
-  tps: 17056.31344
+  dps: 24021.13017
+  tps: 17057.3653
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24323.70021
-  tps: 17270.03731
+  dps: 24313.21649
+  tps: 17262.59387
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27240.99485
-  tps: 19341.67434
+  dps: 27341.67944
+  tps: 19413.1604
  }
 }
 dps_results: {
@@ -2750,15 +2750,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 40830.85343
-  tps: 55761.37711
+  dps: 40619.66786
+  tps: 54645.60482
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37830.90559
-  tps: 48740.92487
+  dps: 37795.37241
+  tps: 48423.29996
  }
 }
 dps_results: {
@@ -2771,15 +2771,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 25803.48973
-  tps: 35310.62995
+  dps: 25920.52543
+  tps: 35657.08918
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24341.5788
-  tps: 32323.7649
+  dps: 24369.7514
+  tps: 32413.71208
  }
 }
 dps_results: {
@@ -2792,15 +2792,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 37467.63643
-  tps: 26604.28251
+  dps: 37480.14869
+  tps: 26613.16621
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37004.10443
-  tps: 26272.91415
+  dps: 37033.66513
+  tps: 26293.90224
  }
 }
 dps_results: {
@@ -2813,15 +2813,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 23332.98344
-  tps: 16568.78112
+  dps: 23326.46704
+  tps: 16564.15448
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 23519.07972
-  tps: 16698.75676
+  dps: 23549.85984
+  tps: 16720.61065
  }
 }
 dps_results: {
@@ -2876,15 +2876,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 36045.96185
-  tps: 52033.1329
+  dps: 36219.01396
+  tps: 54042.81604
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 32710.91126
-  tps: 44415.53096
+  dps: 32686.64482
+  tps: 44482.746
  }
 }
 dps_results: {
@@ -2897,15 +2897,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 23107.08792
-  tps: 35720.32232
+  dps: 23216.7332
+  tps: 35712.07414
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20773.00701
-  tps: 30149.73894
+  dps: 20774.00735
+  tps: 30035.50408
  }
 }
 dps_results: {
@@ -2918,15 +2918,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 32299.21954
-  tps: 22934.70652
+  dps: 32303.27384
+  tps: 22937.58507
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 31701.97199
-  tps: 22508.40011
+  dps: 31693.17643
+  tps: 22502.15526
  }
 }
 dps_results: {
@@ -2939,15 +2939,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 19876.41463
-  tps: 14114.61727
+  dps: 19869.91766
+  tps: 14110.00442
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 19996.93398
-  tps: 14198.03329
+  dps: 20004.21156
+  tps: 14203.20036
  }
 }
 dps_results: {
@@ -3002,15 +3002,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 35309.35779
-  tps: 51602.78186
+  dps: 35345.01366
+  tps: 51797.97436
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 31852.84613
-  tps: 42662.49483
+  dps: 31821.75102
+  tps: 42819.71006
  }
 }
 dps_results: {
@@ -3023,15 +3023,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 22491.44365
-  tps: 33968.05023
+  dps: 22464.84996
+  tps: 33964.68549
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20314.44506
-  tps: 29173.84098
+  dps: 20304.80156
+  tps: 29347.41258
  }
 }
 dps_results: {
@@ -3044,15 +3044,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 31534.47015
-  tps: 22391.73445
+  dps: 31573.2669
+  tps: 22419.28014
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 30991.51437
-  tps: 22003.9752
+  dps: 31005.64388
+  tps: 22014.00715
  }
 }
 dps_results: {
@@ -3065,15 +3065,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 19336.29478
-  tps: 13731.13217
+  dps: 19336.64811
+  tps: 13731.38304
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 19465.63885
-  tps: 13820.81374
+  dps: 19457.45074
+  tps: 13815.00019
  }
 }
 dps_results: {
@@ -3086,7 +3086,7 @@ dps_results: {
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 28757.09835
-  tps: 40315.80425
+  dps: 28810.07048
+  tps: 40335.14026
  }
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -38,2041 +38,2041 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 32729.3344
-  tps: 44115.26496
+  dps: 32753.20322
+  tps: 44186.0023
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 30737.66776
-  tps: 41795.8477
+  dps: 30766.65324
+  tps: 41558.24042
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 32977.36252
-  tps: 45547.69223
+  dps: 32934.97397
+  tps: 44380.3835
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 30726.20844
-  tps: 41795.83803
+  dps: 30755.19392
+  tps: 41558.23422
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 30710.24942
-  tps: 41896.57406
+  dps: 30739.2349
+  tps: 41658.97024
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 31739.98368
-  tps: 43849.35529
+  dps: 31732.16582
+  tps: 43754.40086
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 31916.29719
-  tps: 44384.70068
+  dps: 31914.31587
+  tps: 44212.6666
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ArrowofTime-72897"
  value: {
-  dps: 32847.86476
-  tps: 44400.71053
+  dps: 32902.57544
+  tps: 45132.58022
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 31880.92646
-  tps: 43083.31747
+  dps: 31913.28255
+  tps: 43163.74081
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 30737.66776
-  tps: 41795.96964
+  dps: 30766.65324
+  tps: 41558.36582
   hps: 96.77966
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 30737.66776
-  tps: 41795.96964
+  dps: 30766.65324
+  tps: 41558.36582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 31131.79078
-  tps: 42076.88675
+  dps: 31199.05969
+  tps: 42187.20832
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 31203.41561
-  tps: 42095.97363
+  dps: 31288.66606
+  tps: 42169.42165
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BindingPromise-67037"
  value: {
-  dps: 30754.02975
-  tps: 41745.61299
+  dps: 30775.90736
+  tps: 41426.16014
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 32094.43234
-  tps: 42654.20137
+  dps: 32201.04757
+  tps: 42746.77942
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 31096.7629
-  tps: 42460.57722
+  dps: 31088.11293
+  tps: 42168.58841
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 31139.42743
-  tps: 42527.11622
+  dps: 31130.69137
+  tps: 42234.50711
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 32620.67646
-  tps: 42583.92965
+  dps: 32759.04581
+  tps: 43453.91287
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 30754.02975
-  tps: 41745.61299
+  dps: 30775.90736
+  tps: 41426.16014
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 31291.97801
-  tps: 42331.54895
+  dps: 31326.86411
+  tps: 42264.049
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 31140.94556
-  tps: 42015.33222
+  dps: 31199.77531
+  tps: 41969.6236
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 30747.95367
-  tps: 41711.20909
+  dps: 30775.90736
+  tps: 41426.16014
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 30747.95367
-  tps: 41711.20909
+  dps: 30775.90736
+  tps: 41426.16014
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 32171.6558
-  tps: 43460.80789
+  dps: 32196.28505
+  tps: 43255.87141
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 30734.99805
-  tps: 41826.13367
+  dps: 30763.98353
+  tps: 41588.52985
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 31326.2923
-  tps: 42104.62385
+  dps: 31321.62283
+  tps: 41952.14893
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 32444.58765
-  tps: 43812.48824
+  dps: 32397.26042
+  tps: 43873.73778
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 32218.69771
-  tps: 43494.98986
+  dps: 32230.01859
+  tps: 43738.67431
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 32812.08488
-  tps: 44778.10058
+  dps: 32768.75942
+  tps: 44769.50726
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledLightning-66879"
  value: {
-  dps: 30888.19318
-  tps: 41946.69354
+  dps: 30921.79249
+  tps: 41836.11807
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledWishes-77114"
  value: {
-  dps: 31230.54497
-  tps: 41913.48968
+  dps: 31236.43032
+  tps: 42333.47532
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 31880.92646
-  tps: 42221.88446
+  dps: 31913.28255
+  tps: 42300.7039
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 30754.02975
-  tps: 41745.61299
+  dps: 30775.90736
+  tps: 41426.16014
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 32479.78206
-  tps: 43862.91879
+  dps: 32512.19531
+  tps: 43945.07439
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sBadgeofConquest-73648"
  value: {
-  dps: 33116.93611
-  tps: 43858.8891
+  dps: 33194.34594
+  tps: 43583.60165
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sBadgeofDominance-73498"
  value: {
-  dps: 30754.02975
-  tps: 41745.61299
+  dps: 30775.90736
+  tps: 41426.16014
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sBadgeofVictory-73496"
  value: {
-  dps: 31574.42125
-  tps: 42792.19308
+  dps: 31573.87869
+  tps: 42701.764
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sInsigniaofConquest-73643"
  value: {
-  dps: 32858.10547
-  tps: 43481.1858
+  dps: 32945.50399
+  tps: 43842.32771
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sInsigniaofDominance-73497"
  value: {
-  dps: 30734.99805
-  tps: 41826.13367
+  dps: 30760.08124
+  tps: 41698.02524
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sInsigniaofVictory-73491"
  value: {
-  dps: 31605.73432
-  tps: 42577.06211
+  dps: 31680.583
+  tps: 41837.8233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 32586.40873
-  tps: 43983.00955
+  dps: 32623.60547
+  tps: 44148.05853
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 31932.56807
-  tps: 42818.28364
+  dps: 32080.57909
+  tps: 42931.71022
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 30754.95786
-  tps: 41746.04114
+  dps: 30777.76359
+  tps: 41427.24618
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 30737.66776
-  tps: 41795.96964
+  dps: 30766.65324
+  tps: 41558.36582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 32354.01889
-  tps: 44030.09431
+  dps: 32377.36936
+  tps: 44267.29606
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 32026.6096
-  tps: 43363.05801
+  dps: 32115.53684
+  tps: 43449.79466
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 32463.20905
-  tps: 43558.81969
+  dps: 32559.28857
+  tps: 43660.39871
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-59506"
  value: {
-  dps: 31589.88985
-  tps: 42737.04356
+  dps: 31526.49181
+  tps: 42359.3718
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-65118"
  value: {
-  dps: 31716.85479
-  tps: 42850.91035
+  dps: 31726.2088
+  tps: 42884.49758
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 31079.72415
-  tps: 42286.05473
+  dps: 31085.02095
+  tps: 42013.17461
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 31018.75333
-  tps: 42382.22586
+  dps: 31001.68887
+  tps: 42070.1628
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-78000"
  value: {
-  dps: 31076.05089
-  tps: 42339.18026
+  dps: 31125.3509
+  tps: 42405.46972
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 30747.95367
-  tps: 41711.20909
+  dps: 30775.90736
+  tps: 41426.16014
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 31515.80843
-  tps: 42620.13427
+  dps: 31521.41602
+  tps: 42218.92394
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 32338.26296
-  tps: 43605.24738
+  dps: 32321.65242
+  tps: 43453.9648
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 30738.59587
-  tps: 41796.40103
+  dps: 30768.50947
+  tps: 41559.4497
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 31230.78022
-  tps: 43975.64454
+  dps: 31212.40105
+  tps: 44051.19326
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 31657.35005
-  tps: 43509.25019
+  dps: 31695.56291
+  tps: 43472.35668
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeepEarthRegalia"
  value: {
-  dps: 22048.83885
-  tps: 28418.94953
+  dps: 22028.80755
+  tps: 28501.15473
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 31982.4836
-  tps: 43196.55253
+  dps: 32019.03904
+  tps: 43357.50073
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 30863.57752
-  tps: 42762.76326
+  dps: 30918.37581
+  tps: 42421.39999
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dragonwrath,Tarecgosa'sRest-71086"
  value: {
-  dps: 33145.78468
-  tps: 43654.48031
+  dps: 33138.40222
+  tps: 43832.9012
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 31796.80818
-  tps: 42896.62255
+  dps: 31847.78414
+  tps: 42703.57158
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 31880.92646
-  tps: 43083.31747
+  dps: 31913.28255
+  tps: 43163.74081
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 30754.95786
-  tps: 41782.8902
+  dps: 30776.83548
+  tps: 41463.58716
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 31880.92646
-  tps: 43083.25474
+  dps: 31913.28255
+  tps: 43163.67368
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 31982.4836
-  tps: 43196.55253
+  dps: 32019.03904
+  tps: 43357.50073
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 32558.8054
-  tps: 43687.75245
+  dps: 32575.15248
+  tps: 43687.88491
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 31870.63662
-  tps: 44097.86067
+  dps: 31928.96626
+  tps: 44233.23782
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 31880.92646
-  tps: 43083.31747
+  dps: 31913.28255
+  tps: 43163.74081
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 32155.8443
-  tps: 43602.59685
+  dps: 32187.41412
+  tps: 43356.80684
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 32000.03283
-  tps: 43388.71321
+  dps: 32031.30898
+  tps: 43143.85345
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 32327.23691
-  tps: 43837.86886
+  dps: 32359.12978
+  tps: 43591.05557
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-59500"
  value: {
-  dps: 30738.59587
-  tps: 41796.40103
+  dps: 30768.50947
+  tps: 41559.4497
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-65124"
  value: {
-  dps: 30738.59587
-  tps: 41796.37126
+  dps: 30768.50947
+  tps: 41559.41908
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 30752.87295
-  tps: 41987.4249
+  dps: 30783.39032
+  tps: 41732.30815
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 32107.32909
-  tps: 42498.68757
+  dps: 32130.90206
+  tps: 42415.20057
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 30754.95786
-  tps: 41746.06703
+  dps: 30776.83548
+  tps: 41426.61322
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 30754.02975
-  tps: 41745.61299
+  dps: 30775.90736
+  tps: 41426.16014
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 30754.95786
-  tps: 41746.06703
+  dps: 30776.83548
+  tps: 41426.61322
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 31664.1958
-  tps: 42994.51374
+  dps: 31661.53448
+  tps: 43000.84635
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 31420.00596
-  tps: 44119.54507
+  dps: 31440.74743
+  tps: 44162.8965
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 31951.61901
-  tps: 43192.88247
+  dps: 31984.25721
+  tps: 43273.42414
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FluidDeath-58181"
  value: {
-  dps: 32360.99826
-  tps: 43757.40896
+  dps: 32343.64156
+  tps: 43685.95231
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 31880.92646
-  tps: 43083.2761
+  dps: 31913.28255
+  tps: 43163.69654
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 31266.15646
-  tps: 42766.42688
+  dps: 31267.82466
+  tps: 42792.01298
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 31812.86785
-  tps: 43490.69218
+  dps: 31892.29031
+  tps: 43065.80386
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56138"
  value: {
-  dps: 31042.79329
-  tps: 41988.58628
+  dps: 31085.16805
+  tps: 42537.83233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56462"
  value: {
-  dps: 31055.02472
-  tps: 41764.94944
+  dps: 31091.19093
+  tps: 41883.20233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GearDetector-61462"
  value: {
-  dps: 31767.35737
-  tps: 43547.85872
+  dps: 31685.90847
+  tps: 43583.89963
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 26164.27222
-  tps: 34616.5186
+  dps: 26227.70645
+  tps: 34738.71656
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 30737.66776
-  tps: 41795.83919
+  dps: 30766.65324
+  tps: 41558.23167
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 31782.22711
-  tps: 42485.31269
+  dps: 31765.78533
+  tps: 42240.5537
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 32247.63382
-  tps: 43146.25391
+  dps: 32139.51077
+  tps: 43104.4378
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HarmlightToken-63839"
  value: {
-  dps: 30773.26079
-  tps: 41899.14767
+  dps: 30808.24724
+  tps: 41762.00978
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 31290.78249
-  tps: 42466.64286
+  dps: 31308.87948
+  tps: 42438.79316
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 30737.66776
-  tps: 41795.96964
+  dps: 30766.65324
+  tps: 41558.36582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 30737.66776
-  tps: 41795.96964
+  dps: 30766.65324
+  tps: 41558.36582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-59224"
  value: {
-  dps: 31441.85773
-  tps: 42899.52938
+  dps: 31481.64745
+  tps: 42519.12721
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-65072"
  value: {
-  dps: 31498.2038
-  tps: 42336.16537
+  dps: 31535.25547
+  tps: 42229.73922
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-55868"
  value: {
-  dps: 31513.00246
-  tps: 42960.53596
+  dps: 31574.85053
+  tps: 43486.96252
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-56393"
  value: {
-  dps: 31596.0964
-  tps: 42735.569
+  dps: 31646.71748
+  tps: 42644.03341
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-55845"
  value: {
-  dps: 30737.66776
-  tps: 41795.96964
+  dps: 30766.65324
+  tps: 41558.36582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-56370"
  value: {
-  dps: 30737.66776
-  tps: 41795.96964
+  dps: 30766.65324
+  tps: 41558.36582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 31823.34961
-  tps: 43245.15333
+  dps: 31828.12542
+  tps: 42916.6557
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-50641"
  value: {
-  dps: 33161.37949
-  tps: 43846.76652
+  dps: 33215.7302
+  tps: 44730.41573
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 31982.4836
-  tps: 43196.55253
+  dps: 32019.03904
+  tps: 43357.50073
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 31840.06337
-  tps: 44374.53058
+  dps: 31861.91614
+  tps: 44401.22381
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 31840.06337
-  tps: 44374.53058
+  dps: 31861.91614
+  tps: 44401.22381
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 31108.72685
-  tps: 42378.2113
+  dps: 31099.10029
+  tps: 42038.35886
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 31151.38577
-  tps: 42444.39056
+  dps: 31141.68034
+  tps: 42103.86303
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndomitablePride-77211"
  value: {
-  dps: 30737.66776
-  tps: 41795.96964
+  dps: 30766.65324
+  tps: 41558.36582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndomitablePride-77983"
  value: {
-  dps: 30737.66776
-  tps: 41795.96964
+  dps: 30766.65324
+  tps: 41558.36582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndomitablePride-78003"
  value: {
-  dps: 30737.66776
-  tps: 41795.96964
+  dps: 30766.65324
+  tps: 41558.36582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 30737.66776
-  tps: 41795.96964
+  dps: 30766.65324
+  tps: 41558.36582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 31538.15309
-  tps: 42260.95989
+  dps: 31462.62379
+  tps: 41645.11913
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 31307.04958
-  tps: 42354.02646
+  dps: 31287.86202
+  tps: 42032.11788
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 31492.87985
-  tps: 41486.99551
+  dps: 31408.50305
+  tps: 41378.42527
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 31002.42875
-  tps: 42260.04331
+  dps: 31031.20238
+  tps: 42018.64675
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 30737.66776
-  tps: 41796.20264
+  dps: 30766.65324
+  tps: 41558.59911
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 30737.66776
-  tps: 41796.20264
+  dps: 30766.65324
+  tps: 41558.59911
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 30738.59587
-  tps: 41796.35708
+  dps: 30768.50947
+  tps: 41559.4045
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 30738.59587
-  tps: 41796.32163
+  dps: 30768.50947
+  tps: 41559.36804
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 32094.43234
-  tps: 42654.20137
+  dps: 32201.04757
+  tps: 42746.77942
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 31887.95354
-  tps: 43404.30817
+  dps: 31929.69917
+  tps: 43276.5963
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 32339.02604
-  tps: 43544.66336
+  dps: 32344.43031
+  tps: 43563.76284
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-77194"
  value: {
-  dps: 36291.4185
-  tps: 48891.60956
+  dps: 36330.71227
+  tps: 48747.90051
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-78473"
  value: {
-  dps: 36759.262
-  tps: 49472.57816
+  dps: 36761.7145
+  tps: 49318.4179
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-78482"
  value: {
-  dps: 35931.57795
-  tps: 48905.72077
+  dps: 35943.9044
+  tps: 48873.45887
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 33905.35604
-  tps: 43924.2597
+  dps: 33847.99809
+  tps: 44129.08281
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 31035.0928
-  tps: 42334.31524
+  dps: 31210.84253
+  tps: 42199.51097
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 31035.0928
-  tps: 42334.31524
+  dps: 31210.84253
+  tps: 42199.51097
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 30862.52989
-  tps: 42264.87451
+  dps: 30867.51644
+  tps: 42469.81868
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50708"
  value: {
-  dps: 32913.46786
-  tps: 44366.22906
+  dps: 32909.44713
+  tps: 44306.41384
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-55816"
  value: {
-  dps: 30737.66776
-  tps: 41795.96964
+  dps: 30766.65324
+  tps: 41558.36582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-56347"
  value: {
-  dps: 30737.66776
-  tps: 41795.96964
+  dps: 30766.65324
+  tps: 41558.36582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 31952.35245
-  tps: 42507.51144
+  dps: 31957.01423
+  tps: 42252.72937
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 32196.66105
-  tps: 43170.20193
+  dps: 32216.89744
+  tps: 43308.86056
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 31307.28879
-  tps: 42700.92797
+  dps: 31337.39023
+  tps: 42459.7892
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 31223.9626
-  tps: 42515.82931
+  dps: 31273.26464
+  tps: 42250.51652
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 31371.69074
-  tps: 42667.20483
+  dps: 31422.4527
+  tps: 42403.46739
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 30737.66776
-  tps: 41795.96964
+  dps: 30766.65324
+  tps: 41558.36582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 30737.66776
-  tps: 41795.96964
+  dps: 30766.65324
+  tps: 41558.36582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 31601.85294
-  tps: 42867.74886
+  dps: 31696.22935
+  tps: 42723.81479
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 31642.48439
-  tps: 42584.50996
+  dps: 31734.33912
+  tps: 42745.11156
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 33107.50987
-  tps: 45639.50565
+  dps: 33052.47976
+  tps: 45728.1863
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 33368.43849
-  tps: 46025.5716
+  dps: 33355.24953
+  tps: 45808.48233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 31065.73477
-  tps: 42294.78984
+  dps: 31106.66472
+  tps: 42060.80238
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 31348.8081
-  tps: 42568.78735
+  dps: 31399.57006
+  tps: 42305.04991
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 31237.62367
-  tps: 43725.28927
+  dps: 31258.71807
+  tps: 43770.93792
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 31237.62367
-  tps: 43725.28927
+  dps: 31258.71807
+  tps: 43770.93792
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 31130.74359
-  tps: 42132.62515
+  dps: 31192.28129
+  tps: 42264.58319
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 31277.13335
-  tps: 41946.24042
+  dps: 31185.69969
+  tps: 41439.5422
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 30754.02975
-  tps: 41745.61299
+  dps: 30775.90736
+  tps: 41426.16014
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 30738.59587
-  tps: 41796.35708
+  dps: 30768.50947
+  tps: 41559.4045
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 30738.59587
-  tps: 41796.32163
+  dps: 30768.50947
+  tps: 41559.36804
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ObsidianArborweaveBattlegarb"
  value: {
-  dps: 31004.01992
-  tps: 38852.04751
+  dps: 31018.82722
+  tps: 38710.21998
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ObsidianArborweaveRegalia"
  value: {
-  dps: 22412.165
-  tps: 29225.81225
+  dps: 22405.35
+  tps: 28873.01479
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 31357.82431
-  tps: 42403.22921
+  dps: 31391.46239
+  tps: 42299.25631
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 30738.59587
-  tps: 41796.41308
+  dps: 30767.58136
+  tps: 41558.80314
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 30737.66776
-  tps: 41795.96964
+  dps: 30766.65324
+  tps: 41558.36582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 30995.40291
-  tps: 42056.24684
+  dps: 30974.86393
+  tps: 41975.18583
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 31081.9232
-  tps: 42273.03632
+  dps: 31068.23377
+  tps: 42034.9067
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 31211.65944
-  tps: 42288.20634
+  dps: 31192.11986
+  tps: 42206.42508
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 31880.92646
-  tps: 43083.31747
+  dps: 31913.28255
+  tps: 43163.74081
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 32556.13333
-  tps: 43664.31426
+  dps: 32569.33252
+  tps: 43632.39191
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-55854"
  value: {
-  dps: 30737.66776
-  tps: 41795.96964
+  dps: 30766.65324
+  tps: 41558.36582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-56377"
  value: {
-  dps: 30737.66776
-  tps: 41795.96964
+  dps: 30766.65324
+  tps: 41558.36582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rathrak,thePoisonousMind-77195"
  value: {
-  dps: 29553.46552
-  tps: 39680.49599
+  dps: 29538.96705
+  tps: 39603.77005
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rathrak,thePoisonousMind-78475"
  value: {
-  dps: 30134.57476
-  tps: 40180.78841
+  dps: 30121.50435
+  tps: 40109.62362
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rathrak,thePoisonousMind-78484"
  value: {
-  dps: 29113.14427
-  tps: 39449.27937
+  dps: 29099.25501
+  tps: 39358.49037
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 30752.01618
-  tps: 41869.93091
+  dps: 30781.00166
+  tps: 41632.32709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 30737.66776
-  tps: 41795.96964
+  dps: 30766.65324
+  tps: 41558.36582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 30737.66776
-  tps: 41795.96964
+  dps: 30766.65324
+  tps: 41558.36582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 30737.66776
-  tps: 41795.96964
+  dps: 30766.65324
+  tps: 41558.36582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 32566.74591
-  tps: 43981.20115
+  dps: 32599.22293
+  tps: 44063.5671
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 32479.78206
-  tps: 43862.96016
+  dps: 32512.19531
+  tps: 43945.11866
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 32693.11976
-  tps: 44430.99863
+  dps: 32638.74742
+  tps: 44321.53624
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 31292.0939
-  tps: 42810.03058
+  dps: 31322.95621
+  tps: 42188.95499
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 31357.06568
-  tps: 42423.88847
+  dps: 31357.865
+  tps: 42205.84103
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RosaryofLight-72901"
  value: {
-  dps: 31943.64718
-  tps: 42974.44459
+  dps: 31997.44384
+  tps: 42826.57732
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RottingSkull-77116"
  value: {
-  dps: 32349.15969
-  tps: 43246.99163
+  dps: 32441.07718
+  tps: 43582.57453
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuneofZeth-68998"
  value: {
-  dps: 31175.26075
-  tps: 42758.7432
+  dps: 31221.82399
+  tps: 42606.23698
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofConquest-70399"
  value: {
-  dps: 32733.73868
-  tps: 43089.44276
+  dps: 32759.06107
+  tps: 42868.97509
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofConquest-72304"
  value: {
-  dps: 32847.49606
-  tps: 43221.12611
+  dps: 32869.31396
+  tps: 42995.35441
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofDominance-70401"
  value: {
-  dps: 30754.02975
-  tps: 41745.61299
+  dps: 30775.90736
+  tps: 41426.16014
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofDominance-72448"
  value: {
-  dps: 30754.02975
-  tps: 41745.61299
+  dps: 30775.90736
+  tps: 41426.16014
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofVictory-70400"
  value: {
-  dps: 31441.71354
-  tps: 42698.2366
+  dps: 31457.66972
+  tps: 42633.98392
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofVictory-72450"
  value: {
-  dps: 31464.06952
-  tps: 42616.49271
+  dps: 31479.933
+  tps: 42552.84525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofConquest-70404"
  value: {
-  dps: 32603.29534
-  tps: 43312.95867
+  dps: 32587.93732
+  tps: 42970.72003
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofConquest-72309"
  value: {
-  dps: 32612.0763
-  tps: 43442.01788
+  dps: 32634.58278
+  tps: 43193.60289
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofDominance-70402"
  value: {
-  dps: 30737.66776
-  tps: 41795.96964
+  dps: 30766.65324
+  tps: 41558.36582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofDominance-72449"
  value: {
-  dps: 30763.21974
-  tps: 41907.12749
+  dps: 30766.65324
+  tps: 41558.36582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofVictory-70403"
  value: {
-  dps: 31492.44339
-  tps: 42419.73252
+  dps: 31522.79188
+  tps: 42002.31009
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofVictory-72455"
  value: {
-  dps: 31556.47083
-  tps: 42851.2468
+  dps: 31542.52855
+  tps: 42370.4235
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ScalesofLife-68915"
  value: {
-  dps: 30737.66776
-  tps: 41795.96964
+  dps: 30766.65324
+  tps: 41558.36582
   hps: 315.97258
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ScalesofLife-69109"
  value: {
-  dps: 30737.66776
-  tps: 41795.96964
+  dps: 30766.65324
+  tps: 41558.36582
   hps: 356.41412
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 31949.18994
-  tps: 43194.12886
+  dps: 31882.41564
+  tps: 43183.03738
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-55256"
  value: {
-  dps: 30754.02975
-  tps: 41745.61299
+  dps: 30775.90736
+  tps: 41426.16014
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-56290"
  value: {
-  dps: 30754.02975
-  tps: 41745.61299
+  dps: 30775.90736
+  tps: 41426.16014
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShardofWoe-60233"
  value: {
-  dps: 31077.45283
-  tps: 42070.74548
+  dps: 30988.86464
+  tps: 42114.13212
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 31364.56619
-  tps: 42190.88777
+  dps: 31423.54457
+  tps: 42690.93767
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 30752.41932
-  tps: 41737.72494
+  dps: 30780.37301
+  tps: 41452.67598
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 32179.39786
-  tps: 43245.39154
+  dps: 32113.07578
+  tps: 42924.63516
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 32359.4561
-  tps: 43501.94257
+  dps: 32272.06465
+  tps: 43021.61986
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-55879"
  value: {
-  dps: 31093.36181
-  tps: 42313.74677
+  dps: 31081.00868
+  tps: 42132.50019
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-56400"
  value: {
-  dps: 31136.01989
-  tps: 42379.84937
+  dps: 31123.60673
+  tps: 42198.14577
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 31065.73477
-  tps: 42294.78984
+  dps: 31106.66472
+  tps: 42060.80238
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulCasket-58183"
  value: {
-  dps: 31233.16568
-  tps: 43699.06004
+  dps: 31254.26009
+  tps: 43744.70868
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 31694.47528
-  tps: 43303.4445
+  dps: 31657.09793
+  tps: 42614.36885
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 31460.55643
-  tps: 42305.16533
+  dps: 31424.10069
+  tps: 42044.21701
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 31768.71717
-  tps: 42420.73013
+  dps: 31737.79798
+  tps: 42220.73131
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 31303.1308
-  tps: 43915.03117
+  dps: 31324.06548
+  tps: 43959.6402
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 31367.73344
-  tps: 44019.1381
+  dps: 31388.53931
+  tps: 44062.90872
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 33357.60407
-  tps: 44564.11944
+  dps: 33250.33614
+  tps: 44798.83307
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 32843.32417
-  tps: 43637.76825
+  dps: 32886.17768
+  tps: 43710.11156
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 33596.07221
-  tps: 44458.33473
+  dps: 33497.5952
+  tps: 43803.76681
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StayofExecution-68996"
  value: {
-  dps: 30737.66776
-  tps: 41795.96964
+  dps: 30766.65324
+  tps: 41558.36582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 30776.44118
-  tps: 41770.41475
+  dps: 30806.62361
+  tps: 41649.31412
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stormrider'sBattlegarb"
  value: {
-  dps: 28509.78907
-  tps: 37294.92336
+  dps: 28460.47215
+  tps: 37007.62766
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stormrider'sRegalia"
  value: {
-  dps: 22267.53534
-  tps: 28415.83615
+  dps: 22193.14961
+  tps: 28511.48424
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62465"
  value: {
-  dps: 30716.89947
-  tps: 41885.52327
+  dps: 30745.88495
+  tps: 41647.91946
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62470"
  value: {
-  dps: 30714.22975
-  tps: 41915.6873
+  dps: 30743.21524
+  tps: 41678.08349
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 30737.66776
-  tps: 41795.96964
+  dps: 30766.65324
+  tps: 41558.36582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 30737.66776
-  tps: 41795.96964
+  dps: 30766.65324
+  tps: 41558.36582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 30776.60766
-  tps: 41882.81363
+  dps: 30816.43214
+  tps: 41629.73916
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 31472.82751
-  tps: 42867.5046
+  dps: 31427.54481
+  tps: 42853.34782
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-55819"
  value: {
-  dps: 30737.66776
-  tps: 41795.81722
+  dps: 30766.65324
+  tps: 41558.20907
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-56351"
  value: {
-  dps: 30738.59587
-  tps: 41796.42655
+  dps: 30767.58136
+  tps: 41558.81699
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 31048.9269
-  tps: 42385.97289
+  dps: 31040.37347
+  tps: 42094.67956
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 31139.42743
-  tps: 42527.11622
+  dps: 31130.69137
+  tps: 42234.50711
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheHungerer-68927"
  value: {
-  dps: 32779.97322
-  tps: 45253.41724
+  dps: 32735.16647
+  tps: 45225.22101
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheHungerer-69112"
  value: {
-  dps: 33022.76193
-  tps: 44348.24853
+  dps: 32945.11927
+  tps: 44762.50446
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 30781.41985
-  tps: 41815.52853
+  dps: 30802.56029
+  tps: 41567.80009
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 30797.11812
-  tps: 41693.69106
+  dps: 30832.96075
+  tps: 41492.1563
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 30737.66776
-  tps: 41795.96964
+  dps: 30766.65324
+  tps: 41558.36582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 30737.66776
-  tps: 41795.96964
+  dps: 30766.65324
+  tps: 41558.36582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-77190"
  value: {
-  dps: 32752.26093
-  tps: 44041.92698
+  dps: 32764.15194
+  tps: 43805.63189
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-78477"
  value: {
-  dps: 32757.19476
-  tps: 43816.64928
+  dps: 32718.84079
+  tps: 43856.19318
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-78486"
  value: {
-  dps: 32719.74357
-  tps: 44024.62039
+  dps: 32814.22995
+  tps: 44020.01938
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 32444.02647
-  tps: 44000.10809
+  dps: 32379.09602
+  tps: 43860.92813
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 32504.68545
-  tps: 45849.66241
+  dps: 32498.3788
+  tps: 45515.65075
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 30994.8909
-  tps: 42750.39818
+  dps: 30940.5559
+  tps: 43049.10165
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 30684.4455
-  tps: 42099.59429
+  dps: 30697.48896
+  tps: 41961.17866
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnheededWarning-59520"
  value: {
-  dps: 32689.82607
-  tps: 44340.4614
+  dps: 32665.49089
+  tps: 43786.54664
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 30754.02975
-  tps: 41745.61299
+  dps: 30775.90736
+  tps: 41426.16014
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 32785.20731
-  tps: 44779.07249
+  dps: 32720.55083
+  tps: 44260.98776
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 32785.20731
-  tps: 44779.07249
+  dps: 32720.55083
+  tps: 44260.98776
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 32785.20731
-  tps: 44779.07249
+  dps: 32720.55083
+  tps: 44260.98776
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 26670.37638
-  tps: 37203.79885
+  dps: 26664.97333
+  tps: 37230.75552
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 30749.7926
-  tps: 41837.60097
+  dps: 30771.93429
+  tps: 41637.79654
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 30740.78247
-  tps: 41830.43757
+  dps: 30777.47543
+  tps: 41569.4617
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 31915.78564
-  tps: 43294.49138
+  dps: 31897.02284
+  tps: 43084.51034
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VeilofLies-72900"
  value: {
-  dps: 30735.05196
-  tps: 41742.50577
+  dps: 30766.65324
+  tps: 41558.36582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 31970.08639
-  tps: 43219.13345
+  dps: 32031.60888
+  tps: 43124.61822
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 32123.98499
-  tps: 43566.87772
+  dps: 32186.8082
+  tps: 43466.15425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77207"
  value: {
-  dps: 33319.49995
-  tps: 45482.24716
+  dps: 33328.81561
+  tps: 45945.48176
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77979"
  value: {
-  dps: 32802.97073
-  tps: 44676.47208
+  dps: 32772.7039
+  tps: 44896.97584
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77999"
  value: {
-  dps: 33483.81077
-  tps: 45121.48804
+  dps: 33549.9842
+  tps: 45768.65898
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 30754.02975
-  tps: 41745.61299
+  dps: 30775.90736
+  tps: 41426.16014
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 30754.02975
-  tps: 41745.61299
+  dps: 30775.90736
+  tps: 41426.16014
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 32286.03405
-  tps: 42552.01267
+  dps: 32310.85798
+  tps: 42513.44114
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-70517"
  value: {
-  dps: 32489.17915
-  tps: 42911.45301
+  dps: 32516.8077
+  tps: 42879.76203
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 30754.02975
-  tps: 41745.61299
+  dps: 30775.90736
+  tps: 41426.16014
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-70518"
  value: {
-  dps: 30754.02975
-  tps: 41745.61299
+  dps: 30775.90736
+  tps: 41426.16014
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 31323.30207
-  tps: 42369.84638
+  dps: 31358.0311
+  tps: 42302.11739
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-70519"
  value: {
-  dps: 31392.2444
-  tps: 42467.47193
+  dps: 31415.40051
+  tps: 42435.73748
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 30727.18538
-  tps: 41800.76272
+  dps: 30755.13907
+  tps: 41515.71377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 31138.43215
-  tps: 41961.38436
+  dps: 31077.44441
+  tps: 41923.3831
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 31181.91549
-  tps: 42068.96997
+  dps: 31241.24795
+  tps: 42019.68718
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 30747.95367
-  tps: 41711.20909
+  dps: 30775.90736
+  tps: 41426.16014
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 31257.70618
-  tps: 43738.49531
+  dps: 31278.75163
+  tps: 43783.82536
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 30747.95367
-  tps: 41711.20909
+  dps: 30775.90736
+  tps: 41426.16014
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 32151.34563
-  tps: 42850.65343
+  dps: 32243.75154
+  tps: 42240.15282
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-70577"
  value: {
-  dps: 32402.39888
-  tps: 43467.08342
+  dps: 32393.86596
+  tps: 43256.99184
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 30737.66776
-  tps: 41795.96964
+  dps: 30766.65324
+  tps: 41558.36582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-70578"
  value: {
-  dps: 30732.44792
-  tps: 41742.63093
+  dps: 30761.43341
+  tps: 41505.02712
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 31370.76829
-  tps: 42589.3151
+  dps: 31405.91695
+  tps: 42328.83251
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-70579"
  value: {
-  dps: 31441.2765
-  tps: 42555.68551
+  dps: 31495.77994
+  tps: 42354.54187
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 30737.66776
-  tps: 41808.97806
+  dps: 30766.65324
+  tps: 41570.66326
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 30737.66776
-  tps: 41807.06622
+  dps: 30766.65324
+  tps: 41568.88492
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WillofUnbinding-77995"
  value: {
-  dps: 30737.66776
-  tps: 41811.08107
+  dps: 30766.65324
+  tps: 41572.61576
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 30805.92457
-  tps: 41642.25666
+  dps: 30830.8228
+  tps: 41363.37483
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 30746.8915
-  tps: 41670.74056
+  dps: 30747.85171
+  tps: 41284.97913
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 31054.09836
-  tps: 42394.03822
+  dps: 31045.5345
+  tps: 42102.6697
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 34372.34297
-  tps: 46594.55557
+  dps: 34438.24053
+  tps: 46471.93575
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 33990.18786
-  tps: 46014.82245
+  dps: 34056.40583
+  tps: 45905.36681
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 34831.23812
-  tps: 47154.45162
+  dps: 34898.31975
+  tps: 47048.53364
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 31152.1904
-  tps: 42429.30533
+  dps: 31237.46701
+  tps: 41990.57243
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 31152.1904
-  tps: 42429.30533
+  dps: 31237.46701
+  tps: 41990.57243
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 33045.27214
-  tps: 44122.88962
+  dps: 33064.4923
+  tps: 44254.55049
  }
 }
 dps_results: {
@@ -2120,85 +2120,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 41727.35725
-  tps: 56119.65493
+  dps: 41891.03519
+  tps: 56226.73219
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38737.625
-  tps: 49280.64941
+  dps: 38728.16417
+  tps: 49465.33225
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 50353.51305
-  tps: 43664.7744
+  dps: 50143.86971
+  tps: 44367.97712
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 26425.57665
-  tps: 35432.00064
+  dps: 26334.88808
+  tps: 35362.5747
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25114.06356
-  tps: 32608.05496
+  dps: 25042.87137
+  tps: 32773.84962
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 28051.50279
-  tps: 25608.59264
+  dps: 28193.24488
+  tps: 25335.23013
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38378.62616
-  tps: 27251.08521
+  dps: 38409.47815
+  tps: 27272.99013
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38082.34667
-  tps: 27038.46614
+  dps: 38037.12528
+  tps: 27006.35895
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 50137.92159
-  tps: 35597.92433
+  dps: 49883.70748
+  tps: 35417.43231
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24083.32183
-  tps: 17101.52138
+  dps: 24128.14274
+  tps: 17133.34422
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24239.64175
-  tps: 17210.3558
+  dps: 24172.85667
+  tps: 17162.9384
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27774.74336
-  tps: 19720.63579
+  dps: 27873.82586
+  tps: 19790.98436
  }
 }
 dps_results: {
@@ -2246,85 +2246,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 40837.54896
-  tps: 55624.29524
+  dps: 40586.10789
+  tps: 54760.40356
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37955.62149
-  tps: 48008.00256
+  dps: 37825.52678
+  tps: 47220.50851
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 49050.82217
-  tps: 42739.38483
+  dps: 48846.92505
+  tps: 42922.84355
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 25821.12899
-  tps: 35387.50873
+  dps: 26017.63616
+  tps: 35916.45726
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24434.42371
-  tps: 31892.38853
+  dps: 24442.7231
+  tps: 32185.43405
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27132.2619
-  tps: 23399.30285
+  dps: 27058.74606
+  tps: 23448.87105
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 37469.5314
-  tps: 26605.62793
+  dps: 37579.60651
+  tps: 26683.78126
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37063.89143
-  tps: 26315.36291
+  dps: 37030.6823
+  tps: 26291.78443
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 48876.13959
-  tps: 34702.05911
+  dps: 48571.39012
+  tps: 34485.68698
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 23539.64765
-  tps: 16715.51271
+  dps: 23573.75987
+  tps: 16739.73239
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 23633.03482
-  tps: 16779.66488
+  dps: 23608.10561
+  tps: 16761.96514
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 26856.66253
-  tps: 19068.7984
+  dps: 26880.8295
+  tps: 19085.95695
  }
 }
 dps_results: {
@@ -2372,85 +2372,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 36208.00646
-  tps: 52493.0076
+  dps: 35921.44367
+  tps: 51178.91842
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 32751.94722
-  tps: 43472.31467
+  dps: 32723.91769
+  tps: 43584.95278
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 41273.90308
-  tps: 39230.36868
+  dps: 41149.13441
+  tps: 39983.84383
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 23322.768
-  tps: 36628.57159
+  dps: 23269.38028
+  tps: 36282.9067
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20863.95814
-  tps: 29638.07599
+  dps: 20937.38111
+  tps: 30220.38351
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 22970.09221
-  tps: 24070.70668
+  dps: 22921.65307
+  tps: 24313.0124
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 32378.94591
-  tps: 22991.31223
+  dps: 32290.67369
+  tps: 22928.63896
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 31860.69954
-  tps: 22621.09667
+  dps: 31734.65169
+  tps: 22531.6027
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 40608.47655
-  tps: 28832.01835
+  dps: 40431.76952
+  tps: 28706.55636
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 19913.89514
-  tps: 14141.22843
+  dps: 19861.74797
+  tps: 14104.20394
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 19979.22851
-  tps: 14185.4624
+  dps: 19972.1714
+  tps: 14180.45185
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 22512.78571
-  tps: 15984.64586
+  dps: 22430.55728
+  tps: 15926.26367
  }
 }
 dps_results: {
@@ -2498,85 +2498,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 35243.51201
-  tps: 51331.03946
+  dps: 35296.43981
+  tps: 51325.22568
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 32010.23011
-  tps: 41825.63546
+  dps: 32027.24529
+  tps: 41740.40951
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 40361.05517
-  tps: 37001.92913
+  dps: 40307.34724
+  tps: 37641.79053
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 22561.41165
-  tps: 33589.18449
+  dps: 22299.17756
+  tps: 32869.49386
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20258.09152
-  tps: 28433.54508
+  dps: 20272.29798
+  tps: 28615.37973
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 22198.68503
-  tps: 24268.74512
+  dps: 22220.66509
+  tps: 24343.86138
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 31603.566
-  tps: 22440.7925
+  dps: 31649.42277
+  tps: 22473.35081
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 31142.29578
-  tps: 22111.03
+  dps: 31078.55962
+  tps: 22065.77733
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 39741.60909
-  tps: 28216.54246
+  dps: 39566.34632
+  tps: 28092.10589
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 19496.895
-  tps: 13845.15833
+  dps: 19471.50471
+  tps: 13827.13122
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 19432.51539
-  tps: 13797.29609
+  dps: 19430.97779
+  tps: 13796.20439
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 21878.25067
-  tps: 15534.12597
+  dps: 21864.5271
+  tps: 15524.38224
  }
 }
 dps_results: {
@@ -2624,85 +2624,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 41890.88673
-  tps: 56954.32118
+  dps: 41334.7913
+  tps: 56749.16645
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38732.20014
-  tps: 49685.56727
+  dps: 38628.1682
+  tps: 49479.71525
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 49685.54461
-  tps: 44773.32513
+  dps: 49626.09511
+  tps: 44311.2675
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 26760.02751
-  tps: 36902.30261
+  dps: 26763.99268
+  tps: 37474.98443
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24951.07237
-  tps: 32822.00838
+  dps: 24977.99174
+  tps: 32761.48232
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27314.79688
-  tps: 24607.57637
+  dps: 27407.43625
+  tps: 24361.20948
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38342.33694
-  tps: 27225.31987
+  dps: 38313.344
+  tps: 27204.73488
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37851.69905
-  tps: 26874.70633
+  dps: 37825.92962
+  tps: 26856.41003
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 49599.20513
-  tps: 35215.43565
+  dps: 49547.02326
+  tps: 35178.38652
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 23998.62124
-  tps: 17041.38396
+  dps: 24022.95017
+  tps: 17058.6575
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24228.44439
-  tps: 17202.40568
+  dps: 24245.96398
+  tps: 17214.84458
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27141.34992
-  tps: 19270.92644
+  dps: 27240.99485
+  tps: 19341.67434
  }
 }
 dps_results: {
@@ -2750,85 +2750,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 40941.65057
-  tps: 55680.5158
+  dps: 40874.00861
+  tps: 56083.55957
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37833.94812
-  tps: 48014.36177
+  dps: 37752.73835
+  tps: 47813.1923
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 48466.15948
-  tps: 43950.42609
+  dps: 48348.4658
+  tps: 43297.05009
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 25636.17115
-  tps: 34817.42447
+  dps: 25670.37534
+  tps: 34939.60713
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24375.41111
-  tps: 31973.5814
+  dps: 24299.65296
+  tps: 32076.58318
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 26694.56009
-  tps: 24174.95963
+  dps: 26692.92345
+  tps: 24102.81043
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 37539.52825
-  tps: 26655.3257
+  dps: 37498.22369
+  tps: 26625.99946
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37059.15039
-  tps: 26311.99678
+  dps: 37008.50555
+  tps: 26276.03894
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 48015.37372
-  tps: 34090.91534
+  dps: 48038.64622
+  tps: 34107.43882
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 23329.66779
-  tps: 16566.42701
+  dps: 23321.5164
+  tps: 16560.63952
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 23594.16796
-  tps: 16752.06941
+  dps: 23539.47352
+  tps: 16713.23636
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 26408.7808
-  tps: 18750.80236
+  dps: 26434.37127
+  tps: 18768.9716
  }
 }
 dps_results: {
@@ -2876,85 +2876,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 36060.20018
-  tps: 53237.78684
+  dps: 36082.1024
+  tps: 53192.84708
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 32729.3344
-  tps: 44115.26496
+  dps: 32753.20322
+  tps: 44186.0023
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 40778.43038
-  tps: 39322.73834
+  dps: 40651.20136
+  tps: 40039.44218
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 22831.97988
-  tps: 34401.41026
+  dps: 23066.66019
+  tps: 35471.58455
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20765.53364
-  tps: 30419.61423
+  dps: 20778.89051
+  tps: 30364.8238
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 22622.04726
-  tps: 25386.62066
+  dps: 22563.80272
+  tps: 25594.41077
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 32326.58603
-  tps: 22954.13672
+  dps: 32355.17884
+  tps: 22974.43762
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 31753.39831
-  tps: 22544.9128
+  dps: 31761.32136
+  tps: 22550.53816
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 40185.46212
-  tps: 28531.67811
+  dps: 39996.82856
+  tps: 28397.74828
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 19921.7333
-  tps: 14146.79353
+  dps: 19937.09629
+  tps: 14157.70124
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 19977.6253
-  tps: 14184.32412
+  dps: 19977.9364
+  tps: 14184.54501
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 22309.30517
-  tps: 15840.17467
+  dps: 22242.34939
+  tps: 15792.63607
  }
 }
 dps_results: {
@@ -3002,91 +3002,91 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 35173.05779
-  tps: 51878.25421
+  dps: 35179.05063
+  tps: 50935.25267
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 31865.57593
-  tps: 42101.00297
+  dps: 31839.45474
+  tps: 42451.69213
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 39787.37543
-  tps: 38169.39694
+  dps: 39712.6521
+  tps: 38253.12066
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 22457.78122
-  tps: 33912.02962
+  dps: 22480.97982
+  tps: 34086.42467
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20305.03522
-  tps: 29276.48749
+  dps: 20302.99035
+  tps: 29184.79881
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 21920.80528
-  tps: 24795.51075
+  dps: 21942.0896
+  tps: 24804.06404
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 31438.54652
-  tps: 22323.62867
+  dps: 31536.41106
+  tps: 22393.11249
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 31017.50758
-  tps: 22022.43038
+  dps: 30932.64164
+  tps: 21962.17556
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 38924.68628
-  tps: 27636.52726
+  dps: 38854.04285
+  tps: 27586.37042
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 19329.71478
-  tps: 13726.46037
+  dps: 19351.74399
+  tps: 13742.10112
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 19456.52728
-  tps: 13814.34453
+  dps: 19465.77178
+  tps: 13820.90812
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 21628.9525
-  tps: 15357.12428
+  dps: 21607.26623
+  tps: 15341.72703
  }
 }
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 28686.80105
-  tps: 39940.58496
+  dps: 28665.377
+  tps: 39933.2262
  }
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -851,8 +851,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 31437.77558
-  tps: 42851.41472
+  dps: 31454.29191
+  tps: 42912.27485
  }
 }
 dps_results: {
@@ -1131,8 +1131,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-ObsidianArborweaveBattlegarb"
  value: {
-  dps: 30940.10479
-  tps: 38723.7898
+  dps: 30926.6513
+  tps: 38608.02132
  }
 }
 dps_results: {
@@ -2071,8 +2071,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 33083.4175
-  tps: 44526.03517
+  dps: 33083.96381
+  tps: 44525.79976
  }
 }
 dps_results: {
@@ -2120,15 +2120,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 41849.06211
-  tps: 56849.99366
+  dps: 41846.9646
+  tps: 56825.60524
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38936.15288
-  tps: 50479.25806
+  dps: 38907.93351
+  tps: 50450.59593
  }
 }
 dps_results: {
@@ -2141,36 +2141,36 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 26359.63568
-  tps: 35528.78101
+  dps: 26352.40374
+  tps: 35478.30261
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25057.38185
-  tps: 33071.01959
+  dps: 25063.00568
+  tps: 32847.57802
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 28342.64563
-  tps: 25591.92973
+  dps: 28384.68622
+  tps: 26179.49388
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38450.20917
-  tps: 27301.90915
+  dps: 38467.4937
+  tps: 27314.18117
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38142.62761
-  tps: 27081.2656
+  dps: 38181.89167
+  tps: 27109.14309
  }
 }
 dps_results: {
@@ -2183,22 +2183,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24105.57553
-  tps: 17117.3215
+  dps: 24118.15352
+  tps: 17126.25188
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24166.06667
-  tps: 17158.11749
+  dps: 24236.31627
+  tps: 17207.99471
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27859.9495
-  tps: 19781.13214
+  dps: 27913.14575
+  tps: 19818.90148
  }
 }
 dps_results: {
@@ -2246,15 +2246,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 40820.29345
-  tps: 55604.75785
+  dps: 40830.85068
+  tps: 55591.23007
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37847.04224
-  tps: 47806.45424
+  dps: 37836.33581
+  tps: 47914.6553
  }
 }
 dps_results: {
@@ -2267,36 +2267,36 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 26021.24947
-  tps: 36030.19355
+  dps: 26057.47866
+  tps: 36206.62255
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24462.3301
-  tps: 31674.24532
+  dps: 24517.85431
+  tps: 31496.82003
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27058.74606
-  tps: 23448.87105
+  dps: 27077.72441
+  tps: 23882.87629
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 37534.79209
-  tps: 26651.96303
+  dps: 37556.84977
+  tps: 26667.62398
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37114.68211
-  tps: 26351.4243
+  dps: 37154.60148
+  tps: 26379.76705
  }
 }
 dps_results: {
@@ -2309,22 +2309,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 23539.88771
-  tps: 16715.68315
+  dps: 23530.41862
+  tps: 16708.9601
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 23607.31327
-  tps: 16761.40258
+  dps: 23704.75019
+  tps: 16830.58279
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 26880.8295
-  tps: 19085.95695
+  dps: 26905.68076
+  tps: 19103.60134
  }
 }
 dps_results: {
@@ -2624,15 +2624,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 41381.18785
-  tps: 56417.76683
+  dps: 41381.95907
+  tps: 56453.46584
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38725.58659
-  tps: 50147.5389
+  dps: 38779.88761
+  tps: 50012.40347
  }
 }
 dps_results: {
@@ -2645,36 +2645,36 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 26820.18223
-  tps: 37664.02261
+  dps: 26825.2031
+  tps: 37858.83202
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25032.68028
-  tps: 33037.21645
+  dps: 25043.59899
+  tps: 33174.06052
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27552.11081
-  tps: 25394.1767
+  dps: 27741.48844
+  tps: 26045.39775
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38322.11173
-  tps: 27210.95997
+  dps: 38324.69502
+  tps: 27212.79411
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37899.65567
-  tps: 26908.75553
+  dps: 37858.05237
+  tps: 26879.21718
  }
 }
 dps_results: {
@@ -2687,22 +2687,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24021.13017
-  tps: 17057.3653
+  dps: 24004.69969
+  tps: 17045.69966
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24313.21649
-  tps: 17262.59387
+  dps: 24337.61931
+  tps: 17279.91987
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27341.67944
-  tps: 19413.1604
+  dps: 27496.61523
+  tps: 19523.16482
  }
 }
 dps_results: {
@@ -2750,15 +2750,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 40619.66786
-  tps: 54645.60482
+  dps: 40570.91805
+  tps: 54668.79465
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37795.37241
-  tps: 48423.29996
+  dps: 37784.81169
+  tps: 48404.09569
  }
 }
 dps_results: {
@@ -2771,36 +2771,36 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 25920.52543
-  tps: 35657.08918
+  dps: 25668.77161
+  tps: 34701.35677
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24369.7514
-  tps: 32413.71208
+  dps: 24403.26185
+  tps: 31713.02836
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 26692.92345
-  tps: 24102.81043
+  dps: 26747.86609
+  tps: 24214.8177
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 37480.14869
-  tps: 26613.16621
+  dps: 37475.70218
+  tps: 26610.00919
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37033.66513
-  tps: 26293.90224
+  dps: 37030.04926
+  tps: 26291.33497
  }
 }
 dps_results: {
@@ -2813,22 +2813,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 23326.46704
-  tps: 16564.15448
+  dps: 23355.89458
+  tps: 16585.04803
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 23549.85984
-  tps: 16720.61065
+  dps: 23628.14071
+  tps: 16776.19006
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 26434.37127
-  tps: 18768.9716
+  dps: 26527.42972
+  tps: 18835.0431
  }
 }
 dps_results: {
@@ -2918,8 +2918,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 32303.27384
-  tps: 22937.58507
+  dps: 32298.95707
+  tps: 22934.52016
  }
 }
 dps_results: {

--- a/sim/druid/feral/feral.go
+++ b/sim/druid/feral/feral.go
@@ -90,7 +90,9 @@ func (cat *FeralDruid) Initialize() {
 		cat.UpdateBleedPower(cat.Rake, sim, cat.CurrentTarget, false, true)
 
 		if cat.Rip.NewSnapshotPower > previousRipSnapshotPower+0.001 {
-			cat.tempSnapshotAura = aura
+			if !cat.tempSnapshotAura.IsActive() || (aura.ExpiresAt() < cat.tempSnapshotAura.ExpiresAt()) {
+				cat.tempSnapshotAura = aura
+			}
 		} else if cat.tempSnapshotAura.IsActive() {
 			cat.Rip.NewSnapshotPower = previousRipSnapshotPower
 			cat.Rake.NewSnapshotPower = previousRakeSnapshotPower

--- a/sim/druid/feral/feral.go
+++ b/sim/druid/feral/feral.go
@@ -84,14 +84,18 @@ func (cat *FeralDruid) Initialize() {
 	cat.RegisterFeralCatSpells()
 
 	snapshotHandler := func(aura *core.Aura, sim *core.Simulation) {
-		previousRipSnapshotPower := core.TernaryFloat64(cat.tempSnapshotAura.IsActive(), cat.Rip.NewSnapshotPower, cat.Rip.CurrentSnapshotPower)
-		previousRakeSnapshotPower := core.TernaryFloat64(cat.tempSnapshotAura.IsActive(), cat.Rake.NewSnapshotPower, cat.Rake.CurrentSnapshotPower)
+		previousRipSnapshotPower := cat.Rip.NewSnapshotPower
+		previousRakeSnapshotPower := cat.Rake.NewSnapshotPower
 		cat.UpdateBleedPower(cat.Rip, sim, cat.CurrentTarget, false, true)
 		cat.UpdateBleedPower(cat.Rake, sim, cat.CurrentTarget, false, true)
 
 		if cat.Rip.NewSnapshotPower > previousRipSnapshotPower+0.001 {
 			if !cat.tempSnapshotAura.IsActive() || (aura.ExpiresAt() < cat.tempSnapshotAura.ExpiresAt()) {
 				cat.tempSnapshotAura = aura
+
+				if sim.Log != nil {
+					cat.Log(sim, "New bleed snapshot aura found: %s", aura.ActionID)
+				}
 			}
 		} else if cat.tempSnapshotAura.IsActive() {
 			cat.Rip.NewSnapshotPower = previousRipSnapshotPower

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -514,7 +514,7 @@ func (cat *FeralDruid) doRotation(sim *core.Simulation) (bool, time.Duration) {
 	biteAtEnd := (curCp >= rotation.MinCombosForBite) && ((simTimeRemain < endThreshForClip) || (ripDot.IsActive() && (simTimeRemain-ripDot.RemainingDuration(sim) < baseEndThresh)))
 
 	// Delay Rip refreshes if Tiger's Fury will be usable soon enough for the snapshot to outweigh the lost Rip ticks from waiting
-	if ripNow && !tfActive {
+	if ripNow && !tfActive && !cat.BerserkAura.IsActive() {
 		buffedTickCount := min(cat.maxRipTicks, int32((simTimeRemain-finalTickLeeway)/ripDot.BaseTickLength))
 		delayBreakpoint := finalTickLeeway + core.DurationFromSeconds(0.15*float64(buffedTickCount)*ripDot.BaseTickLength.Seconds())
 

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -514,7 +514,7 @@ func (cat *FeralDruid) doRotation(sim *core.Simulation) (bool, time.Duration) {
 	biteAtEnd := (curCp >= rotation.MinCombosForBite) && ((simTimeRemain < endThreshForClip) || (ripDot.IsActive() && (simTimeRemain-ripDot.RemainingDuration(sim) < baseEndThresh)))
 
 	// Delay Rip refreshes if Tiger's Fury will be usable soon enough for the snapshot to outweigh the lost Rip ticks from waiting
-	if ripNow && !tfActive && !cat.tempSnapshotAura.IsActive() {
+	if ripNow && !tfActive {
 		buffedTickCount := min(cat.maxRipTicks, int32((simTimeRemain-finalTickLeeway)/ripDot.BaseTickLength))
 		delayBreakpoint := finalTickLeeway + core.DurationFromSeconds(0.15*float64(buffedTickCount)*ripDot.BaseTickLength.Seconds())
 
@@ -523,7 +523,7 @@ func (cat *FeralDruid) doRotation(sim *core.Simulation) (bool, time.Duration) {
 			energyToDump := curEnergy + delaySeconds*regenRate - cat.calcTfEnergyThresh(cat.ReactionTime)
 			secondsToDump := math.Ceil(energyToDump / cat.Shred.DefaultCast.Cost)
 
-			if secondsToDump < delaySeconds {
+			if (secondsToDump < delaySeconds) && (!cat.tempSnapshotAura.IsActive() || (cat.tempSnapshotAura.RemainingDuration(sim) > delayBreakpoint)) {
 				ripNow = false
 			}
 		}

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -98,7 +98,7 @@ func (cat *FeralDruid) canBite(sim *core.Simulation, isExecutePhase bool) bool {
 	}
 
 	if isExecutePhase {
-		return cat.Rip.NewSnapshotPower > cat.Rip.CurrentSnapshotPower-0.001
+		return (cat.Rip.NewSnapshotPower > cat.Rip.CurrentSnapshotPower-0.001) || cat.BerserkAura.IsActive()
 	}
 
 	return cat.Rip.CurDot().RemainingDuration(sim) >= biteTime


### PR DESCRIPTION
- Allow degrading a Rip snapshot during Execute phase if Berserk is active. Adds 8-14 DPS for select 4pT12 configurations.
- Allow Rip delays for TF even with another snapshot aura active, as long as the aura will still be active before the delay breakpoint. Adds 7-40 DPS depending on gear and rotation settings.
- Use the shortest active snapshot aura rather than the most recently applied for bleed clipping calculations. Adds anywhere from 15-70 DPS depending on gear/talents/rotation config.
- Fixed a bug where newly activated bleed-enhancing snapshot auras were sometimes not detected. Increases DPS by 9-35 depending on config.
- Block Rip delays for an upcoming TF during Berserk. Increases DPS for 4pT12 setups by 22-67, no impact on non-4pT12 configs.