### PR TITLE
Feral Rotation Updates

### DIFF
--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -38,2041 +38,2041 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 32828.56968
-  tps: 46030.72445
+  dps: 32962.6725
+  tps: 47037.70092
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 30790.39889
-  tps: 45332.17649
+  dps: 30818.54942
+  tps: 45814.47709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 33109.72215
-  tps: 47471.60365
+  dps: 33111.29338
+  tps: 47781.78801
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 30792.35277
-  tps: 45342.16716
+  dps: 30819.52636
+  tps: 45823.53376
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 30792.35277
-  tps: 45342.16716
+  dps: 30819.52636
+  tps: 45823.53376
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 31939.05233
-  tps: 46387.309
+  dps: 32001.66252
+  tps: 47472.7821
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 32116.92742
-  tps: 46638.42801
+  dps: 32129.34095
+  tps: 47726.4021
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ArrowofTime-72897"
  value: {
-  dps: 32972.29655
-  tps: 46099.47551
+  dps: 32888.62758
+  tps: 46977.07021
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 32027.80544
-  tps: 45143.2076
+  dps: 32159.33701
+  tps: 46264.32442
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 30790.39889
-  tps: 45332.31778
+  dps: 30818.54942
+  tps: 45814.6233
   hps: 96.77966
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 30790.39889
-  tps: 45332.31778
+  dps: 30818.54942
+  tps: 45814.6233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 31329.69715
-  tps: 46051.27945
+  dps: 31231.01939
+  tps: 46326.72178
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 31367.12801
-  tps: 46314.72536
+  dps: 31314.14669
+  tps: 46618.59367
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BindingPromise-67037"
  value: {
-  dps: 30800.93643
-  tps: 45286.36706
+  dps: 30836.11415
+  tps: 46023.54832
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 32418.18773
-  tps: 47404.51161
+  dps: 32456.4423
+  tps: 47869.75216
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 31114.02437
-  tps: 45873.8036
+  dps: 31144.15185
+  tps: 46367.66189
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 31156.68543
-  tps: 45945.01406
+  dps: 31186.79026
+  tps: 46440.08361
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 32873.64181
-  tps: 46765.40849
+  dps: 32945.9576
+  tps: 46928.1624
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 30800.93643
-  tps: 45286.36706
+  dps: 30832.65262
+  tps: 45979.60274
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 31401.70359
-  tps: 46224.86702
+  dps: 31360.53431
+  tps: 46164.52505
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 31294.74506
-  tps: 46456.35916
+  dps: 31185.94354
+  tps: 46413.12995
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 30824.30422
-  tps: 45548.47401
+  dps: 30818.29312
+  tps: 45997.47364
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 30824.30422
-  tps: 45548.47401
+  dps: 30818.29312
+  tps: 45997.47364
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 32179.59335
-  tps: 45920.78505
+  dps: 32159.21601
+  tps: 46290.43404
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 30790.39889
-  tps: 45332.31778
+  dps: 30818.54942
+  tps: 45814.6233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 31310.07801
-  tps: 45784.981
+  dps: 31365.30063
+  tps: 46945.67394
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 32776.2667
-  tps: 47203.65934
+  dps: 32903.79114
+  tps: 49492.00383
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 32552.24333
-  tps: 47351.67064
+  dps: 32605.73804
+  tps: 48471.6952
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 33059.62133
-  tps: 47603.89977
+  dps: 33100.84171
+  tps: 48834.65775
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledLightning-66879"
  value: {
-  dps: 30965.89155
-  tps: 45290.93635
+  dps: 30962.42208
+  tps: 46192.04092
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledWishes-77114"
  value: {
-  dps: 31409.70799
-  tps: 44232.04581
+  dps: 31407.35743
+  tps: 46528.07688
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 32027.80544
-  tps: 44240.58931
+  dps: 32159.33701
+  tps: 45339.29491
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 30800.93643
-  tps: 45286.36706
+  dps: 30836.11415
+  tps: 46023.54832
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 32630.84084
-  tps: 45960.26363
+  dps: 32764.72345
+  tps: 47107.66663
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sBadgeofConquest-73648"
  value: {
-  dps: 33228.90179
-  tps: 47733.29625
+  dps: 33392.84873
+  tps: 48021.95466
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sBadgeofDominance-73498"
  value: {
-  dps: 30800.93643
-  tps: 45286.36706
+  dps: 30832.65262
+  tps: 45979.60274
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sBadgeofVictory-73496"
  value: {
-  dps: 31777.45711
-  tps: 46417.89536
+  dps: 31725.82555
+  tps: 46754.74833
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sInsigniaofConquest-73643"
  value: {
-  dps: 33113.1963
-  tps: 46961.4811
+  dps: 33151.69229
+  tps: 47724.67129
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sInsigniaofDominance-73497"
  value: {
-  dps: 30870.91722
-  tps: 45103.71461
+  dps: 30833.68589
+  tps: 46227.79244
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sInsigniaofVictory-73491"
  value: {
-  dps: 31760.07855
-  tps: 45426.34693
+  dps: 31766.5056
+  tps: 46771.39888
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 32666.41418
-  tps: 45830.39854
+  dps: 32810.19613
+  tps: 46811.7225
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 32085.81699
-  tps: 46233.33332
+  dps: 32143.09976
+  tps: 46874.87606
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 30802.79266
-  tps: 45291.40515
+  dps: 30834.50885
+  tps: 45984.64327
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 30790.39889
-  tps: 45332.31778
+  dps: 30818.54942
+  tps: 45814.6233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 32321.6875
-  tps: 46537.44474
+  dps: 32445.45257
+  tps: 48195.35687
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 32210.56208
-  tps: 46024.21289
+  dps: 32334.65364
+  tps: 47487.26121
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 32435.16082
-  tps: 46411.44452
+  dps: 32667.59144
+  tps: 47502.22805
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-59506"
  value: {
-  dps: 31811.53016
-  tps: 44952.88544
+  dps: 31704.71626
+  tps: 45798.18933
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-65118"
  value: {
-  dps: 31984.10637
-  tps: 45178.32235
+  dps: 32125.97471
+  tps: 46397.72781
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 31229.11794
-  tps: 46282.57591
+  dps: 31212.37781
+  tps: 46719.09186
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 31132.61475
-  tps: 46038.00932
+  dps: 31134.34997
+  tps: 46577.86739
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-78000"
  value: {
-  dps: 31233.59092
-  tps: 46175.89993
+  dps: 31276.27256
+  tps: 46830.4796
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 30824.30422
-  tps: 45548.47401
+  dps: 30818.29312
+  tps: 45997.47364
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 31788.15143
-  tps: 47480.32575
+  dps: 31645.65487
+  tps: 47258.56282
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 32510.33116
-  tps: 48243.00358
+  dps: 32417.59281
+  tps: 48060.60059
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 30792.25511
-  tps: 45337.35802
+  dps: 30820.40565
+  tps: 45819.65412
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 31208.81633
-  tps: 46165.72007
+  dps: 31249.55661
+  tps: 46485.62031
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 31718.97313
-  tps: 45904.55608
+  dps: 31800.57958
+  tps: 46780.86137
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeepEarthRegalia"
  value: {
-  dps: 21992.41394
-  tps: 29141.43009
+  dps: 22121.6559
+  tps: 30636.27681
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 32060.08126
-  tps: 45015.08416
+  dps: 32200.51028
+  tps: 45970.48761
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 31087.57019
-  tps: 46231.51299
+  dps: 31056.62115
+  tps: 47175.99268
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dragonwrath,Tarecgosa'sRest-71086"
  value: {
-  dps: 33318.85626
-  tps: 46028.93646
+  dps: 33311.86251
+  tps: 48209.62755
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 31846.02305
-  tps: 46202.03704
+  dps: 31918.47245
+  tps: 47176.30232
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 32027.80544
-  tps: 45143.2076
+  dps: 32159.33701
+  tps: 46264.32442
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 30801.86455
-  tps: 45323.45771
+  dps: 30833.58073
+  tps: 46017.40136
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 32027.80544
-  tps: 45143.13441
+  dps: 32159.33701
+  tps: 46264.26279
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 32060.08126
-  tps: 45015.08416
+  dps: 32200.51028
+  tps: 45970.48761
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 32552.87024
-  tps: 46524.47389
+  dps: 32603.30392
+  tps: 47249.99649
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 31926.88075
-  tps: 46688.28351
+  dps: 32051.76152
+  tps: 47270.21921
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 32027.80544
-  tps: 45143.2076
+  dps: 32159.33701
+  tps: 46264.32442
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 32152.3445
-  tps: 47336.37049
+  dps: 32184.74951
+  tps: 47840.93758
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 31997.33364
-  tps: 47108.3755
+  dps: 32029.4995
+  tps: 47610.67459
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 32322.85643
-  tps: 47587.16498
+  dps: 32355.52452
+  tps: 48094.22686
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-59500"
  value: {
-  dps: 30792.25511
-  tps: 45337.35802
+  dps: 30820.40565
+  tps: 45819.65412
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-65124"
  value: {
-  dps: 30792.25511
-  tps: 45337.32359
+  dps: 30820.40565
+  tps: 45819.61842
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 30799.75883
-  tps: 45443.39637
+  dps: 30829.64021
+  tps: 45909.55769
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 32262.28132
-  tps: 46383.6401
+  dps: 32272.31249
+  tps: 47262.92597
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 30801.86455
-  tps: 45286.79018
+  dps: 30833.58073
+  tps: 45980.02805
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 30800.93643
-  tps: 45286.36706
+  dps: 30836.11415
+  tps: 46023.54832
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 30801.86455
-  tps: 45286.79018
+  dps: 30833.58073
+  tps: 45980.02805
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 31739.82532
-  tps: 46808.02413
+  dps: 31699.99636
+  tps: 46750.76713
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 31483.01578
-  tps: 46653.90223
+  dps: 31417.07654
+  tps: 46897.39565
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 32099.35466
-  tps: 45258.86261
+  dps: 32231.19887
+  tps: 46382.74164
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FluidDeath-58181"
  value: {
-  dps: 32362.46935
-  tps: 47817.56893
+  dps: 32370.33371
+  tps: 48013.19251
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 32027.80544
-  tps: 45143.15933
+  dps: 32159.33701
+  tps: 46264.28378
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 31307.8376
-  tps: 44240.69946
+  dps: 31327.82041
+  tps: 45360.85844
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 32122.7914
-  tps: 47248.14661
+  dps: 31948.27077
+  tps: 47969.49162
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56138"
  value: {
-  dps: 31197.98857
-  tps: 44739.49308
+  dps: 31270.91475
+  tps: 45715.55016
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56462"
  value: {
-  dps: 31277.46509
-  tps: 44396.13691
+  dps: 31286.0787
+  tps: 44469.53327
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GearDetector-61462"
  value: {
-  dps: 31704.32944
-  tps: 44968.43669
+  dps: 31786.71015
+  tps: 46335.41998
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 26434.04676
-  tps: 36327.76939
+  dps: 26461.56843
+  tps: 38138.01178
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 30790.39889
-  tps: 45332.16665
+  dps: 30818.54942
+  tps: 45814.46689
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 31759.74763
-  tps: 46894.68163
+  dps: 31911.59554
+  tps: 47813.15212
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 32168.98338
-  tps: 46307.00861
+  dps: 32353.21248
+  tps: 47359.85819
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HarmlightToken-63839"
  value: {
-  dps: 30791.66059
-  tps: 45312.50228
+  dps: 30827.34354
+  tps: 45809.74653
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 31504.69804
-  tps: 45796.46713
+  dps: 31414.85873
+  tps: 45980.03503
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 30790.39889
-  tps: 45332.31778
+  dps: 30818.54942
+  tps: 45814.6233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 30790.39889
-  tps: 45332.31778
+  dps: 30818.54942
+  tps: 45814.6233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-59224"
  value: {
-  dps: 31509.74387
-  tps: 44790.3129
+  dps: 31550.28859
+  tps: 46546.31409
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-65072"
  value: {
-  dps: 31687.16162
-  tps: 45912.67159
+  dps: 31644.46663
+  tps: 46495.5707
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-55868"
  value: {
-  dps: 31681.10382
-  tps: 45799.67879
+  dps: 31711.95092
+  tps: 46153.13271
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-56393"
  value: {
-  dps: 31765.98054
-  tps: 43504.49309
+  dps: 31913.78416
+  tps: 45313.05873
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-55845"
  value: {
-  dps: 30818.3447
-  tps: 45479.20423
+  dps: 30818.54942
+  tps: 45814.6233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-56370"
  value: {
-  dps: 30818.3447
-  tps: 45479.20423
+  dps: 30818.54942
+  tps: 45814.6233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 31815.26906
-  tps: 46592.05827
+  dps: 31888.99428
+  tps: 46948.34244
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-50641"
  value: {
-  dps: 33565.41955
-  tps: 46440.32872
+  dps: 33762.62156
+  tps: 47561.02322
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 32060.08126
-  tps: 45015.08416
+  dps: 32200.51028
+  tps: 45970.48761
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 31856.71741
-  tps: 46973.46462
+  dps: 31817.00237
+  tps: 46919.11386
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 31856.71741
-  tps: 46973.46462
+  dps: 31817.00237
+  tps: 46919.11386
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 31153.48676
-  tps: 46035.22197
+  dps: 31106.38942
+  tps: 46076.57555
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 31196.17292
-  tps: 46106.73771
+  dps: 31148.95342
+  tps: 46148.4091
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndomitablePride-77211"
  value: {
-  dps: 30790.39889
-  tps: 45332.31778
+  dps: 30818.54942
+  tps: 45814.6233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndomitablePride-77983"
  value: {
-  dps: 30790.39889
-  tps: 45332.31778
+  dps: 30818.54942
+  tps: 45814.6233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndomitablePride-78003"
  value: {
-  dps: 30790.39889
-  tps: 45332.31778
+  dps: 30818.54942
+  tps: 45814.6233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 30818.3447
-  tps: 45479.20423
+  dps: 30818.54942
+  tps: 45814.6233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 31580.82009
-  tps: 45138.25535
+  dps: 31607.00884
+  tps: 46116.66374
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 31426.55985
-  tps: 43931.17624
+  dps: 31545.34788
+  tps: 44601.01081
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 31630.51201
-  tps: 44788.11886
+  dps: 31765.15801
+  tps: 46494.70348
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 31085.97903
-  tps: 46136.86665
+  dps: 31105.47022
+  tps: 46011.96203
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 30790.39889
-  tps: 45332.53521
+  dps: 30818.54942
+  tps: 45814.9803
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 30790.39889
-  tps: 45332.53521
+  dps: 30818.54942
+  tps: 45814.9803
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 30792.25511
-  tps: 45337.3072
+  dps: 30820.40565
+  tps: 45819.60142
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 30792.25511
-  tps: 45337.26621
+  dps: 30820.40565
+  tps: 45819.55892
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 32418.18773
-  tps: 47404.51161
+  dps: 32456.4423
+  tps: 47869.75216
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 32079.47621
-  tps: 45801.62461
+  dps: 32104.85489
+  tps: 47242.05218
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 32403.35811
-  tps: 47037.49033
+  dps: 32434.4554
+  tps: 46846.8732
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-77194"
  value: {
-  dps: 36559.60507
-  tps: 51209.63595
+  dps: 36591.05312
+  tps: 52018.07043
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-78473"
  value: {
-  dps: 36783.69482
-  tps: 50670.98374
+  dps: 36960.00904
+  tps: 52305.98259
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-78482"
  value: {
-  dps: 36088.95417
-  tps: 51148.42765
+  dps: 36212.78769
+  tps: 52258.2258
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 33942.9626
-  tps: 47099.17834
+  dps: 34300.43516
+  tps: 49086.08909
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 31339.14375
-  tps: 46352.58415
+  dps: 31379.99721
+  tps: 46418.21006
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 31339.14375
-  tps: 46352.58415
+  dps: 31379.99721
+  tps: 46418.21006
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 31061.63154
-  tps: 43838.535
+  dps: 31220.72981
+  tps: 45892.08706
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50708"
  value: {
-  dps: 33012.49505
-  tps: 46287.48766
+  dps: 33147.35439
+  tps: 47299.96373
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-55816"
  value: {
-  dps: 30790.39889
-  tps: 45332.31778
+  dps: 30818.54942
+  tps: 45814.6233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-56347"
  value: {
-  dps: 30790.39889
-  tps: 45332.31778
+  dps: 30818.54942
+  tps: 45814.6233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 32070.26546
-  tps: 46166.94564
+  dps: 32050.73873
+  tps: 46833.95035
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 32351.79615
-  tps: 46828.02682
+  dps: 32395.15486
+  tps: 48172.00099
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 31381.43554
-  tps: 46208.6107
+  dps: 31409.48838
+  tps: 46698.59302
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 31329.93121
-  tps: 46025.61783
+  dps: 31356.98321
+  tps: 46455.6098
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 31473.23458
-  tps: 46066.96229
+  dps: 31472.16898
+  tps: 46323.65365
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 30790.39889
-  tps: 45332.31778
+  dps: 30818.54942
+  tps: 45814.6233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 30790.39889
-  tps: 45332.31778
+  dps: 30818.54942
+  tps: 45814.6233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 31714.9948
-  tps: 46509.71616
+  dps: 31773.92231
+  tps: 46909.89852
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 31829.12268
-  tps: 46670.60158
+  dps: 31888.75375
+  tps: 47071.571
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 33228.71315
-  tps: 47006.49607
+  dps: 33219.37278
+  tps: 48096.50885
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 33437.74379
-  tps: 48452.55563
+  dps: 33564.36574
+  tps: 48123.15162
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 31204.18653
-  tps: 45884.64807
+  dps: 31226.73022
+  tps: 46302.94979
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 31475.23339
-  tps: 46077.03637
+  dps: 31473.5416
+  tps: 46326.57098
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 31242.73965
-  tps: 46184.75488
+  dps: 31195.38687
+  tps: 46226.77298
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 31242.73965
-  tps: 46184.75488
+  dps: 31195.38687
+  tps: 46226.77298
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 31276.54952
-  tps: 46172.86668
+  dps: 31156.15178
+  tps: 46109.17821
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 31357.35701
-  tps: 45191.4582
+  dps: 31371.24785
+  tps: 46527.76425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 30800.93643
-  tps: 45286.36706
+  dps: 30836.11415
+  tps: 46023.54832
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 30792.25511
-  tps: 45337.3072
+  dps: 30820.40565
+  tps: 45819.60142
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 30792.25511
-  tps: 45337.26621
+  dps: 30820.40565
+  tps: 45819.55892
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ObsidianArborweaveBattlegarb"
  value: {
-  dps: 31258.00465
-  tps: 40967.08924
+  dps: 31216.37673
+  tps: 41209.63111
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ObsidianArborweaveRegalia"
  value: {
-  dps: 22462.66147
-  tps: 30308.87935
+  dps: 22558.85742
+  tps: 31405.20949
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 31337.2987
-  tps: 45924.12736
+  dps: 31396.69227
+  tps: 45840.13396
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 30791.327
-  tps: 45332.72723
+  dps: 30819.47754
+  tps: 45815.02384
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 30790.39889
-  tps: 45332.31778
+  dps: 30818.54942
+  tps: 45814.6233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 31013.06708
-  tps: 45830.69039
+  dps: 31059.80136
+  tps: 46152.52768
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 31129.84262
-  tps: 45488.09319
+  dps: 31075.80514
+  tps: 45469.41204
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 31259.34936
-  tps: 44800.11877
+  dps: 31225.47893
+  tps: 45826.20725
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 32027.80544
-  tps: 45143.2076
+  dps: 32159.33701
+  tps: 46264.32442
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 32648.59796
-  tps: 45542.83955
+  dps: 32729.6792
+  tps: 46835.28563
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-55854"
  value: {
-  dps: 30790.39889
-  tps: 45332.31778
+  dps: 30818.54942
+  tps: 45814.6233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-56377"
  value: {
-  dps: 30790.39889
-  tps: 45332.31778
+  dps: 30818.54942
+  tps: 45814.6233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rathrak,thePoisonousMind-77195"
  value: {
-  dps: 29802.43146
-  tps: 42873.1607
+  dps: 29804.71863
+  tps: 43753.7781
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rathrak,thePoisonousMind-78475"
  value: {
-  dps: 30380.05958
-  tps: 43602.58523
+  dps: 30379.50316
+  tps: 44484.4953
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rathrak,thePoisonousMind-78484"
  value: {
-  dps: 29296.14943
-  tps: 42569.4502
+  dps: 29266.48247
+  tps: 43015.60282
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 30836.57186
-  tps: 45716.85901
+  dps: 30854.77651
+  tps: 45588.83194
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 30790.39889
-  tps: 45332.31778
+  dps: 30818.54942
+  tps: 45814.6233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 30790.39889
-  tps: 45332.31778
+  dps: 30818.54942
+  tps: 45814.6233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 30790.39889
-  tps: 45332.31778
+  dps: 30818.54942
+  tps: 45814.6233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 32717.80408
-  tps: 46081.78446
+  dps: 32852.00454
+  tps: 47232.10585
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 32630.84084
-  tps: 45960.31189
+  dps: 32764.72345
+  tps: 47107.70728
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 32727.97807
-  tps: 47910.24564
+  dps: 32854.98026
+  tps: 48160.24645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 31270.01689
-  tps: 45660.65808
+  dps: 31309.60304
+  tps: 46410.64775
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 31385.87016
-  tps: 45566.49188
+  dps: 31357.14324
+  tps: 45393.86971
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RosaryofLight-72901"
  value: {
-  dps: 32060.95979
-  tps: 46725.37766
+  dps: 32137.47743
+  tps: 46994.02839
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RottingSkull-77116"
  value: {
-  dps: 32466.65158
-  tps: 47512.15962
+  dps: 32387.48438
+  tps: 48249.78669
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuneofZeth-68998"
  value: {
-  dps: 31358.99347
-  tps: 46344.21621
+  dps: 31337.99711
+  tps: 46646.78832
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofConquest-70399"
  value: {
-  dps: 32828.39228
-  tps: 46823.44623
+  dps: 32936.57565
+  tps: 47455.44926
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofConquest-72304"
  value: {
-  dps: 32932.1093
-  tps: 46956.4946
+  dps: 33047.08164
+  tps: 47593.39428
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofDominance-70401"
  value: {
-  dps: 30800.93643
-  tps: 45286.36706
+  dps: 30832.65262
+  tps: 45979.60274
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofDominance-72448"
  value: {
-  dps: 30800.93643
-  tps: 45286.36706
+  dps: 30832.65262
+  tps: 45979.60274
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofVictory-70400"
  value: {
-  dps: 31628.05283
-  tps: 46236.17952
+  dps: 31576.90237
+  tps: 46564.34262
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofVictory-72450"
  value: {
-  dps: 31672.10794
-  tps: 46289.7624
+  dps: 31620.81561
+  tps: 46620.48789
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofConquest-70404"
  value: {
-  dps: 32779.28094
-  tps: 47193.52987
+  dps: 32628.3147
+  tps: 47078.60578
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofConquest-72309"
  value: {
-  dps: 32844.74608
-  tps: 47180.64746
+  dps: 32966.58671
+  tps: 47553.54189
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofDominance-70402"
  value: {
-  dps: 30858.56384
-  tps: 45256.49878
+  dps: 30761.34093
+  tps: 45621.48566
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofDominance-72449"
  value: {
-  dps: 30847.77871
-  tps: 45176.10969
+  dps: 30772.63183
+  tps: 45818.4598
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofVictory-70403"
  value: {
-  dps: 31580.85472
-  tps: 46016.8352
+  dps: 31565.408
+  tps: 46672.0733
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofVictory-72455"
  value: {
-  dps: 31553.5097
-  tps: 45556.55216
+  dps: 31540.1685
+  tps: 46062.92169
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ScalesofLife-68915"
  value: {
-  dps: 30790.39889
-  tps: 45332.31778
+  dps: 30818.54942
+  tps: 45814.6233
   hps: 315.97258
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ScalesofLife-69109"
  value: {
-  dps: 30790.39889
-  tps: 45332.31778
+  dps: 30818.54942
+  tps: 45814.6233
   hps: 356.41412
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 32069.89411
-  tps: 46356.57208
+  dps: 32016.32977
+  tps: 46792.12051
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-55256"
  value: {
-  dps: 30800.93643
-  tps: 45286.36706
+  dps: 30832.65262
+  tps: 45979.60274
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-56290"
  value: {
-  dps: 30800.93643
-  tps: 45286.36706
+  dps: 30832.65262
+  tps: 45979.60274
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShardofWoe-60233"
  value: {
-  dps: 31204.62036
-  tps: 45316.79431
+  dps: 31342.56685
+  tps: 45633.45338
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 31544.51856
-  tps: 46043.39376
+  dps: 31565.44736
+  tps: 45897.41333
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 30825.40438
-  tps: 45520.83775
+  dps: 30781.35527
+  tps: 45528.02838
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 32291.5184
-  tps: 47182.63705
+  dps: 32252.44333
+  tps: 47183.31203
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 32443.40789
-  tps: 47199.98233
+  dps: 32473.05247
+  tps: 47666.48116
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-55879"
  value: {
-  dps: 31102.00495
-  tps: 45841.80774
+  dps: 31144.15185
+  tps: 46367.66189
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-56400"
  value: {
-  dps: 31144.68226
-  tps: 45913.00533
+  dps: 31186.79026
+  tps: 46440.08361
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 31204.18653
-  tps: 45884.64807
+  dps: 31226.73022
+  tps: 46302.94979
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulCasket-58183"
  value: {
-  dps: 31216.46139
-  tps: 45979.88424
+  dps: 31247.24736
+  tps: 46684.81942
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 31682.6508
-  tps: 45289.70575
+  dps: 31612.58178
+  tps: 46090.46203
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 31481.09943
-  tps: 44864.21081
+  dps: 31611.10878
+  tps: 46576.6644
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 31793.1771
-  tps: 45106.5698
+  dps: 31878.12732
+  tps: 46475.38567
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 31283.37585
-  tps: 46156.48757
+  dps: 31313.41343
+  tps: 46655.15417
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 31408.2182
-  tps: 46384.6927
+  dps: 31348.94986
+  tps: 46864.49901
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 33529.71978
-  tps: 47022.3749
+  dps: 33564.71869
+  tps: 48416.71505
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 33210.84784
-  tps: 46735.95139
+  dps: 32980.93717
+  tps: 47109.5186
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 33942.74222
-  tps: 47806.96288
+  dps: 33908.22452
+  tps: 49196.20665
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StayofExecution-68996"
  value: {
-  dps: 30790.39889
-  tps: 45332.31778
+  dps: 30818.54942
+  tps: 45814.6233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 30819.3016
-  tps: 45551.37884
+  dps: 30863.46487
+  tps: 45855.7368
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stormrider'sBattlegarb"
  value: {
-  dps: 28552.42073
-  tps: 39608.14122
+  dps: 28560.76069
+  tps: 40477.97777
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stormrider'sRegalia"
  value: {
-  dps: 22310.47963
-  tps: 30448.15535
+  dps: 22412.18364
+  tps: 31285.2602
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62465"
  value: {
-  dps: 30792.35277
-  tps: 45342.16716
+  dps: 30819.52636
+  tps: 45823.53376
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62470"
  value: {
-  dps: 30792.35277
-  tps: 45342.16716
+  dps: 30819.52636
+  tps: 45823.53376
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 30790.39889
-  tps: 45332.31778
+  dps: 30818.54942
+  tps: 45814.6233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 30790.39889
-  tps: 45332.31778
+  dps: 30818.54942
+  tps: 45814.6233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 30803.08005
-  tps: 45421.58998
+  dps: 30839.74784
+  tps: 45736.97868
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 31610.72331
-  tps: 45696.94575
+  dps: 31641.20441
+  tps: 46329.18913
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-55819"
  value: {
-  dps: 30790.39889
-  tps: 45332.14124
+  dps: 30818.54942
+  tps: 45814.44054
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-56351"
  value: {
-  dps: 30791.327
-  tps: 45332.74281
+  dps: 30819.47754
+  tps: 45815.03999
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 31066.19228
-  tps: 45793.96156
+  dps: 31096.34514
+  tps: 46286.46178
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 31156.68543
-  tps: 45945.01406
+  dps: 31186.79026
+  tps: 46440.08361
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheHungerer-68927"
  value: {
-  dps: 32997.05092
-  tps: 46537.8735
+  dps: 32986.6211
+  tps: 47717.76044
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheHungerer-69112"
  value: {
-  dps: 33191.34495
-  tps: 46442.98301
+  dps: 33218.70235
+  tps: 48404.46652
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 30808.01533
-  tps: 45190.69616
+  dps: 30836.83086
+  tps: 45741.46268
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 30791.65421
-  tps: 45050.11189
+  dps: 30819.7969
+  tps: 45542.70745
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 30790.39889
-  tps: 45332.31778
+  dps: 30818.54942
+  tps: 45814.6233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 30790.39889
-  tps: 45332.31778
+  dps: 30818.54942
+  tps: 45814.6233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-77190"
  value: {
-  dps: 32819.75771
-  tps: 45790.36199
+  dps: 32981.24576
+  tps: 47031.54234
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-78477"
  value: {
-  dps: 32831.19345
-  tps: 46009.52453
+  dps: 32989.07465
+  tps: 47104.86928
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-78486"
  value: {
-  dps: 32828.00172
-  tps: 45862.50391
+  dps: 32955.86463
+  tps: 46865.10609
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 32385.02853
-  tps: 48011.39649
+  dps: 32390.4886
+  tps: 48167.91683
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 32573.03225
-  tps: 48228.8608
+  dps: 32537.48939
+  tps: 48370.99707
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 31029.12308
-  tps: 45623.97149
+  dps: 31295.25065
+  tps: 47776.95517
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 30850.64055
-  tps: 45654.33182
+  dps: 30898.65071
+  tps: 46254.90973
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnheededWarning-59520"
  value: {
-  dps: 32692.43898
-  tps: 48238.69953
+  dps: 32787.09194
+  tps: 48604.58742
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 30800.93643
-  tps: 45286.36706
+  dps: 30832.65262
+  tps: 45979.60274
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 32817.42697
-  tps: 47159.55072
+  dps: 32893.76932
+  tps: 47922.68491
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 32817.42697
-  tps: 47159.55072
+  dps: 32893.76932
+  tps: 47922.68491
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 32817.42697
-  tps: 47159.55072
+  dps: 32893.76932
+  tps: 47922.68491
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 26689.40762
-  tps: 36599.63336
+  dps: 26790.04514
+  tps: 38029.87973
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 30793.70756
-  tps: 45348.53632
+  dps: 30827.55065
+  tps: 45828.18342
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 30792.85867
-  tps: 45340.26346
+  dps: 30821.0092
+  tps: 45822.55542
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 32021.93599
-  tps: 45180.73531
+  dps: 32044.52517
+  tps: 46380.38443
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VeilofLies-72900"
  value: {
-  dps: 30796.77622
-  tps: 45397.82896
+  dps: 30796.14142
+  tps: 46058.88938
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 31991.14567
-  tps: 47190.32208
+  dps: 31977.89439
+  tps: 47638.6956
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 32178.64836
-  tps: 47937.71133
+  dps: 32130.62285
+  tps: 47704.64209
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77207"
  value: {
-  dps: 33606.59814
-  tps: 48878.42583
+  dps: 33569.75927
+  tps: 50731.65362
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77979"
  value: {
-  dps: 33198.52124
-  tps: 49346.10461
+  dps: 33395.43067
+  tps: 51201.18655
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77999"
  value: {
-  dps: 33701.23254
-  tps: 49158.51976
+  dps: 33780.26377
+  tps: 50460.5852
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 30800.93643
-  tps: 45286.36706
+  dps: 30836.11415
+  tps: 46023.54832
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 30800.93643
-  tps: 45286.36706
+  dps: 30836.11415
+  tps: 46023.54832
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 32378.4554
-  tps: 46442.88471
+  dps: 32446.9874
+  tps: 47236.46234
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-70517"
  value: {
-  dps: 32593.89712
-  tps: 46778.12753
+  dps: 32684.82838
+  tps: 47585.98941
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 30800.93643
-  tps: 45286.36706
+  dps: 30832.65262
+  tps: 45979.60274
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-70518"
  value: {
-  dps: 30800.93643
-  tps: 45286.36706
+  dps: 30832.65262
+  tps: 45979.60274
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 31433.98579
-  tps: 46264.69621
+  dps: 31392.90887
+  tps: 46205.57354
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-70519"
  value: {
-  dps: 31505.76621
-  tps: 46353.25759
+  dps: 31464.89466
+  tps: 46296.84607
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 30826.25809
-  tps: 45558.32339
+  dps: 30819.27005
+  tps: 46006.3841
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 31304.11621
-  tps: 43881.28236
+  dps: 31415.22075
+  tps: 45764.41001
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 31338.43897
-  tps: 46542.00863
+  dps: 31256.31321
+  tps: 46559.0372
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 30824.30422
-  tps: 45548.47401
+  dps: 30818.29312
+  tps: 45997.47364
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 31265.74524
-  tps: 46253.3174
+  dps: 31257.47907
+  tps: 46745.32848
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 30824.30422
-  tps: 45548.47401
+  dps: 30818.29312
+  tps: 45997.47364
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 32383.92462
-  tps: 46265.38977
+  dps: 32405.23741
+  tps: 46788.66831
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-70577"
  value: {
-  dps: 32569.09794
-  tps: 46672.07703
+  dps: 32546.01116
+  tps: 47380.93082
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 30861.0497
-  tps: 45302.82439
+  dps: 30803.54917
+  tps: 46387.90214
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-70578"
  value: {
-  dps: 30852.68045
-  tps: 45242.1664
+  dps: 30863.96316
+  tps: 45668.43308
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 31474.38071
-  tps: 46509.62926
+  dps: 31497.98234
+  tps: 46674.35887
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-70579"
  value: {
-  dps: 31407.67474
-  tps: 46226.07553
+  dps: 31495.76419
+  tps: 46464.24353
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 30790.39889
-  tps: 45334.70349
+  dps: 30818.54942
+  tps: 45817.44367
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 30790.39889
-  tps: 45334.35151
+  dps: 30818.54942
+  tps: 45817.05812
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WillofUnbinding-77995"
  value: {
-  dps: 30790.39889
-  tps: 45335.08699
+  dps: 30818.54942
+  tps: 45817.86777
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 30810.67539
-  tps: 45229.92849
+  dps: 30809.23908
+  tps: 45863.61418
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 30815.42022
-  tps: 45270.98794
+  dps: 30807.34122
+  tps: 45787.67461
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 31071.36331
-  tps: 45802.59313
+  dps: 31101.51344
+  tps: 46295.24017
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 34443.30123
-  tps: 51321.61545
+  dps: 34408.39726
+  tps: 50838.38956
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 34037.19433
-  tps: 50661.86593
+  dps: 33996.20835
+  tps: 50417.81874
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 34917.9732
-  tps: 51843.42068
+  dps: 34862.4552
+  tps: 51394.17321
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 31264.2639
-  tps: 45775.52532
+  dps: 31307.77708
+  tps: 46301.59557
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 31264.2639
-  tps: 45775.52532
+  dps: 31307.77708
+  tps: 46301.59557
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 33269.15739
-  tps: 46582.67073
+  dps: 33336.79432
+  tps: 47796.21804
  }
 }
 dps_results: {
@@ -2120,15 +2120,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 39297.74985
-  tps: 49962.09904
+  dps: 39375.65632
+  tps: 50364.00413
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39010.86507
-  tps: 51558.37376
+  dps: 39113.64121
+  tps: 52137.61238
  }
 }
 dps_results: {
@@ -2141,15 +2141,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 25034.89749
-  tps: 32239.04249
+  dps: 25031.98363
+  tps: 33018.17421
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25281.76835
-  tps: 34864.4505
+  dps: 25381.69594
+  tps: 35808.60026
  }
 }
 dps_results: {
@@ -2246,15 +2246,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38517.50989
-  tps: 48701.18168
+  dps: 38536.58075
+  tps: 49098.10023
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38148.85794
-  tps: 48696.93414
+  dps: 38241.42333
+  tps: 49479.58401
  }
 }
 dps_results: {
@@ -2267,22 +2267,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24355.60249
-  tps: 31458.73292
+  dps: 24463.63593
+  tps: 31945.0867
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24500.83457
-  tps: 32202.3316
+  dps: 24673.4839
+  tps: 32930.4052
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27083.07578
-  tps: 24409.18153
+  dps: 27097.49338
+  tps: 24546.44424
  }
 }
 dps_results: {
@@ -2372,15 +2372,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 33373.47392
-  tps: 45726.11565
+  dps: 33445.35108
+  tps: 47544.22036
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 32938.32251
-  tps: 46506.34074
+  dps: 33032.76662
+  tps: 47298.80702
  }
 }
 dps_results: {
@@ -2393,15 +2393,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 20832.55916
-  tps: 29945.34418
+  dps: 20875.14051
+  tps: 30067.6764
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 21070.74422
-  tps: 31202.72129
+  dps: 21097.49212
+  tps: 31612.10088
  }
 }
 dps_results: {
@@ -2498,15 +2498,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 32664.51672
-  tps: 43873.62066
+  dps: 32642.49061
+  tps: 45681.25368
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 32140.77065
-  tps: 43574.00162
+  dps: 32163.61035
+  tps: 44679.37479
  }
 }
 dps_results: {
@@ -2519,15 +2519,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 20294.03545
-  tps: 28152.16945
+  dps: 20273.65952
+  tps: 28587.33542
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20385.93938
-  tps: 29296.72486
+  dps: 20508.24183
+  tps: 29865.26358
  }
 }
 dps_results: {
@@ -2624,15 +2624,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 39357.30235
-  tps: 50893.23508
+  dps: 39346.30777
+  tps: 51444.14425
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39129.39387
-  tps: 51737.54175
+  dps: 39119.86447
+  tps: 52152.79952
  }
 }
 dps_results: {
@@ -2645,15 +2645,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24982.47095
-  tps: 33154.19917
+  dps: 24992.19163
+  tps: 33558.73682
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25254.76308
-  tps: 34353.85315
+  dps: 25302.74319
+  tps: 35400.95454
  }
 }
 dps_results: {
@@ -2750,15 +2750,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38482.21731
-  tps: 48799.92628
+  dps: 38439.5913
+  tps: 50817.44871
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37918.70874
-  tps: 48660.60252
+  dps: 38042.09312
+  tps: 49236.94575
  }
 }
 dps_results: {
@@ -2771,15 +2771,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24311.43916
-  tps: 31303.84833
+  dps: 24323.84477
+  tps: 32689.78904
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24449.95854
-  tps: 33042.52063
+  dps: 24508.09652
+  tps: 33798.33243
  }
 }
 dps_results: {
@@ -2876,15 +2876,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 33172.81619
-  tps: 45811.97334
+  dps: 33322.22445
+  tps: 47481.57352
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 32828.56968
-  tps: 46030.72445
+  dps: 32962.6725
+  tps: 47037.70092
  }
 }
 dps_results: {
@@ -2897,15 +2897,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 20791.36197
-  tps: 29041.46546
+  dps: 20759.99081
+  tps: 30001.92621
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20993.90073
-  tps: 30848.52461
+  dps: 20976.99455
+  tps: 31511.5265
  }
 }
 dps_results: {
@@ -3002,36 +3002,36 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 32527.24739
-  tps: 43632.17678
+  dps: 32630.90123
+  tps: 44736.92016
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 31926.56933
-  tps: 43569.57536
+  dps: 32037.98413
+  tps: 44608.541
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 39917.31375
-  tps: 41050.46928
+  dps: 39916.21835
+  tps: 41203.85499
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 20233.18087
-  tps: 28658.51039
+  dps: 20283.17714
+  tps: 28928.43609
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20347.66645
-  tps: 29426.91271
+  dps: 20457.32661
+  tps: 30439.28138
  }
 }
 dps_results: {
@@ -3086,7 +3086,7 @@ dps_results: {
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 28828.90646
-  tps: 42397.29131
+  dps: 28868.64363
+  tps: 43312.26839
  }
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -662,8 +662,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-GearDetector-61462"
  value: {
-  dps: 31693.16369
-  tps: 45212.1371
+  dps: 31704.32944
+  tps: 44968.43669
  }
 }
 dps_results: {
@@ -1131,8 +1131,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-ObsidianArborweaveBattlegarb"
  value: {
-  dps: 31113.88145
-  tps: 40515.40864
+  dps: 31258.00465
+  tps: 40967.08924
  }
 }
 dps_results: {
@@ -1299,8 +1299,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-RosaryofLight-72901"
  value: {
-  dps: 32065.23555
-  tps: 46636.76809
+  dps: 32060.95979
+  tps: 46725.37766
  }
 }
 dps_results: {
@@ -1383,8 +1383,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofDominance-72449"
  value: {
-  dps: 30865.51433
-  tps: 45295.93153
+  dps: 30847.77871
+  tps: 45176.10969
  }
 }
 dps_results: {
@@ -2071,8 +2071,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 33269.15491
-  tps: 46583.20647
+  dps: 33269.15739
+  tps: 46582.67073
  }
 }
 dps_results: {
@@ -2120,85 +2120,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 39239.22776
-  tps: 50615.90879
+  dps: 39297.74985
+  tps: 49962.09904
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39157.33442
-  tps: 50808.0671
+  dps: 39010.86507
+  tps: 51558.37376
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 50317.11255
-  tps: 44055.05737
+  dps: 50559.60519
+  tps: 43737.41598
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 25054.01751
-  tps: 32928.75021
+  dps: 25034.89749
+  tps: 32239.04249
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25170.95682
-  tps: 33685.43776
+  dps: 25281.76835
+  tps: 34864.4505
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 28347.71226
-  tps: 26817.66518
+  dps: 28300.51636
+  tps: 26747.24366
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38489.12038
-  tps: 27329.53611
+  dps: 38433.73843
+  tps: 27290.21492
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38110.14459
-  tps: 27058.20266
+  dps: 38066.96424
+  tps: 27027.54461
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 49877.56545
-  tps: 35413.07147
+  dps: 49864.82439
+  tps: 35404.02531
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24086.72481
-  tps: 17103.93749
+  dps: 24037.60193
+  tps: 17069.06025
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24269.42454
-  tps: 17231.50158
+  dps: 24161.25222
+  tps: 17154.69924
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 28038.10813
-  tps: 19907.62477
+  dps: 27875.22467
+  tps: 19791.97751
  }
 }
 dps_results: {
@@ -2246,85 +2246,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38384.46368
-  tps: 48328.30978
+  dps: 38517.50989
+  tps: 48701.18168
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38161.62511
-  tps: 47982.85529
+  dps: 38148.85794
+  tps: 48696.93414
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 48527.70438
-  tps: 41286.2268
+  dps: 48711.07902
+  tps: 42477.46907
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24305.34633
-  tps: 31265.82842
+  dps: 24355.60249
+  tps: 31458.73292
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24523.12604
-  tps: 32781.71801
+  dps: 24500.83457
+  tps: 32202.3316
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27155.10681
-  tps: 25028.5006
+  dps: 27083.07578
+  tps: 24409.18153
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 37589.17117
-  tps: 26690.57217
+  dps: 37671.988
+  tps: 26749.37212
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37225.55917
-  tps: 26430.14701
+  dps: 37234.78705
+  tps: 26436.6988
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 48375.07077
-  tps: 34346.30025
+  dps: 48361.36508
+  tps: 34336.56921
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 23565.27959
-  tps: 16733.71139
+  dps: 23591.03494
+  tps: 16751.99769
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 23664.03203
-  tps: 16801.6729
+  dps: 23666.92377
+  tps: 16803.72603
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 26932.20563
-  tps: 19122.434
+  dps: 26866.82914
+  tps: 19076.01669
  }
 }
 dps_results: {
@@ -2624,85 +2624,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 39198.73406
-  tps: 49278.28373
+  dps: 39357.30235
+  tps: 50893.23508
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39036.03507
-  tps: 52257.56883
+  dps: 39129.39387
+  tps: 51737.54175
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 49762.12472
-  tps: 43432.29374
+  dps: 49506.19335
+  tps: 43902.78457
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24810.3148
-  tps: 32481.43634
+  dps: 24982.47095
+  tps: 33154.19917
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25140.61521
-  tps: 34049.82513
+  dps: 25254.76308
+  tps: 34353.85315
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27753.63963
-  tps: 27727.31908
+  dps: 27830.10178
+  tps: 27375.89646
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38338.88143
-  tps: 27222.86645
+  dps: 38341.48317
+  tps: 27224.71369
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37942.61447
-  tps: 26939.25627
+  dps: 37849.06553
+  tps: 26872.83652
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 49335.04402
-  tps: 35027.88125
+  dps: 49320.54229
+  tps: 35017.58503
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24011.48734
-  tps: 17050.51889
+  dps: 24115.74126
+  tps: 17124.53918
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24242.14237
-  tps: 17212.13124
+  dps: 24224.14549
+  tps: 17199.35346
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27608.78405
-  tps: 19602.80467
+  dps: 27504.48667
+  tps: 19528.75354
  }
 }
 dps_results: {
@@ -2750,85 +2750,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38464.58726
-  tps: 48818.69314
+  dps: 38482.21731
+  tps: 48799.92628
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37967.65388
-  tps: 48474.17054
+  dps: 37918.70874
+  tps: 48660.60252
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 48150.21979
-  tps: 42394.22819
+  dps: 48086.931
+  tps: 42207.17384
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24253.39528
-  tps: 31090.2905
+  dps: 24311.43916
+  tps: 31303.84833
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24388.8634
-  tps: 31733.75373
+  dps: 24449.95854
+  tps: 33042.52063
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 26743.38933
-  tps: 25357.69679
+  dps: 26705.43427
+  tps: 25311.77097
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 37519.9235
-  tps: 26641.40633
+  dps: 37631.50735
+  tps: 26720.63086
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37084.88486
-  tps: 26330.26825
+  dps: 37020.3483
+  tps: 26284.4473
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 47863.73169
-  tps: 33983.2495
+  dps: 47817.37091
+  tps: 33950.33335
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 23494.85542
-  tps: 16683.71023
+  dps: 23503.83287
+  tps: 16690.08422
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 23660.00831
-  tps: 16798.81606
+  dps: 23613.1353
+  tps: 16765.53622
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 26549.49229
-  tps: 18850.70753
+  dps: 26446.02829
+  tps: 18777.24809
  }
 }
 dps_results: {
@@ -3065,8 +3065,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 19362.9156
-  tps: 13750.03295
+  dps: 19363.54128
+  tps: 13750.47719
  }
 }
 dps_results: {

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -38,2041 +38,2041 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 32813.85285
-  tps: 46094.91377
+  dps: 32828.56968
+  tps: 46030.72445
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 30833.9083
-  tps: 45225.46518
+  dps: 30790.39889
+  tps: 45332.17649
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 33135.19437
-  tps: 48062.79372
+  dps: 33109.72215
+  tps: 47471.60365
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 30834.88524
-  tps: 45230.53868
+  dps: 30792.35277
+  tps: 45342.16716
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 30834.88524
-  tps: 45230.53868
+  dps: 30792.35277
+  tps: 45342.16716
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 31941.59859
-  tps: 46530.46102
+  dps: 31939.05233
+  tps: 46387.309
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 32122.24384
-  tps: 46761.03244
+  dps: 32116.92742
+  tps: 46638.42801
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ArrowofTime-72897"
  value: {
-  dps: 32956.63312
-  tps: 46864.34111
+  dps: 32972.29655
+  tps: 46099.47551
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 32036.3906
-  tps: 45235.45478
+  dps: 32027.80544
+  tps: 45143.2076
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 30833.9083
-  tps: 45225.61399
+  dps: 30790.39889
+  tps: 45332.31778
   hps: 96.77966
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 30833.9083
-  tps: 45225.61399
+  dps: 30790.39889
+  tps: 45332.31778
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 31276.43421
-  tps: 46102.45509
+  dps: 31329.69715
+  tps: 46051.27945
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 31325.51537
-  tps: 46468.05522
+  dps: 31367.12801
+  tps: 46314.72536
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BindingPromise-67037"
  value: {
-  dps: 30872.4129
-  tps: 45213.21281
+  dps: 30800.93643
+  tps: 45286.36706
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 32395.54942
-  tps: 46634.74927
+  dps: 32418.18773
+  tps: 47404.51161
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 31161.2104
-  tps: 45772.87999
+  dps: 31114.02437
+  tps: 45873.8036
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 31204.07139
-  tps: 45844.54577
+  dps: 31156.68543
+  tps: 45945.01406
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 32877.29745
-  tps: 46458.40291
+  dps: 32873.64181
+  tps: 46765.40849
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 30870.24856
-  tps: 45205.01081
+  dps: 30800.93643
+  tps: 45286.36706
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 31417.29996
-  tps: 45865.21309
+  dps: 31401.70359
+  tps: 46224.86702
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 31254.66817
-  tps: 46550.63118
+  dps: 31294.74506
+  tps: 46456.35916
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 30889.17456
-  tps: 45449.19065
+  dps: 30824.30422
+  tps: 45548.47401
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 30889.17456
-  tps: 45449.19065
+  dps: 30824.30422
+  tps: 45548.47401
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 32229.03975
-  tps: 45448.82753
+  dps: 32179.59335
+  tps: 45920.78505
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 30833.9083
-  tps: 45225.61399
+  dps: 30790.39889
+  tps: 45332.31778
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 31295.92482
-  tps: 45317.51091
+  dps: 31310.07801
+  tps: 45784.981
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 32767.68591
-  tps: 48290.26431
+  dps: 32776.2667
+  tps: 47203.65934
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 32616.5124
-  tps: 47666.10801
+  dps: 32552.24333
+  tps: 47351.67064
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 33155.04337
-  tps: 48305.50301
+  dps: 33059.62133
+  tps: 47603.89977
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledLightning-66879"
  value: {
-  dps: 31006.94369
-  tps: 45348.7259
+  dps: 30965.89155
+  tps: 45290.93635
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledWishes-77114"
  value: {
-  dps: 31549.72733
-  tps: 44755.86853
+  dps: 31409.70799
+  tps: 44232.04581
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 32036.3906
-  tps: 44331.00419
+  dps: 32027.80544
+  tps: 44240.58931
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 30872.4129
-  tps: 45213.21281
+  dps: 30800.93643
+  tps: 45286.36706
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 32638.28241
-  tps: 46054.10507
+  dps: 32630.84084
+  tps: 45960.26363
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sBadgeofConquest-73648"
  value: {
-  dps: 33304.8872
-  tps: 47791.28966
+  dps: 33228.90179
+  tps: 47733.29625
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sBadgeofDominance-73498"
  value: {
-  dps: 30870.24856
-  tps: 45205.01081
+  dps: 30800.93643
+  tps: 45286.36706
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sBadgeofVictory-73496"
  value: {
-  dps: 31776.88328
-  tps: 46164.1513
+  dps: 31777.45711
+  tps: 46417.89536
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sInsigniaofConquest-73643"
  value: {
-  dps: 33091.36959
-  tps: 46795.55831
+  dps: 33113.1963
+  tps: 46961.4811
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sInsigniaofDominance-73497"
  value: {
-  dps: 30854.33387
-  tps: 45463.63533
+  dps: 30870.91722
+  tps: 45103.71461
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sInsigniaofVictory-73491"
  value: {
-  dps: 31735.43108
-  tps: 45455.90777
+  dps: 31760.07855
+  tps: 45426.34693
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 32655.86369
-  tps: 45897.32826
+  dps: 32666.41418
+  tps: 45830.39854
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 32113.82009
-  tps: 46441.23812
+  dps: 32085.81699
+  tps: 46233.33332
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 30872.10478
-  tps: 45210.03919
+  dps: 30802.79266
+  tps: 45291.40515
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 30833.9083
-  tps: 45225.61399
+  dps: 30790.39889
+  tps: 45332.31778
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 32314.81888
-  tps: 46372.88131
+  dps: 32321.6875
+  tps: 46537.44474
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 32209.48367
-  tps: 46172.6678
+  dps: 32210.56208
+  tps: 46024.21289
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 32505.83579
-  tps: 46989.92662
+  dps: 32435.16082
+  tps: 46411.44452
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-59506"
  value: {
-  dps: 31766.3902
-  tps: 44955.03262
+  dps: 31811.53016
+  tps: 44952.88544
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-65118"
  value: {
-  dps: 32024.202
-  tps: 45439.90233
+  dps: 31984.10637
+  tps: 45178.32235
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 31209.88875
-  tps: 46042.69427
+  dps: 31229.11794
+  tps: 46282.57591
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 31122.43251
-  tps: 45610.29152
+  dps: 31132.61475
+  tps: 46038.00932
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-78000"
  value: {
-  dps: 31285.49724
-  tps: 46538.6153
+  dps: 31233.59092
+  tps: 46175.89993
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 30889.17456
-  tps: 45449.19065
+  dps: 30824.30422
+  tps: 45548.47401
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 31709.48317
-  tps: 46765.75318
+  dps: 31788.15143
+  tps: 47480.32575
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 32466.51393
-  tps: 47633.5565
+  dps: 32510.33116
+  tps: 48243.00358
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 30835.76453
-  tps: 45230.64021
+  dps: 30792.25511
+  tps: 45337.35802
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 31272.72103
-  tps: 46085.0405
+  dps: 31208.81633
+  tps: 46165.72007
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 31748.2585
-  tps: 45710.21234
+  dps: 31718.97313
+  tps: 45904.55608
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeepEarthRegalia"
  value: {
-  dps: 22092.78361
-  tps: 29745.1499
+  dps: 21992.41394
+  tps: 29141.43009
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 32051.0639
-  tps: 45075.71313
+  dps: 32060.08126
+  tps: 45015.08416
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 31047.26992
-  tps: 45677.80917
+  dps: 31087.57019
+  tps: 46231.51299
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dragonwrath,Tarecgosa'sRest-71086"
  value: {
-  dps: 33300.35303
-  tps: 45702.06678
+  dps: 33318.85626
+  tps: 46028.93646
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 31863.95033
-  tps: 46152.56948
+  dps: 31846.02305
+  tps: 46202.03704
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 32036.3906
-  tps: 45235.45478
+  dps: 32027.80544
+  tps: 45143.2076
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 30871.17667
-  tps: 45241.74033
+  dps: 30801.86455
+  tps: 45323.45771
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 32036.3906
-  tps: 45235.39095
+  dps: 32027.80544
+  tps: 45143.13441
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 32051.0639
-  tps: 45075.71313
+  dps: 32060.08126
+  tps: 45015.08416
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 32662.05616
-  tps: 46743.02581
+  dps: 32552.87024
+  tps: 46524.47389
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 31989.0931
-  tps: 46743.54579
+  dps: 31926.88075
+  tps: 46688.28351
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 32036.3906
-  tps: 45235.45478
+  dps: 32027.80544
+  tps: 45143.2076
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 32201.14133
-  tps: 47228.58384
+  dps: 32152.3445
+  tps: 47336.37049
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 32045.77394
-  tps: 47000.97363
+  dps: 31997.33364
+  tps: 47108.3755
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 32372.04546
-  tps: 47478.95507
+  dps: 32322.85643
+  tps: 47587.16498
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-59500"
  value: {
-  dps: 30835.76453
-  tps: 45230.64021
+  dps: 30792.25511
+  tps: 45337.35802
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-65124"
  value: {
-  dps: 30835.76453
-  tps: 45230.60394
+  dps: 30792.25511
+  tps: 45337.32359
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 30814.36065
-  tps: 45267.75012
+  dps: 30799.75883
+  tps: 45443.39637
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 32297.92543
-  tps: 46621.0373
+  dps: 32262.28132
+  tps: 46383.6401
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 30871.17667
-  tps: 45205.42531
+  dps: 30801.86455
+  tps: 45286.79018
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 30872.4129
-  tps: 45213.21281
+  dps: 30800.93643
+  tps: 45286.36706
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 30871.17667
-  tps: 45205.42531
+  dps: 30801.86455
+  tps: 45286.79018
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 31758.52547
-  tps: 46452.63541
+  dps: 31739.82532
+  tps: 46808.02413
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 31403.15903
-  tps: 46151.72799
+  dps: 31483.01578
+  tps: 46653.90223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 32107.8192
-  tps: 45349.42222
+  dps: 32099.35466
+  tps: 45258.86261
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FluidDeath-58181"
  value: {
-  dps: 32352.48151
-  tps: 47761.72797
+  dps: 32362.46935
+  tps: 47817.56893
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 32036.3906
-  tps: 45235.41268
+  dps: 32027.80544
+  tps: 45143.15933
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 31338.61833
-  tps: 44616.13734
+  dps: 31307.8376
+  tps: 44240.69946
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 32120.228
-  tps: 47440.91682
+  dps: 32122.7914
+  tps: 47248.14661
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56138"
  value: {
-  dps: 31151.42919
-  tps: 45064.66071
+  dps: 31197.98857
+  tps: 44739.49308
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56462"
  value: {
-  dps: 31339.96834
-  tps: 45523.43704
+  dps: 31277.46509
+  tps: 44396.13691
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GearDetector-61462"
  value: {
-  dps: 31707.04831
-  tps: 45611.2253
+  dps: 31693.16369
+  tps: 45212.1371
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 26466.43172
-  tps: 37129.76677
+  dps: 26434.04676
+  tps: 36327.76939
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 30833.9083
-  tps: 45225.45482
+  dps: 30790.39889
+  tps: 45332.16665
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 31749.27599
-  tps: 46921.19664
+  dps: 31759.74763
+  tps: 46894.68163
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 32128.51456
-  tps: 46729.84973
+  dps: 32168.98338
+  tps: 46307.00861
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HarmlightToken-63839"
  value: {
-  dps: 30828.38448
-  tps: 45208.63581
+  dps: 30791.66059
+  tps: 45312.50228
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 31458.8725
-  tps: 45754.44011
+  dps: 31504.69804
+  tps: 45796.46713
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 30833.9083
-  tps: 45225.61399
+  dps: 30790.39889
+  tps: 45332.31778
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 30833.9083
-  tps: 45225.61399
+  dps: 30790.39889
+  tps: 45332.31778
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-59224"
  value: {
-  dps: 31567.19185
-  tps: 44816.47297
+  dps: 31509.74387
+  tps: 44790.3129
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-65072"
  value: {
-  dps: 31701.9774
-  tps: 46545.48623
+  dps: 31687.16162
+  tps: 45912.67159
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-55868"
  value: {
-  dps: 31706.36979
-  tps: 45659.68922
+  dps: 31681.10382
+  tps: 45799.67879
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-56393"
  value: {
-  dps: 31782.61834
-  tps: 44610.14803
+  dps: 31765.98054
+  tps: 43504.49309
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-55845"
  value: {
-  dps: 30833.9083
-  tps: 45225.61399
+  dps: 30818.3447
+  tps: 45479.20423
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-56370"
  value: {
-  dps: 30833.9083
-  tps: 45225.61399
+  dps: 30818.3447
+  tps: 45479.20423
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 31843.65437
-  tps: 46497.96049
+  dps: 31815.26906
+  tps: 46592.05827
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-50641"
  value: {
-  dps: 33560.1167
-  tps: 46355.61386
+  dps: 33565.41955
+  tps: 46440.32872
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 32051.0639
-  tps: 45075.71313
+  dps: 32060.08126
+  tps: 45015.08416
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 31876.07918
-  tps: 46615.68506
+  dps: 31856.71741
+  tps: 46973.46462
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 31876.07918
-  tps: 46615.68506
+  dps: 31856.71741
+  tps: 46973.46462
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 31208.65215
-  tps: 45892.98294
+  dps: 31153.48676
+  tps: 46035.22197
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 31251.50918
-  tps: 45964.57465
+  dps: 31196.17292
+  tps: 46106.73771
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndomitablePride-77211"
  value: {
-  dps: 30833.9083
-  tps: 45225.61399
+  dps: 30790.39889
+  tps: 45332.31778
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndomitablePride-77983"
  value: {
-  dps: 30833.9083
-  tps: 45225.61399
+  dps: 30790.39889
+  tps: 45332.31778
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndomitablePride-78003"
  value: {
-  dps: 30833.9083
-  tps: 45225.61399
+  dps: 30790.39889
+  tps: 45332.31778
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 30833.9083
-  tps: 45225.61399
+  dps: 30818.3447
+  tps: 45479.20423
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 31496.97998
-  tps: 44699.39791
+  dps: 31580.82009
+  tps: 45138.25535
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 31465.47275
-  tps: 44213.01138
+  dps: 31426.55985
+  tps: 43931.17624
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 31674.66506
-  tps: 44794.33036
+  dps: 31630.51201
+  tps: 44788.11886
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 31067.23745
-  tps: 46116.06995
+  dps: 31085.97903
+  tps: 46136.86665
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 30833.9083
-  tps: 45225.80056
+  dps: 30790.39889
+  tps: 45332.53521
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 30833.9083
-  tps: 45225.80056
+  dps: 30790.39889
+  tps: 45332.53521
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 30835.76453
-  tps: 45230.58668
+  dps: 30792.25511
+  tps: 45337.3072
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 30835.76453
-  tps: 45230.5435
+  dps: 30792.25511
+  tps: 45337.26621
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 32395.54942
-  tps: 46634.74927
+  dps: 32418.18773
+  tps: 47404.51161
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 32038.98925
-  tps: 45906.20999
+  dps: 32079.47621
+  tps: 45801.62461
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 32377.90454
-  tps: 46652.52737
+  dps: 32403.35811
+  tps: 47037.49033
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-77194"
  value: {
-  dps: 36557.84613
-  tps: 51204.54512
+  dps: 36559.60507
+  tps: 51209.63595
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-78473"
  value: {
-  dps: 36917.22331
-  tps: 51558.9647
+  dps: 36783.69482
+  tps: 50670.98374
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-78482"
  value: {
-  dps: 36077.88307
-  tps: 51268.89903
+  dps: 36088.95417
+  tps: 51148.42765
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 34058.48214
-  tps: 47278.97637
+  dps: 33942.9626
+  tps: 47099.17834
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 31350.19265
-  tps: 46198.67415
+  dps: 31339.14375
+  tps: 46352.58415
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 31350.19265
-  tps: 46198.67415
+  dps: 31339.14375
+  tps: 46352.58415
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 31053.6135
-  tps: 43713.91919
+  dps: 31061.63154
+  tps: 43838.535
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50708"
  value: {
-  dps: 32997.66042
-  tps: 46351.91827
+  dps: 33012.49505
+  tps: 46287.48766
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-55816"
  value: {
-  dps: 30833.9083
-  tps: 45225.61399
+  dps: 30790.39889
+  tps: 45332.31778
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-56347"
  value: {
-  dps: 30833.9083
-  tps: 45225.61399
+  dps: 30790.39889
+  tps: 45332.31778
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 32047.98732
-  tps: 46243.9841
+  dps: 32070.26546
+  tps: 46166.94564
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 32362.56998
-  tps: 47270.94993
+  dps: 32351.79615
+  tps: 46828.02682
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 31425.29331
-  tps: 46095.5174
+  dps: 31381.43554
+  tps: 46208.6107
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 31338.61691
-  tps: 45788.77403
+  dps: 31329.93121
+  tps: 46025.61783
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 31425.30334
-  tps: 45348.13114
+  dps: 31473.23458
+  tps: 46066.96229
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 30833.9083
-  tps: 45225.61399
+  dps: 30790.39889
+  tps: 45332.31778
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 30833.9083
-  tps: 45225.61399
+  dps: 30790.39889
+  tps: 45332.31778
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 31694.09962
-  tps: 45889.17483
+  dps: 31714.9948
+  tps: 46509.71616
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 31829.37602
-  tps: 46165.15955
+  dps: 31829.12268
+  tps: 46670.60158
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 33303.1657
-  tps: 47625.88184
+  dps: 33228.71315
+  tps: 47006.49607
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 33523.87027
-  tps: 48902.94162
+  dps: 33437.74379
+  tps: 48452.55563
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 31207.98497
-  tps: 45639.25725
+  dps: 31204.18653
+  tps: 45884.64807
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 31426.28028
-  tps: 45353.05583
+  dps: 31475.23339
+  tps: 46077.03637
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 31298.2623
-  tps: 46042.6747
+  dps: 31242.73965
+  tps: 46184.75488
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 31298.2623
-  tps: 46042.6747
+  dps: 31242.73965
+  tps: 46184.75488
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 31242.41902
-  tps: 46250.59511
+  dps: 31276.54952
+  tps: 46172.86668
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 31405.43317
-  tps: 45662.39933
+  dps: 31357.35701
+  tps: 45191.4582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 30872.4129
-  tps: 45213.21281
+  dps: 30800.93643
+  tps: 45286.36706
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 30835.76453
-  tps: 45230.58668
+  dps: 30792.25511
+  tps: 45337.3072
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 30835.76453
-  tps: 45230.5435
+  dps: 30792.25511
+  tps: 45337.26621
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ObsidianArborweaveBattlegarb"
  value: {
-  dps: 31024.33811
-  tps: 39556.66218
+  dps: 31113.88145
+  tps: 40515.40864
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ObsidianArborweaveRegalia"
  value: {
-  dps: 22451.51427
-  tps: 30369.97671
+  dps: 22462.66147
+  tps: 30308.87935
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 31399.67331
-  tps: 45478.17421
+  dps: 31337.2987
+  tps: 45924.12736
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 30834.83642
-  tps: 45226.01016
+  dps: 30791.327
+  tps: 45332.72723
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 30833.9083
-  tps: 45225.61399
+  dps: 30790.39889
+  tps: 45332.31778
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 31055.53296
-  tps: 45843.54891
+  dps: 31013.06708
+  tps: 45830.69039
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 31124.96876
-  tps: 45066.29398
+  dps: 31129.84262
+  tps: 45488.09319
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 31361.79395
-  tps: 45205.35668
+  dps: 31259.34936
+  tps: 44800.11877
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 32036.3906
-  tps: 45235.45478
+  dps: 32027.80544
+  tps: 45143.2076
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 32688.96972
-  tps: 45898.13862
+  dps: 32648.59796
+  tps: 45542.83955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-55854"
  value: {
-  dps: 30833.9083
-  tps: 45225.61399
+  dps: 30790.39889
+  tps: 45332.31778
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-56377"
  value: {
-  dps: 30833.9083
-  tps: 45225.61399
+  dps: 30790.39889
+  tps: 45332.31778
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rathrak,thePoisonousMind-77195"
  value: {
-  dps: 29766.59607
-  tps: 42619.43308
+  dps: 29802.43146
+  tps: 42873.1607
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rathrak,thePoisonousMind-78475"
  value: {
-  dps: 30345.74428
-  tps: 43347.41552
+  dps: 30380.05958
+  tps: 43602.58523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rathrak,thePoisonousMind-78484"
  value: {
-  dps: 29262.47446
-  tps: 42306.18591
+  dps: 29296.14943
+  tps: 42569.4502
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 30814.91338
-  tps: 45690.32057
+  dps: 30836.57186
+  tps: 45716.85901
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 30833.9083
-  tps: 45225.61399
+  dps: 30790.39889
+  tps: 45332.31778
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 30833.9083
-  tps: 45225.61399
+  dps: 30790.39889
+  tps: 45332.31778
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 30833.9083
-  tps: 45225.61399
+  dps: 30790.39889
+  tps: 45332.31778
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 32725.23793
-  tps: 46175.86829
+  dps: 32717.80408
+  tps: 46081.78446
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 32638.28241
-  tps: 46054.14717
+  dps: 32630.84084
+  tps: 45960.31189
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 32701.94507
-  tps: 47380.50912
+  dps: 32727.97807
+  tps: 47910.24564
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 31270.79021
-  tps: 45134.89072
+  dps: 31270.01689
+  tps: 45660.65808
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 31373.58312
-  tps: 45158.93091
+  dps: 31385.87016
+  tps: 45566.49188
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RosaryofLight-72901"
  value: {
-  dps: 31918.29422
-  tps: 45774.27252
+  dps: 32065.23555
+  tps: 46636.76809
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RottingSkull-77116"
  value: {
-  dps: 32367.82188
-  tps: 46292.03856
+  dps: 32466.65158
+  tps: 47512.15962
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuneofZeth-68998"
  value: {
-  dps: 31337.86992
-  tps: 46684.14216
+  dps: 31358.99347
+  tps: 46344.21621
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofConquest-70399"
  value: {
-  dps: 32900.33448
-  tps: 47021.91832
+  dps: 32828.39228
+  tps: 46823.44623
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofConquest-72304"
  value: {
-  dps: 33007.02887
-  tps: 47154.60098
+  dps: 32932.1093
+  tps: 46956.4946
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofDominance-70401"
  value: {
-  dps: 30870.24856
-  tps: 45205.01081
+  dps: 30800.93643
+  tps: 45286.36706
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofDominance-72448"
  value: {
-  dps: 30870.24856
-  tps: 45205.01081
+  dps: 30800.93643
+  tps: 45286.36706
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofVictory-70400"
  value: {
-  dps: 31626.89076
-  tps: 45987.73091
+  dps: 31628.05283
+  tps: 46236.17952
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofVictory-72450"
  value: {
-  dps: 31671.11933
-  tps: 46039.7523
+  dps: 31672.10794
+  tps: 46289.7624
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofConquest-70404"
  value: {
-  dps: 32730.67655
-  tps: 47222.20688
+  dps: 32779.28094
+  tps: 47193.52987
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofConquest-72309"
  value: {
-  dps: 32899.86346
-  tps: 47157.14836
+  dps: 32844.74608
+  tps: 47180.64746
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofDominance-70402"
  value: {
-  dps: 30835.53977
-  tps: 44874.51896
+  dps: 30858.56384
+  tps: 45256.49878
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofDominance-72449"
  value: {
-  dps: 30848.09096
-  tps: 45154.51546
+  dps: 30865.51433
+  tps: 45295.93153
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofVictory-70403"
  value: {
-  dps: 31589.66249
-  tps: 45564.37717
+  dps: 31580.85472
+  tps: 46016.8352
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofVictory-72455"
  value: {
-  dps: 31522.56254
-  tps: 45655.76743
+  dps: 31553.5097
+  tps: 45556.55216
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ScalesofLife-68915"
  value: {
-  dps: 30833.9083
-  tps: 45225.61399
+  dps: 30790.39889
+  tps: 45332.31778
   hps: 315.97258
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ScalesofLife-69109"
  value: {
-  dps: 30833.9083
-  tps: 45225.61399
+  dps: 30790.39889
+  tps: 45332.31778
   hps: 356.41412
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 32085.93359
-  tps: 46620.48493
+  dps: 32069.89411
+  tps: 46356.57208
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-55256"
  value: {
-  dps: 30870.24856
-  tps: 45205.01081
+  dps: 30800.93643
+  tps: 45286.36706
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-56290"
  value: {
-  dps: 30870.24856
-  tps: 45205.01081
+  dps: 30800.93643
+  tps: 45286.36706
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShardofWoe-60233"
  value: {
-  dps: 31192.29022
-  tps: 44965.31081
+  dps: 31204.62036
+  tps: 45316.79431
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 31655.54641
-  tps: 46145.02547
+  dps: 31544.51856
+  tps: 46043.39376
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 30877.11515
-  tps: 45375.71538
+  dps: 30825.40438
+  tps: 45520.83775
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 32321.88308
-  tps: 46981.85554
+  dps: 32291.5184
+  tps: 47182.63705
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 32481.70308
-  tps: 47195.89001
+  dps: 32443.40789
+  tps: 47199.98233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-55879"
  value: {
-  dps: 31161.2104
-  tps: 45772.87999
+  dps: 31102.00495
+  tps: 45841.80774
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-56400"
  value: {
-  dps: 31204.07139
-  tps: 45844.54577
+  dps: 31144.68226
+  tps: 45913.00533
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 31207.98497
-  tps: 45639.25725
+  dps: 31204.18653
+  tps: 45884.64807
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulCasket-58183"
  value: {
-  dps: 31287.34367
-  tps: 45901.49567
+  dps: 31216.46139
+  tps: 45979.88424
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 31729.11982
-  tps: 45574.60879
+  dps: 31682.6508
+  tps: 45289.70575
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 31599.36583
-  tps: 45584.03415
+  dps: 31481.09943
+  tps: 44864.21081
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 31823.77845
-  tps: 45177.3087
+  dps: 31793.1771
+  tps: 45106.5698
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 31331.35553
-  tps: 46057.37144
+  dps: 31283.37585
+  tps: 46156.48757
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 31377.06985
-  tps: 45974.79138
+  dps: 31408.2182
+  tps: 46384.6927
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 33488.03279
-  tps: 47159.49757
+  dps: 33529.71978
+  tps: 47022.3749
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 33113.8038
-  tps: 46725.16571
+  dps: 33210.84784
+  tps: 46735.95139
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 33926.73666
-  tps: 48511.04843
+  dps: 33942.74222
+  tps: 47806.96288
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StayofExecution-68996"
  value: {
-  dps: 30833.9083
-  tps: 45225.61399
+  dps: 30790.39889
+  tps: 45332.31778
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 30878.72288
-  tps: 45466.86418
+  dps: 30819.3016
+  tps: 45551.37884
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stormrider'sBattlegarb"
  value: {
-  dps: 28571.83031
-  tps: 39605.89635
+  dps: 28552.42073
+  tps: 39608.14122
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stormrider'sRegalia"
  value: {
-  dps: 22318.06732
-  tps: 30431.59579
+  dps: 22310.47963
+  tps: 30448.15535
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62465"
  value: {
-  dps: 30834.88524
-  tps: 45230.53868
+  dps: 30792.35277
+  tps: 45342.16716
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62470"
  value: {
-  dps: 30834.88524
-  tps: 45230.53868
+  dps: 30792.35277
+  tps: 45342.16716
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 30833.9083
-  tps: 45225.61399
+  dps: 30790.39889
+  tps: 45332.31778
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 30833.9083
-  tps: 45225.61399
+  dps: 30790.39889
+  tps: 45332.31778
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 30846.58946
-  tps: 45314.87597
+  dps: 30803.08005
+  tps: 45421.58998
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 31676.77496
-  tps: 45833.51591
+  dps: 31610.72331
+  tps: 45696.94575
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-55819"
  value: {
-  dps: 30833.9083
-  tps: 45225.42805
+  dps: 30790.39889
+  tps: 45332.14124
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-56351"
  value: {
-  dps: 30834.83642
-  tps: 45226.02657
+  dps: 30791.327
+  tps: 45332.74281
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 31113.15414
-  tps: 45692.52744
+  dps: 31066.19228
+  tps: 45793.96156
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 31204.07139
-  tps: 45844.54577
+  dps: 31156.68543
+  tps: 45945.01406
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheHungerer-68927"
  value: {
-  dps: 32967.84533
-  tps: 46532.76019
+  dps: 32997.05092
+  tps: 46537.8735
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheHungerer-69112"
  value: {
-  dps: 33221.4033
-  tps: 46648.30094
+  dps: 33191.34495
+  tps: 46442.98301
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 30856.31575
-  tps: 45093.721
+  dps: 30808.01533
+  tps: 45190.69616
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 30835.16363
-  tps: 44943.39224
+  dps: 30791.65421
+  tps: 45050.11189
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 30833.9083
-  tps: 45225.61399
+  dps: 30790.39889
+  tps: 45332.31778
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 30833.9083
-  tps: 45225.61399
+  dps: 30790.39889
+  tps: 45332.31778
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-77190"
  value: {
-  dps: 32811.59139
-  tps: 45989.21671
+  dps: 32819.75771
+  tps: 45790.36199
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-78477"
  value: {
-  dps: 32815.70908
-  tps: 46095.78076
+  dps: 32831.19345
+  tps: 46009.52453
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-78486"
  value: {
-  dps: 32812.0349
-  tps: 45988.23037
+  dps: 32828.00172
+  tps: 45862.50391
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 32392.93696
-  tps: 47882.31136
+  dps: 32385.02853
+  tps: 48011.39649
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 32583.18831
-  tps: 48263.0312
+  dps: 32573.03225
+  tps: 48228.8608
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 31104.73315
-  tps: 46269.91891
+  dps: 31029.12308
+  tps: 45623.97149
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 30880.1071
-  tps: 45752.57649
+  dps: 30850.64055
+  tps: 45654.33182
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnheededWarning-59520"
  value: {
-  dps: 32712.12079
-  tps: 47829.35151
+  dps: 32692.43898
+  tps: 48238.69953
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 30870.24856
-  tps: 45205.01081
+  dps: 30800.93643
+  tps: 45286.36706
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 32882.79705
-  tps: 47096.05642
+  dps: 32817.42697
+  tps: 47159.55072
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 32882.79705
-  tps: 47096.05642
+  dps: 32817.42697
+  tps: 47159.55072
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 32882.79705
-  tps: 47096.05642
+  dps: 32817.42697
+  tps: 47159.55072
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 26678.9382
-  tps: 36682.61431
+  dps: 26689.40762
+  tps: 36599.63336
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 30837.21697
-  tps: 45241.81479
+  dps: 30793.70756
+  tps: 45348.53632
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 30836.36808
-  tps: 45233.53967
+  dps: 30792.85867
+  tps: 45340.26346
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 32093.19724
-  tps: 45371.06686
+  dps: 32021.93599
+  tps: 45180.73531
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VeilofLies-72900"
  value: {
-  dps: 30838.4547
-  tps: 45145.46969
+  dps: 30796.77622
+  tps: 45397.82896
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 31940.69602
-  tps: 47088.60446
+  dps: 31991.14567
+  tps: 47190.32208
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 32065.02431
-  tps: 47105.23757
+  dps: 32178.64836
+  tps: 47937.71133
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77207"
  value: {
-  dps: 33612.49588
-  tps: 48838.73145
+  dps: 33606.59814
+  tps: 48878.42583
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77979"
  value: {
-  dps: 33224.41709
-  tps: 49345.06082
+  dps: 33198.52124
+  tps: 49346.10461
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77999"
  value: {
-  dps: 33688.5963
-  tps: 48903.99478
+  dps: 33701.23254
+  tps: 49158.51976
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 30872.4129
-  tps: 45213.21281
+  dps: 30800.93643
+  tps: 45286.36706
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 30872.4129
-  tps: 45213.21281
+  dps: 30800.93643
+  tps: 45286.36706
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 32443.26184
-  tps: 46375.93308
+  dps: 32378.4554
+  tps: 46442.88471
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-70517"
  value: {
-  dps: 32650.43944
-  tps: 46708.18872
+  dps: 32593.89712
+  tps: 46778.12753
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 30870.24856
-  tps: 45205.01081
+  dps: 30800.93643
+  tps: 45286.36706
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-70518"
  value: {
-  dps: 30870.24856
-  tps: 45205.01081
+  dps: 30800.93643
+  tps: 45286.36706
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 31449.81136
-  tps: 45903.87587
+  dps: 31433.98579
+  tps: 46264.69621
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-70519"
  value: {
-  dps: 31522.10142
-  tps: 45989.84369
+  dps: 31505.76621
+  tps: 46353.25759
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 30890.1515
-  tps: 45454.11534
+  dps: 30826.25809
+  tps: 45558.32339
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 31311.56935
-  tps: 44341.63374
+  dps: 31304.11621
+  tps: 43881.28236
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 31304.00976
-  tps: 46657.96117
+  dps: 31338.43897
+  tps: 46542.00863
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 30889.17456
-  tps: 45449.19065
+  dps: 30824.30422
+  tps: 45548.47401
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 31334.77829
-  tps: 46160.32536
+  dps: 31265.74524
+  tps: 46253.3174
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 30889.17456
-  tps: 45449.19065
+  dps: 30824.30422
+  tps: 45548.47401
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 32272.11212
-  tps: 45792.61256
+  dps: 32383.92462
+  tps: 46265.38977
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-70577"
  value: {
-  dps: 32614.65889
-  tps: 46488.52187
+  dps: 32569.09794
+  tps: 46672.07703
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 30837.39005
-  tps: 45011.05437
+  dps: 30861.0497
+  tps: 45302.82439
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-70578"
  value: {
-  dps: 30893.01829
-  tps: 45192.37201
+  dps: 30852.68045
+  tps: 45242.1664
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 31386.84221
-  tps: 45898.39853
+  dps: 31474.38071
+  tps: 46509.62926
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-70579"
  value: {
-  dps: 31432.78468
-  tps: 45813.82581
+  dps: 31407.67474
+  tps: 46226.07553
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 30833.9083
-  tps: 45227.77454
+  dps: 30790.39889
+  tps: 45334.70349
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 30833.9083
-  tps: 45227.47276
+  dps: 30790.39889
+  tps: 45334.35151
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WillofUnbinding-77995"
  value: {
-  dps: 30833.9083
-  tps: 45228.10282
+  dps: 30790.39889
+  tps: 45335.08699
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 30869.88775
-  tps: 45209.5305
+  dps: 30810.67539
+  tps: 45229.92849
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 30874.63259
-  tps: 45250.58567
+  dps: 30815.42022
+  tps: 45270.98794
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 31118.34941
-  tps: 45701.2142
+  dps: 31071.36331
+  tps: 45802.59313
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 34355.37951
-  tps: 50468.77238
+  dps: 34443.30123
+  tps: 51321.61545
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 33919.35498
-  tps: 49782.81196
+  dps: 34037.19433
+  tps: 50661.86593
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 34867.01107
-  tps: 51299.45621
+  dps: 34917.9732
+  tps: 51843.42068
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 31228.28013
-  tps: 45226.40711
+  dps: 31264.2639
+  tps: 45775.52532
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 31228.28013
-  tps: 45226.40711
+  dps: 31264.2639
+  tps: 45775.52532
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 33272.9097
-  tps: 46654.97278
+  dps: 33269.15491
+  tps: 46583.20647
  }
 }
 dps_results: {
@@ -2120,36 +2120,36 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 39235.83864
-  tps: 49907.86722
+  dps: 39239.22776
+  tps: 50615.90879
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39218.15611
-  tps: 50957.18764
+  dps: 39157.33442
+  tps: 50808.0671
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 50310.56737
-  tps: 44115.75691
+  dps: 50317.11255
+  tps: 44055.05737
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24972.80979
-  tps: 32936.48158
+  dps: 25054.01751
+  tps: 32928.75021
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25201.45855
-  tps: 33908.56669
+  dps: 25170.95682
+  tps: 33685.43776
  }
 }
 dps_results: {
@@ -2246,43 +2246,43 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38582.18595
-  tps: 49525.83809
+  dps: 38384.46368
+  tps: 48328.30978
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38092.66851
-  tps: 48597.32401
+  dps: 38161.62511
+  tps: 47982.85529
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 48559.09691
-  tps: 41622.5781
+  dps: 48527.70438
+  tps: 41286.2268
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24321.56102
-  tps: 31253.18424
+  dps: 24305.34633
+  tps: 31265.82842
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24486.13583
-  tps: 32403.74311
+  dps: 24523.12604
+  tps: 32781.71801
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27075.57938
-  tps: 25294.14997
+  dps: 27155.10681
+  tps: 25028.5006
  }
 }
 dps_results: {
@@ -2372,15 +2372,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 33328.10015
-  tps: 45119.96559
+  dps: 33373.47392
+  tps: 45726.11565
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 32887.64043
-  tps: 46315.38842
+  dps: 32938.32251
+  tps: 46506.34074
  }
 }
 dps_results: {
@@ -2393,15 +2393,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 20815.03947
-  tps: 30174.89456
+  dps: 20832.55916
+  tps: 29945.34418
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 21079.84491
-  tps: 31027.85457
+  dps: 21070.74422
+  tps: 31202.72129
  }
 }
 dps_results: {
@@ -2498,15 +2498,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 32660.51489
-  tps: 44132.68003
+  dps: 32664.51672
+  tps: 43873.62066
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 32138.78192
-  tps: 43705.54335
+  dps: 32140.77065
+  tps: 43574.00162
  }
 }
 dps_results: {
@@ -2519,15 +2519,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 20244.13503
-  tps: 28006.32556
+  dps: 20294.03545
+  tps: 28152.16945
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20374.36447
-  tps: 29147.29242
+  dps: 20385.93938
+  tps: 29296.72486
  }
 }
 dps_results: {
@@ -2624,36 +2624,36 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 39108.59431
-  tps: 49017.55539
+  dps: 39198.73406
+  tps: 49278.28373
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39100.74033
-  tps: 52076.93299
+  dps: 39036.03507
+  tps: 52257.56883
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 49688.6079
-  tps: 43509.89935
+  dps: 49762.12472
+  tps: 43432.29374
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24803.36437
-  tps: 32430.55973
+  dps: 24810.3148
+  tps: 32481.43634
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25127.841
-  tps: 33888.29727
+  dps: 25140.61521
+  tps: 34049.82513
  }
 }
 dps_results: {
@@ -2750,43 +2750,43 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38464.41944
-  tps: 48314.27312
+  dps: 38464.58726
+  tps: 48818.69314
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38062.96739
-  tps: 49299.05682
+  dps: 37967.65388
+  tps: 48474.17054
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 48238.95708
-  tps: 42931.29527
+  dps: 48150.21979
+  tps: 42394.22819
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24224.08689
-  tps: 30896.19215
+  dps: 24253.39528
+  tps: 31090.2905
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24352.67811
-  tps: 32019.37637
+  dps: 24388.8634
+  tps: 31733.75373
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 26671.31803
-  tps: 25940.17033
+  dps: 26743.38933
+  tps: 25357.69679
  }
 }
 dps_results: {
@@ -2876,15 +2876,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 33209.18396
-  tps: 45950.76974
+  dps: 33172.81619
+  tps: 45811.97334
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 32813.85285
-  tps: 46094.91377
+  dps: 32828.56968
+  tps: 46030.72445
  }
 }
 dps_results: {
@@ -2897,15 +2897,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 20832.58739
-  tps: 29010.21564
+  dps: 20791.36197
+  tps: 29041.46546
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 21041.24738
-  tps: 31203.67013
+  dps: 20993.90073
+  tps: 30848.52461
  }
 }
 dps_results: {
@@ -3002,15 +3002,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 32554.58679
-  tps: 43559.59736
+  dps: 32527.24739
+  tps: 43632.17678
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 31906.41953
-  tps: 43512.49453
+  dps: 31926.56933
+  tps: 43569.57536
  }
 }
 dps_results: {
@@ -3023,15 +3023,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 20215.87465
-  tps: 28612.42486
+  dps: 20233.18087
+  tps: 28658.51039
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20371.01491
-  tps: 29604.25428
+  dps: 20347.66645
+  tps: 29426.91271
  }
 }
 dps_results: {
@@ -3086,7 +3086,7 @@ dps_results: {
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 28792.94055
-  tps: 41995.89772
+  dps: 28828.90646
+  tps: 42397.29131
  }
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -38,2125 +38,2125 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 32980.68483
-  tps: 47408.6878
+  dps: 32952.52049
+  tps: 47431.18348
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 30798.08048
-  tps: 45747.03094
+  dps: 30834.70877
+  tps: 45474.60477
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 33106.00557
-  tps: 47967.07104
+  dps: 33040.76111
+  tps: 48209.98811
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 30799.05742
-  tps: 45756.08125
+  dps: 30836.08139
+  tps: 45481.64772
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 30799.05742
-  tps: 45756.08125
+  dps: 30836.08139
+  tps: 45481.64772
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 31978.99062
-  tps: 47424.42135
+  dps: 32029.05005
+  tps: 47229.53467
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 32134.71899
-  tps: 47728.7217
+  dps: 32175.0755
+  tps: 47694.40597
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ArrowofTime-72897"
  value: {
-  dps: 32926.66848
-  tps: 47169.87315
+  dps: 33067.20072
+  tps: 47306.97108
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 32173.07722
-  tps: 46522.34733
+  dps: 32139.79229
+  tps: 46471.31935
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 30798.08048
-  tps: 45747.17079
+  dps: 30834.70877
+  tps: 45474.74463
   hps: 96.77966
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 30798.08048
-  tps: 45747.17079
+  dps: 30834.70877
+  tps: 45474.74463
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 31250.21655
-  tps: 47016.07489
+  dps: 31311.18449
+  tps: 46842.82038
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 31341.94468
-  tps: 46981.24857
+  dps: 31315.88695
+  tps: 47131.30035
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BindingPromise-67037"
  value: {
-  dps: 30828.60413
-  tps: 46130.327
+  dps: 30870.09404
+  tps: 45759.99385
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 32425.33288
-  tps: 47327.32685
+  dps: 32438.1851
+  tps: 47621.2653
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 31124.04729
-  tps: 46298.90364
+  dps: 31164.81251
+  tps: 46014.68404
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 31166.73342
-  tps: 46371.15437
+  dps: 31207.68998
+  tps: 46086.50755
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 32936.26434
-  tps: 47079.8624
+  dps: 32925.77033
+  tps: 46920.20492
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 30831.53467
-  tps: 46116.77013
+  dps: 30870.09404
+  tps: 45759.99385
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 31355.40245
-  tps: 46417.41866
+  dps: 31387.94638
+  tps: 45942.45425
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 31203.8732
-  tps: 46826.29629
+  dps: 31255.92759
+  tps: 46448.39495
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 30817.6422
-  tps: 46020.57181
+  dps: 30855.1896
+  tps: 45660.69715
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 30817.6422
-  tps: 46020.57181
+  dps: 30855.1896
+  tps: 45660.69715
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 32217.20342
-  tps: 46304.75726
+  dps: 32208.51166
+  tps: 46296.00022
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 30798.08048
-  tps: 45747.17079
+  dps: 30834.62352
+  tps: 45474.68409
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 31295.60514
-  tps: 46603.78035
+  dps: 31372.07996
+  tps: 46609.78939
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 32948.17384
-  tps: 48692.69327
+  dps: 32915.64919
+  tps: 48733.76573
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 32642.39408
-  tps: 48194.53248
+  dps: 32614.71573
+  tps: 48420.49244
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 33229.06014
-  tps: 48910.713
+  dps: 33157.22177
+  tps: 48892.72629
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledLightning-66879"
  value: {
-  dps: 30978.08761
-  tps: 46382.42348
+  dps: 30986.39689
+  tps: 45893.59934
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledWishes-77114"
  value: {
-  dps: 31454.58805
-  tps: 46254.18631
+  dps: 31365.55946
+  tps: 46795.43993
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 32173.07722
-  tps: 45592.14363
+  dps: 32139.79229
+  tps: 45542.14642
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 30828.60413
-  tps: 46130.327
+  dps: 30870.09404
+  tps: 45759.99385
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 32778.52771
-  tps: 47365.62043
+  dps: 32743.85706
+  tps: 47313.03126
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sBadgeofConquest-73648"
  value: {
-  dps: 33328.80063
-  tps: 48038.86845
+  dps: 33318.16785
+  tps: 48255.87473
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sBadgeofDominance-73498"
  value: {
-  dps: 30831.53467
-  tps: 46116.77013
+  dps: 30870.09404
+  tps: 45759.99385
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sBadgeofVictory-73496"
  value: {
-  dps: 31707.61818
-  tps: 47078.27916
+  dps: 31690.05426
+  tps: 46619.72016
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sInsigniaofConquest-73643"
  value: {
-  dps: 33096.86739
-  tps: 47287.67693
+  dps: 33072.1555
+  tps: 48541.78432
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sInsigniaofDominance-73497"
  value: {
-  dps: 30851.866
-  tps: 46298.50962
+  dps: 30886.13001
+  tps: 45728.27651
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sInsigniaofVictory-73491"
  value: {
-  dps: 31742.96987
-  tps: 46567.73246
+  dps: 31805.36221
+  tps: 46659.55765
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 32821.77239
-  tps: 47224.96943
+  dps: 32786.27567
+  tps: 47007.08458
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 32243.79058
-  tps: 47789.11277
+  dps: 32204.04972
+  tps: 47228.4222
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 30833.39089
-  tps: 46117.82705
+  dps: 30871.95026
+  tps: 45761.04969
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 30798.08048
-  tps: 45747.17079
+  dps: 30834.70877
+  tps: 45474.74463
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 32417.56854
-  tps: 48396.17444
+  dps: 32344.26463
+  tps: 48024.38317
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 32349.46944
-  tps: 47245.38627
+  dps: 32317.19204
+  tps: 47354.44505
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 32696.11821
-  tps: 47703.76451
+  dps: 32781.66385
+  tps: 48198.02728
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-59506"
  value: {
-  dps: 31660.25392
-  tps: 45548.74831
+  dps: 31740.89042
+  tps: 45917.13066
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-65118"
  value: {
-  dps: 32073.40528
-  tps: 46417.93437
+  dps: 32107.99678
+  tps: 46273.13183
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 31206.03146
-  tps: 46540.98735
+  dps: 31208.44483
+  tps: 46134.85374
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 31127.37892
-  tps: 46387.30705
+  dps: 31162.35858
+  tps: 45601.00239
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-78000"
  value: {
-  dps: 31267.71767
-  tps: 46604.24633
+  dps: 31307.29978
+  tps: 45977.36633
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 30817.6422
-  tps: 46020.57181
+  dps: 30855.1896
+  tps: 45660.69715
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 31654.61862
-  tps: 47472.8582
+  dps: 31544.35261
+  tps: 46696.72987
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 32473.8399
-  tps: 48628.02019
+  dps: 32304.04669
+  tps: 47975.92507
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 30799.93671
-  tps: 45748.22771
+  dps: 30836.565
+  tps: 45475.80154
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 31213.36384
-  tps: 46456.6332
+  dps: 31254.52912
+  tps: 46171.52032
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 31757.1958
-  tps: 45788.0822
+  dps: 31826.40274
+  tps: 46399.18824
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeepEarthRegalia"
  value: {
-  dps: 22165.38127
-  tps: 30643.63553
+  dps: 22145.75699
+  tps: 30746.68514
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 32212.4571
-  tps: 46374.88104
+  dps: 32177.87626
+  tps: 46165.93042
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 31066.4218
-  tps: 46807.18281
+  dps: 31021.44354
+  tps: 46765.21715
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dragonwrath,Tarecgosa'sRest-71086"
  value: {
-  dps: 33279.83072
-  tps: 47244.19885
+  dps: 33307.00374
+  tps: 48101.70428
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 31860.33519
-  tps: 46922.45275
+  dps: 31957.16989
+  tps: 47882.54045
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 32173.07722
-  tps: 46522.34733
+  dps: 32139.79229
+  tps: 46471.31935
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 30833.39089
-  tps: 46155.22492
+  dps: 30871.95026
+  tps: 45798.30227
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 32173.07722
-  tps: 46522.28212
+  dps: 32139.79229
+  tps: 46471.25442
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 32212.4571
-  tps: 46374.88104
+  dps: 32177.87626
+  tps: 46165.93042
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 32592.10516
-  tps: 47158.62892
+  dps: 32650.47544
+  tps: 47636.81355
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 32013.36733
-  tps: 47146.37831
+  dps: 32045.01901
+  tps: 47638.32845
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 32173.07722
-  tps: 46522.34733
+  dps: 32139.79229
+  tps: 46471.31935
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 32162.72991
-  tps: 47771.21407
+  dps: 32205.88393
+  tps: 47482.61081
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 32007.65611
-  tps: 47541.20915
+  dps: 32050.37264
+  tps: 47253.47476
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 32333.31109
-  tps: 48024.21948
+  dps: 32376.94635
+  tps: 47734.66047
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-59500"
  value: {
-  dps: 30799.93671
-  tps: 45748.22771
+  dps: 30836.565
+  tps: 45475.80154
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-65124"
  value: {
-  dps: 30799.93671
-  tps: 45748.19356
+  dps: 30836.565
+  tps: 45475.76739
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 30798.11602
-  tps: 45797.37788
+  dps: 30847.21062
+  tps: 45532.91849
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 32269.82723
-  tps: 47570.74922
+  dps: 32234.54473
+  tps: 47124.26843
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 30832.46278
-  tps: 46117.19736
+  dps: 30871.02215
+  tps: 45760.42012
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 30828.60413
-  tps: 46130.327
+  dps: 30870.09404
+  tps: 45759.99385
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 30832.46278
-  tps: 46117.19736
+  dps: 30871.02215
+  tps: 45760.42012
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 31695.89113
-  tps: 47004.33586
+  dps: 31734.98716
+  tps: 46560.06057
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 31374.58801
-  tps: 46819.113
+  dps: 31428.71709
+  tps: 47004.04645
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 32244.84543
-  tps: 46641.44374
+  dps: 32211.52817
+  tps: 46590.0183
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FluidDeath-58181"
  value: {
-  dps: 32329.99661
-  tps: 48184.2389
+  dps: 32379.92963
+  tps: 48066.88023
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 32173.07722
-  tps: 46522.30433
+  dps: 32139.79229
+  tps: 46471.27653
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 31280.38874
-  tps: 44933.43914
+  dps: 31319.27161
+  tps: 45257.26372
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 31983.98504
-  tps: 48082.86305
+  dps: 32021.53674
+  tps: 47887.80346
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56138"
  value: {
-  dps: 31221.16654
-  tps: 46208.60244
+  dps: 31159.72242
+  tps: 45571.11003
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56462"
  value: {
-  dps: 31337.10633
-  tps: 45130.79245
+  dps: 31349.58548
+  tps: 44860.30215
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GearDetector-61462"
  value: {
-  dps: 31906.06062
-  tps: 46811.94819
+  dps: 31892.30179
+  tps: 46807.87249
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 26607.0118
-  tps: 37704.48832
+  dps: 26449.80073
+  tps: 37869.19681
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 30798.08048
-  tps: 45747.02118
+  dps: 30834.70877
+  tps: 45474.59502
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 31736.23786
-  tps: 47474.55024
+  dps: 31894.62201
+  tps: 47449.57467
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 32241.75284
-  tps: 46291.29485
+  dps: 32413.06509
+  tps: 47299.79255
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HarmlightToken-63839"
  value: {
-  dps: 30796.02594
-  tps: 45711.30913
+  dps: 30860.01565
+  tps: 45532.87336
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 31518.5119
-  tps: 46008.17949
+  dps: 31558.6434
+  tps: 46081.65458
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 30798.08048
-  tps: 45747.17079
+  dps: 30834.70877
+  tps: 45474.74463
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 30798.08048
-  tps: 45747.17079
+  dps: 30834.70877
+  tps: 45474.74463
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-59224"
  value: {
-  dps: 31478.7544
-  tps: 46433.60571
+  dps: 31531.32825
+  tps: 46815.9639
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-65072"
  value: {
-  dps: 31586.78767
-  tps: 46150.27709
+  dps: 31655.88263
+  tps: 46114.83987
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-55868"
  value: {
-  dps: 31694.20929
-  tps: 46338.00278
+  dps: 31737.53707
+  tps: 46770.08785
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-56393"
  value: {
-  dps: 31938.83265
-  tps: 45907.58993
+  dps: 31942.03863
+  tps: 45233.55533
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-55845"
  value: {
-  dps: 30798.08048
-  tps: 45747.17079
+  dps: 30834.70877
+  tps: 45474.74463
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-56370"
  value: {
-  dps: 30798.08048
-  tps: 45747.17079
+  dps: 30834.70877
+  tps: 45474.74463
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 31728.75046
-  tps: 46878.97493
+  dps: 31886.7468
+  tps: 46777.01908
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-50641"
  value: {
-  dps: 33788.79057
-  tps: 47588.0529
+  dps: 33608.34535
+  tps: 47609.16212
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 32212.4571
-  tps: 46374.88104
+  dps: 32177.87626
+  tps: 46165.93042
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 31813.018
-  tps: 47174.06747
+  dps: 31838.4651
+  tps: 46911.66572
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 31813.018
-  tps: 47174.06747
+  dps: 31838.4651
+  tps: 46911.66572
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 31086.73416
-  tps: 46052.86663
+  dps: 31173.55648
+  tps: 45913.13811
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 31129.36267
-  tps: 46124.81956
+  dps: 31216.3406
+  tps: 45984.54159
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndomitablePride-77211"
  value: {
-  dps: 30798.08048
-  tps: 45747.17079
+  dps: 30834.70877
+  tps: 45474.74463
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndomitablePride-77983"
  value: {
-  dps: 30798.08048
-  tps: 45747.17079
+  dps: 30834.70877
+  tps: 45474.74463
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndomitablePride-78003"
  value: {
-  dps: 30798.08048
-  tps: 45747.17079
+  dps: 30834.70877
+  tps: 45474.74463
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 30798.08048
-  tps: 45747.17079
+  dps: 30834.70877
+  tps: 45474.74463
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 31568.73072
-  tps: 46015.24362
+  dps: 31641.12376
+  tps: 46001.39865
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 31479.71222
-  tps: 44915.63219
+  dps: 31499.68408
+  tps: 44854.97001
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 31840.43486
-  tps: 45925.82512
+  dps: 31783.26908
+  tps: 45579.60246
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 31042.92529
-  tps: 45897.07778
+  dps: 31133.34082
+  tps: 46122.86362
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 30798.08048
-  tps: 45747.55865
+  dps: 30834.70877
+  tps: 45474.97763
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 30798.08048
-  tps: 45747.55865
+  dps: 30834.70877
+  tps: 45474.97763
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 30799.93671
-  tps: 45748.1773
+  dps: 30836.565
+  tps: 45475.75113
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 30799.93671
-  tps: 45748.13664
+  dps: 30836.565
+  tps: 45475.71048
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 32425.33288
-  tps: 47327.32685
+  dps: 32438.1851
+  tps: 47621.2653
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 32087.95169
-  tps: 47047.98396
+  dps: 32085.68944
+  tps: 47027.94506
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 32484.19233
-  tps: 47441.6142
+  dps: 32523.77402
+  tps: 47674.58567
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-77194"
  value: {
-  dps: 36547.60616
-  tps: 52174.55162
+  dps: 36477.55298
+  tps: 51790.521
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-78473"
  value: {
-  dps: 36986.06045
-  tps: 53057.33948
+  dps: 37072.5764
+  tps: 52956.01831
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-78482"
  value: {
-  dps: 36109.38524
-  tps: 52385.43028
+  dps: 36142.38073
+  tps: 52273.77024
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 34159.17657
-  tps: 48721.37552
+  dps: 34232.87608
+  tps: 49216.32183
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 31404.85801
-  tps: 47282.25771
+  dps: 31390.53602
+  tps: 46675.6197
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 31404.85801
-  tps: 47282.25771
+  dps: 31390.53602
+  tps: 46675.6197
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 31090.30048
-  tps: 45801.29691
+  dps: 31083.0855
+  tps: 45443.573
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50708"
  value: {
-  dps: 33165.35894
-  tps: 47673.02901
+  dps: 33137.09036
+  tps: 47695.88371
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-55816"
  value: {
-  dps: 30798.08048
-  tps: 45747.17079
+  dps: 30834.70877
+  tps: 45474.74463
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-56347"
  value: {
-  dps: 30798.08048
-  tps: 45747.17079
+  dps: 30834.70877
+  tps: 45474.74463
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 32155.27297
-  tps: 46910.78758
+  dps: 32064.07085
+  tps: 47196.80164
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 32326.07148
-  tps: 47288.13943
+  dps: 32345.91101
+  tps: 47190.23185
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 31388.34984
-  tps: 46630.15986
+  dps: 31426.80841
+  tps: 46351.9452
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 31298.84651
-  tps: 46118.27719
+  dps: 31366.43447
+  tps: 46529.78731
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 31460.16518
-  tps: 46159.55152
+  dps: 31468.9178
+  tps: 46432.84236
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 30798.08048
-  tps: 45747.17079
+  dps: 30834.70877
+  tps: 45474.74463
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 30798.08048
-  tps: 45747.17079
+  dps: 30834.70877
+  tps: 45474.74463
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 31780.73767
-  tps: 46329.37575
+  dps: 31728.16019
+  tps: 46716.81757
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 31934.23285
-  tps: 46679.90816
+  dps: 31880.85746
+  tps: 47072.65385
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 33218.52222
-  tps: 47574.15329
+  dps: 33186.35694
+  tps: 48096.72671
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 33541.82523
-  tps: 48669.27472
+  dps: 33437.05741
+  tps: 48971.60515
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 31169.11134
-  tps: 45971.53544
+  dps: 31209.92249
+  tps: 46367.66122
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 31461.5378
-  tps: 46162.46885
+  dps: 31469.89474
+  tps: 46437.76705
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 31175.86651
-  tps: 46203.31366
+  dps: 31263.01418
+  tps: 46062.43629
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 31175.86651
-  tps: 46203.31366
+  dps: 31263.01418
+  tps: 46062.43629
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 31184.07961
-  tps: 46565.18687
+  dps: 31253.24371
+  tps: 46549.357
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 31330.79412
-  tps: 46840.64008
+  dps: 31360.75568
+  tps: 46447.79708
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 30828.60413
-  tps: 46130.327
+  dps: 30870.09404
+  tps: 45759.99385
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 30799.93671
-  tps: 45748.1773
+  dps: 30836.565
+  tps: 45475.75113
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 30799.93671
-  tps: 45748.13664
+  dps: 30836.565
+  tps: 45475.71048
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ObsidianArborweaveBattlegarb"
  value: {
-  dps: 31194.64136
-  tps: 41513.25982
+  dps: 31184.87357
+  tps: 40845.78505
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ObsidianArborweaveRegalia"
  value: {
-  dps: 22560.58476
-  tps: 31142.76903
+  dps: 22554.36858
+  tps: 31908.61081
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 31339.21419
-  tps: 45741.51
+  dps: 31429.52542
+  tps: 45865.05942
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 30799.0086
-  tps: 45747.58257
+  dps: 30835.63689
+  tps: 45475.15641
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 30798.08048
-  tps: 45747.17079
+  dps: 30834.70877
+  tps: 45474.74463
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 30997.33412
-  tps: 46117.2005
+  dps: 31088.3229
+  tps: 46194.74311
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 31051.47549
-  tps: 45359.344
+  dps: 31126.11998
+  tps: 45429.88345
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 31135.46927
-  tps: 45674.59112
+  dps: 31278.98249
+  tps: 45873.77539
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 32173.07722
-  tps: 46522.34733
+  dps: 32139.79229
+  tps: 46471.31935
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 32703.78563
-  tps: 46500.56319
+  dps: 32792.66635
+  tps: 47002.77374
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-55854"
  value: {
-  dps: 30798.08048
-  tps: 45747.17079
+  dps: 30834.70877
+  tps: 45474.74463
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-56377"
  value: {
-  dps: 30798.08048
-  tps: 45747.17079
+  dps: 30834.70877
+  tps: 45474.74463
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rathrak,thePoisonousMind-77195"
  value: {
-  dps: 29836.7928
-  tps: 43536.99109
+  dps: 29868.54853
+  tps: 43782.0148
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rathrak,thePoisonousMind-78475"
  value: {
-  dps: 30413.35899
-  tps: 44257.45438
+  dps: 30451.23541
+  tps: 44548.09801
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rathrak,thePoisonousMind-78484"
  value: {
-  dps: 29342.06182
-  tps: 42770.64552
+  dps: 29318.27698
+  tps: 43211.54588
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 30792.07755
-  tps: 45475.05873
+  dps: 30878.18093
+  tps: 45706.93998
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 30798.08048
-  tps: 45747.17079
+  dps: 30834.70877
+  tps: 45474.74463
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 30798.08048
-  tps: 45747.17079
+  dps: 30834.70877
+  tps: 45474.74463
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 30798.08048
-  tps: 45747.17079
+  dps: 30834.70877
+  tps: 45474.74463
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 32865.80599
-  tps: 47490.74435
+  dps: 32831.09599
+  tps: 47438.3131
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 32778.52771
-  tps: 47365.66343
+  dps: 32743.85706
+  tps: 47313.07408
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 32838.591
-  tps: 48364.90095
+  dps: 32916.72402
+  tps: 48916.02209
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 31204.46193
-  tps: 46223.90156
+  dps: 31308.71457
+  tps: 45981.89592
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 31333.44932
-  tps: 45719.50784
+  dps: 31312.82177
+  tps: 45307.31455
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RosaryofLight-72901"
  value: {
-  dps: 32082.29615
-  tps: 46806.87302
+  dps: 32073.97409
+  tps: 46974.96884
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RottingSkull-77116"
  value: {
-  dps: 32441.22454
-  tps: 47947.54546
+  dps: 32539.49357
+  tps: 48198.07966
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuneofZeth-68998"
  value: {
-  dps: 31337.83145
-  tps: 46946.76089
+  dps: 31405.00753
+  tps: 46712.94062
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofConquest-70399"
  value: {
-  dps: 32903.18233
-  tps: 47484.79286
+  dps: 32887.6983
+  tps: 47661.93355
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofConquest-72304"
  value: {
-  dps: 33013.96014
-  tps: 47628.21556
+  dps: 33005.8009
+  tps: 47762.71434
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofDominance-70401"
  value: {
-  dps: 30831.53467
-  tps: 46116.77013
+  dps: 30870.09404
+  tps: 45759.99385
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofDominance-72448"
  value: {
-  dps: 30831.53467
-  tps: 46116.77013
+  dps: 30870.09404
+  tps: 45759.99385
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofVictory-70400"
  value: {
-  dps: 31558.53051
-  tps: 46886.08353
+  dps: 31541.83775
+  tps: 46432.06505
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofVictory-72450"
  value: {
-  dps: 31602.49226
-  tps: 46942.7566
+  dps: 31585.54262
+  tps: 46487.39925
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofConquest-70404"
  value: {
-  dps: 32632.25269
-  tps: 47318.27096
+  dps: 32774.66361
+  tps: 47297.74446
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofConquest-72309"
  value: {
-  dps: 32891.92791
-  tps: 47493.68209
+  dps: 32988.49297
+  tps: 47185.83729
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofDominance-70402"
  value: {
-  dps: 30779.99069
-  tps: 45957.76752
+  dps: 30889.23499
+  tps: 45888.4304
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofDominance-72449"
  value: {
-  dps: 30785.64045
-  tps: 45778.71526
+  dps: 30858.98008
+  tps: 45017.99001
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofVictory-70403"
  value: {
-  dps: 31505.65984
-  tps: 46168.23822
+  dps: 31582.57534
+  tps: 45991.53952
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofVictory-72455"
  value: {
-  dps: 31542.77432
-  tps: 46247.93909
+  dps: 31538.09456
+  tps: 45915.91601
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ScalesofLife-68915"
  value: {
-  dps: 30798.08048
-  tps: 45747.17079
+  dps: 30834.70877
+  tps: 45474.74463
   hps: 315.97258
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ScalesofLife-69109"
  value: {
-  dps: 30798.08048
-  tps: 45747.17079
+  dps: 30834.70877
+  tps: 45474.74463
   hps: 356.41412
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 32059.09063
-  tps: 46739.52781
+  dps: 32165.46156
+  tps: 47100.95745
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-55256"
  value: {
-  dps: 30831.53467
-  tps: 46116.77013
+  dps: 30870.09404
+  tps: 45759.99385
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-56290"
  value: {
-  dps: 30831.53467
-  tps: 46116.77013
+  dps: 30870.09404
+  tps: 45759.99385
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShardofWoe-60233"
  value: {
-  dps: 31393.16434
-  tps: 45543.34296
+  dps: 31466.16253
+  tps: 46162.56241
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 31628.42617
-  tps: 45964.62003
+  dps: 31591.63302
+  tps: 45956.88002
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 30761.20732
-  tps: 45503.4079
+  dps: 30844.16556
+  tps: 45376.40622
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 32241.47797
-  tps: 47752.91295
+  dps: 32219.45697
+  tps: 47487.82706
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 32460.11061
-  tps: 48222.46385
+  dps: 32455.29451
+  tps: 48017.87695
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-55879"
  value: {
-  dps: 31124.04729
-  tps: 46298.90364
+  dps: 31164.81251
+  tps: 46014.68404
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-56400"
  value: {
-  dps: 31166.73342
-  tps: 46371.15437
+  dps: 31207.68998
+  tps: 46086.50755
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 31169.11134
-  tps: 45971.53544
+  dps: 31209.92249
+  tps: 46367.66122
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulCasket-58183"
  value: {
-  dps: 31246.89936
-  tps: 46823.9345
+  dps: 31290.13872
+  tps: 46455.21465
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 31602.90351
-  tps: 46177.68836
+  dps: 31625.13853
+  tps: 45848.40918
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 31573.91297
-  tps: 47110.61096
+  dps: 31587.02691
+  tps: 46779.04987
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 31744.53723
-  tps: 46657.38891
+  dps: 31836.67789
+  tps: 46472.03661
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 31311.44032
-  tps: 46636.56836
+  dps: 31335.02306
+  tps: 46299.80162
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 31350.74864
-  tps: 46917.50558
+  dps: 31371.43149
+  tps: 46783.44237
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 33561.66027
-  tps: 48666.1103
+  dps: 33484.29797
+  tps: 48745.44508
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 33129.61502
-  tps: 47126.28154
+  dps: 33075.88037
+  tps: 47517.34444
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 33916.70016
-  tps: 48759.88599
+  dps: 34117.17599
+  tps: 49284.40491
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StayofExecution-68996"
  value: {
-  dps: 30798.08048
-  tps: 45747.17079
+  dps: 30834.70877
+  tps: 45474.74463
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 30802.54563
-  tps: 45754.52605
+  dps: 30837.74047
+  tps: 45483.42958
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stormrider'sBattlegarb"
  value: {
-  dps: 28666.58386
-  tps: 40826.11415
+  dps: 28619.67113
+  tps: 40540.23459
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stormrider'sRegalia"
  value: {
-  dps: 22481.42223
-  tps: 31160.93872
+  dps: 22438.52966
+  tps: 31219.84449
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62465"
  value: {
-  dps: 30799.05742
-  tps: 45756.08125
+  dps: 30836.08139
+  tps: 45481.64772
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62470"
  value: {
-  dps: 30799.05742
-  tps: 45756.08125
+  dps: 30836.08139
+  tps: 45481.64772
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 30798.08048
-  tps: 45747.17079
+  dps: 30834.70877
+  tps: 45474.74463
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 30798.08048
-  tps: 45747.17079
+  dps: 30834.70877
+  tps: 45474.74463
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 30806.06826
-  tps: 45764.32765
+  dps: 30836.17036
+  tps: 45654.335
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 31696.0439
-  tps: 47049.05233
+  dps: 31592.66994
+  tps: 46816.32038
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-55819"
  value: {
-  dps: 30798.08048
-  tps: 45746.99598
+  dps: 30834.70877
+  tps: 45474.56981
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-56351"
  value: {
-  dps: 30799.0086
-  tps: 45747.59802
+  dps: 30835.63689
+  tps: 45475.17186
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 31076.18709
-  tps: 46217.89525
+  dps: 31116.73778
+  tps: 45934.15464
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 31166.73342
-  tps: 46371.15437
+  dps: 31207.60472
+  tps: 46086.44702
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheHungerer-68927"
  value: {
-  dps: 33049.21266
-  tps: 47848.39858
+  dps: 32974.13612
+  tps: 47886.82684
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheHungerer-69112"
  value: {
-  dps: 33250.18281
-  tps: 48249.43029
+  dps: 33301.60234
+  tps: 48261.41171
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 30799.93671
-  tps: 45748.22771
+  dps: 30860.34679
+  tps: 45518.07546
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 30800.93133
-  tps: 45748.89974
+  dps: 30830.26102
+  tps: 45577.95178
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 30798.08048
-  tps: 45747.17079
+  dps: 30834.70877
+  tps: 45474.74463
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 30798.08048
-  tps: 45747.17079
+  dps: 30834.70877
+  tps: 45474.74463
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-77190"
  value: {
-  dps: 33057.43344
-  tps: 47885.56655
+  dps: 32983.20597
+  tps: 47449.61705
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-78477"
  value: {
-  dps: 32989.64254
-  tps: 47554.0568
+  dps: 32985.81676
+  tps: 47370.00051
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-78486"
  value: {
-  dps: 33011.92138
-  tps: 47537.14894
+  dps: 32981.24046
+  tps: 47441.14174
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 32329.34691
-  tps: 48141.05221
+  dps: 32398.44499
+  tps: 48065.64558
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 32519.63874
-  tps: 48833.12213
+  dps: 32555.04011
+  tps: 48648.81692
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 31299.62488
-  tps: 47144.61116
+  dps: 31267.29093
+  tps: 46637.22394
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 30828.509
-  tps: 46072.34575
+  dps: 30874.51914
+  tps: 45773.55442
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnheededWarning-59520"
  value: {
-  dps: 32857.151
-  tps: 49118.4859
+  dps: 32883.16766
+  tps: 48993.36259
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 30831.53467
-  tps: 46116.77013
+  dps: 30870.09404
+  tps: 45759.99385
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 32841.45646
-  tps: 47899.2614
+  dps: 32824.15274
+  tps: 47865.08269
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 32841.45646
-  tps: 47899.2614
+  dps: 32824.15274
+  tps: 47865.08269
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 32841.45646
-  tps: 47899.2614
+  dps: 32824.15274
+  tps: 47865.08269
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 26750.79371
-  tps: 37918.7571
+  dps: 26890.62789
+  tps: 37798.85334
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 30799.9631
-  tps: 45756.2621
+  dps: 30838.11073
+  tps: 45487.44688
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 30799.93671
-  tps: 45748.11632
+  dps: 30837.83243
+  tps: 45482.02729
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 32055.47057
-  tps: 46142.97471
+  dps: 32116.75819
+  tps: 46630.58584
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VeilofLies-72900"
  value: {
-  dps: 30697.54913
-  tps: 45813.89772
+  dps: 30894.31818
+  tps: 45828.89254
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 31956.12164
-  tps: 47919.1244
+  dps: 32041.39296
+  tps: 47915.63257
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 32126.35572
-  tps: 48185.88544
+  dps: 32196.56543
+  tps: 47992.56655
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77207"
  value: {
-  dps: 33675.52538
-  tps: 51048.99034
+  dps: 33748.24137
+  tps: 51372.86153
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77979"
  value: {
-  dps: 33413.37073
-  tps: 50721.03429
+  dps: 33388.15868
+  tps: 50769.60263
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77999"
  value: {
-  dps: 33764.67236
-  tps: 50598.76119
+  dps: 33737.8177
+  tps: 50128.00562
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 30828.60413
-  tps: 46130.327
+  dps: 30870.09404
+  tps: 45759.99385
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 30828.60413
-  tps: 46130.327
+  dps: 30870.09404
+  tps: 45759.99385
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 32406.56636
-  tps: 47261.51724
+  dps: 32384.52544
+  tps: 47138.31628
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-70517"
  value: {
-  dps: 32662.58803
-  tps: 47535.73184
+  dps: 32627.97325
+  tps: 47712.9776
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 30831.53467
-  tps: 46116.77013
+  dps: 30870.09404
+  tps: 45759.99385
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-70518"
  value: {
-  dps: 30831.53467
-  tps: 46116.77013
+  dps: 30870.09404
+  tps: 45759.99385
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 31387.76787
-  tps: 46459.03615
+  dps: 31407.02429
+  tps: 46164.5384
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-70519"
  value: {
-  dps: 31459.73334
-  tps: 46551.57386
+  dps: 31478.33525
+  tps: 46255.0235
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 30818.61914
-  tps: 46029.48227
+  dps: 30856.56222
+  tps: 45667.60024
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 31408.31388
-  tps: 45466.13233
+  dps: 31325.21232
+  tps: 45211.67345
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 31258.19393
-  tps: 46870.72111
+  dps: 31294.70205
+  tps: 46475.00495
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 30817.6422
-  tps: 46020.57181
+  dps: 30855.1896
+  tps: 45660.69715
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 31257.76609
-  tps: 46768.90556
+  dps: 31299.74967
+  tps: 46394.44937
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 30817.6422
-  tps: 46020.57181
+  dps: 30855.1896
+  tps: 45660.69715
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 32431.21504
-  tps: 46605.2323
+  dps: 32488.96564
+  tps: 47265.41985
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-70577"
  value: {
-  dps: 32666.38772
-  tps: 48099.5278
+  dps: 32730.07374
+  tps: 48164.29402
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 30796.4902
-  tps: 46190.27423
+  dps: 30802.35635
+  tps: 45697.36937
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-70578"
  value: {
-  dps: 30832.57237
-  tps: 45702.20925
+  dps: 30881.38967
+  tps: 45350.63824
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 31440.45322
-  tps: 46404.75167
+  dps: 31487.08431
+  tps: 46480.05871
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-70579"
  value: {
-  dps: 31464.25227
-  tps: 46487.10409
+  dps: 31529.50337
+  tps: 46126.3434
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 30798.08048
-  tps: 45748.82609
+  dps: 30834.70877
+  tps: 45476.53134
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 30798.08048
-  tps: 45748.6081
+  dps: 30834.70877
+  tps: 45476.26325
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WillofUnbinding-77995"
  value: {
-  dps: 30798.08048
-  tps: 45749.06588
+  dps: 30834.70877
+  tps: 45476.82255
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 30798.08048
-  tps: 45747.00817
+  dps: 30826.32599
+  tps: 45562.9942
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 30799.0086
-  tps: 45747.59802
+  dps: 30838.35427
+  tps: 45476.86182
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 31081.36116
-  tps: 46226.65291
+  dps: 31121.93504
+  tps: 45942.86052
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 34379.18946
-  tps: 51294.69632
+  dps: 34474.40681
+  tps: 51254.83725
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 33977.54389
-  tps: 50897.84073
+  dps: 34076.85176
+  tps: 50681.55706
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 34828.22693
-  tps: 51745.78856
+  dps: 34952.71263
+  tps: 52081.55293
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 31293.80972
-  tps: 45693.56586
+  dps: 31263.48213
+  tps: 46043.94882
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 31293.80972
-  tps: 45693.56586
+  dps: 31263.48213
+  tps: 46043.94882
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 33339.35794
-  tps: 47877.17762
+  dps: 33366.86685
+  tps: 47999.6282
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 86244.47974
-  tps: 118604.72118
+  dps: 86229.45044
+  tps: 118271.53475
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20917.8581
-  tps: 37093.25414
+  dps: 20973.20724
+  tps: 37297.15905
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 24705.99381
-  tps: 34126.84391
+  dps: 24707.0993
+  tps: 33995.72405
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 58766.21917
-  tps: 82472.65277
+  dps: 58714.35106
+  tps: 82217.28
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 12898.72404
-  tps: 23114.53205
+  dps: 12865.36827
+  tps: 23035.61931
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 13220.31331
-  tps: 22607.01267
+  dps: 13225.96312
+  tps: 22706.37043
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 39349.74257
-  tps: 50457.03006
+  dps: 39318.31973
+  tps: 51204.4882
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39183.279
-  tps: 51359.80542
+  dps: 39085.45231
+  tps: 51443.47078
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 50550.68619
-  tps: 43680.00268
+  dps: 50516.21059
+  tps: 43943.57556
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 25034.54189
-  tps: 32798.7067
+  dps: 25090.65739
+  tps: 33303.51314
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25381.39749
-  tps: 35852.61827
+  dps: 25297.65577
+  tps: 36071.80127
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 28288.41246
-  tps: 26683.22966
+  dps: 28233.01234
+  tps: 26760.23231
  }
 }
 dps_results: {
@@ -2204,85 +2204,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 85832.90463
-  tps: 118295.91295
+  dps: 85967.42798
+  tps: 118349.84907
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20763.50263
-  tps: 36029.13655
+  dps: 20766.07723
+  tps: 36000.90948
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 24456.49131
-  tps: 32595.16944
+  dps: 24524.35176
+  tps: 32547.8982
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 58429.56579
-  tps: 82546.05294
+  dps: 58456.6906
+  tps: 81884.00566
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 12804.64238
-  tps: 23016.12218
+  dps: 12810.67533
+  tps: 23005.05877
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 13233.74008
-  tps: 23412.41398
+  dps: 13213.72333
+  tps: 23274.03432
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38570.09933
-  tps: 49702.33544
+  dps: 38625.99711
+  tps: 50278.2846
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38182.55538
-  tps: 49688.73532
+  dps: 38172.89375
+  tps: 49455.68531
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 48663.29532
-  tps: 42299.34633
+  dps: 48650.95704
+  tps: 42382.00099
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24499.88882
-  tps: 32142.52111
+  dps: 24532.26953
+  tps: 32020.32134
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24620.34367
-  tps: 32599.72889
+  dps: 24680.6252
+  tps: 32556.59621
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27099.85884
-  tps: 24648.373
+  dps: 27093.48532
+  tps: 24706.70297
  }
 }
 dps_results: {
@@ -2330,85 +2330,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 78179.73814
-  tps: 108207.51888
+  dps: 78251.34734
+  tps: 108408.63704
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 17988.74724
-  tps: 30933.37004
+  dps: 18001.46184
+  tps: 31011.05838
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 21362.3352
-  tps: 27068.65921
+  dps: 21383.40409
+  tps: 27093.10343
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 52439.13601
-  tps: 74967.11319
+  dps: 52475.89999
+  tps: 75102.91079
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 10986.24864
-  tps: 19583.94461
+  dps: 11038.2453
+  tps: 19700.40857
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 11366.03158
-  tps: 18576.65563
+  dps: 11369.52015
+  tps: 18565.21784
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 33445.64816
-  tps: 47462.20264
+  dps: 33426.83741
+  tps: 46817.24503
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 33147.00555
-  tps: 47753.21114
+  dps: 33172.0329
+  tps: 48205.05369
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 41329.22848
-  tps: 42021.07717
+  dps: 41357.49006
+  tps: 41929.35355
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 20870.8513
-  tps: 30309.82443
+  dps: 20914.27707
+  tps: 30711.0709
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 21154.12053
-  tps: 32025.20379
+  dps: 21154.68466
+  tps: 31873.49781
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 22955.01994
-  tps: 25228.45058
+  dps: 22972.25377
+  tps: 25221.30858
  }
 }
 dps_results: {
@@ -2456,85 +2456,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 78027.57269
-  tps: 110472.49481
+  dps: 78022.04107
+  tps: 110410.45197
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 17825.42585
-  tps: 30011.75032
+  dps: 17880.2219
+  tps: 30231.67503
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 21046.97201
-  tps: 26240.32354
+  dps: 21130.12504
+  tps: 26448.3554
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 52089.09609
-  tps: 73672.6854
+  dps: 52166.4392
+  tps: 73750.47811
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 10900.47304
-  tps: 19224.87538
+  dps: 10913.6248
+  tps: 19227.20377
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 11231.5587
-  tps: 18699.0658
+  dps: 11267.92074
+  tps: 18701.15693
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 32713.80875
-  tps: 46211.18794
+  dps: 32770.03242
+  tps: 46972.62798
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 32124.00853
-  tps: 44966.67392
+  dps: 32194.73585
+  tps: 45296.32738
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 40711.73561
-  tps: 40663.8705
+  dps: 40815.67099
+  tps: 41133.08591
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 20332.92123
-  tps: 28689.67066
+  dps: 20358.00581
+  tps: 28837.42792
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20451.11755
-  tps: 29804.99845
+  dps: 20563.05814
+  tps: 30341.23784
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 22250.90299
-  tps: 24752.90466
+  dps: 22271.61635
+  tps: 24903.60554
  }
 }
 dps_results: {
@@ -2582,85 +2582,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 85920.58787
-  tps: 118263.87277
+  dps: 85930.70689
+  tps: 118283.54271
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20915.12583
-  tps: 36960.17818
+  dps: 20879.42481
+  tps: 36824.73936
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 24485.96833
-  tps: 34449.83282
+  dps: 24511.1196
+  tps: 34741.70326
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 58844.47907
-  tps: 84144.24266
+  dps: 58917.40986
+  tps: 84544.54766
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 12911.06719
-  tps: 23703.10126
+  dps: 12935.44987
+  tps: 23880.65471
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 13038.27986
-  tps: 23244.08443
+  dps: 13052.84442
+  tps: 23268.1739
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 39290.01238
-  tps: 51153.06962
+  dps: 39481.3653
+  tps: 52314.38305
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39113.19483
-  tps: 52321.23593
+  dps: 39175.18661
+  tps: 52245.38863
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 49545.48656
-  tps: 44296.58917
+  dps: 49680.333
+  tps: 44544.57168
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24935.85889
-  tps: 33255.87671
+  dps: 24976.5365
+  tps: 33382.07842
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25272.05547
-  tps: 35320.92378
+  dps: 25372.23273
+  tps: 35282.74271
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27832.94424
-  tps: 27400.21423
+  dps: 27846.34598
+  tps: 27522.05444
  }
 }
 dps_results: {
@@ -2708,85 +2708,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 85167.28642
-  tps: 119142.41641
+  dps: 85484.77591
+  tps: 119884.22842
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20737.18468
-  tps: 35895.77004
+  dps: 20815.48141
+  tps: 36032.75207
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 24126.59728
-  tps: 32002.68611
+  dps: 24137.66298
+  tps: 32057.31373
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 58726.9726
-  tps: 84693.54076
+  dps: 58771.95406
+  tps: 84524.97264
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 12913.86034
-  tps: 23229.07008
+  dps: 12865.20232
+  tps: 23049.41224
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 13059.89065
-  tps: 23567.15688
+  dps: 13061.60631
+  tps: 23211.79672
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38508.56466
-  tps: 50401.13765
+  dps: 38560.93978
+  tps: 50634.28729
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38124.54779
-  tps: 49670.37259
+  dps: 38168.61759
+  tps: 49996.27068
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 48136.60586
-  tps: 42417.08309
+  dps: 48138.84938
+  tps: 42554.68903
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24325.93367
-  tps: 32613.86327
+  dps: 24277.94367
+  tps: 32504.95572
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24518.70559
-  tps: 33864.28669
+  dps: 24540.50028
+  tps: 34002.39905
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 26720.10041
-  tps: 25382.86646
+  dps: 26696.82698
+  tps: 25386.88424
  }
 }
 dps_results: {
@@ -2834,85 +2834,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 77922.85952
-  tps: 109101.0638
+  dps: 78052.1809
+  tps: 109511.48129
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 17968.06989
-  tps: 31488.56223
+  dps: 17962.61779
+  tps: 31491.01989
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 20849.58013
-  tps: 27407.96077
+  dps: 20873.98316
+  tps: 27436.53246
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 52977.81618
-  tps: 76952.65243
+  dps: 52982.3873
+  tps: 76826.8522
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 10962.52835
-  tps: 19898.5417
+  dps: 10948.38988
+  tps: 20018.35799
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 11126.44231
-  tps: 19140.31027
+  dps: 11164.20146
+  tps: 19159.50472
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 33366.94238
-  tps: 46784.59409
+  dps: 33423.37137
+  tps: 46944.80192
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 32980.68483
-  tps: 47408.6878
+  dps: 32952.52049
+  tps: 47431.18348
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 40987.7975
-  tps: 42273.20622
+  dps: 40987.28801
+  tps: 42443.00713
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 20850.94288
-  tps: 29974.26562
+  dps: 20773.64943
+  tps: 30125.25919
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 21062.13507
-  tps: 31752.33723
+  dps: 20995.90159
+  tps: 32037.65766
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 22656.06419
-  tps: 26348.9387
+  dps: 22651.37779
+  tps: 26349.54927
  }
 }
 dps_results: {
@@ -2960,85 +2960,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 77271.17453
-  tps: 107567.604
+  dps: 77364.2496
+  tps: 108293.30524
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 17819.75319
-  tps: 30764.13224
+  dps: 17786.7546
+  tps: 30684.99002
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 20748.37344
-  tps: 26353.85826
+  dps: 20785.72101
+  tps: 26325.2336
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 52695.87997
-  tps: 76291.84439
+  dps: 52740.64878
+  tps: 76621.29895
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 10941.77816
-  tps: 19805.27401
+  dps: 10977.43448
+  tps: 19939.56803
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 11068.74828
-  tps: 20518.77428
+  dps: 11067.14016
+  tps: 20351.84002
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 32677.80144
-  tps: 44951.61029
+  dps: 32575.24608
+  tps: 45224.61077
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 31975.05985
-  tps: 44612.06318
+  dps: 32013.61165
+  tps: 45226.07168
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 39888.81769
-  tps: 41039.48139
+  dps: 39757.57722
+  tps: 40401.21536
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 20284.2567
-  tps: 28950.38765
+  dps: 20249.51238
+  tps: 28861.58376
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20432.8728
-  tps: 29613.7181
+  dps: 20479.59879
+  tps: 29932.17765
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 21965.48026
-  tps: 24865.25858
+  dps: 22049.23212
+  tps: 25258.82049
  }
 }
 dps_results: {
@@ -3086,7 +3086,7 @@ dps_results: {
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 28799.72711
-  tps: 42867.97986
+  dps: 28919.75848
+  tps: 43066.15051
  }
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -38,2125 +38,2125 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 32962.6725
-  tps: 47037.70092
+  dps: 32980.68483
+  tps: 47408.6878
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 30818.54942
-  tps: 45814.47709
+  dps: 30798.08048
+  tps: 45747.03094
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 33111.29338
-  tps: 47781.78801
+  dps: 33106.00557
+  tps: 47967.07104
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 30819.52636
-  tps: 45823.53376
+  dps: 30799.05742
+  tps: 45756.08125
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 30819.52636
-  tps: 45823.53376
+  dps: 30799.05742
+  tps: 45756.08125
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 32001.66252
-  tps: 47472.7821
+  dps: 31978.99062
+  tps: 47424.42135
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 32129.34095
-  tps: 47726.4021
+  dps: 32134.71899
+  tps: 47728.7217
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ArrowofTime-72897"
  value: {
-  dps: 32888.62758
-  tps: 46977.07021
+  dps: 32926.66848
+  tps: 47169.87315
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 32159.33701
-  tps: 46264.32442
+  dps: 32173.07722
+  tps: 46522.34733
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 30818.54942
-  tps: 45814.6233
+  dps: 30798.08048
+  tps: 45747.17079
   hps: 96.77966
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 30818.54942
-  tps: 45814.6233
+  dps: 30798.08048
+  tps: 45747.17079
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 31231.01939
-  tps: 46326.72178
+  dps: 31250.21655
+  tps: 47016.07489
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 31314.14669
-  tps: 46618.59367
+  dps: 31341.94468
+  tps: 46981.24857
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BindingPromise-67037"
  value: {
-  dps: 30836.11415
-  tps: 46023.54832
+  dps: 30828.60413
+  tps: 46130.327
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 32456.4423
-  tps: 47869.75216
+  dps: 32425.33288
+  tps: 47327.32685
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 31144.15185
-  tps: 46367.66189
+  dps: 31124.04729
+  tps: 46298.90364
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 31186.79026
-  tps: 46440.08361
+  dps: 31166.73342
+  tps: 46371.15437
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 32945.9576
-  tps: 46928.1624
+  dps: 32936.26434
+  tps: 47079.8624
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 30832.65262
-  tps: 45979.60274
+  dps: 30831.53467
+  tps: 46116.77013
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 31360.53431
-  tps: 46164.52505
+  dps: 31355.40245
+  tps: 46417.41866
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 31185.94354
-  tps: 46413.12995
+  dps: 31203.8732
+  tps: 46826.29629
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 30818.29312
-  tps: 45997.47364
+  dps: 30817.6422
+  tps: 46020.57181
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 30818.29312
-  tps: 45997.47364
+  dps: 30817.6422
+  tps: 46020.57181
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 32159.21601
-  tps: 46290.43404
+  dps: 32217.20342
+  tps: 46304.75726
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 30818.54942
-  tps: 45814.6233
+  dps: 30798.08048
+  tps: 45747.17079
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 31365.30063
-  tps: 46945.67394
+  dps: 31295.60514
+  tps: 46603.78035
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 32903.79114
-  tps: 49492.00383
+  dps: 32948.17384
+  tps: 48692.69327
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 32605.73804
-  tps: 48471.6952
+  dps: 32642.39408
+  tps: 48194.53248
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 33100.84171
-  tps: 48834.65775
+  dps: 33229.06014
+  tps: 48910.713
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledLightning-66879"
  value: {
-  dps: 30962.42208
-  tps: 46192.04092
+  dps: 30978.08761
+  tps: 46382.42348
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledWishes-77114"
  value: {
-  dps: 31407.35743
-  tps: 46528.07688
+  dps: 31454.58805
+  tps: 46254.18631
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 32159.33701
-  tps: 45339.29491
+  dps: 32173.07722
+  tps: 45592.14363
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 30836.11415
-  tps: 46023.54832
+  dps: 30828.60413
+  tps: 46130.327
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 32764.72345
-  tps: 47107.66663
+  dps: 32778.52771
+  tps: 47365.62043
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sBadgeofConquest-73648"
  value: {
-  dps: 33392.84873
-  tps: 48021.95466
+  dps: 33328.80063
+  tps: 48038.86845
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sBadgeofDominance-73498"
  value: {
-  dps: 30832.65262
-  tps: 45979.60274
+  dps: 30831.53467
+  tps: 46116.77013
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sBadgeofVictory-73496"
  value: {
-  dps: 31725.82555
-  tps: 46754.74833
+  dps: 31707.61818
+  tps: 47078.27916
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sInsigniaofConquest-73643"
  value: {
-  dps: 33151.69229
-  tps: 47724.67129
+  dps: 33096.86739
+  tps: 47287.67693
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sInsigniaofDominance-73497"
  value: {
-  dps: 30833.68589
-  tps: 46227.79244
+  dps: 30851.866
+  tps: 46298.50962
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sInsigniaofVictory-73491"
  value: {
-  dps: 31766.5056
-  tps: 46771.39888
+  dps: 31742.96987
+  tps: 46567.73246
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 32810.19613
-  tps: 46811.7225
+  dps: 32821.77239
+  tps: 47224.96943
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 32143.09976
-  tps: 46874.87606
+  dps: 32243.79058
+  tps: 47789.11277
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 30834.50885
-  tps: 45984.64327
+  dps: 30833.39089
+  tps: 46117.82705
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 30818.54942
-  tps: 45814.6233
+  dps: 30798.08048
+  tps: 45747.17079
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 32445.45257
-  tps: 48195.35687
+  dps: 32417.56854
+  tps: 48396.17444
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 32334.65364
-  tps: 47487.26121
+  dps: 32349.46944
+  tps: 47245.38627
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 32667.59144
-  tps: 47502.22805
+  dps: 32696.11821
+  tps: 47703.76451
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-59506"
  value: {
-  dps: 31704.71626
-  tps: 45798.18933
+  dps: 31660.25392
+  tps: 45548.74831
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-65118"
  value: {
-  dps: 32125.97471
-  tps: 46397.72781
+  dps: 32073.40528
+  tps: 46417.93437
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 31212.37781
-  tps: 46719.09186
+  dps: 31206.03146
+  tps: 46540.98735
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 31134.34997
-  tps: 46577.86739
+  dps: 31127.37892
+  tps: 46387.30705
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-78000"
  value: {
-  dps: 31276.27256
-  tps: 46830.4796
+  dps: 31267.71767
+  tps: 46604.24633
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 30818.29312
-  tps: 45997.47364
+  dps: 30817.6422
+  tps: 46020.57181
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 31645.65487
-  tps: 47258.56282
+  dps: 31654.61862
+  tps: 47472.8582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 32417.59281
-  tps: 48060.60059
+  dps: 32473.8399
+  tps: 48628.02019
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 30820.40565
-  tps: 45819.65412
+  dps: 30799.93671
+  tps: 45748.22771
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 31249.55661
-  tps: 46485.62031
+  dps: 31213.36384
+  tps: 46456.6332
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 31800.57958
-  tps: 46780.86137
+  dps: 31757.1958
+  tps: 45788.0822
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeepEarthRegalia"
  value: {
-  dps: 22121.6559
-  tps: 30636.27681
+  dps: 22165.38127
+  tps: 30643.63553
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 32200.51028
-  tps: 45970.48761
+  dps: 32212.4571
+  tps: 46374.88104
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 31056.62115
-  tps: 47175.99268
+  dps: 31066.4218
+  tps: 46807.18281
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dragonwrath,Tarecgosa'sRest-71086"
  value: {
-  dps: 33311.86251
-  tps: 48209.62755
+  dps: 33279.83072
+  tps: 47244.19885
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 31918.47245
-  tps: 47176.30232
+  dps: 31860.33519
+  tps: 46922.45275
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 32159.33701
-  tps: 46264.32442
+  dps: 32173.07722
+  tps: 46522.34733
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 30833.58073
-  tps: 46017.40136
+  dps: 30833.39089
+  tps: 46155.22492
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 32159.33701
-  tps: 46264.26279
+  dps: 32173.07722
+  tps: 46522.28212
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 32200.51028
-  tps: 45970.48761
+  dps: 32212.4571
+  tps: 46374.88104
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 32603.30392
-  tps: 47249.99649
+  dps: 32592.10516
+  tps: 47158.62892
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 32051.76152
-  tps: 47270.21921
+  dps: 32013.36733
+  tps: 47146.37831
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 32159.33701
-  tps: 46264.32442
+  dps: 32173.07722
+  tps: 46522.34733
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 32184.74951
-  tps: 47840.93758
+  dps: 32162.72991
+  tps: 47771.21407
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 32029.4995
-  tps: 47610.67459
+  dps: 32007.65611
+  tps: 47541.20915
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 32355.52452
-  tps: 48094.22686
+  dps: 32333.31109
+  tps: 48024.21948
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-59500"
  value: {
-  dps: 30820.40565
-  tps: 45819.65412
+  dps: 30799.93671
+  tps: 45748.22771
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-65124"
  value: {
-  dps: 30820.40565
-  tps: 45819.61842
+  dps: 30799.93671
+  tps: 45748.19356
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 30829.64021
-  tps: 45909.55769
+  dps: 30798.11602
+  tps: 45797.37788
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 32272.31249
-  tps: 47262.92597
+  dps: 32269.82723
+  tps: 47570.74922
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 30833.58073
-  tps: 45980.02805
+  dps: 30832.46278
+  tps: 46117.19736
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 30836.11415
-  tps: 46023.54832
+  dps: 30828.60413
+  tps: 46130.327
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 30833.58073
-  tps: 45980.02805
+  dps: 30832.46278
+  tps: 46117.19736
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 31699.99636
-  tps: 46750.76713
+  dps: 31695.89113
+  tps: 47004.33586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 31417.07654
-  tps: 46897.39565
+  dps: 31374.58801
+  tps: 46819.113
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 32231.19887
-  tps: 46382.74164
+  dps: 32244.84543
+  tps: 46641.44374
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FluidDeath-58181"
  value: {
-  dps: 32370.33371
-  tps: 48013.19251
+  dps: 32329.99661
+  tps: 48184.2389
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 32159.33701
-  tps: 46264.28378
+  dps: 32173.07722
+  tps: 46522.30433
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 31327.82041
-  tps: 45360.85844
+  dps: 31280.38874
+  tps: 44933.43914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 31948.27077
-  tps: 47969.49162
+  dps: 31983.98504
+  tps: 48082.86305
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56138"
  value: {
-  dps: 31270.91475
-  tps: 45715.55016
+  dps: 31221.16654
+  tps: 46208.60244
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56462"
  value: {
-  dps: 31286.0787
-  tps: 44469.53327
+  dps: 31337.10633
+  tps: 45130.79245
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GearDetector-61462"
  value: {
-  dps: 31786.71015
-  tps: 46335.41998
+  dps: 31906.06062
+  tps: 46811.94819
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 26461.56843
-  tps: 38138.01178
+  dps: 26607.0118
+  tps: 37704.48832
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 30818.54942
-  tps: 45814.46689
+  dps: 30798.08048
+  tps: 45747.02118
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 31911.59554
-  tps: 47813.15212
+  dps: 31736.23786
+  tps: 47474.55024
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 32353.21248
-  tps: 47359.85819
+  dps: 32241.75284
+  tps: 46291.29485
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HarmlightToken-63839"
  value: {
-  dps: 30827.34354
-  tps: 45809.74653
+  dps: 30796.02594
+  tps: 45711.30913
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 31414.85873
-  tps: 45980.03503
+  dps: 31518.5119
+  tps: 46008.17949
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 30818.54942
-  tps: 45814.6233
+  dps: 30798.08048
+  tps: 45747.17079
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 30818.54942
-  tps: 45814.6233
+  dps: 30798.08048
+  tps: 45747.17079
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-59224"
  value: {
-  dps: 31550.28859
-  tps: 46546.31409
+  dps: 31478.7544
+  tps: 46433.60571
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-65072"
  value: {
-  dps: 31644.46663
-  tps: 46495.5707
+  dps: 31586.78767
+  tps: 46150.27709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-55868"
  value: {
-  dps: 31711.95092
-  tps: 46153.13271
+  dps: 31694.20929
+  tps: 46338.00278
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-56393"
  value: {
-  dps: 31913.78416
-  tps: 45313.05873
+  dps: 31938.83265
+  tps: 45907.58993
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-55845"
  value: {
-  dps: 30818.54942
-  tps: 45814.6233
+  dps: 30798.08048
+  tps: 45747.17079
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-56370"
  value: {
-  dps: 30818.54942
-  tps: 45814.6233
+  dps: 30798.08048
+  tps: 45747.17079
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 31888.99428
-  tps: 46948.34244
+  dps: 31728.75046
+  tps: 46878.97493
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-50641"
  value: {
-  dps: 33762.62156
-  tps: 47561.02322
+  dps: 33788.79057
+  tps: 47588.0529
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 32200.51028
-  tps: 45970.48761
+  dps: 32212.4571
+  tps: 46374.88104
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 31817.00237
-  tps: 46919.11386
+  dps: 31813.018
+  tps: 47174.06747
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 31817.00237
-  tps: 46919.11386
+  dps: 31813.018
+  tps: 47174.06747
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 31106.38942
-  tps: 46076.57555
+  dps: 31086.73416
+  tps: 46052.86663
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 31148.95342
-  tps: 46148.4091
+  dps: 31129.36267
+  tps: 46124.81956
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndomitablePride-77211"
  value: {
-  dps: 30818.54942
-  tps: 45814.6233
+  dps: 30798.08048
+  tps: 45747.17079
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndomitablePride-77983"
  value: {
-  dps: 30818.54942
-  tps: 45814.6233
+  dps: 30798.08048
+  tps: 45747.17079
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndomitablePride-78003"
  value: {
-  dps: 30818.54942
-  tps: 45814.6233
+  dps: 30798.08048
+  tps: 45747.17079
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 30818.54942
-  tps: 45814.6233
+  dps: 30798.08048
+  tps: 45747.17079
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 31607.00884
-  tps: 46116.66374
+  dps: 31568.73072
+  tps: 46015.24362
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 31545.34788
-  tps: 44601.01081
+  dps: 31479.71222
+  tps: 44915.63219
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 31765.15801
-  tps: 46494.70348
+  dps: 31840.43486
+  tps: 45925.82512
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 31105.47022
-  tps: 46011.96203
+  dps: 31042.92529
+  tps: 45897.07778
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 30818.54942
-  tps: 45814.9803
+  dps: 30798.08048
+  tps: 45747.55865
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 30818.54942
-  tps: 45814.9803
+  dps: 30798.08048
+  tps: 45747.55865
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 30820.40565
-  tps: 45819.60142
+  dps: 30799.93671
+  tps: 45748.1773
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 30820.40565
-  tps: 45819.55892
+  dps: 30799.93671
+  tps: 45748.13664
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 32456.4423
-  tps: 47869.75216
+  dps: 32425.33288
+  tps: 47327.32685
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 32104.85489
-  tps: 47242.05218
+  dps: 32087.95169
+  tps: 47047.98396
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 32434.4554
-  tps: 46846.8732
+  dps: 32484.19233
+  tps: 47441.6142
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-77194"
  value: {
-  dps: 36591.05312
-  tps: 52018.07043
+  dps: 36547.60616
+  tps: 52174.55162
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-78473"
  value: {
-  dps: 36960.00904
-  tps: 52305.98259
+  dps: 36986.06045
+  tps: 53057.33948
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-78482"
  value: {
-  dps: 36212.78769
-  tps: 52258.2258
+  dps: 36109.38524
+  tps: 52385.43028
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 34300.43516
-  tps: 49086.08909
+  dps: 34159.17657
+  tps: 48721.37552
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 31379.99721
-  tps: 46418.21006
+  dps: 31404.85801
+  tps: 47282.25771
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 31379.99721
-  tps: 46418.21006
+  dps: 31404.85801
+  tps: 47282.25771
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 31220.72981
-  tps: 45892.08706
+  dps: 31090.30048
+  tps: 45801.29691
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50708"
  value: {
-  dps: 33147.35439
-  tps: 47299.96373
+  dps: 33165.35894
+  tps: 47673.02901
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-55816"
  value: {
-  dps: 30818.54942
-  tps: 45814.6233
+  dps: 30798.08048
+  tps: 45747.17079
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-56347"
  value: {
-  dps: 30818.54942
-  tps: 45814.6233
+  dps: 30798.08048
+  tps: 45747.17079
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 32050.73873
-  tps: 46833.95035
+  dps: 32155.27297
+  tps: 46910.78758
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 32395.15486
-  tps: 48172.00099
+  dps: 32326.07148
+  tps: 47288.13943
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 31409.48838
-  tps: 46698.59302
+  dps: 31388.34984
+  tps: 46630.15986
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 31356.98321
-  tps: 46455.6098
+  dps: 31298.84651
+  tps: 46118.27719
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 31472.16898
-  tps: 46323.65365
+  dps: 31460.16518
+  tps: 46159.55152
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 30818.54942
-  tps: 45814.6233
+  dps: 30798.08048
+  tps: 45747.17079
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 30818.54942
-  tps: 45814.6233
+  dps: 30798.08048
+  tps: 45747.17079
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 31773.92231
-  tps: 46909.89852
+  dps: 31780.73767
+  tps: 46329.37575
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 31888.75375
-  tps: 47071.571
+  dps: 31934.23285
+  tps: 46679.90816
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 33219.37278
-  tps: 48096.50885
+  dps: 33218.52222
+  tps: 47574.15329
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 33564.36574
-  tps: 48123.15162
+  dps: 33541.82523
+  tps: 48669.27472
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 31226.73022
-  tps: 46302.94979
+  dps: 31169.11134
+  tps: 45971.53544
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 31473.5416
-  tps: 46326.57098
+  dps: 31461.5378
+  tps: 46162.46885
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 31195.38687
-  tps: 46226.77298
+  dps: 31175.86651
+  tps: 46203.31366
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 31195.38687
-  tps: 46226.77298
+  dps: 31175.86651
+  tps: 46203.31366
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 31156.15178
-  tps: 46109.17821
+  dps: 31184.07961
+  tps: 46565.18687
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 31371.24785
-  tps: 46527.76425
+  dps: 31330.79412
+  tps: 46840.64008
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 30836.11415
-  tps: 46023.54832
+  dps: 30828.60413
+  tps: 46130.327
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 30820.40565
-  tps: 45819.60142
+  dps: 30799.93671
+  tps: 45748.1773
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 30820.40565
-  tps: 45819.55892
+  dps: 30799.93671
+  tps: 45748.13664
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ObsidianArborweaveBattlegarb"
  value: {
-  dps: 31216.37673
-  tps: 41209.63111
+  dps: 31194.64136
+  tps: 41513.25982
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ObsidianArborweaveRegalia"
  value: {
-  dps: 22558.85742
-  tps: 31405.20949
+  dps: 22560.58476
+  tps: 31142.76903
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 31396.69227
-  tps: 45840.13396
+  dps: 31339.21419
+  tps: 45741.51
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 30819.47754
-  tps: 45815.02384
+  dps: 30799.0086
+  tps: 45747.58257
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 30818.54942
-  tps: 45814.6233
+  dps: 30798.08048
+  tps: 45747.17079
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 31059.80136
-  tps: 46152.52768
+  dps: 30997.33412
+  tps: 46117.2005
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 31075.80514
-  tps: 45469.41204
+  dps: 31051.47549
+  tps: 45359.344
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 31225.47893
-  tps: 45826.20725
+  dps: 31135.46927
+  tps: 45674.59112
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 32159.33701
-  tps: 46264.32442
+  dps: 32173.07722
+  tps: 46522.34733
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 32729.6792
-  tps: 46835.28563
+  dps: 32703.78563
+  tps: 46500.56319
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-55854"
  value: {
-  dps: 30818.54942
-  tps: 45814.6233
+  dps: 30798.08048
+  tps: 45747.17079
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-56377"
  value: {
-  dps: 30818.54942
-  tps: 45814.6233
+  dps: 30798.08048
+  tps: 45747.17079
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rathrak,thePoisonousMind-77195"
  value: {
-  dps: 29804.71863
-  tps: 43753.7781
+  dps: 29836.7928
+  tps: 43536.99109
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rathrak,thePoisonousMind-78475"
  value: {
-  dps: 30379.50316
-  tps: 44484.4953
+  dps: 30413.35899
+  tps: 44257.45438
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rathrak,thePoisonousMind-78484"
  value: {
-  dps: 29266.48247
-  tps: 43015.60282
+  dps: 29342.06182
+  tps: 42770.64552
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 30854.77651
-  tps: 45588.83194
+  dps: 30792.07755
+  tps: 45475.05873
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 30818.54942
-  tps: 45814.6233
+  dps: 30798.08048
+  tps: 45747.17079
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 30818.54942
-  tps: 45814.6233
+  dps: 30798.08048
+  tps: 45747.17079
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 30818.54942
-  tps: 45814.6233
+  dps: 30798.08048
+  tps: 45747.17079
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 32852.00454
-  tps: 47232.10585
+  dps: 32865.80599
+  tps: 47490.74435
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 32764.72345
-  tps: 47107.70728
+  dps: 32778.52771
+  tps: 47365.66343
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 32854.98026
-  tps: 48160.24645
+  dps: 32838.591
+  tps: 48364.90095
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 31309.60304
-  tps: 46410.64775
+  dps: 31204.46193
+  tps: 46223.90156
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 31357.14324
-  tps: 45393.86971
+  dps: 31333.44932
+  tps: 45719.50784
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RosaryofLight-72901"
  value: {
-  dps: 32137.47743
-  tps: 46994.02839
+  dps: 32082.29615
+  tps: 46806.87302
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RottingSkull-77116"
  value: {
-  dps: 32387.48438
-  tps: 48249.78669
+  dps: 32441.22454
+  tps: 47947.54546
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuneofZeth-68998"
  value: {
-  dps: 31337.99711
-  tps: 46646.78832
+  dps: 31337.83145
+  tps: 46946.76089
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofConquest-70399"
  value: {
-  dps: 32936.57565
-  tps: 47455.44926
+  dps: 32903.18233
+  tps: 47484.79286
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofConquest-72304"
  value: {
-  dps: 33047.08164
-  tps: 47593.39428
+  dps: 33013.96014
+  tps: 47628.21556
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofDominance-70401"
  value: {
-  dps: 30832.65262
-  tps: 45979.60274
+  dps: 30831.53467
+  tps: 46116.77013
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofDominance-72448"
  value: {
-  dps: 30832.65262
-  tps: 45979.60274
+  dps: 30831.53467
+  tps: 46116.77013
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofVictory-70400"
  value: {
-  dps: 31576.90237
-  tps: 46564.34262
+  dps: 31558.53051
+  tps: 46886.08353
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofVictory-72450"
  value: {
-  dps: 31620.81561
-  tps: 46620.48789
+  dps: 31602.49226
+  tps: 46942.7566
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofConquest-70404"
  value: {
-  dps: 32628.3147
-  tps: 47078.60578
+  dps: 32632.25269
+  tps: 47318.27096
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofConquest-72309"
  value: {
-  dps: 32966.58671
-  tps: 47553.54189
+  dps: 32891.92791
+  tps: 47493.68209
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofDominance-70402"
  value: {
-  dps: 30761.34093
-  tps: 45621.48566
+  dps: 30779.99069
+  tps: 45957.76752
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofDominance-72449"
  value: {
-  dps: 30772.63183
-  tps: 45818.4598
+  dps: 30785.64045
+  tps: 45778.71526
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofVictory-70403"
  value: {
-  dps: 31565.408
-  tps: 46672.0733
+  dps: 31505.65984
+  tps: 46168.23822
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofVictory-72455"
  value: {
-  dps: 31540.1685
-  tps: 46062.92169
+  dps: 31542.77432
+  tps: 46247.93909
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ScalesofLife-68915"
  value: {
-  dps: 30818.54942
-  tps: 45814.6233
+  dps: 30798.08048
+  tps: 45747.17079
   hps: 315.97258
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ScalesofLife-69109"
  value: {
-  dps: 30818.54942
-  tps: 45814.6233
+  dps: 30798.08048
+  tps: 45747.17079
   hps: 356.41412
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 32016.32977
-  tps: 46792.12051
+  dps: 32059.09063
+  tps: 46739.52781
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-55256"
  value: {
-  dps: 30832.65262
-  tps: 45979.60274
+  dps: 30831.53467
+  tps: 46116.77013
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-56290"
  value: {
-  dps: 30832.65262
-  tps: 45979.60274
+  dps: 30831.53467
+  tps: 46116.77013
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShardofWoe-60233"
  value: {
-  dps: 31342.56685
-  tps: 45633.45338
+  dps: 31393.16434
+  tps: 45543.34296
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 31565.44736
-  tps: 45897.41333
+  dps: 31628.42617
+  tps: 45964.62003
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 30781.35527
-  tps: 45528.02838
+  dps: 30761.20732
+  tps: 45503.4079
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 32252.44333
-  tps: 47183.31203
+  dps: 32241.47797
+  tps: 47752.91295
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 32473.05247
-  tps: 47666.48116
+  dps: 32460.11061
+  tps: 48222.46385
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-55879"
  value: {
-  dps: 31144.15185
-  tps: 46367.66189
+  dps: 31124.04729
+  tps: 46298.90364
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-56400"
  value: {
-  dps: 31186.79026
-  tps: 46440.08361
+  dps: 31166.73342
+  tps: 46371.15437
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 31226.73022
-  tps: 46302.94979
+  dps: 31169.11134
+  tps: 45971.53544
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulCasket-58183"
  value: {
-  dps: 31247.24736
-  tps: 46684.81942
+  dps: 31246.89936
+  tps: 46823.9345
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 31612.58178
-  tps: 46090.46203
+  dps: 31602.90351
+  tps: 46177.68836
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 31611.10878
-  tps: 46576.6644
+  dps: 31573.91297
+  tps: 47110.61096
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 31878.12732
-  tps: 46475.38567
+  dps: 31744.53723
+  tps: 46657.38891
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 31313.41343
-  tps: 46655.15417
+  dps: 31311.44032
+  tps: 46636.56836
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 31348.94986
-  tps: 46864.49901
+  dps: 31350.74864
+  tps: 46917.50558
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 33564.71869
-  tps: 48416.71505
+  dps: 33561.66027
+  tps: 48666.1103
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 32980.93717
-  tps: 47109.5186
+  dps: 33129.61502
+  tps: 47126.28154
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 33908.22452
-  tps: 49196.20665
+  dps: 33916.70016
+  tps: 48759.88599
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StayofExecution-68996"
  value: {
-  dps: 30818.54942
-  tps: 45814.6233
+  dps: 30798.08048
+  tps: 45747.17079
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 30863.46487
-  tps: 45855.7368
+  dps: 30802.54563
+  tps: 45754.52605
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stormrider'sBattlegarb"
  value: {
-  dps: 28560.76069
-  tps: 40477.97777
+  dps: 28666.58386
+  tps: 40826.11415
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stormrider'sRegalia"
  value: {
-  dps: 22412.18364
-  tps: 31285.2602
+  dps: 22481.42223
+  tps: 31160.93872
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62465"
  value: {
-  dps: 30819.52636
-  tps: 45823.53376
+  dps: 30799.05742
+  tps: 45756.08125
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62470"
  value: {
-  dps: 30819.52636
-  tps: 45823.53376
+  dps: 30799.05742
+  tps: 45756.08125
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 30818.54942
-  tps: 45814.6233
+  dps: 30798.08048
+  tps: 45747.17079
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 30818.54942
-  tps: 45814.6233
+  dps: 30798.08048
+  tps: 45747.17079
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 30839.74784
-  tps: 45736.97868
+  dps: 30806.06826
+  tps: 45764.32765
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 31641.20441
-  tps: 46329.18913
+  dps: 31696.0439
+  tps: 47049.05233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-55819"
  value: {
-  dps: 30818.54942
-  tps: 45814.44054
+  dps: 30798.08048
+  tps: 45746.99598
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-56351"
  value: {
-  dps: 30819.47754
-  tps: 45815.03999
+  dps: 30799.0086
+  tps: 45747.59802
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 31096.34514
-  tps: 46286.46178
+  dps: 31076.18709
+  tps: 46217.89525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 31186.79026
-  tps: 46440.08361
+  dps: 31166.73342
+  tps: 46371.15437
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheHungerer-68927"
  value: {
-  dps: 32986.6211
-  tps: 47717.76044
+  dps: 33049.21266
+  tps: 47848.39858
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheHungerer-69112"
  value: {
-  dps: 33218.70235
-  tps: 48404.46652
+  dps: 33250.18281
+  tps: 48249.43029
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 30836.83086
-  tps: 45741.46268
+  dps: 30799.93671
+  tps: 45748.22771
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 30819.7969
-  tps: 45542.70745
+  dps: 30800.93133
+  tps: 45748.89974
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 30818.54942
-  tps: 45814.6233
+  dps: 30798.08048
+  tps: 45747.17079
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 30818.54942
-  tps: 45814.6233
+  dps: 30798.08048
+  tps: 45747.17079
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-77190"
  value: {
-  dps: 32981.24576
-  tps: 47031.54234
+  dps: 33057.43344
+  tps: 47885.56655
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-78477"
  value: {
-  dps: 32989.07465
-  tps: 47104.86928
+  dps: 32989.64254
+  tps: 47554.0568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-78486"
  value: {
-  dps: 32955.86463
-  tps: 46865.10609
+  dps: 33011.92138
+  tps: 47537.14894
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 32390.4886
-  tps: 48167.91683
+  dps: 32329.34691
+  tps: 48141.05221
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 32537.48939
-  tps: 48370.99707
+  dps: 32519.63874
+  tps: 48833.12213
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 31295.25065
-  tps: 47776.95517
+  dps: 31299.62488
+  tps: 47144.61116
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 30898.65071
-  tps: 46254.90973
+  dps: 30828.509
+  tps: 46072.34575
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnheededWarning-59520"
  value: {
-  dps: 32787.09194
-  tps: 48604.58742
+  dps: 32857.151
+  tps: 49118.4859
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 30832.65262
-  tps: 45979.60274
+  dps: 30831.53467
+  tps: 46116.77013
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 32893.76932
-  tps: 47922.68491
+  dps: 32841.45646
+  tps: 47899.2614
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 32893.76932
-  tps: 47922.68491
+  dps: 32841.45646
+  tps: 47899.2614
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 32893.76932
-  tps: 47922.68491
+  dps: 32841.45646
+  tps: 47899.2614
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 26790.04514
-  tps: 38029.87973
+  dps: 26750.79371
+  tps: 37918.7571
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 30827.55065
-  tps: 45828.18342
+  dps: 30799.9631
+  tps: 45756.2621
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 30821.0092
-  tps: 45822.55542
+  dps: 30799.93671
+  tps: 45748.11632
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 32044.52517
-  tps: 46380.38443
+  dps: 32055.47057
+  tps: 46142.97471
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VeilofLies-72900"
  value: {
-  dps: 30796.14142
-  tps: 46058.88938
+  dps: 30697.54913
+  tps: 45813.89772
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 31977.89439
-  tps: 47638.6956
+  dps: 31956.12164
+  tps: 47919.1244
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 32130.62285
-  tps: 47704.64209
+  dps: 32126.35572
+  tps: 48185.88544
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77207"
  value: {
-  dps: 33569.75927
-  tps: 50731.65362
+  dps: 33675.52538
+  tps: 51048.99034
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77979"
  value: {
-  dps: 33395.43067
-  tps: 51201.18655
+  dps: 33413.37073
+  tps: 50721.03429
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77999"
  value: {
-  dps: 33780.26377
-  tps: 50460.5852
+  dps: 33764.67236
+  tps: 50598.76119
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 30836.11415
-  tps: 46023.54832
+  dps: 30828.60413
+  tps: 46130.327
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 30836.11415
-  tps: 46023.54832
+  dps: 30828.60413
+  tps: 46130.327
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 32446.9874
-  tps: 47236.46234
+  dps: 32406.56636
+  tps: 47261.51724
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-70517"
  value: {
-  dps: 32684.82838
-  tps: 47585.98941
+  dps: 32662.58803
+  tps: 47535.73184
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 30832.65262
-  tps: 45979.60274
+  dps: 30831.53467
+  tps: 46116.77013
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-70518"
  value: {
-  dps: 30832.65262
-  tps: 45979.60274
+  dps: 30831.53467
+  tps: 46116.77013
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 31392.90887
-  tps: 46205.57354
+  dps: 31387.76787
+  tps: 46459.03615
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-70519"
  value: {
-  dps: 31464.89466
-  tps: 46296.84607
+  dps: 31459.73334
+  tps: 46551.57386
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 30819.27005
-  tps: 46006.3841
+  dps: 30818.61914
+  tps: 46029.48227
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 31415.22075
-  tps: 45764.41001
+  dps: 31408.31388
+  tps: 45466.13233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 31256.31321
-  tps: 46559.0372
+  dps: 31258.19393
+  tps: 46870.72111
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 30818.29312
-  tps: 45997.47364
+  dps: 30817.6422
+  tps: 46020.57181
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 31257.47907
-  tps: 46745.32848
+  dps: 31257.76609
+  tps: 46768.90556
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 30818.29312
-  tps: 45997.47364
+  dps: 30817.6422
+  tps: 46020.57181
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 32405.23741
-  tps: 46788.66831
+  dps: 32431.21504
+  tps: 46605.2323
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-70577"
  value: {
-  dps: 32546.01116
-  tps: 47380.93082
+  dps: 32666.38772
+  tps: 48099.5278
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 30803.54917
-  tps: 46387.90214
+  dps: 30796.4902
+  tps: 46190.27423
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-70578"
  value: {
-  dps: 30863.96316
-  tps: 45668.43308
+  dps: 30832.57237
+  tps: 45702.20925
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 31497.98234
-  tps: 46674.35887
+  dps: 31440.45322
+  tps: 46404.75167
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-70579"
  value: {
-  dps: 31495.76419
-  tps: 46464.24353
+  dps: 31464.25227
+  tps: 46487.10409
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 30818.54942
-  tps: 45817.44367
+  dps: 30798.08048
+  tps: 45748.82609
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 30818.54942
-  tps: 45817.05812
+  dps: 30798.08048
+  tps: 45748.6081
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WillofUnbinding-77995"
  value: {
-  dps: 30818.54942
-  tps: 45817.86777
+  dps: 30798.08048
+  tps: 45749.06588
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 30809.23908
-  tps: 45863.61418
+  dps: 30798.08048
+  tps: 45747.00817
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 30807.34122
-  tps: 45787.67461
+  dps: 30799.0086
+  tps: 45747.59802
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 31101.51344
-  tps: 46295.24017
+  dps: 31081.36116
+  tps: 46226.65291
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 34408.39726
-  tps: 50838.38956
+  dps: 34379.18946
+  tps: 51294.69632
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 33996.20835
-  tps: 50417.81874
+  dps: 33977.54389
+  tps: 50897.84073
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 34862.4552
-  tps: 51394.17321
+  dps: 34828.22693
+  tps: 51745.78856
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 31307.77708
-  tps: 46301.59557
+  dps: 31293.80972
+  tps: 45693.56586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 31307.77708
-  tps: 46301.59557
+  dps: 31293.80972
+  tps: 45693.56586
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 33336.79432
-  tps: 47796.21804
+  dps: 33339.35794
+  tps: 47877.17762
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 86234.83332
-  tps: 118475.79316
+  dps: 86244.47974
+  tps: 118604.72118
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20915.45051
-  tps: 37073.34817
+  dps: 20917.8581
+  tps: 37093.25414
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 24700.24888
-  tps: 34095.49087
+  dps: 24705.99381
+  tps: 34126.84391
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 58764.58945
-  tps: 82454.96193
+  dps: 58766.21917
+  tps: 82472.65277
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 12899.44545
-  tps: 23106.8782
+  dps: 12898.72404
+  tps: 23114.53205
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 13221.22223
-  tps: 22599.59466
+  dps: 13220.31331
+  tps: 22607.01267
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 39375.65632
-  tps: 50364.00413
+  dps: 39349.74257
+  tps: 50457.03006
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39113.64121
-  tps: 52137.61238
+  dps: 39183.279
+  tps: 51359.80542
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 50559.60519
-  tps: 43737.41598
+  dps: 50550.68619
+  tps: 43680.00268
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 25031.98363
-  tps: 33018.17421
+  dps: 25034.54189
+  tps: 32798.7067
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25381.69594
-  tps: 35808.60026
+  dps: 25381.39749
+  tps: 35852.61827
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 28300.51636
-  tps: 26747.24366
+  dps: 28288.41246
+  tps: 26683.22966
  }
 }
 dps_results: {
@@ -2204,85 +2204,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 86094.30431
-  tps: 118190.04864
+  dps: 85832.90463
+  tps: 118295.91295
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20745.94677
-  tps: 36099.44576
+  dps: 20763.50263
+  tps: 36029.13655
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 24327.8427
-  tps: 32251.26307
+  dps: 24456.49131
+  tps: 32595.16944
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 58481.84671
-  tps: 82157.73726
+  dps: 58429.56579
+  tps: 82546.05294
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 12895.11512
-  tps: 23279.32899
+  dps: 12804.64238
+  tps: 23016.12218
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 13291.39053
-  tps: 22953.35918
+  dps: 13233.74008
+  tps: 23412.41398
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38536.58075
-  tps: 49098.10023
+  dps: 38570.09933
+  tps: 49702.33544
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38241.42333
-  tps: 49479.58401
+  dps: 38182.55538
+  tps: 49688.73532
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 48711.07902
-  tps: 42477.46907
+  dps: 48663.29532
+  tps: 42299.34633
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24463.63593
-  tps: 31945.0867
+  dps: 24499.88882
+  tps: 32142.52111
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24673.4839
-  tps: 32930.4052
+  dps: 24620.34367
+  tps: 32599.72889
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27097.49338
-  tps: 24546.44424
+  dps: 27099.85884
+  tps: 24648.373
  }
 }
 dps_results: {
@@ -2330,85 +2330,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 78183.12186
-  tps: 108204.50357
+  dps: 78179.73814
+  tps: 108207.51888
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 17988.84074
-  tps: 30915.1449
+  dps: 17988.74724
+  tps: 30933.37004
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 21353.04329
-  tps: 27001.62243
+  dps: 21362.3352
+  tps: 27068.65921
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 52465.60346
-  tps: 74989.09933
+  dps: 52439.13601
+  tps: 74967.11319
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 11004.75558
-  tps: 19538.78221
+  dps: 10986.24864
+  tps: 19583.94461
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 11366.46693
-  tps: 18598.73425
+  dps: 11366.03158
+  tps: 18576.65563
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 33445.35108
-  tps: 47544.22036
+  dps: 33445.64816
+  tps: 47462.20264
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 33032.76662
-  tps: 47298.80702
+  dps: 33147.00555
+  tps: 47753.21114
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 41284.18464
-  tps: 41941.5991
+  dps: 41329.22848
+  tps: 42021.07717
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 20875.14051
-  tps: 30067.6764
+  dps: 20870.8513
+  tps: 30309.82443
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 21097.49212
-  tps: 31612.10088
+  dps: 21154.12053
+  tps: 32025.20379
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 22943.56874
-  tps: 25205.50681
+  dps: 22955.01994
+  tps: 25228.45058
  }
 }
 dps_results: {
@@ -2456,85 +2456,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 77959.97062
-  tps: 110211.3202
+  dps: 78027.57269
+  tps: 110472.49481
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 17757.59121
-  tps: 30372.71949
+  dps: 17825.42585
+  tps: 30011.75032
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 21043.73918
-  tps: 25942.55655
+  dps: 21046.97201
+  tps: 26240.32354
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 52126.95402
-  tps: 73171.64705
+  dps: 52089.09609
+  tps: 73672.6854
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 10875.61011
-  tps: 19116.81398
+  dps: 10900.47304
+  tps: 19224.87538
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 11186.20811
-  tps: 18318.89524
+  dps: 11231.5587
+  tps: 18699.0658
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 32642.49061
-  tps: 45681.25368
+  dps: 32713.80875
+  tps: 46211.18794
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 32163.61035
-  tps: 44679.37479
+  dps: 32124.00853
+  tps: 44966.67392
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 40692.74182
-  tps: 40493.61408
+  dps: 40711.73561
+  tps: 40663.8705
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 20273.65952
-  tps: 28587.33542
+  dps: 20332.92123
+  tps: 28689.67066
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20508.24183
-  tps: 29865.26358
+  dps: 20451.11755
+  tps: 29804.99845
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 22276.61764
-  tps: 24848.73883
+  dps: 22250.90299
+  tps: 24752.90466
  }
 }
 dps_results: {
@@ -2582,85 +2582,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 85925.91773
-  tps: 118298.1786
+  dps: 85920.58787
+  tps: 118263.87277
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20905.51202
-  tps: 36907.60437
+  dps: 20915.12583
+  tps: 36960.17818
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 24483.81466
-  tps: 34401.8812
+  dps: 24485.96833
+  tps: 34449.83282
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 58882.25381
-  tps: 84222.21896
+  dps: 58844.47907
+  tps: 84144.24266
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 12910.74447
-  tps: 23695.53719
+  dps: 12911.06719
+  tps: 23703.10126
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 13038.94097
-  tps: 23232.6255
+  dps: 13038.27986
+  tps: 23244.08443
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 39346.30777
-  tps: 51444.14425
+  dps: 39290.01238
+  tps: 51153.06962
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39119.86447
-  tps: 52152.79952
+  dps: 39113.19483
+  tps: 52321.23593
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 49506.19335
-  tps: 43902.78457
+  dps: 49545.48656
+  tps: 44296.58917
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24992.19163
-  tps: 33558.73682
+  dps: 24935.85889
+  tps: 33255.87671
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25302.74319
-  tps: 35400.95454
+  dps: 25272.05547
+  tps: 35320.92378
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27830.10178
-  tps: 27375.89646
+  dps: 27832.94424
+  tps: 27400.21423
  }
 }
 dps_results: {
@@ -2708,85 +2708,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 85352.54288
-  tps: 119648.751
+  dps: 85167.28642
+  tps: 119142.41641
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20774.13221
-  tps: 36244.60755
+  dps: 20737.18468
+  tps: 35895.77004
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 24215.55586
-  tps: 32077.19171
+  dps: 24126.59728
+  tps: 32002.68611
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 58782.85544
-  tps: 84516.91162
+  dps: 58726.9726
+  tps: 84693.54076
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 12911.66584
-  tps: 23094.33041
+  dps: 12913.86034
+  tps: 23229.07008
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 13062.03927
-  tps: 23427.85312
+  dps: 13059.89065
+  tps: 23567.15688
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38439.5913
-  tps: 50817.44871
+  dps: 38508.56466
+  tps: 50401.13765
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38042.09312
-  tps: 49236.94575
+  dps: 38124.54779
+  tps: 49670.37259
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 48086.931
-  tps: 42207.17384
+  dps: 48136.60586
+  tps: 42417.08309
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24323.84477
-  tps: 32689.78904
+  dps: 24325.93367
+  tps: 32613.86327
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24508.09652
-  tps: 33798.33243
+  dps: 24518.70559
+  tps: 33864.28669
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 26705.43427
-  tps: 25311.77097
+  dps: 26720.10041
+  tps: 25382.86646
  }
 }
 dps_results: {
@@ -2834,85 +2834,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 77919.83168
-  tps: 109062.35509
+  dps: 77922.85952
+  tps: 109101.0638
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 17965.47616
-  tps: 31465.04937
+  dps: 17968.06989
+  tps: 31488.56223
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 20852.36275
-  tps: 27389.18271
+  dps: 20849.58013
+  tps: 27407.96077
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 52980.94488
-  tps: 76961.65787
+  dps: 52977.81618
+  tps: 76952.65243
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 10966.96606
-  tps: 19914.57223
+  dps: 10962.52835
+  tps: 19898.5417
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 11125.36376
-  tps: 19140.107
+  dps: 11126.44231
+  tps: 19140.31027
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 33322.22445
-  tps: 47481.57352
+  dps: 33366.94238
+  tps: 46784.59409
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 32962.6725
-  tps: 47037.70092
+  dps: 32980.68483
+  tps: 47408.6878
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 40971.51055
-  tps: 42302.28515
+  dps: 40987.7975
+  tps: 42273.20622
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 20759.99081
-  tps: 30001.92621
+  dps: 20850.94288
+  tps: 29974.26562
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20976.99455
-  tps: 31511.5265
+  dps: 21062.13507
+  tps: 31752.33723
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 22657.96265
-  tps: 26355.4533
+  dps: 22656.06419
+  tps: 26348.9387
  }
 }
 dps_results: {
@@ -2960,85 +2960,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 77283.39432
-  tps: 108584.35409
+  dps: 77271.17453
+  tps: 107567.604
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 17822.57249
-  tps: 30562.54526
+  dps: 17819.75319
+  tps: 30764.13224
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 20646.47557
-  tps: 26154.86989
+  dps: 20748.37344
+  tps: 26353.85826
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 52612.60696
-  tps: 76429.74178
+  dps: 52695.87997
+  tps: 76291.84439
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 10924.3815
-  tps: 20025.91838
+  dps: 10941.77816
+  tps: 19805.27401
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 11049.04811
-  tps: 20356.22891
+  dps: 11068.74828
+  tps: 20518.77428
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 32630.90123
-  tps: 44736.92016
+  dps: 32677.80144
+  tps: 44951.61029
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 32037.98413
-  tps: 44608.541
+  dps: 31975.05985
+  tps: 44612.06318
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 39916.21835
-  tps: 41203.85499
+  dps: 39888.81769
+  tps: 41039.48139
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 20283.17714
-  tps: 28928.43609
+  dps: 20284.2567
+  tps: 28950.38765
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20457.32661
-  tps: 30439.28138
+  dps: 20432.8728
+  tps: 29613.7181
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 21954.15642
-  tps: 24832.83666
+  dps: 21965.48026
+  tps: 24865.25858
  }
 }
 dps_results: {
@@ -3086,7 +3086,7 @@ dps_results: {
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 28868.64363
-  tps: 43312.26839
+  dps: 28799.72711
+  tps: 42867.97986
  }
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -38,2041 +38,2041 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 32761.11702
-  tps: 44801.75124
+  dps: 32791.51226
+  tps: 45106.22211
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 30815.13596
-  tps: 43027.44218
+  dps: 30833.03821
+  tps: 43079.19741
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 33008.28209
-  tps: 45513.00882
+  dps: 33026.49598
+  tps: 45568.6992
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 30830.3278
-  tps: 42954.8259
+  dps: 30848.39559
+  tps: 43007.44359
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 30802.25662
-  tps: 43019.72049
+  dps: 30820.75083
+  tps: 43073.58316
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 31833.84933
-  tps: 44102.69291
+  dps: 31841.2833
+  tps: 44085.47816
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 31961.70039
-  tps: 44063.87679
+  dps: 31969.26255
+  tps: 44046.95931
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ArrowofTime-72897"
  value: {
-  dps: 32696.90981
-  tps: 44636.38254
+  dps: 32761.82757
+  tps: 44856.91306
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 31961.94473
-  tps: 43860.34934
+  dps: 31984.4025
+  tps: 44109.21753
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 30815.13596
-  tps: 43027.58694
+  dps: 30833.03821
+  tps: 43079.34332
   hps: 96.77966
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 30815.13596
-  tps: 43027.58694
+  dps: 30833.03821
+  tps: 43079.34332
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 31218.97962
-  tps: 43592.6607
+  dps: 31237.44133
+  tps: 43645.61224
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 31234.71309
-  tps: 43761.76226
+  dps: 31254.16217
+  tps: 43820.31744
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BindingPromise-67037"
  value: {
-  dps: 30864.49212
-  tps: 42917.19867
+  dps: 30882.22245
+  tps: 42967.20957
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 32361.68776
-  tps: 44755.0597
+  dps: 32383.27707
+  tps: 44815.47187
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 31143.55616
-  tps: 43534.69486
+  dps: 31161.67077
+  tps: 43587.20936
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 31186.18908
-  tps: 43602.76451
+  dps: 31204.30369
+  tps: 43655.27901
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 32856.87426
-  tps: 44976.83113
+  dps: 32865.60311
+  tps: 44847.59305
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 30871.63718
-  tps: 42947.21692
+  dps: 30889.75165
+  tps: 42998.30866
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 31398.99651
-  tps: 43382.18097
+  dps: 31417.96745
+  tps: 43436.67978
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 31170.86248
-  tps: 43712.02351
+  dps: 31189.41203
+  tps: 43767.17182
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 30812.14879
-  tps: 43047.17317
+  dps: 30830.21158
+  tps: 43099.33871
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 30812.14879
-  tps: 43047.17317
+  dps: 30830.21158
+  tps: 43099.33871
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 32156.52198
-  tps: 43840.60484
+  dps: 32157.62969
+  tps: 43818.18361
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 30812.28481
-  tps: 42962.55617
+  dps: 30831.06036
+  tps: 43015.91057
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 31321.01417
-  tps: 43345.83604
+  dps: 31340.06167
+  tps: 43406.65286
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 32572.08246
-  tps: 46171.5764
+  dps: 32547.55765
+  tps: 46106.20977
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 32359.36063
-  tps: 45159.59127
+  dps: 32382.08368
+  tps: 45214.36152
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 32757.68425
-  tps: 46246.40633
+  dps: 32756.22108
+  tps: 46209.16446
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledLightning-66879"
  value: {
-  dps: 30985.33667
-  tps: 42845.03776
+  dps: 31002.96456
+  tps: 42895.52416
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledWishes-77114"
  value: {
-  dps: 31364.17635
-  tps: 42877.85189
+  dps: 31364.78084
+  tps: 42810.41116
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 31961.94473
-  tps: 42983.38709
+  dps: 31984.4025
+  tps: 43227.28016
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 30864.49212
-  tps: 42917.19867
+  dps: 30882.22245
+  tps: 42967.20957
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 32561.1034
-  tps: 44654.80622
+  dps: 32584.84529
+  tps: 44911.77186
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sBadgeofConquest-73648"
  value: {
-  dps: 33076.64966
-  tps: 44456.05684
+  dps: 33126.93888
+  tps: 44755.09485
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sBadgeofDominance-73498"
  value: {
-  dps: 30871.63718
-  tps: 42947.21692
+  dps: 30889.75165
+  tps: 42998.30866
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sBadgeofVictory-73496"
  value: {
-  dps: 31754.90022
-  tps: 43961.59308
+  dps: 31773.61024
+  tps: 44014.25768
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sInsigniaofConquest-73643"
  value: {
-  dps: 32992.42307
-  tps: 44188.76913
+  dps: 33012.59382
+  tps: 44246.88829
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sInsigniaofDominance-73497"
  value: {
-  dps: 30809.12133
-  tps: 42825.07044
+  dps: 30850.94788
+  tps: 43028.01134
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sInsigniaofVictory-73491"
  value: {
-  dps: 31713.47364
-  tps: 43443.49095
+  dps: 31735.3289
+  tps: 43497.48572
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 32617.85157
-  tps: 44459.15921
+  dps: 32626.0585
+  tps: 44669.51376
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 32108.17264
-  tps: 43833.37362
+  dps: 32127.67192
+  tps: 43892.52815
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 30872.5653
-  tps: 42947.61567
+  dps: 30890.67976
+  tps: 42998.70525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 30815.13596
-  tps: 43027.58694
+  dps: 30833.03821
+  tps: 43079.34332
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 32350.64768
-  tps: 44357.14331
+  dps: 32383.32624
+  tps: 44559.30123
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 32121.13049
-  tps: 44235.84895
+  dps: 32113.35328
+  tps: 44083.37401
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 32453.20991
-  tps: 44807.83723
+  dps: 32490.1543
+  tps: 45147.07145
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-59506"
  value: {
-  dps: 31641.08066
-  tps: 42672.58982
+  dps: 31663.76422
+  tps: 42700.12099
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-65118"
  value: {
-  dps: 31897.17259
-  tps: 42558.74997
+  dps: 31987.11125
+  tps: 42915.7365
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 31214.04526
-  tps: 43595.62421
+  dps: 31227.50677
+  tps: 43648.67047
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 31046.11563
-  tps: 43706.96889
+  dps: 31064.32111
+  tps: 43757.54001
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-78000"
  value: {
-  dps: 31189.20276
-  tps: 43828.33482
+  dps: 31207.86331
+  tps: 43878.79406
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 30812.14879
-  tps: 43047.17317
+  dps: 30830.21158
+  tps: 43099.33871
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 31586.55295
-  tps: 43883.61807
+  dps: 31611.15883
+  tps: 43952.81171
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 32350.90127
-  tps: 44931.9848
+  dps: 32376.24395
+  tps: 45003.60906
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 30816.06407
-  tps: 43027.97598
+  dps: 30833.96632
+  tps: 43079.73021
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 31166.72178
-  tps: 43831.97959
+  dps: 31184.90942
+  tps: 43883.49297
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 31565.39776
-  tps: 43920.15805
+  dps: 31579.07368
+  tps: 43863.80956
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeepEarthRegalia"
  value: {
-  dps: 21966.89083
-  tps: 29000.57096
+  dps: 21988.62819
+  tps: 28967.03049
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 32013.92992
-  tps: 43668.80329
+  dps: 32022.12817
+  tps: 43873.24227
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 31131.85268
-  tps: 43662.22181
+  dps: 31112.30306
+  tps: 43342.25637
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dragonwrath,Tarecgosa'sRest-71086"
  value: {
-  dps: 33168.71099
-  tps: 45509.14898
+  dps: 33175.4427
+  tps: 45550.87357
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 31873.53901
-  tps: 44222.64813
+  dps: 31892.03706
+  tps: 44364.53862
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 31961.94473
-  tps: 43860.34934
+  dps: 31984.4025
+  tps: 44109.21753
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 30872.5653
-  tps: 42984.71039
+  dps: 30890.67976
+  tps: 43035.80214
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 31961.94473
-  tps: 43860.2833
+  dps: 31984.4025
+  tps: 44109.15315
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 32013.92992
-  tps: 43668.80329
+  dps: 32022.12817
+  tps: 43873.24227
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 32634.92429
-  tps: 45520.43125
+  dps: 32659.3232
+  tps: 45565.19015
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 32008.79274
-  tps: 44380.01368
+  dps: 32027.98306
+  tps: 44439.00016
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 31961.94473
-  tps: 43860.34934
+  dps: 31984.4025
+  tps: 44109.21753
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 32193.28238
-  tps: 44965.86982
+  dps: 32211.98708
+  tps: 45019.98186
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 32036.9998
-  tps: 44744.1676
+  dps: 32055.63744
+  tps: 44798.0981
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 32365.19321
-  tps: 45209.74226
+  dps: 32383.97168
+  tps: 45264.054
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-59500"
  value: {
-  dps: 30816.06407
-  tps: 43027.97598
+  dps: 30833.96632
+  tps: 43079.73021
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-65124"
  value: {
-  dps: 30816.06407
-  tps: 43027.9407
+  dps: 30833.96632
+  tps: 43079.69465
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 30816.06729
-  tps: 42986.03148
+  dps: 30834.29563
+  tps: 43038.26
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 32201.65598
-  tps: 44117.27372
+  dps: 32220.72906
+  tps: 44172.95401
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 30872.5653
-  tps: 42947.64482
+  dps: 30890.67976
+  tps: 42998.73465
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 30864.49212
-  tps: 42917.19867
+  dps: 30882.22245
+  tps: 42967.20957
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 30872.5653
-  tps: 42947.64482
+  dps: 30890.67976
+  tps: 42998.73465
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 31739.8001
-  tps: 43934.05506
+  dps: 31758.89498
+  tps: 43988.51366
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 31456.4751
-  tps: 44014.75041
+  dps: 31477.85243
+  tps: 44075.2819
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 32033.39576
-  tps: 43972.24979
+  dps: 32055.76818
+  tps: 44221.69983
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FluidDeath-58181"
  value: {
-  dps: 32302.30178
-  tps: 45210.07298
+  dps: 32320.69035
+  tps: 45264.71079
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 31961.94473
-  tps: 43860.30579
+  dps: 31984.4025
+  tps: 44109.17508
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 31118.72571
-  tps: 42255.88008
+  dps: 31200.59722
+  tps: 42636.87279
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 31917.22086
-  tps: 44067.36039
+  dps: 31940.29243
+  tps: 44131.88999
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56138"
  value: {
-  dps: 31156.55231
-  tps: 43070.02805
+  dps: 31176.9543
+  tps: 43127.12903
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56462"
  value: {
-  dps: 31143.18315
-  tps: 42380.56502
+  dps: 31160.98801
+  tps: 42477.48883
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GearDetector-61462"
  value: {
-  dps: 31642.18237
-  tps: 43367.32251
+  dps: 31661.8835
+  tps: 43421.85593
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 26274.85595
-  tps: 34693.26198
+  dps: 26264.76913
+  tps: 34587.4201
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 30815.13596
-  tps: 43027.4321
+  dps: 30833.03821
+  tps: 43079.18725
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 31648.79757
-  tps: 44112.37111
+  dps: 31686.23675
+  tps: 44083.53046
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 32217.797
-  tps: 44295.96054
+  dps: 32233.80235
+  tps: 44229.23087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HarmlightToken-63839"
  value: {
-  dps: 30832.71478
-  tps: 43027.29103
+  dps: 30850.61703
+  tps: 43079.04595
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 31305.83918
-  tps: 42947.66961
+  dps: 31342.75563
+  tps: 42984.89318
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 30815.13596
-  tps: 43027.58694
+  dps: 30833.03821
+  tps: 43079.34332
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 30815.13596
-  tps: 43027.58694
+  dps: 30833.03821
+  tps: 43079.34332
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-59224"
  value: {
-  dps: 31416.14972
-  tps: 43143.70327
+  dps: 31435.6976
+  tps: 43196.29198
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-65072"
  value: {
-  dps: 31635.26463
-  tps: 43533.89455
+  dps: 31651.17974
+  tps: 43583.48625
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-55868"
  value: {
-  dps: 31724.83016
-  tps: 43240.63785
+  dps: 31744.39431
+  tps: 43286.92323
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-56393"
  value: {
-  dps: 31671.1915
-  tps: 42803.07763
+  dps: 31725.32184
+  tps: 43020.08398
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-55845"
  value: {
-  dps: 30799.39973
-  tps: 43030.09198
+  dps: 30817.5233
+  tps: 43082.39848
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-56370"
  value: {
-  dps: 30799.39973
-  tps: 43030.09198
+  dps: 30817.5233
+  tps: 43082.39848
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 31775.93577
-  tps: 44355.17997
+  dps: 31834.99449
+  tps: 44342.36246
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-50641"
  value: {
-  dps: 33423.70395
-  tps: 45448.38545
+  dps: 33437.53252
+  tps: 45610.06321
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 32013.92992
-  tps: 43668.80329
+  dps: 32022.12817
+  tps: 43873.24227
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 31857.01116
-  tps: 44089.80971
+  dps: 31876.1075
+  tps: 44144.27018
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 31857.01116
-  tps: 44089.80971
+  dps: 31876.1075
+  tps: 44144.27018
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 31206.93918
-  tps: 43589.89913
+  dps: 31225.99429
+  tps: 43645.07155
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 31249.68165
-  tps: 43657.90286
+  dps: 31268.73676
+  tps: 43713.07528
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndomitablePride-77211"
  value: {
-  dps: 30815.13596
-  tps: 43027.58694
+  dps: 30833.03821
+  tps: 43079.34332
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndomitablePride-77983"
  value: {
-  dps: 30815.13596
-  tps: 43027.58694
+  dps: 30833.03821
+  tps: 43079.34332
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndomitablePride-78003"
  value: {
-  dps: 30815.13596
-  tps: 43027.58694
+  dps: 30833.03821
+  tps: 43079.34332
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 30799.39973
-  tps: 43030.09198
+  dps: 30817.5233
+  tps: 43082.39848
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 31450.30977
-  tps: 42698.48258
+  dps: 31466.39189
+  tps: 42742.18355
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 31303.08072
-  tps: 42194.02512
+  dps: 31324.39604
+  tps: 42171.06616
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 31589.86769
-  tps: 42526.4659
+  dps: 31611.11529
+  tps: 42590.87996
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 31079.32482
-  tps: 43184.86039
+  dps: 31100.35855
+  tps: 43244.2667
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 30815.13596
-  tps: 43027.91308
+  dps: 30833.03821
+  tps: 43079.66947
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 30815.13596
-  tps: 43027.91308
+  dps: 30833.03821
+  tps: 43079.66947
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 30816.06407
-  tps: 43027.9239
+  dps: 30833.96632
+  tps: 43079.67772
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 30816.06407
-  tps: 43027.88191
+  dps: 30833.96632
+  tps: 43079.63538
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 32361.68776
-  tps: 44755.0597
+  dps: 32383.27707
+  tps: 44815.47187
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 31905.00673
-  tps: 43445.01617
+  dps: 31920.63559
+  tps: 43538.66087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 32298.93266
-  tps: 45362.22909
+  dps: 32344.36494
+  tps: 45349.68987
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-77194"
  value: {
-  dps: 36295.59512
-  tps: 48359.40123
+  dps: 36259.06349
+  tps: 48364.05253
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-78473"
  value: {
-  dps: 36760.2456
-  tps: 49510.55851
+  dps: 36724.75762
+  tps: 49552.48107
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-78482"
  value: {
-  dps: 35908.73433
-  tps: 48625.46482
+  dps: 35835.68078
+  tps: 48694.72269
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 33997.39119
-  tps: 44876.63953
+  dps: 33940.46409
+  tps: 45028.74808
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 31214.45529
-  tps: 43044.15524
+  dps: 31251.35765
+  tps: 42991.90552
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 31214.45529
-  tps: 43044.15524
+  dps: 31251.35765
+  tps: 42991.90552
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 30847.66286
-  tps: 42253.87955
+  dps: 30836.60751
+  tps: 42382.36359
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50708"
  value: {
-  dps: 32945.67363
-  tps: 45057.3825
+  dps: 32976.23807
+  tps: 45363.62858
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-55816"
  value: {
-  dps: 30815.13596
-  tps: 43027.58694
+  dps: 30833.03821
+  tps: 43079.34332
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-56347"
  value: {
-  dps: 30815.13596
-  tps: 43027.58694
+  dps: 30833.03821
+  tps: 43079.34332
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 32013.62386
-  tps: 44033.37209
+  dps: 32033.53834
+  tps: 44082.39082
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 32225.08138
-  tps: 44570.38878
+  dps: 32258.26489
+  tps: 44638.98758
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 31415.99128
-  tps: 43947.71517
+  dps: 31434.5345
+  tps: 44001.81455
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 31226.56798
-  tps: 43043.96829
+  dps: 31247.54412
+  tps: 43102.03936
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 31383.62486
-  tps: 43256.58506
+  dps: 31403.75842
+  tps: 43312.80438
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 30815.13596
-  tps: 43027.58694
+  dps: 30833.03821
+  tps: 43079.34332
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 30815.13596
-  tps: 43027.58694
+  dps: 30833.03821
+  tps: 43079.34332
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 31666.72093
-  tps: 43853.15508
+  dps: 31687.17837
+  tps: 43907.75638
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 31780.35117
-  tps: 44002.14103
+  dps: 31800.8342
+  tps: 44056.80427
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 33098.6793
-  tps: 45144.49422
+  dps: 33123.94598
+  tps: 45095.33582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 33284.67672
-  tps: 45162.24852
+  dps: 33318.15499
+  tps: 45365.43213
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 31098.14268
-  tps: 43013.44856
+  dps: 31119.9077
+  tps: 43074.10127
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 31382.30999
-  tps: 43316.75993
+  dps: 31402.84697
+  tps: 43374.52537
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 31296.3098
-  tps: 43732.08876
+  dps: 31315.36491
+  tps: 43787.26118
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 31296.3098
-  tps: 43732.08876
+  dps: 31315.36491
+  tps: 43787.26118
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 31186.45432
-  tps: 43742.58582
+  dps: 31205.05946
+  tps: 43798.09655
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 31272.10168
-  tps: 42832.66086
+  dps: 31311.49345
+  tps: 42899.86942
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 30864.49212
-  tps: 42917.19867
+  dps: 30882.22245
+  tps: 42967.20957
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 30816.06407
-  tps: 43027.9239
+  dps: 30833.96632
+  tps: 43079.67772
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 30816.06407
-  tps: 43027.88191
+  dps: 30833.96632
+  tps: 43079.63538
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ObsidianArborweaveBattlegarb"
  value: {
-  dps: 30999.7174
-  tps: 38857.64699
+  dps: 31042.26917
+  tps: 38744.59307
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ObsidianArborweaveRegalia"
  value: {
-  dps: 22508.46706
-  tps: 29714.21462
+  dps: 22516.50724
+  tps: 29975.63598
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 31369.21889
-  tps: 43347.91312
+  dps: 31388.03557
+  tps: 43398.81554
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 30816.06407
-  tps: 43027.99026
+  dps: 30833.96632
+  tps: 43079.74461
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 30815.13596
-  tps: 43027.58694
+  dps: 30833.03821
+  tps: 43079.34332
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 30993.20369
-  tps: 43313.93604
+  dps: 31011.326
+  tps: 43366.53416
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 31101.47415
-  tps: 43138.93307
+  dps: 31128.12205
+  tps: 43091.82539
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 31149.60511
-  tps: 43027.40143
+  dps: 31170.79067
+  tps: 43091.76991
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 31961.94473
-  tps: 43860.34934
+  dps: 31984.4025
+  tps: 44109.21753
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 32402.61101
-  tps: 43874.3662
+  dps: 32428.79222
+  tps: 43934.88049
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-55854"
  value: {
-  dps: 30815.13596
-  tps: 43027.58694
+  dps: 30833.03821
+  tps: 43079.34332
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-56377"
  value: {
-  dps: 30815.13596
-  tps: 43027.58694
+  dps: 30833.03821
+  tps: 43079.34332
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rathrak,thePoisonousMind-77195"
  value: {
-  dps: 29547.3658
-  tps: 40331.51992
+  dps: 29591.31772
+  tps: 40494.1851
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rathrak,thePoisonousMind-78475"
  value: {
-  dps: 30123.66672
-  tps: 40989.15539
+  dps: 30168.75671
+  tps: 41160.04169
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rathrak,thePoisonousMind-78484"
  value: {
-  dps: 29077.57203
-  tps: 39799.84001
+  dps: 29136.66144
+  tps: 39995.00463
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 30831.37935
-  tps: 42836.94035
+  dps: 30852.84273
+  tps: 42897.52233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 30815.13596
-  tps: 43027.58694
+  dps: 30833.03821
+  tps: 43079.34332
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 30815.13596
-  tps: 43027.58694
+  dps: 30833.03821
+  tps: 43079.34332
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 30815.13596
-  tps: 43027.58694
+  dps: 30833.03821
+  tps: 43079.34332
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 32648.32775
-  tps: 44775.5399
+  dps: 32672.12501
+  tps: 45033.19001
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 32561.1034
-  tps: 44654.84977
+  dps: 32584.84529
+  tps: 44911.81431
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 32564.55738
-  tps: 44874.47699
+  dps: 32603.15268
+  tps: 45156.56699
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 31362.54061
-  tps: 43252.92849
+  dps: 31384.09037
+  tps: 43310.72958
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 31408.7848
-  tps: 43447.30465
+  dps: 31434.23597
+  tps: 43512.05276
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RosaryofLight-72901"
  value: {
-  dps: 31808.59672
-  tps: 43398.42011
+  dps: 31804.07764
+  tps: 43463.27005
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RottingSkull-77116"
  value: {
-  dps: 32411.78825
-  tps: 45162.61527
+  dps: 32450.46393
+  tps: 45309.17992
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuneofZeth-68998"
  value: {
-  dps: 31247.74024
-  tps: 43571.56963
+  dps: 31266.28454
+  tps: 43626.72447
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofConquest-70399"
  value: {
-  dps: 32717.73049
-  tps: 44364.92791
+  dps: 32765.79531
+  tps: 44658.07707
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofConquest-72304"
  value: {
-  dps: 32826.27983
-  tps: 44501.27099
+  dps: 32875.57782
+  tps: 44796.16897
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofDominance-70401"
  value: {
-  dps: 30871.63718
-  tps: 42947.21692
+  dps: 30889.75165
+  tps: 42998.30866
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofDominance-72448"
  value: {
-  dps: 30871.63718
-  tps: 42947.21692
+  dps: 30889.75165
+  tps: 42998.30866
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofVictory-70400"
  value: {
-  dps: 31605.51113
-  tps: 43787.68437
+  dps: 31624.21799
+  tps: 43840.34494
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofVictory-72450"
  value: {
-  dps: 31649.56176
-  tps: 43838.96514
+  dps: 31668.26955
+  tps: 43891.6269
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofConquest-70404"
  value: {
-  dps: 32812.35469
-  tps: 45073.02284
+  dps: 32835.81991
+  tps: 45137.8073
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofConquest-72309"
  value: {
-  dps: 32741.75131
-  tps: 44524.22112
+  dps: 32778.14939
+  tps: 44623.88764
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofDominance-70402"
  value: {
-  dps: 30824.13059
-  tps: 42749.7145
+  dps: 30842.56701
+  tps: 42806.79209
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofDominance-72449"
  value: {
-  dps: 30737.94851
-  tps: 42512.61773
+  dps: 30758.05335
+  tps: 42567.35012
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofVictory-70403"
  value: {
-  dps: 31534.48443
-  tps: 43488.10018
+  dps: 31565.5916
+  tps: 43543.28467
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofVictory-72455"
  value: {
-  dps: 31589.43021
-  tps: 43498.25933
+  dps: 31608.69924
+  tps: 43546.95654
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ScalesofLife-68915"
  value: {
-  dps: 30815.13596
-  tps: 43027.58694
+  dps: 30833.03821
+  tps: 43079.34332
   hps: 315.97258
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ScalesofLife-69109"
  value: {
-  dps: 30815.13596
-  tps: 43027.58694
+  dps: 30833.03821
+  tps: 43079.34332
   hps: 356.41412
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 31867.62853
-  tps: 43784.65927
+  dps: 31904.74199
+  tps: 43823.94344
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-55256"
  value: {
-  dps: 30871.63718
-  tps: 42947.21692
+  dps: 30889.75165
+  tps: 42998.30866
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-56290"
  value: {
-  dps: 30871.63718
-  tps: 42947.21692
+  dps: 30889.75165
+  tps: 42998.30866
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShardofWoe-60233"
  value: {
-  dps: 31130.62553
-  tps: 43341.68818
+  dps: 31152.68556
+  tps: 43400.29603
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 31485.45601
-  tps: 43768.21833
+  dps: 31503.08791
+  tps: 43660.9092
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 30880.5356
-  tps: 43069.87063
+  dps: 30899.60426
+  tps: 43125.04429
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 32132.25838
-  tps: 44094.92961
+  dps: 32172.56148
+  tps: 44164.96436
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 32323.53004
-  tps: 44413.23558
+  dps: 32363.89865
+  tps: 44483.41959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-55879"
  value: {
-  dps: 31168.33108
-  tps: 43643.73264
+  dps: 31186.23152
+  tps: 43695.4388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-56400"
  value: {
-  dps: 31210.99058
-  tps: 43711.97606
+  dps: 31228.89101
+  tps: 43763.68223
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 31098.14268
-  tps: 43013.44856
+  dps: 31119.9077
+  tps: 43074.10127
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulCasket-58183"
  value: {
-  dps: 31289.54014
-  tps: 43592.23872
+  dps: 31307.86696
+  tps: 43644.08858
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 31700.71572
-  tps: 43576.64563
+  dps: 31720.86602
+  tps: 43569.07517
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 31497.84957
-  tps: 42999.25418
+  dps: 31519.70354
+  tps: 43063.28568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 31792.22604
-  tps: 43404.66586
+  dps: 31806.99617
+  tps: 43384.07481
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 31312.79593
-  tps: 43804.91073
+  dps: 31330.91054
+  tps: 43857.42523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 31396.47727
-  tps: 43887.82712
+  dps: 31414.16954
+  tps: 43940.1142
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 33318.71893
-  tps: 45491.16316
+  dps: 33343.79952
+  tps: 45522.85089
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 33056.59773
-  tps: 44383.60876
+  dps: 33081.68623
+  tps: 44428.24861
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 33658.55222
-  tps: 45041.87761
+  dps: 33682.23159
+  tps: 45069.69522
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StayofExecution-68996"
  value: {
-  dps: 30815.13596
-  tps: 43027.58694
+  dps: 30833.03821
+  tps: 43079.34332
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 30862.81507
-  tps: 43082.97631
+  dps: 30884.22844
+  tps: 43145.0408
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stormrider'sBattlegarb"
  value: {
-  dps: 28404.34364
-  tps: 37459.30633
+  dps: 28388.75708
+  tps: 37371.70209
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stormrider'sRegalia"
  value: {
-  dps: 22180.57664
-  tps: 28713.82243
+  dps: 22187.79783
+  tps: 28845.92376
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62465"
  value: {
-  dps: 30834.52824
-  tps: 43273.90062
+  dps: 30853.25115
+  tps: 43327.95138
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62470"
  value: {
-  dps: 30789.85296
-  tps: 43068.41016
+  dps: 30807.64094
+  tps: 43120.12334
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 30815.13596
-  tps: 43027.58694
+  dps: 30833.03821
+  tps: 43079.34332
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 30815.13596
-  tps: 43027.58694
+  dps: 30833.03821
+  tps: 43079.34332
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 30908.43264
-  tps: 42995.61374
+  dps: 30936.24106
+  tps: 43075.46628
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 31488.32921
-  tps: 44129.90012
+  dps: 31507.68955
+  tps: 44324.01623
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-55819"
  value: {
-  dps: 30815.13596
-  tps: 43027.40606
+  dps: 30833.03821
+  tps: 43079.161
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-56351"
  value: {
-  dps: 30816.06407
-  tps: 43028.00622
+  dps: 30833.96632
+  tps: 43079.76069
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 31109.66761
-  tps: 43388.13082
+  dps: 31127.6637
+  tps: 43440.10549
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 31185.01896
-  tps: 43618.02312
+  dps: 31202.6145
+  tps: 43668.74683
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheHungerer-68927"
  value: {
-  dps: 32783.46325
-  tps: 44602.8361
+  dps: 32784.01088
+  tps: 44603.36017
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheHungerer-69112"
  value: {
-  dps: 33094.91363
-  tps: 44650.12227
+  dps: 33113.85198
+  tps: 44701.68356
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 30918.33635
-  tps: 43014.55865
+  dps: 30938.49322
+  tps: 43076.44457
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 30837.58252
-  tps: 43158.48769
+  dps: 30857.3447
+  tps: 43215.08651
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 30815.13596
-  tps: 43027.58694
+  dps: 30833.03821
+  tps: 43079.34332
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 30815.13596
-  tps: 43027.58694
+  dps: 30833.03821
+  tps: 43079.34332
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-77190"
  value: {
-  dps: 32792.5805
-  tps: 44831.09584
+  dps: 32789.5866
+  tps: 44677.38145
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-78477"
  value: {
-  dps: 32837.88287
-  tps: 44937.16972
+  dps: 32866.35504
+  tps: 45073.0782
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-78486"
  value: {
-  dps: 32760.75172
-  tps: 45082.35155
+  dps: 32799.29696
+  tps: 45325.62051
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 32334.53043
-  tps: 45254.4075
+  dps: 32353.26978
+  tps: 45308.87266
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 32554.20403
-  tps: 45519.06507
+  dps: 32571.92676
+  tps: 45572.39957
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 31052.38111
-  tps: 43401.31976
+  dps: 31041.52136
+  tps: 43331.95746
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 30850.62917
-  tps: 43039.34752
+  dps: 30863.17097
+  tps: 43092.4894
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnheededWarning-59520"
  value: {
-  dps: 32767.21808
-  tps: 45135.47653
+  dps: 32766.02567
+  tps: 45253.714
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 30871.63718
-  tps: 42947.21692
+  dps: 30889.75165
+  tps: 42998.30866
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 32805.73558
-  tps: 44864.45115
+  dps: 32826.49333
+  tps: 44926.06028
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 32805.73558
-  tps: 44864.45115
+  dps: 32826.49333
+  tps: 44926.06028
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 32805.73558
-  tps: 44864.45115
+  dps: 32826.49333
+  tps: 44926.06028
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 26620.27936
-  tps: 35728.18361
+  dps: 26619.27361
+  tps: 35717.7899
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 30822.57076
-  tps: 43111.32045
+  dps: 30840.65451
+  tps: 43163.77616
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 30816.79753
-  tps: 43043.15763
+  dps: 30834.72099
+  tps: 43095.2188
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 31958.05672
-  tps: 43559.35927
+  dps: 31994.60849
+  tps: 43848.54631
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VeilofLies-72900"
  value: {
-  dps: 30798.9261
-  tps: 42706.69108
+  dps: 30816.10827
+  tps: 42759.20006
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 31966.73791
-  tps: 45075.18773
+  dps: 31986.59994
+  tps: 45133.10585
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 32111.53524
-  tps: 45299.71523
+  dps: 32131.67869
+  tps: 45358.51043
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77207"
  value: {
-  dps: 33243.0743
-  tps: 46140.61848
+  dps: 33290.00296
+  tps: 46259.12024
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77979"
  value: {
-  dps: 33137.69475
-  tps: 46734.32616
+  dps: 33165.92594
+  tps: 46787.60976
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77999"
  value: {
-  dps: 33655.2767
-  tps: 47092.62957
+  dps: 33656.1926
+  tps: 47149.28781
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 30864.49212
-  tps: 42917.19867
+  dps: 30882.22245
+  tps: 42967.20957
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 30864.49212
-  tps: 42917.19867
+  dps: 30882.22245
+  tps: 42967.20957
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 32360.2707
-  tps: 44166.33556
+  dps: 32381.15039
+  tps: 44228.3926
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-70517"
  value: {
-  dps: 32481.90813
-  tps: 44140.97807
+  dps: 32529.77249
+  tps: 44434.377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 30871.63718
-  tps: 42947.21692
+  dps: 30889.75165
+  tps: 42998.30866
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-70518"
  value: {
-  dps: 30871.63718
-  tps: 42947.21692
+  dps: 30889.75165
+  tps: 42998.30866
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 31431.44267
-  tps: 43419.77851
+  dps: 31450.4143
+  tps: 43474.2782
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-70519"
  value: {
-  dps: 31503.58767
-  tps: 43503.37775
+  dps: 31522.56084
+  tps: 43557.8794
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 30818.95413
-  tps: 43123.20912
+  dps: 30837.3994
+  tps: 43177.01044
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 31194.0086
-  tps: 42770.88347
+  dps: 31194.02393
+  tps: 42824.33257
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 31207.85835
-  tps: 43744.15617
+  dps: 31226.40791
+  tps: 43799.30448
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 30812.14879
-  tps: 43047.17317
+  dps: 30830.21158
+  tps: 43099.33871
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 31254.13974
-  tps: 43736.12984
+  dps: 31272.41489
+  tps: 43789.05349
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 30812.14879
-  tps: 43047.17317
+  dps: 30830.21158
+  tps: 43099.33871
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 32253.3831
-  tps: 44059.90228
+  dps: 32269.1908
+  tps: 44109.16857
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-70577"
  value: {
-  dps: 32643.50454
-  tps: 44694.28799
+  dps: 32667.5889
+  tps: 44763.80327
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 30821.17392
-  tps: 42824.62286
+  dps: 30843.2907
+  tps: 42882.13212
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-70578"
  value: {
-  dps: 30844.81765
-  tps: 42715.20067
+  dps: 30862.76302
+  tps: 42768.9539
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 31331.57583
-  tps: 43185.79377
+  dps: 31350.51801
+  tps: 43238.83949
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-70579"
  value: {
-  dps: 31430.70779
-  tps: 43401.99525
+  dps: 31439.14
+  tps: 43434.42003
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 30815.13596
-  tps: 43041.04021
+  dps: 30833.03821
+  tps: 43092.90622
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 30815.13596
-  tps: 43039.04741
+  dps: 30833.03821
+  tps: 43090.91325
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WillofUnbinding-77995"
  value: {
-  dps: 30815.13596
-  tps: 43043.19429
+  dps: 30833.03821
+  tps: 43095.06048
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 30811.09541
-  tps: 43578.76896
+  dps: 30829.42803
+  tps: 43628.21288
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 30825.33416
-  tps: 43068.58473
+  dps: 30845.55156
+  tps: 43123.49676
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 31100.92324
-  tps: 43466.62521
+  dps: 31119.03785
+  tps: 43519.13972
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 34437.07028
-  tps: 48433.5332
+  dps: 34456.93343
+  tps: 48491.33205
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 34002.5102
-  tps: 47873.53438
+  dps: 34022.76474
+  tps: 47933.88696
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 34892.87912
-  tps: 49076.0547
+  dps: 34912.89558
+  tps: 49134.08053
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 31187.62087
-  tps: 43317.31357
+  dps: 31206.99684
+  tps: 43371.59188
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 31187.62087
-  tps: 43317.31357
+  dps: 31206.99684
+  tps: 43371.59188
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 33125.12595
-  tps: 44791.7306
+  dps: 33140.90939
+  tps: 44836.24599
  }
 }
 dps_results: {
@@ -2120,43 +2120,43 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 42364.52908
-  tps: 59169.41787
+  dps: 42071.653
+  tps: 58057.64153
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39156.43943
-  tps: 50852.4509
+  dps: 39151.79408
+  tps: 50655.03402
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 50372.70273
-  tps: 44010.4221
+  dps: 50398.43609
+  tps: 44063.64498
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 26724.5951
-  tps: 36608.72359
+  dps: 26639.94675
+  tps: 36803.70259
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25136.49447
-  tps: 33149.7432
+  dps: 25157.45067
+  tps: 33261.88236
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 28300.22966
-  tps: 26488.01913
+  dps: 28318.33696
+  tps: 26539.40964
  }
 }
 dps_results: {
@@ -2246,43 +2246,43 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 41009.99398
-  tps: 55409.51745
+  dps: 41012.72091
+  tps: 55066.46081
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37955.33165
-  tps: 48368.25097
+  dps: 37996.5314
+  tps: 48593.46699
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 48588.88122
-  tps: 41755.69095
+  dps: 48612.8091
+  tps: 41814.17569
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 25837.89995
-  tps: 34946.01718
+  dps: 25882.22235
+  tps: 34914.74041
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24388.2265
-  tps: 31567.60031
+  dps: 24403.57122
+  tps: 31603.85417
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27013.21813
-  tps: 24990.0852
+  dps: 27031.88294
+  tps: 25027.8584
  }
 }
 dps_results: {
@@ -2372,43 +2372,43 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 36117.35609
-  tps: 52285.66518
+  dps: 36316.15942
+  tps: 53071.56765
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 32932.18399
-  tps: 44994.37727
+  dps: 32935.47433
+  tps: 44944.47545
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 41198.04753
-  tps: 41366.37365
+  dps: 41208.91483
+  tps: 41323.87817
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 22815.45606
-  tps: 34067.90772
+  dps: 22650.90542
+  tps: 33335.8656
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20924.98715
-  tps: 29278.70978
+  dps: 20941.05911
+  tps: 29319.91898
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 22995.84672
-  tps: 24577.94468
+  dps: 23015.5627
+  tps: 24626.40308
  }
 }
 dps_results: {
@@ -2498,43 +2498,43 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 35673.26502
-  tps: 51764.51321
+  dps: 35585.19148
+  tps: 50911.51073
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 32021.43461
-  tps: 43263.81171
+  dps: 32009.87123
+  tps: 43160.131
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 40459.45839
-  tps: 39800.95305
+  dps: 40480.98275
+  tps: 39852.75979
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 22374.99787
-  tps: 32863.23158
+  dps: 22431.38709
+  tps: 33073.62223
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20234.48128
-  tps: 28505.43448
+  dps: 20258.6681
+  tps: 28588.43526
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 22233.66649
-  tps: 24309.52539
+  dps: 22255.24804
+  tps: 24378.75745
  }
 }
 dps_results: {
@@ -2624,43 +2624,43 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 41370.59167
-  tps: 56467.09896
+  dps: 41558.64916
+  tps: 57290.18631
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38886.6973
-  tps: 49422.58709
+  dps: 38941.25203
+  tps: 49640.26652
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 49612.77228
-  tps: 43058.42561
+  dps: 49636.87788
+  tps: 43106.45982
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 26694.75039
-  tps: 37794.27744
+  dps: 26748.42594
+  tps: 37684.27916
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25070.64685
-  tps: 33539.34886
+  dps: 25075.0565
+  tps: 33444.35028
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27749.17733
-  tps: 27409.0576
+  dps: 27771.33418
+  tps: 27471.55895
  }
 }
 dps_results: {
@@ -2750,43 +2750,43 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 40950.32494
-  tps: 55029.32108
+  dps: 40709.32835
+  tps: 53734.8742
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37905.88974
-  tps: 48338.99277
+  dps: 37929.17767
+  tps: 48384.95405
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 48158.08634
-  tps: 42688.73496
+  dps: 48182.8055
+  tps: 42747.54776
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 25693.70149
-  tps: 34696.34633
+  dps: 25746.46324
+  tps: 34744.22154
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24305.85222
-  tps: 32004.09772
+  dps: 24316.45389
+  tps: 32116.52559
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 26658.91258
-  tps: 25840.30891
+  dps: 26678.88134
+  tps: 25888.73835
  }
 }
 dps_results: {
@@ -2876,43 +2876,43 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 36231.60211
-  tps: 51716.85019
+  dps: 36250.75629
+  tps: 52522.93868
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 32761.11702
-  tps: 44801.75124
+  dps: 32791.51226
+  tps: 45106.22211
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 40964.41438
-  tps: 40869.31682
+  dps: 40983.16925
+  tps: 40950.69741
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 22590.67114
-  tps: 32925.99239
+  dps: 22645.70522
+  tps: 33097.34681
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20806.88248
-  tps: 29620.02595
+  dps: 20822.47138
+  tps: 29669.10113
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 22521.83713
-  tps: 24955.67633
+  dps: 22544.74428
+  tps: 25031.82326
  }
 }
 dps_results: {
@@ -3002,43 +3002,43 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 36045.82483
-  tps: 54185.39465
+  dps: 35509.19217
+  tps: 51494.24239
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 31808.2624
-  tps: 42616.48016
+  dps: 31827.46775
+  tps: 42667.91773
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 40011.51545
-  tps: 40089.25301
+  dps: 40033.47671
+  tps: 40177.06014
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 22307.33743
-  tps: 33710.71441
+  dps: 22288.95884
+  tps: 33499.04252
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20253.87583
-  tps: 28435.58617
+  dps: 20275.56758
+  tps: 28458.95934
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 21902.08576
-  tps: 24414.02161
+  dps: 21920.22873
+  tps: 24462.21977
  }
 }
 dps_results: {
@@ -3086,7 +3086,7 @@ dps_results: {
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 28839.14845
-  tps: 41397.26352
+  dps: 28879.3556
+  tps: 41574.63064
  }
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -38,2041 +38,2041 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 32686.64482
-  tps: 44482.746
+  dps: 32761.11702
+  tps: 44801.75124
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 30675.77563
-  tps: 41775.61051
+  dps: 30815.13596
+  tps: 43027.44218
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 32971.56585
-  tps: 45775.27594
+  dps: 33008.28209
+  tps: 45513.00882
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 30668.75688
-  tps: 41757.48782
+  dps: 30830.3278
+  tps: 42954.8259
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 30685.67504
-  tps: 41877.77641
+  dps: 30802.25662
+  tps: 43019.72049
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 31747.55439
-  tps: 43371.3271
+  dps: 31833.84933
+  tps: 44102.69291
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 31862.3121
-  tps: 43451.89821
+  dps: 31961.70039
+  tps: 44063.87679
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ArrowofTime-72897"
  value: {
-  dps: 32864.60601
-  tps: 44541.86032
+  dps: 32696.90981
+  tps: 44636.38254
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 31901.26997
-  tps: 43500.20471
+  dps: 31961.94473
+  tps: 43860.34934
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 30675.77563
-  tps: 41775.74978
+  dps: 30815.13596
+  tps: 43027.58694
   hps: 96.77966
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 30675.77563
-  tps: 41775.74978
+  dps: 30815.13596
+  tps: 43027.58694
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 31144.51724
-  tps: 42692.66972
+  dps: 31218.97962
+  tps: 43592.6607
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 31181.49243
-  tps: 42571.509
+  dps: 31234.71309
+  tps: 43761.76226
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BindingPromise-67037"
  value: {
-  dps: 30681.12285
-  tps: 41730.03995
+  dps: 30864.49212
+  tps: 42917.19867
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 32156.02307
-  tps: 43795.2129
+  dps: 32361.68776
+  tps: 44755.0597
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 31000.16342
-  tps: 42282.14098
+  dps: 31143.55616
+  tps: 43534.69486
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 31042.64278
-  tps: 42348.45411
+  dps: 31186.18908
+  tps: 43602.76451
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 32719.34444
-  tps: 43870.10314
+  dps: 32856.87426
+  tps: 44976.83113
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 30681.12285
-  tps: 41730.03995
+  dps: 30871.63718
+  tps: 42947.21692
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 31240.3181
-  tps: 42587.96233
+  dps: 31398.99651
+  tps: 43382.18097
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 31102.20705
-  tps: 42397.82799
+  dps: 31170.86248
+  tps: 43712.02351
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 30677.57609
-  tps: 41672.25329
+  dps: 30812.14879
+  tps: 43047.17317
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 30677.57609
-  tps: 41672.25329
+  dps: 30812.14879
+  tps: 43047.17317
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 32115.86277
-  tps: 43968.96374
+  dps: 32156.52198
+  tps: 43840.60484
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 30675.77563
-  tps: 41775.74978
+  dps: 30812.28481
+  tps: 42962.55617
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 31273.35861
-  tps: 42609.30242
+  dps: 31321.01417
+  tps: 43345.83604
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 32502.38009
-  tps: 44382.60797
+  dps: 32572.08246
+  tps: 46171.5764
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 32164.41617
-  tps: 44039.55488
+  dps: 32359.36063
+  tps: 45159.59127
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 32776.57652
-  tps: 45080.22653
+  dps: 32757.68425
+  tps: 46246.40633
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledLightning-66879"
  value: {
-  dps: 30809.86302
-  tps: 41980.54193
+  dps: 30985.33667
+  tps: 42845.03776
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledWishes-77114"
  value: {
-  dps: 31269.3257
-  tps: 42007.00214
+  dps: 31364.17635
+  tps: 42877.85189
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 31901.26997
-  tps: 42630.43613
+  dps: 31961.94473
+  tps: 42983.38709
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 30681.12285
-  tps: 41730.03995
+  dps: 30864.49212
+  tps: 42917.19867
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 32498.96482
-  tps: 44288.71688
+  dps: 32561.1034
+  tps: 44654.80622
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sBadgeofConquest-73648"
  value: {
-  dps: 33194.29612
-  tps: 43708.753
+  dps: 33076.64966
+  tps: 44456.05684
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sBadgeofDominance-73498"
  value: {
-  dps: 30681.12285
-  tps: 41730.03995
+  dps: 30871.63718
+  tps: 42947.21692
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sBadgeofVictory-73496"
  value: {
-  dps: 31563.32031
-  tps: 43108.94931
+  dps: 31754.90022
+  tps: 43961.59308
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sInsigniaofConquest-73643"
  value: {
-  dps: 32878.92285
-  tps: 44131.88559
+  dps: 32992.42307
+  tps: 44188.76913
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sInsigniaofDominance-73497"
  value: {
-  dps: 30621.15284
-  tps: 41871.0802
+  dps: 30809.12133
+  tps: 42825.07044
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sInsigniaofVictory-73491"
  value: {
-  dps: 31593.78934
-  tps: 43291.19854
+  dps: 31713.47364
+  tps: 43443.49095
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 32533.53312
-  tps: 44261.82353
+  dps: 32617.85157
+  tps: 44459.15921
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 32104.81753
-  tps: 42697.93386
+  dps: 32108.17264
+  tps: 43833.37362
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 30682.97908
-  tps: 41731.11197
+  dps: 30872.5653
+  tps: 42947.61567
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 30675.77563
-  tps: 41775.74978
+  dps: 30815.13596
+  tps: 43027.58694
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 32231.27274
-  tps: 43805.61863
+  dps: 32350.64768
+  tps: 44357.14331
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 32031.33166
-  tps: 43303.97604
+  dps: 32121.13049
+  tps: 44235.84895
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 32471.57005
-  tps: 44324.15044
+  dps: 32453.20991
+  tps: 44807.83723
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-59506"
  value: {
-  dps: 31581.20508
-  tps: 42652.51348
+  dps: 31641.08066
+  tps: 42672.58982
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-65118"
  value: {
-  dps: 31770.12441
-  tps: 42429.73633
+  dps: 31897.17259
+  tps: 42558.74997
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 30997.72506
-  tps: 42248.18726
+  dps: 31214.04526
+  tps: 43595.62421
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 30952.87512
-  tps: 41806.35825
+  dps: 31046.11563
+  tps: 43706.96889
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-78000"
  value: {
-  dps: 31068.13264
-  tps: 42565.08884
+  dps: 31189.20276
+  tps: 43828.33482
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 30677.57609
-  tps: 41672.25329
+  dps: 30812.14879
+  tps: 43047.17317
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 31411.08518
-  tps: 42549.81256
+  dps: 31586.55295
+  tps: 43883.61807
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 32200.50238
-  tps: 43635.63562
+  dps: 32350.90127
+  tps: 44931.9848
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 30677.63185
-  tps: 41776.80778
+  dps: 30816.06407
+  tps: 43027.97598
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 31178.86735
-  tps: 43845.47317
+  dps: 31166.72178
+  tps: 43831.97959
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 31691.31939
-  tps: 44044.93184
+  dps: 31565.39776
+  tps: 43920.15805
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeepEarthRegalia"
  value: {
-  dps: 21987.01398
-  tps: 28747.56488
+  dps: 21966.89083
+  tps: 29000.57096
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 31932.65274
-  tps: 43469.25648
+  dps: 32013.92992
+  tps: 43668.80329
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 31024.95543
-  tps: 43220.27699
+  dps: 31131.85268
+  tps: 43662.22181
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dragonwrath,Tarecgosa'sRest-71086"
  value: {
-  dps: 33154.21272
-  tps: 44372.90142
+  dps: 33168.71099
+  tps: 45509.14898
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 31747.88695
-  tps: 43972.06133
+  dps: 31873.53901
+  tps: 44222.64813
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 31901.26997
-  tps: 43500.20471
+  dps: 31961.94473
+  tps: 43860.34934
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 30682.05097
-  tps: 41768.09318
+  dps: 30872.5653
+  tps: 42984.71039
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 31901.26997
-  tps: 43500.14474
+  dps: 31961.94473
+  tps: 43860.2833
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 31932.65274
-  tps: 43469.25648
+  dps: 32013.92992
+  tps: 43668.80329
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 32440.06655
-  tps: 43872.38938
+  dps: 32634.92429
+  tps: 45520.43125
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 31912.55939
-  tps: 44629.65545
+  dps: 32008.79274
+  tps: 44380.01368
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 31901.26997
-  tps: 43500.20471
+  dps: 31961.94473
+  tps: 43860.34934
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 32101.3974
-  tps: 43638.78978
+  dps: 32193.28238
+  tps: 44965.86982
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 31945.68338
-  tps: 43424.04592
+  dps: 32036.9998
+  tps: 44744.1676
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 32272.68284
-  tps: 43875.00802
+  dps: 32365.19321
+  tps: 45209.74226
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-59500"
  value: {
-  dps: 30677.63185
-  tps: 41776.80778
+  dps: 30816.06407
+  tps: 43027.97598
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-65124"
  value: {
-  dps: 30677.63185
-  tps: 41776.77377
+  dps: 30816.06407
+  tps: 43027.9407
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 30711.47531
-  tps: 42215.68276
+  dps: 30816.06729
+  tps: 42986.03148
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 32130.21266
-  tps: 42785.47736
+  dps: 32201.65598
+  tps: 44117.27372
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 30682.05097
-  tps: 41730.48059
+  dps: 30872.5653
+  tps: 42947.64482
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 30681.12285
-  tps: 41730.03995
+  dps: 30864.49212
+  tps: 42917.19867
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 30682.05097
-  tps: 41730.48059
+  dps: 30872.5653
+  tps: 42947.64482
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 31576.4656
-  tps: 43122.16312
+  dps: 31739.8001
+  tps: 43934.05506
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 31408.35355
-  tps: 43995.70558
+  dps: 31456.4751
+  tps: 44014.75041
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 31972.00672
-  tps: 43609.68326
+  dps: 32033.39576
+  tps: 43972.24979
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FluidDeath-58181"
  value: {
-  dps: 32205.69184
-  tps: 43981.67656
+  dps: 32302.30178
+  tps: 45210.07298
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 31901.26997
-  tps: 43500.16516
+  dps: 31961.94473
+  tps: 43860.30579
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 31257.31317
-  tps: 43402.58399
+  dps: 31118.72571
+  tps: 42255.88008
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 31851.86509
-  tps: 43718.86491
+  dps: 31917.22086
+  tps: 44067.36039
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56138"
  value: {
-  dps: 31142.99017
-  tps: 42500.71211
+  dps: 31156.55231
+  tps: 43070.02805
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56462"
  value: {
-  dps: 31097.74107
-  tps: 42630.0814
+  dps: 31143.18315
+  tps: 42380.56502
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GearDetector-61462"
  value: {
-  dps: 31670.6347
-  tps: 44087.03191
+  dps: 31642.18237
+  tps: 43367.32251
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 26313.27593
-  tps: 35279.01318
+  dps: 26274.85595
+  tps: 34693.26198
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 30675.77563
-  tps: 41775.60079
+  dps: 30815.13596
+  tps: 43027.4321
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 31695.32336
-  tps: 43084.49948
+  dps: 31648.79757
+  tps: 44112.37111
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 31984.34776
-  tps: 44125.78367
+  dps: 32217.797
+  tps: 44295.96054
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HarmlightToken-63839"
  value: {
-  dps: 30689.94575
-  tps: 41897.73504
+  dps: 30832.71478
+  tps: 43027.29103
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 31351.4955
-  tps: 43065.3197
+  dps: 31305.83918
+  tps: 42947.66961
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 30675.77563
-  tps: 41775.74978
+  dps: 30815.13596
+  tps: 43027.58694
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 30675.77563
-  tps: 41775.74978
+  dps: 30815.13596
+  tps: 43027.58694
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-59224"
  value: {
-  dps: 31458.83267
-  tps: 43277.91703
+  dps: 31416.14972
+  tps: 43143.70327
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-65072"
  value: {
-  dps: 31513.58777
-  tps: 43097.53614
+  dps: 31635.26463
+  tps: 43533.89455
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-55868"
  value: {
-  dps: 31645.52228
-  tps: 43100.55966
+  dps: 31724.83016
+  tps: 43240.63785
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-56393"
  value: {
-  dps: 31612.55173
-  tps: 43377.52468
+  dps: 31671.1915
+  tps: 42803.07763
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-55845"
  value: {
-  dps: 30658.38661
-  tps: 41815.34274
+  dps: 30799.39973
+  tps: 43030.09198
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-56370"
  value: {
-  dps: 30658.38661
-  tps: 41815.34274
+  dps: 30799.39973
+  tps: 43030.09198
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 31721.10357
-  tps: 43146.38869
+  dps: 31775.93577
+  tps: 44355.17997
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-50641"
  value: {
-  dps: 33329.9059
-  tps: 45290.69533
+  dps: 33423.70395
+  tps: 45448.38545
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 31932.65274
-  tps: 43469.25648
+  dps: 32013.92992
+  tps: 43668.80329
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 31816.8959
-  tps: 44315.36957
+  dps: 31857.01116
+  tps: 44089.80971
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 31816.8959
-  tps: 44315.36957
+  dps: 31857.01116
+  tps: 44089.80971
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 30993.49534
-  tps: 42268.75736
+  dps: 31206.93918
+  tps: 43589.89913
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 31035.94628
-  tps: 42334.83894
+  dps: 31249.68165
+  tps: 43657.90286
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndomitablePride-77211"
  value: {
-  dps: 30675.77563
-  tps: 41775.74978
+  dps: 30815.13596
+  tps: 43027.58694
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndomitablePride-77983"
  value: {
-  dps: 30675.77563
-  tps: 41775.74978
+  dps: 30815.13596
+  tps: 43027.58694
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndomitablePride-78003"
  value: {
-  dps: 30675.77563
-  tps: 41775.74978
+  dps: 30815.13596
+  tps: 43027.58694
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 30658.38661
-  tps: 41815.34274
+  dps: 30799.39973
+  tps: 43030.09198
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 31346.65741
-  tps: 42097.12143
+  dps: 31450.30977
+  tps: 42698.48258
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 31454.29191
-  tps: 42912.27485
+  dps: 31303.08072
+  tps: 42194.02512
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 31503.95239
-  tps: 41848.14849
+  dps: 31589.86769
+  tps: 42526.4659
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 30939.07929
-  tps: 42550.40319
+  dps: 31079.32482
+  tps: 43184.86039
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 30675.77563
-  tps: 41776.09121
+  dps: 30815.13596
+  tps: 43027.91308
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 30675.77563
-  tps: 41776.09121
+  dps: 30815.13596
+  tps: 43027.91308
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 30677.63185
-  tps: 41776.75758
+  dps: 30816.06407
+  tps: 43027.9239
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 30677.63185
-  tps: 41776.71709
+  dps: 30816.06407
+  tps: 43027.88191
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 32156.02307
-  tps: 43795.2129
+  dps: 32361.68776
+  tps: 44755.0597
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 31875.96751
-  tps: 44167.20346
+  dps: 31905.00673
+  tps: 43445.01617
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 32290.67163
-  tps: 43932.75658
+  dps: 32298.93266
+  tps: 45362.22909
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-77194"
  value: {
-  dps: 36236.76638
-  tps: 48851.94822
+  dps: 36295.59512
+  tps: 48359.40123
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-78473"
  value: {
-  dps: 36713.89123
-  tps: 49473.31585
+  dps: 36760.2456
+  tps: 49510.55851
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-78482"
  value: {
-  dps: 35806.07865
-  tps: 49071.19057
+  dps: 35908.73433
+  tps: 48625.46482
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 33892.29644
-  tps: 44561.83269
+  dps: 33997.39119
+  tps: 44876.63953
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 31303.11481
-  tps: 42642.77213
+  dps: 31214.45529
+  tps: 43044.15524
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 31303.11481
-  tps: 42642.77213
+  dps: 31214.45529
+  tps: 43044.15524
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 30860.23999
-  tps: 42373.69705
+  dps: 30847.66286
+  tps: 42253.87955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50708"
  value: {
-  dps: 32870.71711
-  tps: 44736.14036
+  dps: 32945.67363
+  tps: 45057.3825
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-55816"
  value: {
-  dps: 30675.77563
-  tps: 41775.74978
+  dps: 30815.13596
+  tps: 43027.58694
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-56347"
  value: {
-  dps: 30675.77563
-  tps: 41775.74978
+  dps: 30815.13596
+  tps: 43027.58694
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 32018.87872
-  tps: 42984.99681
+  dps: 32013.62386
+  tps: 44033.37209
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 32149.59676
-  tps: 43302.82815
+  dps: 32225.08138
+  tps: 44570.38878
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 31269.04498
-  tps: 42611.08875
+  dps: 31415.99128
+  tps: 43947.71517
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 31129.13443
-  tps: 42994.90506
+  dps: 31226.56798
+  tps: 43043.96829
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 31276.15296
-  tps: 43156.73385
+  dps: 31383.62486
+  tps: 43256.58506
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 30675.77563
-  tps: 41775.74978
+  dps: 30815.13596
+  tps: 43027.58694
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 30675.77563
-  tps: 41775.74978
+  dps: 30815.13596
+  tps: 43027.58694
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 31638.08229
-  tps: 43621.13146
+  dps: 31666.72093
+  tps: 43853.15508
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 31756.11816
-  tps: 43776.97313
+  dps: 31780.35117
+  tps: 44002.14103
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 33009.38232
-  tps: 45763.05896
+  dps: 33098.6793
+  tps: 45144.49422
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 33300.68053
-  tps: 46239.09367
+  dps: 33284.67672
+  tps: 45162.24852
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 31000.44118
-  tps: 42846.03375
+  dps: 31098.14268
+  tps: 43013.44856
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 31289.2764
-  tps: 43099.93136
+  dps: 31382.30999
+  tps: 43316.75993
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 31215.06479
-  tps: 43524.3359
+  dps: 31296.3098
+  tps: 43732.08876
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 31215.06479
-  tps: 43524.3359
+  dps: 31296.3098
+  tps: 43732.08876
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 31096.59376
-  tps: 42444.35915
+  dps: 31186.45432
+  tps: 43742.58582
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 31201.9074
-  tps: 42301.7329
+  dps: 31272.10168
+  tps: 42832.66086
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 30681.12285
-  tps: 41730.03995
+  dps: 30864.49212
+  tps: 42917.19867
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 30677.63185
-  tps: 41776.75758
+  dps: 30816.06407
+  tps: 43027.9239
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 30677.63185
-  tps: 41776.71709
+  dps: 30816.06407
+  tps: 43027.88191
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ObsidianArborweaveBattlegarb"
  value: {
-  dps: 30926.6513
-  tps: 38608.02132
+  dps: 30999.7174
+  tps: 38857.64699
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ObsidianArborweaveRegalia"
  value: {
-  dps: 22456.21836
-  tps: 29591.97053
+  dps: 22508.46706
+  tps: 29714.21462
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 31261.20175
-  tps: 42656.18579
+  dps: 31369.21889
+  tps: 43347.91312
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 30676.70374
-  tps: 41776.16259
+  dps: 30816.06407
+  tps: 43027.99026
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 30675.77563
-  tps: 41775.74978
+  dps: 30815.13596
+  tps: 43027.58694
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 30912.21131
-  tps: 42222.13589
+  dps: 30993.20369
+  tps: 43313.93604
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 30956.09439
-  tps: 42073.94889
+  dps: 31101.47415
+  tps: 43138.93307
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 31143.37654
-  tps: 42104.29158
+  dps: 31149.60511
+  tps: 43027.40143
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 31901.26997
-  tps: 43500.20471
+  dps: 31961.94473
+  tps: 43860.34934
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 32406.0352
-  tps: 43501.36024
+  dps: 32402.61101
+  tps: 43874.3662
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-55854"
  value: {
-  dps: 30675.77563
-  tps: 41775.74978
+  dps: 30815.13596
+  tps: 43027.58694
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-56377"
  value: {
-  dps: 30675.77563
-  tps: 41775.74978
+  dps: 30815.13596
+  tps: 43027.58694
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rathrak,thePoisonousMind-77195"
  value: {
-  dps: 29533.40137
-  tps: 39662.41228
+  dps: 29547.3658
+  tps: 40331.51992
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rathrak,thePoisonousMind-78475"
  value: {
-  dps: 30119.61979
-  tps: 40345.48442
+  dps: 30123.66672
+  tps: 40989.15539
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rathrak,thePoisonousMind-78484"
  value: {
-  dps: 29002.07752
-  tps: 39187.88052
+  dps: 29077.57203
+  tps: 39799.84001
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 30689.48304
-  tps: 42157.69712
+  dps: 30831.37935
+  tps: 42836.94035
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 30675.77563
-  tps: 41775.74978
+  dps: 30815.13596
+  tps: 43027.58694
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 30675.77563
-  tps: 41775.74978
+  dps: 30815.13596
+  tps: 43027.58694
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 30675.77563
-  tps: 41775.74978
+  dps: 30815.13596
+  tps: 43027.58694
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 32585.99081
-  tps: 44408.21533
+  dps: 32648.32775
+  tps: 44775.5399
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 32498.96482
-  tps: 44288.75644
+  dps: 32561.1034
+  tps: 44654.84977
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 32515.53695
-  tps: 44421.64154
+  dps: 32564.55738
+  tps: 44874.47699
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 31210.772
-  tps: 42847.28941
+  dps: 31362.54061
+  tps: 43252.92849
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 31290.64461
-  tps: 43196.99057
+  dps: 31408.7848
+  tps: 43447.30465
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RosaryofLight-72901"
  value: {
-  dps: 31874.61693
-  tps: 43973.21448
+  dps: 31808.59672
+  tps: 43398.42011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RottingSkull-77116"
  value: {
-  dps: 32328.61649
-  tps: 44833.41752
+  dps: 32411.78825
+  tps: 45162.61527
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuneofZeth-68998"
  value: {
-  dps: 31205.66127
-  tps: 42962.26462
+  dps: 31247.74024
+  tps: 43571.56963
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofConquest-70399"
  value: {
-  dps: 32744.18432
-  tps: 43630.34731
+  dps: 32717.73049
+  tps: 44364.92791
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofConquest-72304"
  value: {
-  dps: 32853.85929
-  tps: 43771.06469
+  dps: 32826.27983
+  tps: 44501.27099
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofDominance-70401"
  value: {
-  dps: 30681.12285
-  tps: 41730.03995
+  dps: 30871.63718
+  tps: 42947.21692
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofDominance-72448"
  value: {
-  dps: 30681.12285
-  tps: 41730.03995
+  dps: 30871.63718
+  tps: 42947.21692
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofVictory-70400"
  value: {
-  dps: 31418.04104
-  tps: 42928.36477
+  dps: 31605.51113
+  tps: 43787.68437
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofVictory-72450"
  value: {
-  dps: 31460.8798
-  tps: 42981.61405
+  dps: 31649.56176
+  tps: 43838.96514
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofConquest-70404"
  value: {
-  dps: 32582.47663
-  tps: 44037.21753
+  dps: 32812.35469
+  tps: 45073.02284
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofConquest-72309"
  value: {
-  dps: 32708.75365
-  tps: 43620.19639
+  dps: 32741.75131
+  tps: 44524.22112
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofDominance-70402"
  value: {
-  dps: 30645.17853
-  tps: 41975.71099
+  dps: 30824.13059
+  tps: 42749.7145
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofDominance-72449"
  value: {
-  dps: 30684.41386
-  tps: 42300.42131
+  dps: 30737.94851
+  tps: 42512.61773
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofVictory-70403"
  value: {
-  dps: 31463.47406
-  tps: 42605.82444
+  dps: 31534.48443
+  tps: 43488.10018
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofVictory-72455"
  value: {
-  dps: 31474.77701
-  tps: 43157.09452
+  dps: 31589.43021
+  tps: 43498.25933
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ScalesofLife-68915"
  value: {
-  dps: 30675.77563
-  tps: 41775.74978
+  dps: 30815.13596
+  tps: 43027.58694
   hps: 315.97258
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ScalesofLife-69109"
  value: {
-  dps: 30675.77563
-  tps: 41775.74978
+  dps: 30815.13596
+  tps: 43027.58694
   hps: 356.41412
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 31947.35545
-  tps: 43919.02586
+  dps: 31867.62853
+  tps: 43784.65927
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-55256"
  value: {
-  dps: 30681.12285
-  tps: 41730.03995
+  dps: 30871.63718
+  tps: 42947.21692
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-56290"
  value: {
-  dps: 30681.12285
-  tps: 41730.03995
+  dps: 30871.63718
+  tps: 42947.21692
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShardofWoe-60233"
  value: {
-  dps: 31066.03615
-  tps: 41974.83133
+  dps: 31130.62553
+  tps: 43341.68818
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 31478.9284
-  tps: 43670.11737
+  dps: 31485.45601
+  tps: 43768.21833
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 30669.3245
-  tps: 41764.13436
+  dps: 30880.5356
+  tps: 43069.87063
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 32086.45115
-  tps: 43383.12057
+  dps: 32132.25838
+  tps: 44094.92961
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 32271.99417
-  tps: 43642.31536
+  dps: 32323.53004
+  tps: 44413.23558
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-55879"
  value: {
-  dps: 31024.32326
-  tps: 42420.04587
+  dps: 31168.33108
+  tps: 43643.73264
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-56400"
  value: {
-  dps: 31066.77564
-  tps: 42486.34894
+  dps: 31210.99058
+  tps: 43711.97606
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 31000.44118
-  tps: 42846.03375
+  dps: 31098.14268
+  tps: 43013.44856
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulCasket-58183"
  value: {
-  dps: 31209.87447
-  tps: 43576.51953
+  dps: 31289.54014
+  tps: 43592.23872
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 31503.60344
-  tps: 43028.19417
+  dps: 31700.71572
+  tps: 43576.64563
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 31415.17915
-  tps: 42883.78947
+  dps: 31497.84957
+  tps: 42999.25418
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 31606.56796
-  tps: 42165.12048
+  dps: 31792.22604
+  tps: 43404.66586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 31296.85735
-  tps: 43808.47023
+  dps: 31312.79593
+  tps: 43804.91073
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 31361.39524
-  tps: 43911.23641
+  dps: 31396.47727
+  tps: 43887.82712
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 33372.00332
-  tps: 45040.08381
+  dps: 33318.71893
+  tps: 45491.16316
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 32992.64929
-  tps: 44449.61461
+  dps: 33056.59773
+  tps: 44383.60876
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 33589.63089
-  tps: 44179.5742
+  dps: 33658.55222
+  tps: 45041.87761
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StayofExecution-68996"
  value: {
-  dps: 30675.77563
-  tps: 41775.74978
+  dps: 30815.13596
+  tps: 43027.58694
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 30726.86774
-  tps: 41784.4757
+  dps: 30862.81507
+  tps: 43082.97631
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stormrider'sBattlegarb"
  value: {
-  dps: 28370.16577
-  tps: 37227.54216
+  dps: 28404.34364
+  tps: 37459.30633
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stormrider'sRegalia"
  value: {
-  dps: 22289.88314
-  tps: 28858.82396
+  dps: 22180.57664
+  tps: 28713.82243
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62465"
  value: {
-  dps: 30678.84319
-  tps: 41795.19754
+  dps: 30834.52824
+  tps: 43273.90062
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62470"
  value: {
-  dps: 30658.84916
-  tps: 41820.89807
+  dps: 30789.85296
+  tps: 43068.41016
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 30675.77563
-  tps: 41775.74978
+  dps: 30815.13596
+  tps: 43027.58694
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 30675.77563
-  tps: 41775.74978
+  dps: 30815.13596
+  tps: 43027.58694
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 30734.47897
-  tps: 41738.39835
+  dps: 30908.43264
+  tps: 42995.61374
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 31416.1131
-  tps: 43511.47202
+  dps: 31488.32921
+  tps: 44129.90012
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-55819"
  value: {
-  dps: 30675.77563
-  tps: 41775.57569
+  dps: 30815.13596
+  tps: 43027.40606
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-56351"
  value: {
-  dps: 30676.70374
-  tps: 41776.17797
+  dps: 30816.06407
+  tps: 43028.00622
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 30951.23029
-  tps: 42200.39192
+  dps: 31109.66761
+  tps: 43388.13082
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 31033.50526
-  tps: 42404.43201
+  dps: 31185.01896
+  tps: 43618.02312
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheHungerer-68927"
  value: {
-  dps: 32833.56271
-  tps: 45522.67882
+  dps: 32783.46325
+  tps: 44602.8361
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheHungerer-69112"
  value: {
-  dps: 32892.98376
-  tps: 45530.5862
+  dps: 33094.91363
+  tps: 44650.12227
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 30712.25263
-  tps: 41714.02369
+  dps: 30918.33635
+  tps: 43014.55865
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 30771.96995
-  tps: 42126.13818
+  dps: 30837.58252
+  tps: 43158.48769
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 30675.77563
-  tps: 41775.74978
+  dps: 30815.13596
+  tps: 43027.58694
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 30675.77563
-  tps: 41775.74978
+  dps: 30815.13596
+  tps: 43027.58694
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-77190"
  value: {
-  dps: 32745.5369
-  tps: 44298.9734
+  dps: 32792.5805
+  tps: 44831.09584
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-78477"
  value: {
-  dps: 32730.67963
-  tps: 43935.94572
+  dps: 32837.88287
+  tps: 44937.16972
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-78486"
  value: {
-  dps: 32704.9586
-  tps: 44375.51683
+  dps: 32760.75172
+  tps: 45082.35155
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 32298.33715
-  tps: 44068.58502
+  dps: 32334.53043
+  tps: 45254.4075
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 32498.87169
-  tps: 45685.28167
+  dps: 32554.20403
+  tps: 45519.06507
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 30918.68851
-  tps: 42909.4279
+  dps: 31052.38111
+  tps: 43401.31976
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 30731.92031
-  tps: 41903.42594
+  dps: 30850.62917
+  tps: 43039.34752
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnheededWarning-59520"
  value: {
-  dps: 32571.17235
-  tps: 43849.9123
+  dps: 32767.21808
+  tps: 45135.47653
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 30681.12285
-  tps: 41730.03995
+  dps: 30871.63718
+  tps: 42947.21692
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 32698.90547
-  tps: 44580.49261
+  dps: 32805.73558
+  tps: 44864.45115
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 32698.90547
-  tps: 44580.49261
+  dps: 32805.73558
+  tps: 44864.45115
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 32698.90547
-  tps: 44580.49261
+  dps: 32805.73558
+  tps: 44864.45115
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 26667.09844
-  tps: 37736.17811
+  dps: 26620.27936
+  tps: 35728.18361
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 30702.43781
-  tps: 41950.16409
+  dps: 30822.57076
+  tps: 43111.32045
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 30683.61879
-  tps: 41806.59986
+  dps: 30816.79753
+  tps: 43043.15763
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 31969.75652
-  tps: 43607.60557
+  dps: 31958.05672
+  tps: 43559.35927
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VeilofLies-72900"
  value: {
-  dps: 30726.9603
-  tps: 42379.02311
+  dps: 30798.9261
+  tps: 42706.69108
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 31912.30016
-  tps: 43506.83031
+  dps: 31966.73791
+  tps: 45075.18773
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 32078.08594
-  tps: 43858.36096
+  dps: 32111.53524
+  tps: 45299.71523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77207"
  value: {
-  dps: 33214.61189
-  tps: 45903.89396
+  dps: 33243.0743
+  tps: 46140.61848
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77979"
  value: {
-  dps: 33021.31775
-  tps: 45969.36074
+  dps: 33137.69475
+  tps: 46734.32616
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77999"
  value: {
-  dps: 33489.89602
-  tps: 46096.79422
+  dps: 33655.2767
+  tps: 47092.62957
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 30681.12285
-  tps: 41730.03995
+  dps: 30864.49212
+  tps: 42917.19867
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 30681.12285
-  tps: 41730.03995
+  dps: 30864.49212
+  tps: 42917.19867
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 32353.78429
-  tps: 43227.52811
+  dps: 32360.2707
+  tps: 44166.33556
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-70517"
  value: {
-  dps: 32507.34194
-  tps: 43351.78579
+  dps: 32481.90813
+  tps: 44140.97807
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 30681.12285
-  tps: 41730.03995
+  dps: 30871.63718
+  tps: 42947.21692
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-70518"
  value: {
-  dps: 30681.12285
-  tps: 41730.03995
+  dps: 30871.63718
+  tps: 42947.21692
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 31271.57411
-  tps: 42626.17454
+  dps: 31431.44267
+  tps: 43419.77851
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-70519"
  value: {
-  dps: 31341.07278
-  tps: 42711.14051
+  dps: 31503.58767
+  tps: 43503.37775
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 30680.64365
-  tps: 41691.70105
+  dps: 30818.95413
+  tps: 43123.20912
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 31194.35855
-  tps: 42832.0745
+  dps: 31194.0086
+  tps: 42770.88347
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 31147.1909
-  tps: 42448.21797
+  dps: 31207.85835
+  tps: 43744.15617
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 30677.57609
-  tps: 41672.25329
+  dps: 30812.14879
+  tps: 43047.17317
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 31232.35486
-  tps: 43623.46472
+  dps: 31254.13974
+  tps: 43736.12984
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 30677.57609
-  tps: 41672.25329
+  dps: 30812.14879
+  tps: 43047.17317
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 32291.64049
-  tps: 43758.94771
+  dps: 32253.3831
+  tps: 44059.90228
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-70577"
  value: {
-  dps: 32473.25873
-  tps: 43654.4546
+  dps: 32643.50454
+  tps: 44694.28799
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 30638.62456
-  tps: 41992.38847
+  dps: 30821.17392
+  tps: 42824.62286
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-70578"
  value: {
-  dps: 30688.5749
-  tps: 41723.05423
+  dps: 30844.81765
+  tps: 42715.20067
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 31302.37168
-  tps: 42805.94023
+  dps: 31331.57583
+  tps: 43185.79377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-70579"
  value: {
-  dps: 31406.51587
-  tps: 43022.96205
+  dps: 31430.70779
+  tps: 43401.99525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 30675.77563
-  tps: 41787.95173
+  dps: 30815.13596
+  tps: 43041.04021
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 30675.77563
-  tps: 41786.09164
+  dps: 30815.13596
+  tps: 43039.04741
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WillofUnbinding-77995"
  value: {
-  dps: 30675.77563
-  tps: 41789.99783
+  dps: 30815.13596
+  tps: 43043.19429
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 30695.85331
-  tps: 42060.65149
+  dps: 30811.09541
+  tps: 43578.76896
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 30682.54476
-  tps: 42084.83901
+  dps: 30825.33416
+  tps: 43068.58473
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 30957.68407
-  tps: 42215.82785
+  dps: 31100.92324
+  tps: 43466.62521
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 34369.8336
-  tps: 46994.15327
+  dps: 34437.07028
+  tps: 48433.5332
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 33945.56285
-  tps: 46214.31591
+  dps: 34002.5102
+  tps: 47873.53438
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 34856.89125
-  tps: 47764.48199
+  dps: 34892.87912
+  tps: 49076.0547
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 31213.13878
-  tps: 43027.9298
+  dps: 31187.62087
+  tps: 43317.31357
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 31213.13878
-  tps: 43027.9298
+  dps: 31187.62087
+  tps: 43317.31357
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 33083.96381
-  tps: 44525.79976
+  dps: 33125.12595
+  tps: 44791.7306
  }
 }
 dps_results: {
@@ -2120,85 +2120,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 41846.9646
-  tps: 56825.60524
+  dps: 42364.52908
+  tps: 59169.41787
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38907.93351
-  tps: 50450.59593
+  dps: 39156.43943
+  tps: 50852.4509
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 50364.62301
-  tps: 44163.61089
+  dps: 50372.70273
+  tps: 44010.4221
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 26352.40374
-  tps: 35478.30261
+  dps: 26724.5951
+  tps: 36608.72359
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25063.00568
-  tps: 32847.57802
+  dps: 25136.49447
+  tps: 33149.7432
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 28384.68622
-  tps: 26179.49388
+  dps: 28300.22966
+  tps: 26488.01913
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38467.4937
-  tps: 27314.18117
+  dps: 38489.12038
+  tps: 27329.53611
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38181.89167
-  tps: 27109.14309
+  dps: 38110.14459
+  tps: 27058.20266
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 50056.96654
-  tps: 35540.44625
+  dps: 49877.56545
+  tps: 35413.07147
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24118.15352
-  tps: 17126.25188
+  dps: 24086.72481
+  tps: 17103.93749
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24236.31627
-  tps: 17207.99471
+  dps: 24269.42454
+  tps: 17231.50158
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27913.14575
-  tps: 19818.90148
+  dps: 28038.10813
+  tps: 19907.62477
  }
 }
 dps_results: {
@@ -2246,85 +2246,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 40830.85068
-  tps: 55591.23007
+  dps: 41009.99398
+  tps: 55409.51745
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37836.33581
-  tps: 47914.6553
+  dps: 37955.33165
+  tps: 48368.25097
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 48846.92505
-  tps: 42922.84355
+  dps: 48588.88122
+  tps: 41755.69095
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 26057.47866
-  tps: 36206.62255
+  dps: 25837.89995
+  tps: 34946.01718
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24517.85431
-  tps: 31496.82003
+  dps: 24388.2265
+  tps: 31567.60031
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27077.72441
-  tps: 23882.87629
+  dps: 27013.21813
+  tps: 24990.0852
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 37556.84977
-  tps: 26667.62398
+  dps: 37589.17117
+  tps: 26690.57217
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37154.60148
-  tps: 26379.76705
+  dps: 37225.55917
+  tps: 26430.14701
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 48571.39012
-  tps: 34485.68698
+  dps: 48375.07077
+  tps: 34346.30025
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 23530.41862
-  tps: 16708.9601
+  dps: 23565.27959
+  tps: 16733.71139
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 23704.75019
-  tps: 16830.58279
+  dps: 23664.03203
+  tps: 16801.6729
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 26905.68076
-  tps: 19103.60134
+  dps: 26932.20563
+  tps: 19122.434
  }
 }
 dps_results: {
@@ -2372,85 +2372,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 36066.97278
-  tps: 52651.32581
+  dps: 36117.35609
+  tps: 52285.66518
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 32784.98143
-  tps: 44173.36686
+  dps: 32932.18399
+  tps: 44994.37727
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 41239.82337
-  tps: 40790.12972
+  dps: 41198.04753
+  tps: 41366.37365
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 23391.78804
-  tps: 36507.55667
+  dps: 22815.45606
+  tps: 34067.90772
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20982.06151
-  tps: 30156.15994
+  dps: 20924.98715
+  tps: 29278.70978
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 22921.65307
-  tps: 24313.0124
+  dps: 22995.84672
+  tps: 24577.94468
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 32386.95656
-  tps: 22996.9998
+  dps: 32368.84811
+  tps: 22984.1428
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 31704.4557
-  tps: 22510.16354
+  dps: 31721.10693
+  tps: 22521.98592
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 40418.91567
-  tps: 28697.43013
+  dps: 40417.14079
+  tps: 28696.16996
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 19846.87081
-  tps: 14093.64115
+  dps: 19959.49812
+  tps: 14173.60654
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 19980.40465
-  tps: 14186.29746
+  dps: 20066.06447
+  tps: 14247.11593
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 22430.55728
-  tps: 15926.26367
+  dps: 22418.59778
+  tps: 15917.77243
  }
 }
 dps_results: {
@@ -2498,85 +2498,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 35434.33193
-  tps: 51314.6001
+  dps: 35673.26502
+  tps: 51764.51321
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 31998.83569
-  tps: 41722.73557
+  dps: 32021.43461
+  tps: 43263.81171
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 40271.51722
-  tps: 38116.90423
+  dps: 40459.45839
+  tps: 39800.95305
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 22450.70768
-  tps: 33654.67774
+  dps: 22374.99787
+  tps: 32863.23158
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20255.34668
-  tps: 28502.1264
+  dps: 20234.48128
+  tps: 28505.43448
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 22220.66509
-  tps: 24343.86138
+  dps: 22233.66649
+  tps: 24309.52539
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 31706.80282
-  tps: 22514.09064
+  dps: 31677.5287
+  tps: 22493.30602
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 31084.31049
-  tps: 22069.86044
+  dps: 31152.15481
+  tps: 22118.02991
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 39662.55548
-  tps: 28160.41439
+  dps: 39897.38686
+  tps: 28327.14467
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 19462.29858
-  tps: 13820.59487
+  dps: 19446.29719
+  tps: 13809.23388
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 19468.87988
-  tps: 13823.11488
+  dps: 19490.76603
+  tps: 13838.65404
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 21864.5271
-  tps: 15524.38224
+  dps: 21846.47003
+  tps: 15511.56172
  }
 }
 dps_results: {
@@ -2624,85 +2624,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 41381.95907
-  tps: 56453.46584
+  dps: 41370.59167
+  tps: 56467.09896
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38779.88761
-  tps: 50012.40347
+  dps: 38886.6973
+  tps: 49422.58709
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 49615.80836
-  tps: 43826.77745
+  dps: 49612.77228
+  tps: 43058.42561
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 26825.2031
-  tps: 37858.83202
+  dps: 26694.75039
+  tps: 37794.27744
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25043.59899
-  tps: 33174.06052
+  dps: 25070.64685
+  tps: 33539.34886
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27741.48844
-  tps: 26045.39775
+  dps: 27749.17733
+  tps: 27409.0576
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38324.69502
-  tps: 27212.79411
+  dps: 38338.88143
+  tps: 27222.86645
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37858.05237
-  tps: 26879.21718
+  dps: 37942.61447
+  tps: 26939.25627
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 49521.32701
-  tps: 35160.14218
+  dps: 49335.04402
+  tps: 35027.88125
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24004.69969
-  tps: 17045.69966
+  dps: 24011.48734
+  tps: 17050.51889
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24337.61931
-  tps: 17279.91987
+  dps: 24242.14237
+  tps: 17212.13124
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27496.61523
-  tps: 19523.16482
+  dps: 27608.78405
+  tps: 19602.80467
  }
 }
 dps_results: {
@@ -2750,85 +2750,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 40570.91805
-  tps: 54668.79465
+  dps: 40950.32494
+  tps: 55029.32108
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37784.81169
-  tps: 48404.09569
+  dps: 37905.88974
+  tps: 48338.99277
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 48348.4658
-  tps: 43297.05009
+  dps: 48158.08634
+  tps: 42688.73496
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 25668.77161
-  tps: 34701.35677
+  dps: 25693.70149
+  tps: 34696.34633
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24403.26185
-  tps: 31713.02836
+  dps: 24305.85222
+  tps: 32004.09772
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 26747.86609
-  tps: 24214.8177
+  dps: 26658.91258
+  tps: 25840.30891
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 37475.70218
-  tps: 26610.00919
+  dps: 37519.9235
+  tps: 26641.40633
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37030.04926
-  tps: 26291.33497
+  dps: 37084.88486
+  tps: 26330.26825
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 48038.64622
-  tps: 34107.43882
+  dps: 47863.73169
+  tps: 33983.2495
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 23355.89458
-  tps: 16585.04803
+  dps: 23494.85542
+  tps: 16683.71023
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 23628.14071
-  tps: 16776.19006
+  dps: 23660.00831
+  tps: 16798.81606
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 26527.42972
-  tps: 18835.0431
+  dps: 26549.49229
+  tps: 18850.70753
  }
 }
 dps_results: {
@@ -2876,85 +2876,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 36219.01396
-  tps: 54042.81604
+  dps: 36231.60211
+  tps: 51716.85019
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 32686.64482
-  tps: 44482.746
+  dps: 32761.11702
+  tps: 44801.75124
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 40798.96208
-  tps: 40674.19791
+  dps: 40964.41438
+  tps: 40869.31682
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 23216.7332
-  tps: 35712.07414
+  dps: 22590.67114
+  tps: 32925.99239
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20774.00735
-  tps: 30035.50408
+  dps: 20806.88248
+  tps: 29620.02595
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 22563.80272
-  tps: 25594.41077
+  dps: 22521.83713
+  tps: 24955.67633
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 32298.95707
-  tps: 22934.52016
+  dps: 32271.36189
+  tps: 22914.92759
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 31693.17643
-  tps: 22502.15526
+  dps: 31677.94556
+  tps: 22491.34135
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 40065.45488
-  tps: 28446.47296
+  dps: 39880.92147
+  tps: 28315.45424
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 19869.91766
-  tps: 14110.00442
+  dps: 19947.27587
+  tps: 14164.92875
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20004.21156
-  tps: 14203.20036
+  dps: 20016.58844
+  tps: 14211.98795
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 22242.34939
-  tps: 15792.63607
+  dps: 22187.27908
+  tps: 15753.53615
  }
 }
 dps_results: {
@@ -3002,91 +3002,91 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 35345.01366
-  tps: 51797.97436
+  dps: 36045.82483
+  tps: 54185.39465
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 31821.75102
-  tps: 42819.71006
+  dps: 31808.2624
+  tps: 42616.48016
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 39795.704
-  tps: 38758.91517
+  dps: 40011.51545
+  tps: 40089.25301
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 22464.84996
-  tps: 33964.68549
+  dps: 22307.33743
+  tps: 33710.71441
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20304.80156
-  tps: 29347.41258
+  dps: 20253.87583
+  tps: 28435.58617
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 21942.0896
-  tps: 24804.06404
+  dps: 21902.08576
+  tps: 24414.02161
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 31573.2669
-  tps: 22419.28014
+  dps: 31486.92598
+  tps: 22357.97808
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 31005.64388
-  tps: 22014.00715
+  dps: 30911.28915
+  tps: 21947.01529
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 38918.17703
-  tps: 27631.90569
+  dps: 39040.66451
+  tps: 27718.8718
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 19336.64811
-  tps: 13731.38304
+  dps: 19362.9156
+  tps: 13750.03295
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 19457.45074
-  tps: 13815.00019
+  dps: 19456.94031
+  tps: 13814.63778
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 21607.26623
-  tps: 15341.72703
+  dps: 21588.61736
+  tps: 15328.48632
  }
 }
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 28810.07048
-  tps: 40335.14026
+  dps: 28839.14845
+  tps: 41397.26352
  }
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -38,2041 +38,2041 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 32791.51226
-  tps: 45106.22211
+  dps: 32813.85285
+  tps: 46094.91377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 30833.03821
-  tps: 43079.19741
+  dps: 30833.9083
+  tps: 45225.46518
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 33026.49598
-  tps: 45568.6992
+  dps: 33135.19437
+  tps: 48062.79372
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 30848.39559
-  tps: 43007.44359
+  dps: 30834.88524
+  tps: 45230.53868
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 30820.75083
-  tps: 43073.58316
+  dps: 30834.88524
+  tps: 45230.53868
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 31841.2833
-  tps: 44085.47816
+  dps: 31941.59859
+  tps: 46530.46102
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 31969.26255
-  tps: 44046.95931
+  dps: 32122.24384
+  tps: 46761.03244
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ArrowofTime-72897"
  value: {
-  dps: 32761.82757
-  tps: 44856.91306
+  dps: 32956.63312
+  tps: 46864.34111
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 31984.4025
-  tps: 44109.21753
+  dps: 32036.3906
+  tps: 45235.45478
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 30833.03821
-  tps: 43079.34332
+  dps: 30833.9083
+  tps: 45225.61399
   hps: 96.77966
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 30833.03821
-  tps: 43079.34332
+  dps: 30833.9083
+  tps: 45225.61399
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 31237.44133
-  tps: 43645.61224
+  dps: 31276.43421
+  tps: 46102.45509
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 31254.16217
-  tps: 43820.31744
+  dps: 31325.51537
+  tps: 46468.05522
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BindingPromise-67037"
  value: {
-  dps: 30882.22245
-  tps: 42967.20957
+  dps: 30872.4129
+  tps: 45213.21281
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 32383.27707
-  tps: 44815.47187
+  dps: 32395.54942
+  tps: 46634.74927
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 31161.67077
-  tps: 43587.20936
+  dps: 31161.2104
+  tps: 45772.87999
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 31204.30369
-  tps: 43655.27901
+  dps: 31204.07139
+  tps: 45844.54577
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 32865.60311
-  tps: 44847.59305
+  dps: 32877.29745
+  tps: 46458.40291
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 30889.75165
-  tps: 42998.30866
+  dps: 30870.24856
+  tps: 45205.01081
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 31417.96745
-  tps: 43436.67978
+  dps: 31417.29996
+  tps: 45865.21309
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 31189.41203
-  tps: 43767.17182
+  dps: 31254.66817
+  tps: 46550.63118
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 30830.21158
-  tps: 43099.33871
+  dps: 30889.17456
+  tps: 45449.19065
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 30830.21158
-  tps: 43099.33871
+  dps: 30889.17456
+  tps: 45449.19065
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 32157.62969
-  tps: 43818.18361
+  dps: 32229.03975
+  tps: 45448.82753
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 30831.06036
-  tps: 43015.91057
+  dps: 30833.9083
+  tps: 45225.61399
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 31340.06167
-  tps: 43406.65286
+  dps: 31295.92482
+  tps: 45317.51091
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 32547.55765
-  tps: 46106.20977
+  dps: 32767.68591
+  tps: 48290.26431
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 32382.08368
-  tps: 45214.36152
+  dps: 32616.5124
+  tps: 47666.10801
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 32756.22108
-  tps: 46209.16446
+  dps: 33155.04337
+  tps: 48305.50301
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledLightning-66879"
  value: {
-  dps: 31002.96456
-  tps: 42895.52416
+  dps: 31006.94369
+  tps: 45348.7259
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledWishes-77114"
  value: {
-  dps: 31364.78084
-  tps: 42810.41116
+  dps: 31549.72733
+  tps: 44755.86853
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 31984.4025
-  tps: 43227.28016
+  dps: 32036.3906
+  tps: 44331.00419
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 30882.22245
-  tps: 42967.20957
+  dps: 30872.4129
+  tps: 45213.21281
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 32584.84529
-  tps: 44911.77186
+  dps: 32638.28241
+  tps: 46054.10507
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sBadgeofConquest-73648"
  value: {
-  dps: 33126.93888
-  tps: 44755.09485
+  dps: 33304.8872
+  tps: 47791.28966
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sBadgeofDominance-73498"
  value: {
-  dps: 30889.75165
-  tps: 42998.30866
+  dps: 30870.24856
+  tps: 45205.01081
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sBadgeofVictory-73496"
  value: {
-  dps: 31773.61024
-  tps: 44014.25768
+  dps: 31776.88328
+  tps: 46164.1513
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sInsigniaofConquest-73643"
  value: {
-  dps: 33012.59382
-  tps: 44246.88829
+  dps: 33091.36959
+  tps: 46795.55831
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sInsigniaofDominance-73497"
  value: {
-  dps: 30850.94788
-  tps: 43028.01134
+  dps: 30854.33387
+  tps: 45463.63533
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sInsigniaofVictory-73491"
  value: {
-  dps: 31735.3289
-  tps: 43497.48572
+  dps: 31735.43108
+  tps: 45455.90777
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 32626.0585
-  tps: 44669.51376
+  dps: 32655.86369
+  tps: 45897.32826
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 32127.67192
-  tps: 43892.52815
+  dps: 32113.82009
+  tps: 46441.23812
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 30890.67976
-  tps: 42998.70525
+  dps: 30872.10478
+  tps: 45210.03919
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 30833.03821
-  tps: 43079.34332
+  dps: 30833.9083
+  tps: 45225.61399
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 32383.32624
-  tps: 44559.30123
+  dps: 32314.81888
+  tps: 46372.88131
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 32113.35328
-  tps: 44083.37401
+  dps: 32209.48367
+  tps: 46172.6678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 32490.1543
-  tps: 45147.07145
+  dps: 32505.83579
+  tps: 46989.92662
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-59506"
  value: {
-  dps: 31663.76422
-  tps: 42700.12099
+  dps: 31766.3902
+  tps: 44955.03262
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-65118"
  value: {
-  dps: 31987.11125
-  tps: 42915.7365
+  dps: 32024.202
+  tps: 45439.90233
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 31227.50677
-  tps: 43648.67047
+  dps: 31209.88875
+  tps: 46042.69427
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 31064.32111
-  tps: 43757.54001
+  dps: 31122.43251
+  tps: 45610.29152
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-78000"
  value: {
-  dps: 31207.86331
-  tps: 43878.79406
+  dps: 31285.49724
+  tps: 46538.6153
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 30830.21158
-  tps: 43099.33871
+  dps: 30889.17456
+  tps: 45449.19065
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 31611.15883
-  tps: 43952.81171
+  dps: 31709.48317
+  tps: 46765.75318
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 32376.24395
-  tps: 45003.60906
+  dps: 32466.51393
+  tps: 47633.5565
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 30833.96632
-  tps: 43079.73021
+  dps: 30835.76453
+  tps: 45230.64021
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 31184.90942
-  tps: 43883.49297
+  dps: 31272.72103
+  tps: 46085.0405
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 31579.07368
-  tps: 43863.80956
+  dps: 31748.2585
+  tps: 45710.21234
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeepEarthRegalia"
  value: {
-  dps: 21988.62819
-  tps: 28967.03049
+  dps: 22092.78361
+  tps: 29745.1499
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 32022.12817
-  tps: 43873.24227
+  dps: 32051.0639
+  tps: 45075.71313
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 31112.30306
-  tps: 43342.25637
+  dps: 31047.26992
+  tps: 45677.80917
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dragonwrath,Tarecgosa'sRest-71086"
  value: {
-  dps: 33175.4427
-  tps: 45550.87357
+  dps: 33300.35303
+  tps: 45702.06678
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 31892.03706
-  tps: 44364.53862
+  dps: 31863.95033
+  tps: 46152.56948
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 31984.4025
-  tps: 44109.21753
+  dps: 32036.3906
+  tps: 45235.45478
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 30890.67976
-  tps: 43035.80214
+  dps: 30871.17667
+  tps: 45241.74033
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 31984.4025
-  tps: 44109.15315
+  dps: 32036.3906
+  tps: 45235.39095
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 32022.12817
-  tps: 43873.24227
+  dps: 32051.0639
+  tps: 45075.71313
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 32659.3232
-  tps: 45565.19015
+  dps: 32662.05616
+  tps: 46743.02581
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 32027.98306
-  tps: 44439.00016
+  dps: 31989.0931
+  tps: 46743.54579
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 31984.4025
-  tps: 44109.21753
+  dps: 32036.3906
+  tps: 45235.45478
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 32211.98708
-  tps: 45019.98186
+  dps: 32201.14133
+  tps: 47228.58384
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 32055.63744
-  tps: 44798.0981
+  dps: 32045.77394
+  tps: 47000.97363
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 32383.97168
-  tps: 45264.054
+  dps: 32372.04546
+  tps: 47478.95507
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-59500"
  value: {
-  dps: 30833.96632
-  tps: 43079.73021
+  dps: 30835.76453
+  tps: 45230.64021
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-65124"
  value: {
-  dps: 30833.96632
-  tps: 43079.69465
+  dps: 30835.76453
+  tps: 45230.60394
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 30834.29563
-  tps: 43038.26
+  dps: 30814.36065
+  tps: 45267.75012
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 32220.72906
-  tps: 44172.95401
+  dps: 32297.92543
+  tps: 46621.0373
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 30890.67976
-  tps: 42998.73465
+  dps: 30871.17667
+  tps: 45205.42531
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 30882.22245
-  tps: 42967.20957
+  dps: 30872.4129
+  tps: 45213.21281
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 30890.67976
-  tps: 42998.73465
+  dps: 30871.17667
+  tps: 45205.42531
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 31758.89498
-  tps: 43988.51366
+  dps: 31758.52547
+  tps: 46452.63541
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 31477.85243
-  tps: 44075.2819
+  dps: 31403.15903
+  tps: 46151.72799
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 32055.76818
-  tps: 44221.69983
+  dps: 32107.8192
+  tps: 45349.42222
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FluidDeath-58181"
  value: {
-  dps: 32320.69035
-  tps: 45264.71079
+  dps: 32352.48151
+  tps: 47761.72797
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 31984.4025
-  tps: 44109.17508
+  dps: 32036.3906
+  tps: 45235.41268
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 31200.59722
-  tps: 42636.87279
+  dps: 31338.61833
+  tps: 44616.13734
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 31940.29243
-  tps: 44131.88999
+  dps: 32120.228
+  tps: 47440.91682
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56138"
  value: {
-  dps: 31176.9543
-  tps: 43127.12903
+  dps: 31151.42919
+  tps: 45064.66071
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56462"
  value: {
-  dps: 31160.98801
-  tps: 42477.48883
+  dps: 31339.96834
+  tps: 45523.43704
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GearDetector-61462"
  value: {
-  dps: 31661.8835
-  tps: 43421.85593
+  dps: 31707.04831
+  tps: 45611.2253
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 26264.76913
-  tps: 34587.4201
+  dps: 26466.43172
+  tps: 37129.76677
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 30833.03821
-  tps: 43079.18725
+  dps: 30833.9083
+  tps: 45225.45482
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 31686.23675
-  tps: 44083.53046
+  dps: 31749.27599
+  tps: 46921.19664
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 32233.80235
-  tps: 44229.23087
+  dps: 32128.51456
+  tps: 46729.84973
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HarmlightToken-63839"
  value: {
-  dps: 30850.61703
-  tps: 43079.04595
+  dps: 30828.38448
+  tps: 45208.63581
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 31342.75563
-  tps: 42984.89318
+  dps: 31458.8725
+  tps: 45754.44011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 30833.03821
-  tps: 43079.34332
+  dps: 30833.9083
+  tps: 45225.61399
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 30833.03821
-  tps: 43079.34332
+  dps: 30833.9083
+  tps: 45225.61399
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-59224"
  value: {
-  dps: 31435.6976
-  tps: 43196.29198
+  dps: 31567.19185
+  tps: 44816.47297
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-65072"
  value: {
-  dps: 31651.17974
-  tps: 43583.48625
+  dps: 31701.9774
+  tps: 46545.48623
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-55868"
  value: {
-  dps: 31744.39431
-  tps: 43286.92323
+  dps: 31706.36979
+  tps: 45659.68922
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-56393"
  value: {
-  dps: 31725.32184
-  tps: 43020.08398
+  dps: 31782.61834
+  tps: 44610.14803
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-55845"
  value: {
-  dps: 30817.5233
-  tps: 43082.39848
+  dps: 30833.9083
+  tps: 45225.61399
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-56370"
  value: {
-  dps: 30817.5233
-  tps: 43082.39848
+  dps: 30833.9083
+  tps: 45225.61399
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 31834.99449
-  tps: 44342.36246
+  dps: 31843.65437
+  tps: 46497.96049
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-50641"
  value: {
-  dps: 33437.53252
-  tps: 45610.06321
+  dps: 33560.1167
+  tps: 46355.61386
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 32022.12817
-  tps: 43873.24227
+  dps: 32051.0639
+  tps: 45075.71313
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 31876.1075
-  tps: 44144.27018
+  dps: 31876.07918
+  tps: 46615.68506
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 31876.1075
-  tps: 44144.27018
+  dps: 31876.07918
+  tps: 46615.68506
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 31225.99429
-  tps: 43645.07155
+  dps: 31208.65215
+  tps: 45892.98294
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 31268.73676
-  tps: 43713.07528
+  dps: 31251.50918
+  tps: 45964.57465
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndomitablePride-77211"
  value: {
-  dps: 30833.03821
-  tps: 43079.34332
+  dps: 30833.9083
+  tps: 45225.61399
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndomitablePride-77983"
  value: {
-  dps: 30833.03821
-  tps: 43079.34332
+  dps: 30833.9083
+  tps: 45225.61399
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndomitablePride-78003"
  value: {
-  dps: 30833.03821
-  tps: 43079.34332
+  dps: 30833.9083
+  tps: 45225.61399
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 30817.5233
-  tps: 43082.39848
+  dps: 30833.9083
+  tps: 45225.61399
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 31466.39189
-  tps: 42742.18355
+  dps: 31496.97998
+  tps: 44699.39791
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 31324.39604
-  tps: 42171.06616
+  dps: 31465.47275
+  tps: 44213.01138
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 31611.11529
-  tps: 42590.87996
+  dps: 31674.66506
+  tps: 44794.33036
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 31100.35855
-  tps: 43244.2667
+  dps: 31067.23745
+  tps: 46116.06995
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 30833.03821
-  tps: 43079.66947
+  dps: 30833.9083
+  tps: 45225.80056
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 30833.03821
-  tps: 43079.66947
+  dps: 30833.9083
+  tps: 45225.80056
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 30833.96632
-  tps: 43079.67772
+  dps: 30835.76453
+  tps: 45230.58668
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 30833.96632
-  tps: 43079.63538
+  dps: 30835.76453
+  tps: 45230.5435
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 32383.27707
-  tps: 44815.47187
+  dps: 32395.54942
+  tps: 46634.74927
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 31920.63559
-  tps: 43538.66087
+  dps: 32038.98925
+  tps: 45906.20999
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 32344.36494
-  tps: 45349.68987
+  dps: 32377.90454
+  tps: 46652.52737
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-77194"
  value: {
-  dps: 36259.06349
-  tps: 48364.05253
+  dps: 36557.84613
+  tps: 51204.54512
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-78473"
  value: {
-  dps: 36724.75762
-  tps: 49552.48107
+  dps: 36917.22331
+  tps: 51558.9647
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-78482"
  value: {
-  dps: 35835.68078
-  tps: 48694.72269
+  dps: 36077.88307
+  tps: 51268.89903
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 33940.46409
-  tps: 45028.74808
+  dps: 34058.48214
+  tps: 47278.97637
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 31251.35765
-  tps: 42991.90552
+  dps: 31350.19265
+  tps: 46198.67415
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 31251.35765
-  tps: 42991.90552
+  dps: 31350.19265
+  tps: 46198.67415
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 30836.60751
-  tps: 42382.36359
+  dps: 31053.6135
+  tps: 43713.91919
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50708"
  value: {
-  dps: 32976.23807
-  tps: 45363.62858
+  dps: 32997.66042
+  tps: 46351.91827
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-55816"
  value: {
-  dps: 30833.03821
-  tps: 43079.34332
+  dps: 30833.9083
+  tps: 45225.61399
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-56347"
  value: {
-  dps: 30833.03821
-  tps: 43079.34332
+  dps: 30833.9083
+  tps: 45225.61399
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 32033.53834
-  tps: 44082.39082
+  dps: 32047.98732
+  tps: 46243.9841
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 32258.26489
-  tps: 44638.98758
+  dps: 32362.56998
+  tps: 47270.94993
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 31434.5345
-  tps: 44001.81455
+  dps: 31425.29331
+  tps: 46095.5174
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 31247.54412
-  tps: 43102.03936
+  dps: 31338.61691
+  tps: 45788.77403
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 31403.75842
-  tps: 43312.80438
+  dps: 31425.30334
+  tps: 45348.13114
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 30833.03821
-  tps: 43079.34332
+  dps: 30833.9083
+  tps: 45225.61399
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 30833.03821
-  tps: 43079.34332
+  dps: 30833.9083
+  tps: 45225.61399
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 31687.17837
-  tps: 43907.75638
+  dps: 31694.09962
+  tps: 45889.17483
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 31800.8342
-  tps: 44056.80427
+  dps: 31829.37602
+  tps: 46165.15955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 33123.94598
-  tps: 45095.33582
+  dps: 33303.1657
+  tps: 47625.88184
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 33318.15499
-  tps: 45365.43213
+  dps: 33523.87027
+  tps: 48902.94162
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 31119.9077
-  tps: 43074.10127
+  dps: 31207.98497
+  tps: 45639.25725
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 31402.84697
-  tps: 43374.52537
+  dps: 31426.28028
+  tps: 45353.05583
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 31315.36491
-  tps: 43787.26118
+  dps: 31298.2623
+  tps: 46042.6747
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 31315.36491
-  tps: 43787.26118
+  dps: 31298.2623
+  tps: 46042.6747
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 31205.05946
-  tps: 43798.09655
+  dps: 31242.41902
+  tps: 46250.59511
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 31311.49345
-  tps: 42899.86942
+  dps: 31405.43317
+  tps: 45662.39933
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 30882.22245
-  tps: 42967.20957
+  dps: 30872.4129
+  tps: 45213.21281
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 30833.96632
-  tps: 43079.67772
+  dps: 30835.76453
+  tps: 45230.58668
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 30833.96632
-  tps: 43079.63538
+  dps: 30835.76453
+  tps: 45230.5435
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ObsidianArborweaveBattlegarb"
  value: {
-  dps: 31042.26917
-  tps: 38744.59307
+  dps: 31024.33811
+  tps: 39556.66218
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ObsidianArborweaveRegalia"
  value: {
-  dps: 22516.50724
-  tps: 29975.63598
+  dps: 22451.51427
+  tps: 30369.97671
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 31388.03557
-  tps: 43398.81554
+  dps: 31399.67331
+  tps: 45478.17421
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 30833.96632
-  tps: 43079.74461
+  dps: 30834.83642
+  tps: 45226.01016
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 30833.03821
-  tps: 43079.34332
+  dps: 30833.9083
+  tps: 45225.61399
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 31011.326
-  tps: 43366.53416
+  dps: 31055.53296
+  tps: 45843.54891
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 31128.12205
-  tps: 43091.82539
+  dps: 31124.96876
+  tps: 45066.29398
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 31170.79067
-  tps: 43091.76991
+  dps: 31361.79395
+  tps: 45205.35668
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 31984.4025
-  tps: 44109.21753
+  dps: 32036.3906
+  tps: 45235.45478
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 32428.79222
-  tps: 43934.88049
+  dps: 32688.96972
+  tps: 45898.13862
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-55854"
  value: {
-  dps: 30833.03821
-  tps: 43079.34332
+  dps: 30833.9083
+  tps: 45225.61399
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-56377"
  value: {
-  dps: 30833.03821
-  tps: 43079.34332
+  dps: 30833.9083
+  tps: 45225.61399
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rathrak,thePoisonousMind-77195"
  value: {
-  dps: 29591.31772
-  tps: 40494.1851
+  dps: 29766.59607
+  tps: 42619.43308
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rathrak,thePoisonousMind-78475"
  value: {
-  dps: 30168.75671
-  tps: 41160.04169
+  dps: 30345.74428
+  tps: 43347.41552
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rathrak,thePoisonousMind-78484"
  value: {
-  dps: 29136.66144
-  tps: 39995.00463
+  dps: 29262.47446
+  tps: 42306.18591
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 30852.84273
-  tps: 42897.52233
+  dps: 30814.91338
+  tps: 45690.32057
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 30833.03821
-  tps: 43079.34332
+  dps: 30833.9083
+  tps: 45225.61399
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 30833.03821
-  tps: 43079.34332
+  dps: 30833.9083
+  tps: 45225.61399
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 30833.03821
-  tps: 43079.34332
+  dps: 30833.9083
+  tps: 45225.61399
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 32672.12501
-  tps: 45033.19001
+  dps: 32725.23793
+  tps: 46175.86829
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 32584.84529
-  tps: 44911.81431
+  dps: 32638.28241
+  tps: 46054.14717
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 32603.15268
-  tps: 45156.56699
+  dps: 32701.94507
+  tps: 47380.50912
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 31384.09037
-  tps: 43310.72958
+  dps: 31270.79021
+  tps: 45134.89072
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 31434.23597
-  tps: 43512.05276
+  dps: 31373.58312
+  tps: 45158.93091
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RosaryofLight-72901"
  value: {
-  dps: 31804.07764
-  tps: 43463.27005
+  dps: 31918.29422
+  tps: 45774.27252
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RottingSkull-77116"
  value: {
-  dps: 32450.46393
-  tps: 45309.17992
+  dps: 32367.82188
+  tps: 46292.03856
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuneofZeth-68998"
  value: {
-  dps: 31266.28454
-  tps: 43626.72447
+  dps: 31337.86992
+  tps: 46684.14216
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofConquest-70399"
  value: {
-  dps: 32765.79531
-  tps: 44658.07707
+  dps: 32900.33448
+  tps: 47021.91832
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofConquest-72304"
  value: {
-  dps: 32875.57782
-  tps: 44796.16897
+  dps: 33007.02887
+  tps: 47154.60098
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofDominance-70401"
  value: {
-  dps: 30889.75165
-  tps: 42998.30866
+  dps: 30870.24856
+  tps: 45205.01081
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofDominance-72448"
  value: {
-  dps: 30889.75165
-  tps: 42998.30866
+  dps: 30870.24856
+  tps: 45205.01081
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofVictory-70400"
  value: {
-  dps: 31624.21799
-  tps: 43840.34494
+  dps: 31626.89076
+  tps: 45987.73091
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofVictory-72450"
  value: {
-  dps: 31668.26955
-  tps: 43891.6269
+  dps: 31671.11933
+  tps: 46039.7523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofConquest-70404"
  value: {
-  dps: 32835.81991
-  tps: 45137.8073
+  dps: 32730.67655
+  tps: 47222.20688
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofConquest-72309"
  value: {
-  dps: 32778.14939
-  tps: 44623.88764
+  dps: 32899.86346
+  tps: 47157.14836
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofDominance-70402"
  value: {
-  dps: 30842.56701
-  tps: 42806.79209
+  dps: 30835.53977
+  tps: 44874.51896
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofDominance-72449"
  value: {
-  dps: 30758.05335
-  tps: 42567.35012
+  dps: 30848.09096
+  tps: 45154.51546
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofVictory-70403"
  value: {
-  dps: 31565.5916
-  tps: 43543.28467
+  dps: 31589.66249
+  tps: 45564.37717
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofVictory-72455"
  value: {
-  dps: 31608.69924
-  tps: 43546.95654
+  dps: 31522.56254
+  tps: 45655.76743
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ScalesofLife-68915"
  value: {
-  dps: 30833.03821
-  tps: 43079.34332
+  dps: 30833.9083
+  tps: 45225.61399
   hps: 315.97258
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ScalesofLife-69109"
  value: {
-  dps: 30833.03821
-  tps: 43079.34332
+  dps: 30833.9083
+  tps: 45225.61399
   hps: 356.41412
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 31904.74199
-  tps: 43823.94344
+  dps: 32085.93359
+  tps: 46620.48493
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-55256"
  value: {
-  dps: 30889.75165
-  tps: 42998.30866
+  dps: 30870.24856
+  tps: 45205.01081
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-56290"
  value: {
-  dps: 30889.75165
-  tps: 42998.30866
+  dps: 30870.24856
+  tps: 45205.01081
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShardofWoe-60233"
  value: {
-  dps: 31152.68556
-  tps: 43400.29603
+  dps: 31192.29022
+  tps: 44965.31081
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 31503.08791
-  tps: 43660.9092
+  dps: 31655.54641
+  tps: 46145.02547
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 30899.60426
-  tps: 43125.04429
+  dps: 30877.11515
+  tps: 45375.71538
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 32172.56148
-  tps: 44164.96436
+  dps: 32321.88308
+  tps: 46981.85554
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 32363.89865
-  tps: 44483.41959
+  dps: 32481.70308
+  tps: 47195.89001
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-55879"
  value: {
-  dps: 31186.23152
-  tps: 43695.4388
+  dps: 31161.2104
+  tps: 45772.87999
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-56400"
  value: {
-  dps: 31228.89101
-  tps: 43763.68223
+  dps: 31204.07139
+  tps: 45844.54577
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 31119.9077
-  tps: 43074.10127
+  dps: 31207.98497
+  tps: 45639.25725
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulCasket-58183"
  value: {
-  dps: 31307.86696
-  tps: 43644.08858
+  dps: 31287.34367
+  tps: 45901.49567
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 31720.86602
-  tps: 43569.07517
+  dps: 31729.11982
+  tps: 45574.60879
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 31519.70354
-  tps: 43063.28568
+  dps: 31599.36583
+  tps: 45584.03415
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 31806.99617
-  tps: 43384.07481
+  dps: 31823.77845
+  tps: 45177.3087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 31330.91054
-  tps: 43857.42523
+  dps: 31331.35553
+  tps: 46057.37144
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 31414.16954
-  tps: 43940.1142
+  dps: 31377.06985
+  tps: 45974.79138
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 33343.79952
-  tps: 45522.85089
+  dps: 33488.03279
+  tps: 47159.49757
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 33081.68623
-  tps: 44428.24861
+  dps: 33113.8038
+  tps: 46725.16571
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 33682.23159
-  tps: 45069.69522
+  dps: 33926.73666
+  tps: 48511.04843
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StayofExecution-68996"
  value: {
-  dps: 30833.03821
-  tps: 43079.34332
+  dps: 30833.9083
+  tps: 45225.61399
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 30884.22844
-  tps: 43145.0408
+  dps: 30878.72288
+  tps: 45466.86418
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stormrider'sBattlegarb"
  value: {
-  dps: 28388.75708
-  tps: 37371.70209
+  dps: 28571.83031
+  tps: 39605.89635
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stormrider'sRegalia"
  value: {
-  dps: 22187.79783
-  tps: 28845.92376
+  dps: 22318.06732
+  tps: 30431.59579
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62465"
  value: {
-  dps: 30853.25115
-  tps: 43327.95138
+  dps: 30834.88524
+  tps: 45230.53868
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62470"
  value: {
-  dps: 30807.64094
-  tps: 43120.12334
+  dps: 30834.88524
+  tps: 45230.53868
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 30833.03821
-  tps: 43079.34332
+  dps: 30833.9083
+  tps: 45225.61399
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 30833.03821
-  tps: 43079.34332
+  dps: 30833.9083
+  tps: 45225.61399
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 30936.24106
-  tps: 43075.46628
+  dps: 30846.58946
+  tps: 45314.87597
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 31507.68955
-  tps: 44324.01623
+  dps: 31676.77496
+  tps: 45833.51591
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-55819"
  value: {
-  dps: 30833.03821
-  tps: 43079.161
+  dps: 30833.9083
+  tps: 45225.42805
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-56351"
  value: {
-  dps: 30833.96632
-  tps: 43079.76069
+  dps: 30834.83642
+  tps: 45226.02657
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 31127.6637
-  tps: 43440.10549
+  dps: 31113.15414
+  tps: 45692.52744
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 31202.6145
-  tps: 43668.74683
+  dps: 31204.07139
+  tps: 45844.54577
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheHungerer-68927"
  value: {
-  dps: 32784.01088
-  tps: 44603.36017
+  dps: 32967.84533
+  tps: 46532.76019
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheHungerer-69112"
  value: {
-  dps: 33113.85198
-  tps: 44701.68356
+  dps: 33221.4033
+  tps: 46648.30094
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 30938.49322
-  tps: 43076.44457
+  dps: 30856.31575
+  tps: 45093.721
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 30857.3447
-  tps: 43215.08651
+  dps: 30835.16363
+  tps: 44943.39224
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 30833.03821
-  tps: 43079.34332
+  dps: 30833.9083
+  tps: 45225.61399
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 30833.03821
-  tps: 43079.34332
+  dps: 30833.9083
+  tps: 45225.61399
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-77190"
  value: {
-  dps: 32789.5866
-  tps: 44677.38145
+  dps: 32811.59139
+  tps: 45989.21671
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-78477"
  value: {
-  dps: 32866.35504
-  tps: 45073.0782
+  dps: 32815.70908
+  tps: 46095.78076
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-78486"
  value: {
-  dps: 32799.29696
-  tps: 45325.62051
+  dps: 32812.0349
+  tps: 45988.23037
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 32353.26978
-  tps: 45308.87266
+  dps: 32392.93696
+  tps: 47882.31136
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 32571.92676
-  tps: 45572.39957
+  dps: 32583.18831
+  tps: 48263.0312
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 31041.52136
-  tps: 43331.95746
+  dps: 31104.73315
+  tps: 46269.91891
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 30863.17097
-  tps: 43092.4894
+  dps: 30880.1071
+  tps: 45752.57649
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnheededWarning-59520"
  value: {
-  dps: 32766.02567
-  tps: 45253.714
+  dps: 32712.12079
+  tps: 47829.35151
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 30889.75165
-  tps: 42998.30866
+  dps: 30870.24856
+  tps: 45205.01081
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 32826.49333
-  tps: 44926.06028
+  dps: 32882.79705
+  tps: 47096.05642
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 32826.49333
-  tps: 44926.06028
+  dps: 32882.79705
+  tps: 47096.05642
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 32826.49333
-  tps: 44926.06028
+  dps: 32882.79705
+  tps: 47096.05642
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 26619.27361
-  tps: 35717.7899
+  dps: 26678.9382
+  tps: 36682.61431
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 30840.65451
-  tps: 43163.77616
+  dps: 30837.21697
+  tps: 45241.81479
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 30834.72099
-  tps: 43095.2188
+  dps: 30836.36808
+  tps: 45233.53967
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 31994.60849
-  tps: 43848.54631
+  dps: 32093.19724
+  tps: 45371.06686
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VeilofLies-72900"
  value: {
-  dps: 30816.10827
-  tps: 42759.20006
+  dps: 30838.4547
+  tps: 45145.46969
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 31986.59994
-  tps: 45133.10585
+  dps: 31940.69602
+  tps: 47088.60446
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 32131.67869
-  tps: 45358.51043
+  dps: 32065.02431
+  tps: 47105.23757
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77207"
  value: {
-  dps: 33290.00296
-  tps: 46259.12024
+  dps: 33612.49588
+  tps: 48838.73145
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77979"
  value: {
-  dps: 33165.92594
-  tps: 46787.60976
+  dps: 33224.41709
+  tps: 49345.06082
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77999"
  value: {
-  dps: 33656.1926
-  tps: 47149.28781
+  dps: 33688.5963
+  tps: 48903.99478
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 30882.22245
-  tps: 42967.20957
+  dps: 30872.4129
+  tps: 45213.21281
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 30882.22245
-  tps: 42967.20957
+  dps: 30872.4129
+  tps: 45213.21281
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 32381.15039
-  tps: 44228.3926
+  dps: 32443.26184
+  tps: 46375.93308
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-70517"
  value: {
-  dps: 32529.77249
-  tps: 44434.377
+  dps: 32650.43944
+  tps: 46708.18872
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 30889.75165
-  tps: 42998.30866
+  dps: 30870.24856
+  tps: 45205.01081
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-70518"
  value: {
-  dps: 30889.75165
-  tps: 42998.30866
+  dps: 30870.24856
+  tps: 45205.01081
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 31450.4143
-  tps: 43474.2782
+  dps: 31449.81136
+  tps: 45903.87587
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-70519"
  value: {
-  dps: 31522.56084
-  tps: 43557.8794
+  dps: 31522.10142
+  tps: 45989.84369
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 30837.3994
-  tps: 43177.01044
+  dps: 30890.1515
+  tps: 45454.11534
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 31194.02393
-  tps: 42824.33257
+  dps: 31311.56935
+  tps: 44341.63374
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 31226.40791
-  tps: 43799.30448
+  dps: 31304.00976
+  tps: 46657.96117
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 30830.21158
-  tps: 43099.33871
+  dps: 30889.17456
+  tps: 45449.19065
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 31272.41489
-  tps: 43789.05349
+  dps: 31334.77829
+  tps: 46160.32536
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 30830.21158
-  tps: 43099.33871
+  dps: 30889.17456
+  tps: 45449.19065
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 32269.1908
-  tps: 44109.16857
+  dps: 32272.11212
+  tps: 45792.61256
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-70577"
  value: {
-  dps: 32667.5889
-  tps: 44763.80327
+  dps: 32614.65889
+  tps: 46488.52187
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 30843.2907
-  tps: 42882.13212
+  dps: 30837.39005
+  tps: 45011.05437
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-70578"
  value: {
-  dps: 30862.76302
-  tps: 42768.9539
+  dps: 30893.01829
+  tps: 45192.37201
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 31350.51801
-  tps: 43238.83949
+  dps: 31386.84221
+  tps: 45898.39853
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-70579"
  value: {
-  dps: 31439.14
-  tps: 43434.42003
+  dps: 31432.78468
+  tps: 45813.82581
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 30833.03821
-  tps: 43092.90622
+  dps: 30833.9083
+  tps: 45227.77454
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 30833.03821
-  tps: 43090.91325
+  dps: 30833.9083
+  tps: 45227.47276
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WillofUnbinding-77995"
  value: {
-  dps: 30833.03821
-  tps: 43095.06048
+  dps: 30833.9083
+  tps: 45228.10282
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 30829.42803
-  tps: 43628.21288
+  dps: 30869.88775
+  tps: 45209.5305
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 30845.55156
-  tps: 43123.49676
+  dps: 30874.63259
+  tps: 45250.58567
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 31119.03785
-  tps: 43519.13972
+  dps: 31118.34941
+  tps: 45701.2142
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 34456.93343
-  tps: 48491.33205
+  dps: 34355.37951
+  tps: 50468.77238
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 34022.76474
-  tps: 47933.88696
+  dps: 33919.35498
+  tps: 49782.81196
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 34912.89558
-  tps: 49134.08053
+  dps: 34867.01107
+  tps: 51299.45621
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 31206.99684
-  tps: 43371.59188
+  dps: 31228.28013
+  tps: 45226.40711
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 31206.99684
-  tps: 43371.59188
+  dps: 31228.28013
+  tps: 45226.40711
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 33140.90939
-  tps: 44836.24599
+  dps: 33272.9097
+  tps: 46654.97278
  }
 }
 dps_results: {
@@ -2120,43 +2120,43 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 42071.653
-  tps: 58057.64153
+  dps: 39235.83864
+  tps: 49907.86722
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39151.79408
-  tps: 50655.03402
+  dps: 39218.15611
+  tps: 50957.18764
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 50398.43609
-  tps: 44063.64498
+  dps: 50310.56737
+  tps: 44115.75691
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 26639.94675
-  tps: 36803.70259
+  dps: 24972.80979
+  tps: 32936.48158
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25157.45067
-  tps: 33261.88236
+  dps: 25201.45855
+  tps: 33908.56669
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 28318.33696
-  tps: 26539.40964
+  dps: 28347.71226
+  tps: 26817.66518
  }
 }
 dps_results: {
@@ -2246,43 +2246,43 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 41012.72091
-  tps: 55066.46081
+  dps: 38582.18595
+  tps: 49525.83809
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37996.5314
-  tps: 48593.46699
+  dps: 38092.66851
+  tps: 48597.32401
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 48612.8091
-  tps: 41814.17569
+  dps: 48559.09691
+  tps: 41622.5781
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 25882.22235
-  tps: 34914.74041
+  dps: 24321.56102
+  tps: 31253.18424
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24403.57122
-  tps: 31603.85417
+  dps: 24486.13583
+  tps: 32403.74311
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27031.88294
-  tps: 25027.8584
+  dps: 27075.57938
+  tps: 25294.14997
  }
 }
 dps_results: {
@@ -2372,43 +2372,43 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 36316.15942
-  tps: 53071.56765
+  dps: 33328.10015
+  tps: 45119.96559
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 32935.47433
-  tps: 44944.47545
+  dps: 32887.64043
+  tps: 46315.38842
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 41208.91483
-  tps: 41323.87817
+  dps: 41284.18464
+  tps: 41941.5991
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 22650.90542
-  tps: 33335.8656
+  dps: 20815.03947
+  tps: 30174.89456
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20941.05911
-  tps: 29319.91898
+  dps: 21079.84491
+  tps: 31027.85457
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 23015.5627
-  tps: 24626.40308
+  dps: 22943.56874
+  tps: 25205.50681
  }
 }
 dps_results: {
@@ -2498,43 +2498,43 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 35585.19148
-  tps: 50911.51073
+  dps: 32660.51489
+  tps: 44132.68003
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 32009.87123
-  tps: 43160.131
+  dps: 32138.78192
+  tps: 43705.54335
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 40480.98275
-  tps: 39852.75979
+  dps: 40692.74182
+  tps: 40493.61408
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 22431.38709
-  tps: 33073.62223
+  dps: 20244.13503
+  tps: 28006.32556
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20258.6681
-  tps: 28588.43526
+  dps: 20374.36447
+  tps: 29147.29242
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 22255.24804
-  tps: 24378.75745
+  dps: 22276.61764
+  tps: 24848.73883
  }
 }
 dps_results: {
@@ -2624,43 +2624,43 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 41558.64916
-  tps: 57290.18631
+  dps: 39108.59431
+  tps: 49017.55539
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38941.25203
-  tps: 49640.26652
+  dps: 39100.74033
+  tps: 52076.93299
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 49636.87788
-  tps: 43106.45982
+  dps: 49688.6079
+  tps: 43509.89935
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 26748.42594
-  tps: 37684.27916
+  dps: 24803.36437
+  tps: 32430.55973
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25075.0565
-  tps: 33444.35028
+  dps: 25127.841
+  tps: 33888.29727
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27771.33418
-  tps: 27471.55895
+  dps: 27753.63963
+  tps: 27727.31908
  }
 }
 dps_results: {
@@ -2750,43 +2750,43 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 40709.32835
-  tps: 53734.8742
+  dps: 38464.41944
+  tps: 48314.27312
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37929.17767
-  tps: 48384.95405
+  dps: 38062.96739
+  tps: 49299.05682
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 48182.8055
-  tps: 42747.54776
+  dps: 48238.95708
+  tps: 42931.29527
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 25746.46324
-  tps: 34744.22154
+  dps: 24224.08689
+  tps: 30896.19215
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24316.45389
-  tps: 32116.52559
+  dps: 24352.67811
+  tps: 32019.37637
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 26678.88134
-  tps: 25888.73835
+  dps: 26671.31803
+  tps: 25940.17033
  }
 }
 dps_results: {
@@ -2876,43 +2876,43 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 36250.75629
-  tps: 52522.93868
+  dps: 33209.18396
+  tps: 45950.76974
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 32791.51226
-  tps: 45106.22211
+  dps: 32813.85285
+  tps: 46094.91377
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 40983.16925
-  tps: 40950.69741
+  dps: 40971.51055
+  tps: 42302.28515
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 22645.70522
-  tps: 33097.34681
+  dps: 20832.58739
+  tps: 29010.21564
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20822.47138
-  tps: 29669.10113
+  dps: 21041.24738
+  tps: 31203.67013
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 22544.74428
-  tps: 25031.82326
+  dps: 22657.96265
+  tps: 26355.4533
  }
 }
 dps_results: {
@@ -3002,43 +3002,43 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 35509.19217
-  tps: 51494.24239
+  dps: 32554.58679
+  tps: 43559.59736
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 31827.46775
-  tps: 42667.91773
+  dps: 31906.41953
+  tps: 43512.49453
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 40033.47671
-  tps: 40177.06014
+  dps: 39917.31375
+  tps: 41050.46928
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 22288.95884
-  tps: 33499.04252
+  dps: 20215.87465
+  tps: 28612.42486
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20275.56758
-  tps: 28458.95934
+  dps: 20371.01491
+  tps: 29604.25428
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 21920.22873
-  tps: 24462.21977
+  dps: 21954.15642
+  tps: 24832.83666
  }
 }
 dps_results: {
@@ -3086,7 +3086,7 @@ dps_results: {
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 28879.3556
-  tps: 41574.63064
+  dps: 28792.94055
+  tps: 41995.89772
  }
 }

--- a/sim/druid/feral/apl_values.go
+++ b/sim/druid/feral/apl_values.go
@@ -164,7 +164,7 @@ func (action *APLActionCatOptimalRotationAction) Execute(sim *core.Simulation) {
 	}
 
 	// Off-GCD Maul check.
-	if cat.BearFormAura.IsActive() && !cat.ClearcastingAura.IsActive() && cat.Maul.CanCast(sim, cat.CurrentTarget) && (cat.CurrentRage() >= cat.Maul.DefaultCast.Cost + cat.MangleBear.DefaultCast.Cost) {
+	if cat.BearFormAura.IsActive() && !cat.ClearcastingAura.IsActive() && cat.Maul.CanCast(sim, cat.CurrentTarget) && ((cat.CurrentRage() >= cat.Maul.DefaultCast.Cost + cat.MangleBear.DefaultCast.Cost) || (cat.AutoAttacks.NextAttackAt() < cat.NextGCDAt())) {
 		cat.Maul.Cast(sim, cat.CurrentTarget)
 	}
 

--- a/sim/druid/feral/apl_values.go
+++ b/sim/druid/feral/apl_values.go
@@ -163,6 +163,11 @@ func (action *APLActionCatOptimalRotationAction) Execute(sim *core.Simulation) {
 		}
 	}
 
+	// Off-GCD Maul check.
+	if cat.BearFormAura.IsActive() && !cat.ClearcastingAura.IsActive() && cat.Maul.CanCast(sim, cat.CurrentTarget) && (cat.CurrentRage() >= cat.Maul.DefaultCast.Cost + cat.MangleBear.DefaultCast.Cost) {
+		cat.Maul.Cast(sim, cat.CurrentTarget)
+	}
+
 	// Handle movement before any rotation logic
 	if cat.Moving || (cat.Hardcast.Expires > sim.CurrentTime) {
 		return

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -371,11 +371,14 @@ func (cat *FeralDruid) calcBleedRefreshTime(sim *core.Simulation, bleedSpell *dr
 
 	energyEquivalent := expectedDamageGain / cat.Shred.ExpectedInitialDamage(sim, cat.CurrentTarget) * cat.Shred.DefaultCast.Cost
 
+	// Finally, discount the effective Energy cost of the clip based on the number of clipped ticks.
+	discountedRefreshCost := float64(numClippedTicks) / float64(maxTickCount) * bleedSpell.DefaultCast.Cost
+
 	if sim.Log != nil {
-		cat.Log(sim, "%s buff snapshot is worth %.1f Energy", bleedSpell.ShortName, energyEquivalent)
+		cat.Log(sim, "%s buff snapshot is worth %.1f Energy, discounted refresh cost is %.1f Energy.", bleedSpell.ShortName, energyEquivalent, discountedRefreshCost)
 	}
 
-	return core.TernaryDuration(energyEquivalent > bleedSpell.DefaultCast.Cost, targetClipTime, standardRefreshTime)
+	return core.TernaryDuration(energyEquivalent > discountedRefreshCost, targetClipTime, standardRefreshTime)
 }
 
 func (cat *FeralDruid) canMeleeWeave(sim *core.Simulation, regenRate float64, currentEnergy float64, isClearcast bool, upcomingTimers *PoolingActions) bool {

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -462,7 +462,7 @@ func (cat *FeralDruid) terminateBearWeave(sim *core.Simulation, isClearcast bool
 	}
 
 	// Check Energy pooling leeway
-	nextGCDLength := core.TernaryDuration(cat.Thrash.CanCast(sim, cat.CurrentTarget) || cat.MangleBear.CanCast(sim, cat.CurrentTarget), core.GCDDefault, core.GCDMin)
+	nextGCDLength := core.TernaryDuration(cat.Lacerate.CanCast(sim, cat.CurrentTarget) || cat.MangleBear.CanCast(sim, cat.CurrentTarget), core.GCDDefault, core.GCDMin)
 	smallestWeaveExtension := nextGCDLength + cat.ReactionTime
 	finalEnergy := currentEnergy + smallestWeaveExtension.Seconds()*regenRate
 
@@ -649,8 +649,8 @@ func (cat *FeralDruid) doRotation(sim *core.Simulation) (bool, time.Duration) {
 			cat.readyToShift = true
 		} else if cat.MangleBear.CanCast(sim, cat.CurrentTarget) {
 			cat.MangleBear.Cast(sim, cat.CurrentTarget)
-		} else if cat.Thrash.CanCast(sim, cat.CurrentTarget) {
-			cat.Thrash.Cast(sim, cat.CurrentTarget)
+		} else if cat.Lacerate.CanCast(sim, cat.CurrentTarget) {
+			cat.Lacerate.Cast(sim, cat.CurrentTarget)
 		} else if cat.FaerieFire.CanCast(sim, cat.CurrentTarget) {
 			cat.FaerieFire.Cast(sim, cat.CurrentTarget)
 		} else {

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -411,8 +411,13 @@ func (cat *FeralDruid) canMeleeWeave(sim *core.Simulation, regenRate float64, cu
 	return weaveEnd+timeToDump < sim.Duration
 }
 
-func (cat *FeralDruid) canBearWeave(sim *core.Simulation, furorCap float64, regenRate float64, currentEnergy float64, upcomingTimers *PoolingActions, shiftCost float64) bool {
+func (cat *FeralDruid) canBearWeave(sim *core.Simulation, furorCap float64, regenRate float64, currentEnergy float64, excessEnergy float64, upcomingTimers *PoolingActions, shiftCost float64) bool {
 	if !cat.Rotation.BearWeave || cat.ClearcastingAura.IsActive() || cat.BerserkAura.IsActive() || (cat.StampedeCatAura.IsActive() && (cat.Rotation.RotationType == proto.FeralDruid_Rotation_SingleTarget)) {
+		return false
+	}
+
+	// If we can Shred now and then weave on the next GCD, prefer that.
+	if excessEnergy > cat.Shred.DefaultCast.Cost {
 		return false
 	}
 
@@ -639,7 +644,7 @@ func (cat *FeralDruid) doRotation(sim *core.Simulation) (bool, time.Duration) {
 
 	// Check bear-weaving conditions
 	furorCap := min(float64(100*cat.Talents.Furor)/3.0, 100.0-1.5*regenRate)
-	bearWeaveNow := cat.canBearWeave(sim, furorCap, regenRate, curEnergy, pendingPool, shiftCost)
+	bearWeaveNow := cat.canBearWeave(sim, furorCap, regenRate, curEnergy, excessE, pendingPool, shiftCost)
 	// Main  decision tree starts here
 	timeToNextAction := time.Duration(0)
 

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -668,23 +668,13 @@ func (cat *FeralDruid) doRotation(sim *core.Simulation) (bool, time.Duration) {
 			cat.readyToShift = true
 		}
 
-		// Then Maul if we still have Rage leftover.
-		if cat.Maul.CanCast(sim, cat.CurrentTarget) && !isClearcast {
-			if cat.readyToShift {
-				cat.Maul.Cast(sim, cat.CurrentTarget)
-			} else {
-				core.StartDelayedAction(sim, core.DelayedActionOptions{
-					DoAt: sim.CurrentTime + cat.ReactionTime*2,
-
-					OnAction: func(sim *core.Simulation) {
-						cat.Maul.Cast(sim, cat.CurrentTarget)
-					},
-				})
-			}
+		// Last second Maul check if we are about to shift back..
+		if cat.readyToShift && cat.Maul.CanCast(sim, cat.CurrentTarget) && !isClearcast {
+			cat.Maul.Cast(sim, cat.CurrentTarget)
 		}
 
 		if !cat.readyToShift {
-			return false, 0
+			timeToNextAction = cat.ReactionTime
 		}
 	} else if t11RefreshNow {
 		if cat.MangleCat.CanCast(sim, cat.CurrentTarget) {

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -659,7 +659,17 @@ func (cat *FeralDruid) doRotation(sim *core.Simulation) (bool, time.Duration) {
 
 		// Then Maul if we still have Rage leftover.
 		if cat.Maul.CanCast(sim, cat.CurrentTarget) && !isClearcast {
-			cat.Maul.Cast(sim, cat.CurrentTarget)
+			if cat.readyToShift {
+				cat.Maul.Cast(sim, cat.CurrentTarget)
+			} else {
+				core.StartDelayedAction(sim, core.DelayedActionOptions{
+					DoAt: sim.CurrentTime + cat.ReactionTime*2,
+
+					OnAction: func(sim *core.Simulation) {
+						cat.Maul.Cast(sim, cat.CurrentTarget)
+					},
+				})
+			}
 		}
 
 		if !cat.readyToShift {

--- a/sim/druid/feral/rotation_aoe.go
+++ b/sim/druid/feral/rotation_aoe.go
@@ -164,7 +164,7 @@ func (cat *FeralDruid) doAoeRotation(sim *core.Simulation) (bool, time.Duration)
 	}
 
 	// If we couldn't cast a Cat Form ability, check if we can bear-weave while pooling
-	if cat.canBearWeave(sim, furorCap, regenRate, curEnergy, &PoolingActions{}, cat.CatForm.DefaultCast.Cost) {
+	if cat.canBearWeave(sim, furorCap, regenRate, curEnergy, curEnergy, &PoolingActions{}, cat.CatForm.DefaultCast.Cost) {
 		cat.readyToShift = true
 		timeToNextAction = 0
 	}


### PR DESCRIPTION
- Discount effective refresh Energy cost for bleed clips based on the number of clipped ticks. Adds anywhere from 26 to 83 DPS depending on gear/talents/rotation config.
- Desynchronize Maul casts to be off-GCD when possible to prevent 2pT12 munching. Adds 15-22 DPS depending on gear and talents.
- Replace Thrash with Lacerate in bear-weave rotational priority. Adds 36-124 DPS depending on gear and talents.
- Delay bear-weaves by a global if `excessE` is high enough to Shred first to enable a longer weave. Adds 28-32 DPS depending on talents and gear.
- Block Rake delays for an upcoming TF when Berserk is active (same change previously made for Rip). Adds 25-66 DPS to 4pT12 configs, with no impact on non-4pT12 configs.
- Allow Savage Roar to expire mid-bearweave. Adds 41-63 DPS depending on gear and talents.
- Allow Mauling before the Bear Form GCD is up when Rage is plentiful in order to put it on CD ASAP. Adds 2-25 DPS depending on gear and talents.
- Use lower Rage threshold for Maul if swing timer will expire before the next bear GCD. Adds 27-39 DPS depending on gear and talents.