### PR TITLE
Feral Rotation Updates

### DIFF
--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -38,2055 +38,2055 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 32952.52049
-  tps: 47431.18348
+  dps: 33045.59964
+  tps: 48165.54524
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 30834.70877
-  tps: 45474.60477
+  dps: 30855.04706
+  tps: 45904.90019
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 33040.76111
-  tps: 48209.98811
+  dps: 33030.0425
+  tps: 48172.07932
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 30836.08139
-  tps: 45481.64772
+  dps: 30856.024
+  tps: 45913.94935
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 30836.08139
-  tps: 45481.64772
+  dps: 30856.024
+  tps: 45913.94935
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 32029.05005
-  tps: 47229.53467
+  dps: 32072.64685
+  tps: 47442.39187
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 32175.0755
-  tps: 47694.40597
+  dps: 32216.20448
+  tps: 47902.42812
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ArrowofTime-72897"
  value: {
-  dps: 33067.20072
-  tps: 47306.97108
+  dps: 33057.48457
+  tps: 47422.52878
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 32139.79229
-  tps: 46471.31935
+  dps: 32221.86779
+  tps: 47210.56629
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 30834.70877
-  tps: 45474.74463
+  dps: 30855.04706
+  tps: 45905.03889
   hps: 96.77966
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 30834.70877
-  tps: 45474.74463
+  dps: 30855.04706
+  tps: 45905.03889
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 31311.18449
-  tps: 46842.82038
+  dps: 31335.92851
+  tps: 47043.4417
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 31315.88695
-  tps: 47131.30035
+  dps: 31342.8679
+  tps: 47112.35087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BindingPromise-67037"
  value: {
-  dps: 30870.09404
-  tps: 45759.99385
+  dps: 30890.43412
+  tps: 46190.50388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 32438.1851
-  tps: 47621.2653
+  dps: 32444.20942
+  tps: 47760.99877
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 31164.81251
-  tps: 46014.68404
+  dps: 31185.13755
+  tps: 46448.56502
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 31207.68998
-  tps: 46086.50755
+  dps: 31228.01328
+  tps: 46520.85811
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 32925.77033
-  tps: 46920.20492
+  dps: 32939.02988
+  tps: 46745.56093
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 30870.09404
-  tps: 45759.99385
+  dps: 30890.43412
+  tps: 46190.50388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 31387.94638
-  tps: 45942.45425
+  dps: 31412.71688
+  tps: 46344.96722
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 31255.92759
-  tps: 46448.39495
+  dps: 31301.29632
+  tps: 46639.1591
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 30855.1896
-  tps: 45660.69715
+  dps: 30877.53231
+  tps: 46101.2203
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 30855.1896
-  tps: 45660.69715
+  dps: 30877.53231
+  tps: 46101.2203
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 32208.51166
-  tps: 46296.00022
+  dps: 32276.52823
+  tps: 46408.3922
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 30834.62352
-  tps: 45474.68409
+  dps: 30868.53612
+  tps: 45954.07837
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 31372.07996
-  tps: 46609.78939
+  dps: 31374.84103
+  tps: 46925.02286
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 32915.64919
-  tps: 48733.76573
+  dps: 32897.56401
+  tps: 48467.88987
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 32614.71573
-  tps: 48420.49244
+  dps: 32608.74856
+  tps: 48334.28125
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 33157.22177
-  tps: 48892.72629
+  dps: 33213.65977
+  tps: 48882.55296
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledLightning-66879"
  value: {
-  dps: 30986.39689
-  tps: 45893.59934
+  dps: 31036.46306
+  tps: 46009.19599
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledWishes-77114"
  value: {
-  dps: 31365.55946
-  tps: 46795.43993
+  dps: 31398.8841
+  tps: 46864.29936
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 32139.79229
-  tps: 45542.14642
+  dps: 32221.86779
+  tps: 46266.60826
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 30870.09404
-  tps: 45759.99385
+  dps: 30890.43412
+  tps: 46190.50388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 32743.85706
-  tps: 47313.03126
+  dps: 32827.30517
+  tps: 48068.71036
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sBadgeofConquest-73648"
  value: {
-  dps: 33318.16785
-  tps: 48255.87473
+  dps: 33340.17946
+  tps: 48234.35737
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sBadgeofDominance-73498"
  value: {
-  dps: 30870.09404
-  tps: 45759.99385
+  dps: 30890.43412
+  tps: 46190.50388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sBadgeofVictory-73496"
  value: {
-  dps: 31690.05426
-  tps: 46619.72016
+  dps: 31730.37771
+  tps: 46988.05214
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sInsigniaofConquest-73643"
  value: {
-  dps: 33072.1555
-  tps: 48541.78432
+  dps: 33051.00862
+  tps: 48628.4781
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sInsigniaofDominance-73497"
  value: {
-  dps: 30886.13001
-  tps: 45728.27651
+  dps: 30878.6353
+  tps: 46030.29445
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sInsigniaofVictory-73491"
  value: {
-  dps: 31805.36221
-  tps: 46659.55765
+  dps: 31773.7318
+  tps: 46447.77117
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 32786.27567
-  tps: 47007.08458
+  dps: 32882.39906
+  tps: 47750.78714
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 32204.04972
-  tps: 47228.4222
+  dps: 32199.73254
+  tps: 47367.28934
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 30871.95026
-  tps: 45761.04969
+  dps: 30892.29035
+  tps: 46191.56187
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 30834.70877
-  tps: 45474.74463
+  dps: 30855.04706
+  tps: 45905.03889
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 32344.26463
-  tps: 48024.38317
+  dps: 32343.06631
+  tps: 47914.54527
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 32317.19204
-  tps: 47354.44505
+  dps: 32316.68428
+  tps: 47456.47487
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 32781.66385
-  tps: 48198.02728
+  dps: 32755.05128
+  tps: 48276.96428
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-59506"
  value: {
-  dps: 31740.89042
-  tps: 45917.13066
+  dps: 31828.71114
+  tps: 46050.89523
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-65118"
  value: {
-  dps: 32107.99678
-  tps: 46273.13183
+  dps: 32124.78013
+  tps: 46343.75502
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 31208.44483
-  tps: 46134.85374
+  dps: 31233.67087
+  tps: 46594.99143
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 31162.35858
-  tps: 45601.00239
+  dps: 31204.22661
+  tps: 46069.71661
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-78000"
  value: {
-  dps: 31307.29978
-  tps: 45977.36633
+  dps: 31323.93566
+  tps: 46372.27491
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 30855.1896
-  tps: 45660.69715
+  dps: 30877.53231
+  tps: 46101.2203
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 31544.35261
-  tps: 46696.72987
+  dps: 31549.92426
+  tps: 46635.10563
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 32304.04669
-  tps: 47975.92507
+  dps: 32329.95611
+  tps: 47988.38883
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 30836.565
-  tps: 45475.80154
+  dps: 30856.90328
+  tps: 45906.09796
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 31254.52912
-  tps: 46171.52032
+  dps: 31280.29637
+  tps: 46552.44417
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 31826.40274
-  tps: 46399.18824
+  dps: 31868.69353
+  tps: 46676.00318
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeepEarthRegalia"
  value: {
-  dps: 22145.75699
-  tps: 30746.68514
+  dps: 22155.6964
+  tps: 30614.95423
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 32177.87626
-  tps: 46165.93042
+  dps: 32272.27642
+  tps: 46893.09413
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 31021.44354
-  tps: 46765.21715
+  dps: 31054.66995
+  tps: 46843.76226
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dragonwrath,Tarecgosa'sRest-71086"
  value: {
-  dps: 33307.00374
-  tps: 48101.70428
+  dps: 33332.09471
+  tps: 48217.44369
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 31957.16989
-  tps: 47882.54045
+  dps: 31977.49077
+  tps: 47974.05126
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 32139.79229
-  tps: 46471.31935
+  dps: 32221.86779
+  tps: 47210.56629
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 30871.95026
-  tps: 45798.30227
+  dps: 30892.29035
+  tps: 46228.54007
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 32139.79229
-  tps: 46471.25442
+  dps: 32221.86779
+  tps: 47210.50163
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 32177.87626
-  tps: 46165.93042
+  dps: 32272.27642
+  tps: 46893.09413
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 32650.47544
-  tps: 47636.81355
+  dps: 32628.06822
+  tps: 47587.22153
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 32045.01901
-  tps: 47638.32845
+  dps: 32039.9407
+  tps: 47409.90434
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 32139.79229
-  tps: 46471.31935
+  dps: 32221.86779
+  tps: 47210.56629
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 32205.88393
-  tps: 47482.61081
+  dps: 32226.87862
+  tps: 47932.19098
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 32050.37264
-  tps: 47253.47476
+  dps: 32071.29274
+  tps: 47700.86345
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 32376.94635
-  tps: 47734.66047
+  dps: 32398.02309
+  tps: 48186.65127
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-59500"
  value: {
-  dps: 30836.565
-  tps: 45475.80154
+  dps: 30856.90328
+  tps: 45906.09796
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-65124"
  value: {
-  dps: 30836.565
-  tps: 45475.76739
+  dps: 30856.90328
+  tps: 45906.06409
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 30847.21062
-  tps: 45532.91849
+  dps: 30877.52873
+  tps: 46013.0691
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 32234.54473
-  tps: 47124.26843
+  dps: 32253.24631
+  tps: 47244.82165
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 30871.02215
-  tps: 45760.42012
+  dps: 30891.36224
+  tps: 46190.93206
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 30870.09404
-  tps: 45759.99385
+  dps: 30890.43412
+  tps: 46190.50388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 30871.02215
-  tps: 45760.42012
+  dps: 30891.36224
+  tps: 46190.93206
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 31734.98716
-  tps: 46560.06057
+  dps: 31755.84097
+  tps: 46941.78935
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 31428.71709
-  tps: 47004.04645
+  dps: 31456.72781
+  tps: 47465.11395
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 32211.52817
-  tps: 46590.0183
+  dps: 32293.60897
+  tps: 47331.11542
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FluidDeath-58181"
  value: {
-  dps: 32379.92963
-  tps: 48066.88023
+  dps: 32421.69935
+  tps: 48278.18608
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 32139.79229
-  tps: 46471.27653
+  dps: 32221.86779
+  tps: 47210.52365
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 31319.27161
-  tps: 45257.26372
+  dps: 31293.40174
+  tps: 45189.75838
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 32021.53674
-  tps: 47887.80346
+  dps: 32036.34114
+  tps: 47870.32481
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56138"
  value: {
-  dps: 31159.72242
-  tps: 45571.11003
+  dps: 31226.7845
+  tps: 45961.53013
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56462"
  value: {
-  dps: 31349.58548
-  tps: 44860.30215
+  dps: 31356.59519
+  tps: 44963.97961
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GearDetector-61462"
  value: {
-  dps: 31892.30179
-  tps: 46807.87249
+  dps: 31874.71629
+  tps: 46851.00845
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 26449.80073
-  tps: 37869.19681
+  dps: 26475.88247
+  tps: 37869.82908
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 30834.70877
-  tps: 45474.59502
+  dps: 30855.04706
+  tps: 45904.89051
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 31894.62201
-  tps: 47449.57467
+  dps: 31882.87922
+  tps: 47472.12245
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 32413.06509
-  tps: 47299.79255
+  dps: 32375.49362
+  tps: 47318.22942
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HarmlightToken-63839"
  value: {
-  dps: 30860.01565
-  tps: 45532.87336
+  dps: 30880.34825
+  tps: 45963.16505
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 31558.6434
-  tps: 46081.65458
+  dps: 31598.51938
+  tps: 46287.21397
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 30834.70877
-  tps: 45474.74463
+  dps: 30855.04706
+  tps: 45905.03889
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 30834.70877
-  tps: 45474.74463
+  dps: 30855.04706
+  tps: 45905.03889
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-59224"
  value: {
-  dps: 31531.32825
-  tps: 46815.9639
+  dps: 31545.45458
+  tps: 46770.58397
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-65072"
  value: {
-  dps: 31655.88263
-  tps: 46114.83987
+  dps: 31661.5413
+  tps: 46255.20322
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-55868"
  value: {
-  dps: 31737.53707
-  tps: 46770.08785
+  dps: 31812.03023
+  tps: 46903.038
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-56393"
  value: {
-  dps: 31942.03863
-  tps: 45233.55533
+  dps: 31945.09724
+  tps: 45323.76631
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-55845"
  value: {
-  dps: 30834.70877
-  tps: 45474.74463
+  dps: 30855.04706
+  tps: 45905.03889
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-56370"
  value: {
-  dps: 30834.70877
-  tps: 45474.74463
+  dps: 30855.04706
+  tps: 45905.03889
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 31886.7468
-  tps: 46777.01908
+  dps: 31900.20795
+  tps: 46903.71627
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-50641"
  value: {
-  dps: 33608.34535
-  tps: 47609.16212
+  dps: 33649.85707
+  tps: 47655.32372
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 32177.87626
-  tps: 46165.93042
+  dps: 32272.27642
+  tps: 46893.09413
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 31838.4651
-  tps: 46911.66572
+  dps: 31866.35841
+  tps: 47205.11569
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 31838.4651
-  tps: 46911.66572
+  dps: 31866.35841
+  tps: 47205.11569
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 31173.55648
-  tps: 45913.13811
+  dps: 31210.49082
+  tps: 46483.06778
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 31216.3406
-  tps: 45984.54159
+  dps: 31253.29549
+  tps: 46555.04355
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndomitablePride-77211"
  value: {
-  dps: 30834.70877
-  tps: 45474.74463
+  dps: 30855.04706
+  tps: 45905.03889
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndomitablePride-77983"
  value: {
-  dps: 30834.70877
-  tps: 45474.74463
+  dps: 30855.04706
+  tps: 45905.03889
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndomitablePride-78003"
  value: {
-  dps: 30834.70877
-  tps: 45474.74463
+  dps: 30855.04706
+  tps: 45905.03889
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 30834.70877
-  tps: 45474.74463
+  dps: 30855.04706
+  tps: 45905.03889
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 31641.12376
-  tps: 46001.39865
+  dps: 31642.42529
+  tps: 45556.63053
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 31499.68408
-  tps: 44854.97001
+  dps: 31508.87784
+  tps: 44813.88992
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 31783.26908
-  tps: 45579.60246
+  dps: 31820.4011
+  tps: 45754.94374
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 31133.34082
-  tps: 46122.86362
+  dps: 31150.22222
+  tps: 46479.53215
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 30834.70877
-  tps: 45474.97763
+  dps: 30855.04706
+  tps: 45905.20989
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 30834.70877
-  tps: 45474.97763
+  dps: 30855.04706
+  tps: 45905.20989
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 30836.565
-  tps: 45475.75113
+  dps: 30856.90328
+  tps: 45906.04797
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 30836.565
-  tps: 45475.71048
+  dps: 30856.90328
+  tps: 45906.00765
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 32438.1851
-  tps: 47621.2653
+  dps: 32444.20942
+  tps: 47760.99877
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 32085.68944
-  tps: 47027.94506
+  dps: 32137.41551
+  tps: 47292.86769
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 32523.77402
-  tps: 47674.58567
+  dps: 32564.95472
+  tps: 48009.30081
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-77194"
  value: {
-  dps: 36477.55298
-  tps: 51790.521
+  dps: 36600.24754
+  tps: 52308.39588
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-78473"
  value: {
-  dps: 37072.5764
-  tps: 52956.01831
+  dps: 37163.43207
+  tps: 53123.85801
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-78482"
  value: {
-  dps: 36142.38073
-  tps: 52273.77024
+  dps: 36189.55357
+  tps: 52679.72401
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 34232.87608
-  tps: 49216.32183
+  dps: 34225.95032
+  tps: 49394.80593
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 31390.53602
-  tps: 46675.6197
+  dps: 31425.65499
+  tps: 46865.00839
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 31390.53602
-  tps: 46675.6197
+  dps: 31425.65499
+  tps: 46865.00839
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 31083.0855
-  tps: 45443.573
+  dps: 31111.62716
+  tps: 45787.77165
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50708"
  value: {
-  dps: 33137.09036
-  tps: 47695.88371
+  dps: 33230.67252
+  tps: 48434.38044
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-55816"
  value: {
-  dps: 30834.70877
-  tps: 45474.74463
+  dps: 30855.04706
+  tps: 45905.03889
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-56347"
  value: {
-  dps: 30834.70877
-  tps: 45474.74463
+  dps: 30855.04706
+  tps: 45905.03889
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 32064.07085
-  tps: 47196.80164
+  dps: 32077.02437
+  tps: 47237.4392
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 32345.91101
-  tps: 47190.23185
+  dps: 32445.4083
+  tps: 47427.32591
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 31426.80841
-  tps: 46351.9452
+  dps: 31447.04099
+  tps: 46792.60713
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 31366.43447
-  tps: 46529.78731
+  dps: 31371.32554
+  tps: 46477.08438
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 31468.9178
-  tps: 46432.84236
+  dps: 31496.27514
+  tps: 46567.93222
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 30834.70877
-  tps: 45474.74463
+  dps: 30855.04706
+  tps: 45905.03889
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 30834.70877
-  tps: 45474.74463
+  dps: 30855.04706
+  tps: 45905.03889
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 31728.16019
-  tps: 46716.81757
+  dps: 31726.09602
+  tps: 46840.3777
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 31880.85746
-  tps: 47072.65385
+  dps: 31878.65123
+  tps: 47196.96666
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 33186.35694
-  tps: 48096.72671
+  dps: 33249.05738
+  tps: 48094.77069
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 33437.05741
-  tps: 48971.60515
+  dps: 33460.00835
+  tps: 48742.29532
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 31209.92249
-  tps: 46367.66122
+  dps: 31223.03685
+  tps: 46329.68003
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 31469.89474
-  tps: 46437.76705
+  dps: 31497.25208
+  tps: 46572.85691
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 31263.01418
-  tps: 46062.43629
+  dps: 31299.9915
+  tps: 46633.56258
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 31263.01418
-  tps: 46062.43629
+  dps: 31299.9915
+  tps: 46633.56258
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 31253.24371
-  tps: 46549.357
+  dps: 31300.63749
+  tps: 46750.0511
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 31360.75568
-  tps: 46447.79708
+  dps: 31376.85312
+  tps: 46889.00214
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 30870.09404
-  tps: 45759.99385
+  dps: 30890.43412
+  tps: 46190.50388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 30836.565
-  tps: 45475.75113
+  dps: 30856.90328
+  tps: 45906.04797
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 30836.565
-  tps: 45475.71048
+  dps: 30856.90328
+  tps: 45906.00765
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ObsidianArborweaveBattlegarb"
  value: {
-  dps: 31184.87357
-  tps: 40845.78505
+  dps: 31205.05593
+  tps: 41068.3953
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ObsidianArborweaveRegalia"
  value: {
-  dps: 22554.36858
-  tps: 31908.61081
+  dps: 22573.98033
+  tps: 31953.15455
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 31429.52542
-  tps: 45865.05942
+  dps: 31382.00115
+  tps: 45791.23098
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 30835.63689
-  tps: 45475.15641
+  dps: 30855.97517
+  tps: 45905.45271
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 30834.70877
-  tps: 45474.74463
+  dps: 30855.04706
+  tps: 45905.03889
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 31088.3229
-  tps: 46194.74311
+  dps: 31111.45435
+  tps: 46407.92753
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 31126.11998
-  tps: 45429.88345
+  dps: 31172.44576
+  tps: 45540.87661
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 31278.98249
-  tps: 45873.77539
+  dps: 31250.39819
+  tps: 45711.53337
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 32139.79229
-  tps: 46471.31935
+  dps: 32221.86779
+  tps: 47210.56629
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 32792.66635
-  tps: 47002.77374
+  dps: 32816.69792
+  tps: 47027.75865
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-55854"
  value: {
-  dps: 30834.70877
-  tps: 45474.74463
+  dps: 30855.04706
+  tps: 45905.03889
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-56377"
  value: {
-  dps: 30834.70877
-  tps: 45474.74463
+  dps: 30855.04706
+  tps: 45905.03889
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rathrak,thePoisonousMind-77195"
  value: {
-  dps: 29868.54853
-  tps: 43782.0148
+  dps: 29862.76072
+  tps: 43576.74813
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rathrak,thePoisonousMind-78475"
  value: {
-  dps: 30451.23541
-  tps: 44548.09801
+  dps: 30442.24436
+  tps: 44337.50152
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rathrak,thePoisonousMind-78484"
  value: {
-  dps: 29318.27698
-  tps: 43211.54588
+  dps: 29344.17254
+  tps: 43094.79133
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 30878.18093
-  tps: 45706.93998
+  dps: 30895.28528
+  tps: 46061.66668
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 30834.70877
-  tps: 45474.74463
+  dps: 30855.04706
+  tps: 45905.03889
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 30834.70877
-  tps: 45474.74463
+  dps: 30855.04706
+  tps: 45905.03889
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 30834.70877
-  tps: 45474.74463
+  dps: 30855.04706
+  tps: 45905.03889
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 32831.09599
-  tps: 47438.3131
+  dps: 32914.73841
+  tps: 48195.93015
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 32743.85706
-  tps: 47313.07408
+  dps: 32827.30517
+  tps: 48068.75299
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 32916.72402
-  tps: 48916.02209
+  dps: 32896.27899
+  tps: 48925.62684
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 31308.71457
-  tps: 45981.89592
+  dps: 31331.64711
+  tps: 46382.28256
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 31312.82177
-  tps: 45307.31455
+  dps: 31392.3133
+  tps: 45952.75922
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RosaryofLight-72901"
  value: {
-  dps: 32073.97409
-  tps: 46974.96884
+  dps: 32075.25087
+  tps: 46940.03894
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RottingSkull-77116"
  value: {
-  dps: 32539.49357
-  tps: 48198.07966
+  dps: 32552.95886
+  tps: 48409.98574
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuneofZeth-68998"
  value: {
-  dps: 31405.00753
-  tps: 46712.94062
+  dps: 31386.46951
+  tps: 46787.7682
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofConquest-70399"
  value: {
-  dps: 32887.6983
-  tps: 47661.93355
+  dps: 32895.14715
+  tps: 47591.08981
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofConquest-72304"
  value: {
-  dps: 33005.8009
-  tps: 47762.71434
+  dps: 33015.82752
+  tps: 47681.02558
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofDominance-70401"
  value: {
-  dps: 30870.09404
-  tps: 45759.99385
+  dps: 30890.43412
+  tps: 46190.50388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofDominance-72448"
  value: {
-  dps: 30870.09404
-  tps: 45759.99385
+  dps: 30890.43412
+  tps: 46190.50388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofVictory-70400"
  value: {
-  dps: 31541.83775
-  tps: 46432.06505
+  dps: 31581.57375
+  tps: 46799.16334
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofVictory-72450"
  value: {
-  dps: 31585.54262
-  tps: 46487.39925
+  dps: 31625.45184
+  tps: 46854.86132
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofConquest-70404"
  value: {
-  dps: 32774.66361
-  tps: 47297.74446
+  dps: 32809.07248
+  tps: 47565.49708
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofConquest-72309"
  value: {
-  dps: 32988.49297
-  tps: 47185.83729
+  dps: 32994.07985
+  tps: 47187.96102
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofDominance-70402"
  value: {
-  dps: 30889.23499
-  tps: 45888.4304
+  dps: 30909.80944
+  tps: 46270.77896
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofDominance-72449"
  value: {
-  dps: 30858.98008
-  tps: 45017.99001
+  dps: 30876.26192
+  tps: 45507.78546
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofVictory-70403"
  value: {
-  dps: 31582.57534
-  tps: 45991.53952
+  dps: 31581.92613
+  tps: 46289.30234
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofVictory-72455"
  value: {
-  dps: 31538.09456
-  tps: 45915.91601
+  dps: 31543.89503
+  tps: 46438.24567
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ScalesofLife-68915"
  value: {
-  dps: 30834.70877
-  tps: 45474.74463
+  dps: 30855.04706
+  tps: 45905.03889
   hps: 315.97258
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ScalesofLife-69109"
  value: {
-  dps: 30834.70877
-  tps: 45474.74463
+  dps: 30855.04706
+  tps: 45905.03889
   hps: 356.41412
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 32165.46156
-  tps: 47100.95745
+  dps: 32167.7624
+  tps: 47137.8662
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-55256"
  value: {
-  dps: 30870.09404
-  tps: 45759.99385
+  dps: 30890.43412
+  tps: 46190.50388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-56290"
  value: {
-  dps: 30870.09404
-  tps: 45759.99385
+  dps: 30890.43412
+  tps: 46190.50388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShardofWoe-60233"
  value: {
-  dps: 31466.16253
-  tps: 46162.56241
+  dps: 31480.50668
+  tps: 46090.19946
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 31591.63302
-  tps: 45956.88002
+  dps: 31654.44425
+  tps: 46549.65593
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 30844.16556
-  tps: 45376.40622
+  dps: 30880.94297
+  tps: 45941.96485
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 32219.45697
-  tps: 47487.82706
+  dps: 32252.69499
+  tps: 47625.52429
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 32455.29451
-  tps: 48017.87695
+  dps: 32487.60802
+  tps: 48296.24365
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-55879"
  value: {
-  dps: 31164.81251
-  tps: 46014.68404
+  dps: 31190.40521
+  tps: 46392.97196
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-56400"
  value: {
-  dps: 31207.68998
-  tps: 46086.50755
+  dps: 31233.25821
+  tps: 46465.13842
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 31209.92249
-  tps: 46367.66122
+  dps: 31223.03685
+  tps: 46329.68003
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulCasket-58183"
  value: {
-  dps: 31290.13872
-  tps: 46455.21465
+  dps: 31310.46193
+  tps: 46890.29325
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 31625.13853
-  tps: 45848.40918
+  dps: 31656.35274
+  tps: 46010.72525
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 31587.02691
-  tps: 46779.04987
+  dps: 31618.97434
+  tps: 47272.37999
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 31836.67789
-  tps: 46472.03661
+  dps: 31863.61792
+  tps: 46715.70883
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 31335.02306
-  tps: 46299.80162
+  dps: 31355.34121
+  tps: 46735.54669
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 31371.43149
-  tps: 46783.44237
+  dps: 31386.93961
+  tps: 47193.74161
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 33484.29797
-  tps: 48745.44508
+  dps: 33525.2635
+  tps: 48758.14086
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 33075.88037
-  tps: 47517.34444
+  dps: 33097.93
+  tps: 47531.65694
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 34117.17599
-  tps: 49284.40491
+  dps: 34130.41766
+  tps: 49350.7394
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StayofExecution-68996"
  value: {
-  dps: 30834.70877
-  tps: 45474.74463
+  dps: 30855.04706
+  tps: 45905.03889
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 30837.74047
-  tps: 45483.42958
+  dps: 30858.07875
+  tps: 45913.72515
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stormrider'sBattlegarb"
  value: {
-  dps: 28619.67113
-  tps: 40540.23459
+  dps: 28750.73717
+  tps: 40801.53562
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stormrider'sRegalia"
  value: {
-  dps: 22438.52966
-  tps: 31219.84449
+  dps: 22445.93083
+  tps: 31184.42374
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62465"
  value: {
-  dps: 30836.08139
-  tps: 45481.64772
+  dps: 30856.024
+  tps: 45913.94935
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62470"
  value: {
-  dps: 30836.08139
-  tps: 45481.64772
+  dps: 30856.024
+  tps: 45913.94935
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 30834.70877
-  tps: 45474.74463
+  dps: 30855.04706
+  tps: 45905.03889
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 30834.70877
-  tps: 45474.74463
+  dps: 30855.04706
+  tps: 45905.03889
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 30836.17036
-  tps: 45654.335
+  dps: 30856.50864
+  tps: 46084.63083
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 31592.66994
-  tps: 46816.32038
+  dps: 31578.15042
+  tps: 46731.97459
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-55819"
  value: {
-  dps: 30834.70877
-  tps: 45474.56981
+  dps: 30855.04706
+  tps: 45904.86552
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-56351"
  value: {
-  dps: 30835.63689
-  tps: 45475.17186
+  dps: 30855.97517
+  tps: 45905.46803
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 31116.73778
-  tps: 45934.15464
+  dps: 31137.06476
+  tps: 46367.50912
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 31207.60472
-  tps: 46086.44702
+  dps: 31241.84289
+  tps: 46570.25718
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheHungerer-68927"
  value: {
-  dps: 32974.13612
-  tps: 47886.82684
+  dps: 32978.01861
+  tps: 47780.78314
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheHungerer-69112"
  value: {
-  dps: 33301.60234
-  tps: 48261.41171
+  dps: 33337.8809
+  tps: 48455.84414
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 30860.34679
-  tps: 45518.07546
+  dps: 30875.95081
+  tps: 45922.40939
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 30830.26102
-  tps: 45577.95178
+  dps: 30853.89566
+  tps: 45826.34366
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 30834.70877
-  tps: 45474.74463
+  dps: 30855.04706
+  tps: 45905.03889
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 30834.70877
-  tps: 45474.74463
+  dps: 30855.04706
+  tps: 45905.03889
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-77190"
  value: {
-  dps: 32983.20597
-  tps: 47449.61705
+  dps: 33103.92692
+  tps: 48291.36132
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-78477"
  value: {
-  dps: 32985.81676
-  tps: 47370.00051
+  dps: 33078.89591
+  tps: 48104.37008
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-78486"
  value: {
-  dps: 32981.24046
-  tps: 47441.14174
+  dps: 33084.48254
+  tps: 48253.31917
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 32398.44499
-  tps: 48065.64558
+  dps: 32425.74993
+  tps: 48302.25149
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 32555.04011
-  tps: 48648.81692
+  dps: 32593.61989
+  tps: 48883.00391
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 31267.29093
-  tps: 46637.22394
+  dps: 31262.73975
+  tps: 46666.96602
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 30874.51914
-  tps: 45773.55442
+  dps: 30867.22361
+  tps: 46032.04615
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnheededWarning-59520"
  value: {
-  dps: 32883.16766
-  tps: 48993.36259
+  dps: 32883.60461
+  tps: 49181.07226
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 30870.09404
-  tps: 45759.99385
+  dps: 30890.43412
+  tps: 46190.50388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 32824.15274
-  tps: 47865.08269
+  dps: 32813.71472
+  tps: 48042.80003
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 32824.15274
-  tps: 47865.08269
+  dps: 32813.71472
+  tps: 48042.80003
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 32824.15274
-  tps: 47865.08269
+  dps: 32813.71472
+  tps: 48042.80003
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 26890.62789
-  tps: 37798.85334
+  dps: 26865.96087
+  tps: 37701.06217
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 30838.11073
-  tps: 45487.44688
+  dps: 30857.86043
+  tps: 45914.80092
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 30837.83243
-  tps: 45482.02729
+  dps: 30857.50683
+  tps: 45909.00524
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 32116.75819
-  tps: 46630.58584
+  dps: 32107.10834
+  tps: 46623.22498
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VeilofLies-72900"
  value: {
-  dps: 30894.31818
-  tps: 45828.89254
+  dps: 30904.71153
+  tps: 46177.74673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 32041.39296
-  tps: 47915.63257
+  dps: 32128.27592
+  tps: 48163.93275
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 32196.56543
-  tps: 47992.56655
+  dps: 32283.4224
+  tps: 48247.70717
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77207"
  value: {
-  dps: 33748.24137
-  tps: 51372.86153
+  dps: 33702.40845
+  tps: 51412.5793
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77979"
  value: {
-  dps: 33388.15868
-  tps: 50769.60263
+  dps: 33376.67136
+  tps: 50523.44114
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77999"
  value: {
-  dps: 33737.8177
-  tps: 50128.00562
+  dps: 33757.71299
+  tps: 50250.22908
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 30870.09404
-  tps: 45759.99385
+  dps: 30890.43412
+  tps: 46190.50388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 30870.09404
-  tps: 45759.99385
+  dps: 30890.43412
+  tps: 46190.50388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 32384.52544
-  tps: 47138.31628
+  dps: 32374.11557
+  tps: 47314.69404
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-70517"
  value: {
-  dps: 32627.97325
-  tps: 47712.9776
+  dps: 32603.2351
+  tps: 47699.4103
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 30870.09404
-  tps: 45759.99385
+  dps: 30890.43412
+  tps: 46190.50388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-70518"
  value: {
-  dps: 30870.09404
-  tps: 45759.99385
+  dps: 30890.43412
+  tps: 46190.50388
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 31407.02429
-  tps: 46164.5384
+  dps: 31438.65825
+  tps: 46480.04228
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-70519"
  value: {
-  dps: 31478.33525
-  tps: 46255.0235
+  dps: 31510.07966
+  tps: 46570.5402
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 30856.56222
-  tps: 45667.60024
+  dps: 30878.50925
+  tps: 46110.13076
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 31325.21232
-  tps: 45211.67345
+  dps: 31339.09345
+  tps: 45343.50443
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 31294.70205
-  tps: 46475.00495
+  dps: 31344.05371
+  tps: 46668.81232
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 30855.1896
-  tps: 45660.69715
+  dps: 30877.53231
+  tps: 46101.2203
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 31299.74967
-  tps: 46394.44937
+  dps: 31322.07451
+  tps: 46839.81146
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 30855.1896
-  tps: 45660.69715
+  dps: 30877.53231
+  tps: 46101.2203
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 32488.96564
-  tps: 47265.41985
+  dps: 32550.96811
+  tps: 47453.90507
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-70577"
  value: {
-  dps: 32730.07374
-  tps: 48164.29402
+  dps: 32725.94184
+  tps: 48254.30644
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 30802.35635
-  tps: 45697.36937
+  dps: 30793.96778
+  tps: 45953.26686
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-70578"
  value: {
-  dps: 30881.38967
-  tps: 45350.63824
+  dps: 30875.00923
+  tps: 45601.17667
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 31487.08431
-  tps: 46480.05871
+  dps: 31474.81059
+  tps: 46332.21568
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-70579"
  value: {
-  dps: 31529.50337
-  tps: 46126.3434
+  dps: 31502.90175
+  tps: 46311.16859
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 30834.70877
-  tps: 45476.53134
+  dps: 30855.04706
+  tps: 45907.25353
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 30834.70877
-  tps: 45476.26325
+  dps: 30855.04706
+  tps: 45906.93505
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WillofUnbinding-77995"
  value: {
-  dps: 30834.70877
-  tps: 45476.82255
+  dps: 30855.04706
+  tps: 45907.60018
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 30826.32599
-  tps: 45562.9942
+  dps: 30860.47537
+  tps: 45877.22903
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 30838.35427
-  tps: 45476.86182
+  dps: 30853.95828
+  tps: 45881.1955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 31121.93504
-  tps: 45942.86052
+  dps: 31142.26182
+  tps: 46376.27192
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 34474.40681
-  tps: 51254.83725
+  dps: 34561.6939
+  tps: 51423.54466
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 34076.85176
-  tps: 50681.55706
+  dps: 34171.78278
+  tps: 50964.93151
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 34952.71263
-  tps: 52081.55293
+  dps: 35035.69344
+  tps: 52235.86255
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 31263.48213
-  tps: 46043.94882
+  dps: 31261.27359
+  tps: 46165.54531
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 31263.48213
-  tps: 46043.94882
+  dps: 31261.27359
+  tps: 46165.54531
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 33366.86685
-  tps: 47999.6282
+  dps: 33378.90178
+  tps: 48038.78132
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 86229.45044
-  tps: 118271.53475
+  dps: 86292.03346
+  tps: 118500.8143
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20973.20724
-  tps: 37297.15905
+  dps: 20970.62858
+  tps: 37294.36815
  }
 }
 dps_results: {
@@ -2099,15 +2099,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 58714.35106
-  tps: 82217.28
+  dps: 58755.87266
+  tps: 82348.848
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 12865.36827
-  tps: 23035.61931
+  dps: 12882.95466
+  tps: 23135.27449
  }
 }
 dps_results: {
@@ -2120,15 +2120,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 39318.31973
-  tps: 51204.4882
+  dps: 39331.47853
+  tps: 51042.88253
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39085.45231
-  tps: 51443.47078
+  dps: 39076.92317
+  tps: 51691.43291
  }
 }
 dps_results: {
@@ -2141,15 +2141,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 25090.65739
-  tps: 33303.51314
+  dps: 25077.06862
+  tps: 33081.34372
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25297.65577
-  tps: 36071.80127
+  dps: 25300.65329
+  tps: 36107.98036
  }
 }
 dps_results: {
@@ -2204,15 +2204,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 85967.42798
-  tps: 118349.84907
+  dps: 85955.7798
+  tps: 118431.25768
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20766.07723
-  tps: 36000.90948
+  dps: 20810.86501
+  tps: 36280.64342
  }
 }
 dps_results: {
@@ -2225,15 +2225,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 58456.6906
-  tps: 81884.00566
+  dps: 58414.12487
+  tps: 81735.49585
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 12810.67533
-  tps: 23005.05877
+  dps: 12787.19186
+  tps: 22826.73124
  }
 }
 dps_results: {
@@ -2246,15 +2246,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38625.99711
-  tps: 50278.2846
+  dps: 38638.43727
+  tps: 50012.89847
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38172.89375
-  tps: 49455.68531
+  dps: 38175.64271
+  tps: 49442.40795
  }
 }
 dps_results: {
@@ -2267,15 +2267,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24532.26953
-  tps: 32020.32134
+  dps: 24528.09756
+  tps: 32039.47093
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24680.6252
-  tps: 32556.59621
+  dps: 24676.78752
+  tps: 32674.63943
  }
 }
 dps_results: {
@@ -2330,15 +2330,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 78251.34734
-  tps: 108408.63704
+  dps: 78247.04285
+  tps: 108393.35403
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 18001.46184
-  tps: 31011.05838
+  dps: 17981.77233
+  tps: 30858.15887
  }
 }
 dps_results: {
@@ -2351,15 +2351,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 52475.89999
-  tps: 75102.91079
+  dps: 52512.91425
+  tps: 75252.76175
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 11038.2453
-  tps: 19700.40857
+  dps: 11021.59613
+  tps: 19772.26994
  }
 }
 dps_results: {
@@ -2372,15 +2372,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 33426.83741
-  tps: 46817.24503
+  dps: 33394.82736
+  tps: 46602.0142
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 33172.0329
-  tps: 48205.05369
+  dps: 33133.20219
+  tps: 48193.22962
  }
 }
 dps_results: {
@@ -2393,15 +2393,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 20914.27707
-  tps: 30711.0709
+  dps: 20921.70464
+  tps: 30743.72724
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 21154.68466
-  tps: 31873.49781
+  dps: 21183.10035
+  tps: 31971.26679
  }
 }
 dps_results: {
@@ -2456,15 +2456,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 78022.04107
-  tps: 110410.45197
+  dps: 78000.17217
+  tps: 110492.29064
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 17880.2219
-  tps: 30231.67503
+  dps: 17858.12543
+  tps: 30223.63576
  }
 }
 dps_results: {
@@ -2477,15 +2477,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 52166.4392
-  tps: 73750.47811
+  dps: 52170.41365
+  tps: 73791.30283
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 10913.6248
-  tps: 19227.20377
+  dps: 10927.66354
+  tps: 19284.64691
  }
 }
 dps_results: {
@@ -2498,15 +2498,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 32770.03242
-  tps: 46972.62798
+  dps: 32744.4925
+  tps: 46876.40931
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 32194.73585
-  tps: 45296.32738
+  dps: 32197.11604
+  tps: 45402.65812
  }
 }
 dps_results: {
@@ -2519,15 +2519,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 20358.00581
-  tps: 28837.42792
+  dps: 20373.13916
+  tps: 29002.67019
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20563.05814
-  tps: 30341.23784
+  dps: 20560.52558
+  tps: 30302.86953
  }
 }
 dps_results: {
@@ -2582,15 +2582,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 85930.70689
-  tps: 118283.54271
+  dps: 86026.40476
+  tps: 118416.76541
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20879.42481
-  tps: 36824.73936
+  dps: 20878.88027
+  tps: 36867.76597
  }
 }
 dps_results: {
@@ -2603,15 +2603,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 58917.40986
-  tps: 84544.54766
+  dps: 58922.22321
+  tps: 84460.02523
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 12935.44987
-  tps: 23880.65471
+  dps: 12934.79932
+  tps: 23864.45666
  }
 }
 dps_results: {
@@ -2624,15 +2624,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 39481.3653
-  tps: 52314.38305
+  dps: 39510.76507
+  tps: 52368.96342
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39175.18661
-  tps: 52245.38863
+  dps: 39170.16337
+  tps: 52237.12863
  }
 }
 dps_results: {
@@ -2645,15 +2645,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24976.5365
-  tps: 33382.07842
+  dps: 24970.55318
+  tps: 33367.13477
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25372.23273
-  tps: 35282.74271
+  dps: 25399.95762
+  tps: 35226.09901
  }
 }
 dps_results: {
@@ -2708,15 +2708,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 85484.77591
-  tps: 119884.22842
+  dps: 85568.31855
+  tps: 119900.91686
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20815.48141
-  tps: 36032.75207
+  dps: 20818.57341
+  tps: 36065.28934
  }
 }
 dps_results: {
@@ -2729,15 +2729,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 58771.95406
-  tps: 84524.97264
+  dps: 58825.18782
+  tps: 84893.238
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 12865.20232
-  tps: 23049.41224
+  dps: 12894.97603
+  tps: 23123.94507
  }
 }
 dps_results: {
@@ -2750,15 +2750,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38560.93978
-  tps: 50634.28729
+  dps: 38593.50258
+  tps: 51115.9057
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38168.61759
-  tps: 49996.27068
+  dps: 38183.05067
+  tps: 49986.10539
  }
 }
 dps_results: {
@@ -2771,15 +2771,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24277.94367
-  tps: 32504.95572
+  dps: 24299.65318
+  tps: 32557.78079
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24540.50028
-  tps: 34002.39905
+  dps: 24536.55723
+  tps: 34197.49351
  }
 }
 dps_results: {
@@ -2834,15 +2834,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 78052.1809
-  tps: 109511.48129
+  dps: 78098.4913
+  tps: 109817.63661
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 17962.61779
-  tps: 31491.01989
+  dps: 17969.50991
+  tps: 31565.48041
  }
 }
 dps_results: {
@@ -2855,15 +2855,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 52982.3873
-  tps: 76826.8522
+  dps: 52997.93474
+  tps: 76888.80568
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 10948.38988
-  tps: 20018.35799
+  dps: 10941.62643
+  tps: 19913.36998
  }
 }
 dps_results: {
@@ -2876,15 +2876,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 33423.37137
-  tps: 46944.80192
+  dps: 33438.73077
+  tps: 47065.41224
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 32952.52049
-  tps: 47431.18348
+  dps: 33045.59964
+  tps: 48165.54524
  }
 }
 dps_results: {
@@ -2897,15 +2897,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 20773.64943
-  tps: 30125.25919
+  dps: 20794.65108
+  tps: 30156.17268
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20995.90159
-  tps: 32037.65766
+  dps: 21019.1735
+  tps: 31983.26481
  }
 }
 dps_results: {
@@ -2960,15 +2960,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 77364.2496
-  tps: 108293.30524
+  dps: 77256.82522
+  tps: 108340.98968
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-aoe-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 17786.7546
-  tps: 30684.99002
+  dps: 17799.55346
+  tps: 30720.79932
  }
 }
 dps_results: {
@@ -2981,15 +2981,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 52740.64878
-  tps: 76621.29895
+  dps: 52727.9922
+  tps: 76621.2923
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-aoe-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 10977.43448
-  tps: 19939.56803
+  dps: 10973.06732
+  tps: 19995.63943
  }
 }
 dps_results: {
@@ -3002,15 +3002,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 32575.24608
-  tps: 45224.61077
+  dps: 32582.6374
+  tps: 45409.93938
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 32013.61165
-  tps: 45226.07168
+  dps: 32025.30577
+  tps: 45118.91553
  }
 }
 dps_results: {
@@ -3023,15 +3023,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 20249.51238
-  tps: 28861.58376
+  dps: 20263.75729
+  tps: 28942.84489
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20479.59879
-  tps: 29932.17765
+  dps: 20479.78754
+  tps: 29932.29873
  }
 }
 dps_results: {
@@ -3086,7 +3086,7 @@ dps_results: {
 dps_results: {
  key: "TestFeral-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 28919.75848
-  tps: 43066.15051
+  dps: 28960.90912
+  tps: 43274.88086
  }
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -38,2041 +38,2041 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 33045.59964
-  tps: 48165.54524
+  dps: 33039.01896
+  tps: 47925.46561
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 30855.04706
-  tps: 45904.90019
+  dps: 30945.20504
+  tps: 46122.81749
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 33030.0425
-  tps: 48172.07932
+  dps: 32989.28703
+  tps: 47977.36944
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 30856.024
-  tps: 45913.94935
+  dps: 30946.18198
+  tps: 46131.873
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 30856.024
-  tps: 45913.94935
+  dps: 30946.18198
+  tps: 46131.873
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 32072.64685
-  tps: 47442.39187
+  dps: 32105.84508
+  tps: 47629.05601
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 32216.20448
-  tps: 47902.42812
+  dps: 32243.59225
+  tps: 47791.28171
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ArrowofTime-72897"
  value: {
-  dps: 33057.48457
-  tps: 47422.52878
+  dps: 33094.74508
+  tps: 47372.78964
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 32221.86779
-  tps: 47210.56629
+  dps: 32208.84162
+  tps: 46681.36796
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 30855.04706
-  tps: 45905.03889
-  hps: 96.77966
+  dps: 30945.20504
+  tps: 46122.96254
+  hps: 98.19984
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 30855.04706
-  tps: 45905.03889
+  dps: 30945.20504
+  tps: 46122.96254
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 31335.92851
-  tps: 47043.4417
+  dps: 31379.44912
+  tps: 47398.82049
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 31342.8679
-  tps: 47112.35087
+  dps: 31423.19145
+  tps: 47300.47729
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BindingPromise-67037"
  value: {
-  dps: 30890.43412
-  tps: 46190.50388
+  dps: 30975.09185
+  tps: 46454.53299
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 32444.20942
-  tps: 47760.99877
+  dps: 32597.26119
+  tps: 48377.75344
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 31185.13755
-  tps: 46448.56502
+  dps: 31281.11655
+  tps: 46951.70848
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 31228.01328
-  tps: 46520.85811
+  dps: 31324.08728
+  tps: 47024.77926
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 32939.02988
-  tps: 46745.56093
+  dps: 33063.94923
+  tps: 47588.05166
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 30890.43412
-  tps: 46190.50388
+  dps: 30975.09185
+  tps: 46454.53299
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 31412.71688
-  tps: 46344.96722
+  dps: 31458.40576
+  tps: 46916.67883
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 31301.29632
-  tps: 46639.1591
+  dps: 31316.7629
+  tps: 46786.76821
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 30877.53231
-  tps: 46101.2203
+  dps: 30954.79751
+  tps: 46328.33874
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 30877.53231
-  tps: 46101.2203
+  dps: 30954.79751
+  tps: 46328.33874
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 32276.52823
-  tps: 46408.3922
+  dps: 32314.81402
+  tps: 47005.50215
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 30868.53612
-  tps: 45954.07837
+  dps: 30945.20504
+  tps: 46122.96254
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 31374.84103
-  tps: 46925.02286
+  dps: 31450.69399
+  tps: 47528.74785
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 32897.56401
-  tps: 48467.88987
+  dps: 32890.13085
+  tps: 48200.93479
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 32608.74856
-  tps: 48334.28125
+  dps: 32677.393
+  tps: 48822.2423
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 33213.65977
-  tps: 48882.55296
+  dps: 33127.66089
+  tps: 48240.36994
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledLightning-66879"
  value: {
-  dps: 31036.46306
-  tps: 46009.19599
+  dps: 31071.3956
+  tps: 46426.76594
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BottledWishes-77114"
  value: {
-  dps: 31398.8841
-  tps: 46864.29936
+  dps: 31383.94148
+  tps: 46468.98443
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 32221.86779
-  tps: 46266.60826
+  dps: 32208.84162
+  tps: 45747.98199
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 30890.43412
-  tps: 46190.50388
+  dps: 30975.09185
+  tps: 46454.53299
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 32827.30517
-  tps: 48068.71036
+  dps: 32814.24201
+  tps: 47526.01215
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sBadgeofConquest-73648"
  value: {
-  dps: 33340.17946
-  tps: 48234.35737
+  dps: 33342.75628
+  tps: 48280.72011
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sBadgeofDominance-73498"
  value: {
-  dps: 30890.43412
-  tps: 46190.50388
+  dps: 30975.09185
+  tps: 46454.53299
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sBadgeofVictory-73496"
  value: {
-  dps: 31730.37771
-  tps: 46988.05214
+  dps: 31806.94289
+  tps: 47624.27371
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sInsigniaofConquest-73643"
  value: {
-  dps: 33051.00862
-  tps: 48628.4781
+  dps: 33069.64104
+  tps: 48329.26167
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sInsigniaofDominance-73497"
  value: {
-  dps: 30878.6353
-  tps: 46030.29445
+  dps: 30928.93439
+  tps: 46222.7123
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CataclysmicGladiator'sInsigniaofVictory-73491"
  value: {
-  dps: 31773.7318
-  tps: 46447.77117
+  dps: 31711.38349
+  tps: 46392.34208
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 32882.39906
-  tps: 47750.78714
+  dps: 32872.4882
+  tps: 47502.41821
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 32199.73254
-  tps: 47367.28934
+  dps: 32258.42189
+  tps: 47623.40705
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 30892.29035
-  tps: 46191.56187
+  dps: 30976.94808
+  tps: 46455.58236
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 30855.04706
-  tps: 45905.03889
+  dps: 30945.20504
+  tps: 46122.96254
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 32343.06631
-  tps: 47914.54527
+  dps: 32401.44847
+  tps: 47881.71279
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 32316.68428
-  tps: 47456.47487
+  dps: 32332.92888
+  tps: 47780.86454
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 32755.05128
-  tps: 48276.96428
+  dps: 32676.03692
+  tps: 47684.70429
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-59506"
  value: {
-  dps: 31828.71114
-  tps: 46050.89523
+  dps: 31759.07808
+  tps: 45963.4712
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CrushingWeight-65118"
  value: {
-  dps: 32124.78013
-  tps: 46343.75502
+  dps: 31961.30968
+  tps: 46037.49811
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 31233.67087
-  tps: 46594.99143
+  dps: 31310.30221
+  tps: 47025.58511
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 31204.22661
-  tps: 46069.71661
+  dps: 31247.45787
+  tps: 46428.31851
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-CunningoftheCruel-78000"
  value: {
-  dps: 31323.93566
-  tps: 46372.27491
+  dps: 31366.93694
+  tps: 46687.85886
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 30877.53231
-  tps: 46101.2203
+  dps: 30954.79751
+  tps: 46328.33874
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 31549.92426
-  tps: 46635.10563
+  dps: 31560.80304
+  tps: 47026.52625
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 32329.95611
-  tps: 47988.38883
+  dps: 32400.60166
+  tps: 48409.0082
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 30856.90328
-  tps: 45906.09796
+  dps: 30947.06126
+  tps: 46124.00976
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 31280.29637
-  tps: 46552.44417
+  dps: 31356.82023
+  tps: 47074.98488
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 31868.69353
-  tps: 46676.00318
+  dps: 31958.40404
+  tps: 47058.12955
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DeepEarthRegalia"
  value: {
-  dps: 22155.6964
-  tps: 30614.95423
+  dps: 22094.20226
+  tps: 30637.42312
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 32272.27642
-  tps: 46893.09413
+  dps: 32263.08662
+  tps: 46657.2782
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 31054.66995
-  tps: 46843.76226
+  dps: 31075.76948
+  tps: 46709.05793
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dragonwrath,Tarecgosa'sRest-71086"
  value: {
-  dps: 33332.09471
-  tps: 48217.44369
+  dps: 33393.51806
+  tps: 48489.78001
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 31977.49077
-  tps: 47974.05126
+  dps: 32087.07735
+  tps: 48610.86024
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 32221.86779
-  tps: 47210.56629
+  dps: 32208.84162
+  tps: 46681.36796
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 30892.29035
-  tps: 46228.54007
+  dps: 30976.94808
+  tps: 46492.39711
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 32221.86779
-  tps: 47210.50163
+  dps: 32208.84162
+  tps: 46681.30661
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 32272.27642
-  tps: 46893.09413
+  dps: 32263.08662
+  tps: 46657.2782
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 32628.06822
-  tps: 47587.22153
+  dps: 32720.71431
+  tps: 48341.74211
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 32039.9407
-  tps: 47409.90434
+  dps: 32045.47155
+  tps: 47239.59857
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 32221.86779
-  tps: 47210.56629
+  dps: 32208.84162
+  tps: 46681.36796
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 32226.87862
-  tps: 47932.19098
+  dps: 32326.71963
+  tps: 48452.71819
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 32071.29274
-  tps: 47700.86345
+  dps: 32170.61245
+  tps: 48218.74038
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 32398.02309
-  tps: 48186.65127
+  dps: 32498.43753
+  tps: 48710.09378
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-59500"
  value: {
-  dps: 30856.90328
-  tps: 45906.09796
+  dps: 30947.06126
+  tps: 46124.00976
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FallofMortality-65124"
  value: {
-  dps: 30856.90328
-  tps: 45906.06409
+  dps: 30947.06126
+  tps: 46123.97434
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 30877.52873
-  tps: 46013.0691
+  dps: 30969.97862
+  tps: 46175.5071
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 32253.24631
-  tps: 47244.82165
+  dps: 32253.99162
+  tps: 47763.16057
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 30891.36224
-  tps: 46190.93206
+  dps: 30976.01997
+  tps: 46454.95352
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 30890.43412
-  tps: 46190.50388
+  dps: 30975.09185
+  tps: 46454.53299
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 30891.36224
-  tps: 46190.93206
+  dps: 30976.01997
+  tps: 46454.95352
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 31755.84097
-  tps: 46941.78935
+  dps: 31801.56041
+  tps: 47508.46608
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 31456.72781
-  tps: 47465.11395
+  dps: 31501.69574
+  tps: 47480.2872
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 32293.60897
-  tps: 47331.11542
+  dps: 32280.46115
+  tps: 46800.42694
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FluidDeath-58181"
  value: {
-  dps: 32421.69935
-  tps: 48278.18608
+  dps: 32485.57742
+  tps: 48846.86722
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 32221.86779
-  tps: 47210.52365
+  dps: 32208.84162
+  tps: 46681.3275
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 31293.40174
-  tps: 45189.75838
+  dps: 31419.73007
+  tps: 45754.83384
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 32036.34114
-  tps: 47870.32481
+  dps: 32063.40326
+  tps: 47714.60652
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56138"
  value: {
-  dps: 31226.7845
-  tps: 45961.53013
+  dps: 31325.99356
+  tps: 46194.23853
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GaleofShadows-56462"
  value: {
-  dps: 31356.59519
-  tps: 44963.97961
+  dps: 31234.07937
+  tps: 45101.14031
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GearDetector-61462"
  value: {
-  dps: 31874.71629
-  tps: 46851.00845
+  dps: 31858.87535
+  tps: 47009.53292
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Gladiator'sSanctuary"
  value: {
-  dps: 26475.88247
-  tps: 37869.82908
+  dps: 26406.13904
+  tps: 37939.31795
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 30855.04706
-  tps: 45904.89051
+  dps: 30945.20504
+  tps: 46122.80737
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 31882.87922
-  tps: 47472.12245
+  dps: 31984.46271
+  tps: 47932.02603
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 32375.49362
-  tps: 47318.22942
+  dps: 32428.60357
+  tps: 48199.38502
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HarmlightToken-63839"
  value: {
-  dps: 30880.34825
-  tps: 45963.16505
+  dps: 30959.02034
+  tps: 46158.74778
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 31598.51938
-  tps: 46287.21397
+  dps: 31534.18991
+  tps: 46702.33884
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 30855.04706
-  tps: 45905.03889
+  dps: 30945.20504
+  tps: 46122.96254
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 30855.04706
-  tps: 45905.03889
+  dps: 30945.20504
+  tps: 46122.96254
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-59224"
  value: {
-  dps: 31545.45458
-  tps: 46770.58397
+  dps: 31624.14988
+  tps: 47224.81116
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofRage-65072"
  value: {
-  dps: 31661.5413
-  tps: 46255.20322
+  dps: 31665.57754
+  tps: 46716.64178
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-55868"
  value: {
-  dps: 31812.03023
-  tps: 46903.038
+  dps: 31843.13187
+  tps: 46701.4724
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofSolace-56393"
  value: {
-  dps: 31945.09724
-  tps: 45323.76631
+  dps: 31812.46778
+  tps: 44456.23017
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-55845"
  value: {
-  dps: 30855.04706
-  tps: 45905.03889
+  dps: 30945.44563
+  tps: 46136.76216
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartofThunder-56370"
  value: {
-  dps: 30855.04706
-  tps: 45905.03889
+  dps: 30945.44563
+  tps: 46136.76216
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 31900.20795
-  tps: 46903.71627
+  dps: 31994.70746
+  tps: 47221.11172
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Heartpierce-50641"
  value: {
-  dps: 33649.85707
-  tps: 47655.32372
+  dps: 33653.09308
+  tps: 47780.29303
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 32272.27642
-  tps: 46893.09413
+  dps: 32263.08662
+  tps: 46657.2782
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 31866.35841
-  tps: 47205.11569
+  dps: 31917.63998
+  tps: 47676.96153
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 31866.35841
-  tps: 47205.11569
+  dps: 31917.63998
+  tps: 47676.96153
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 31210.49082
-  tps: 46483.06778
+  dps: 31288.61093
+  tps: 47009.62962
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 31253.29549
-  tps: 46555.04355
+  dps: 31331.58238
+  tps: 47082.55673
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndomitablePride-77211"
  value: {
-  dps: 30855.04706
-  tps: 45905.03889
+  dps: 30945.20504
+  tps: 46122.96254
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndomitablePride-77983"
  value: {
-  dps: 30855.04706
-  tps: 45905.03889
+  dps: 30945.20504
+  tps: 46122.96254
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-IndomitablePride-78003"
  value: {
-  dps: 30855.04706
-  tps: 45905.03889
+  dps: 30945.20504
+  tps: 46122.96254
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 30855.04706
-  tps: 45905.03889
+  dps: 30945.44563
+  tps: 46136.76216
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 31642.42529
-  tps: 45556.63053
+  dps: 31725.53144
+  tps: 45704.43243
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 31508.87784
-  tps: 44813.88992
+  dps: 31610.81092
+  tps: 44803.04912
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 31820.4011
-  tps: 45754.94374
+  dps: 31861.48395
+  tps: 45751.53046
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 31150.22222
-  tps: 46479.53215
+  dps: 31237.91905
+  tps: 46702.96662
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 30855.04706
-  tps: 45905.20989
+  dps: 30945.20504
+  tps: 46123.11797
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 30855.04706
-  tps: 45905.20989
+  dps: 30945.20504
+  tps: 46123.11797
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 30856.90328
-  tps: 45906.04797
+  dps: 30947.06126
+  tps: 46123.95747
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 30856.90328
-  tps: 45906.00765
+  dps: 30947.06126
+  tps: 46123.9153
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 32444.20942
-  tps: 47760.99877
+  dps: 32597.26119
+  tps: 48377.75344
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 32137.41551
-  tps: 47292.86769
+  dps: 32009.16272
+  tps: 47350.9584
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 32564.95472
-  tps: 48009.30081
+  dps: 32602.60629
+  tps: 47940.62551
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-77194"
  value: {
-  dps: 36600.24754
-  tps: 52308.39588
+  dps: 36511.15786
+  tps: 51978.85754
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-78473"
  value: {
-  dps: 37163.43207
-  tps: 53123.85801
+  dps: 37169.44918
+  tps: 52816.38842
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-78482"
  value: {
-  dps: 36189.55357
-  tps: 52679.72401
+  dps: 36246.11554
+  tps: 51603.00328
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 34225.95032
-  tps: 49394.80593
+  dps: 34182.06724
+  tps: 49859.25542
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 31425.65499
-  tps: 46865.00839
+  dps: 31484.1534
+  tps: 46541.32515
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 31425.65499
-  tps: 46865.00839
+  dps: 31484.1534
+  tps: 46541.32515
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 31111.62716
-  tps: 45787.77165
+  dps: 31172.73301
+  tps: 46453.63036
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50708"
  value: {
-  dps: 33230.67252
-  tps: 48434.38044
+  dps: 33224.07101
+  tps: 48192.92789
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-55816"
  value: {
-  dps: 30855.04706
-  tps: 45905.03889
+  dps: 30945.20504
+  tps: 46122.96254
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeadenDespair-56347"
  value: {
-  dps: 30855.04706
-  tps: 45905.03889
+  dps: 30945.20504
+  tps: 46122.96254
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 32077.02437
-  tps: 47237.4392
+  dps: 32142.16297
+  tps: 47256.10914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 32445.4083
-  tps: 47427.32591
+  dps: 32537.5567
+  tps: 47776.928
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 31447.04099
-  tps: 46792.60713
+  dps: 31539.30592
+  tps: 47016.03918
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 31371.32554
-  tps: 46477.08438
+  dps: 31460.60524
+  tps: 46715.22413
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 31496.27514
-  tps: 46567.93222
+  dps: 31612.2305
+  tps: 46783.33641
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 30855.04706
-  tps: 45905.03889
+  dps: 30945.20504
+  tps: 46122.96254
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 30855.04706
-  tps: 45905.03889
+  dps: 30945.20504
+  tps: 46122.96254
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 31726.09602
-  tps: 46840.3777
+  dps: 31898.22676
+  tps: 47222.44736
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 31878.65123
-  tps: 47196.96666
+  dps: 32001.95275
+  tps: 47314.4836
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 33249.05738
-  tps: 48094.77069
+  dps: 33310.73558
+  tps: 48489.26925
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 33460.00835
-  tps: 48742.29532
+  dps: 33495.21834
+  tps: 49185.23716
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 31223.03685
-  tps: 46329.68003
+  dps: 31327.88526
+  tps: 46588.06683
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 31497.25208
-  tps: 46572.85691
+  dps: 31614.18437
+  tps: 46793.18579
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 31299.9915
-  tps: 46633.56258
+  dps: 31378.46032
+  tps: 47162.11359
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 31299.9915
-  tps: 46633.56258
+  dps: 31378.46032
+  tps: 47162.11359
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 31300.63749
-  tps: 46750.0511
+  dps: 31325.47936
+  tps: 46923.68151
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 31376.85312
-  tps: 46889.00214
+  dps: 31418.53319
+  tps: 46938.74302
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 30890.43412
-  tps: 46190.50388
+  dps: 30975.09185
+  tps: 46454.53299
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 30856.90328
-  tps: 45906.04797
+  dps: 30947.06126
+  tps: 46123.95747
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 30856.90328
-  tps: 45906.00765
+  dps: 30947.06126
+  tps: 46123.9153
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ObsidianArborweaveBattlegarb"
  value: {
-  dps: 31205.05593
-  tps: 41068.3953
+  dps: 31355.68966
+  tps: 41834.79541
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ObsidianArborweaveRegalia"
  value: {
-  dps: 22573.98033
-  tps: 31953.15455
+  dps: 22585.42662
+  tps: 31609.94574
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 31382.00115
-  tps: 45791.23098
+  dps: 31464.62658
+  tps: 46523.03766
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 30855.97517
-  tps: 45905.45271
+  dps: 30946.13315
+  tps: 46123.36513
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 30855.04706
-  tps: 45905.03889
+  dps: 30945.20504
+  tps: 46122.96254
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 31111.45435
-  tps: 46407.92753
+  dps: 31168.14006
+  tps: 46731.2988
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 31172.44576
-  tps: 45540.87661
+  dps: 31214.19083
+  tps: 46834.04894
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 31250.39819
-  tps: 45711.53337
+  dps: 31210.82728
+  tps: 45678.71172
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 32221.86779
-  tps: 47210.56629
+  dps: 32208.84162
+  tps: 46681.36796
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 32816.69792
-  tps: 47027.75865
+  dps: 32844.50737
+  tps: 46778.12078
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-55854"
  value: {
-  dps: 30855.04706
-  tps: 45905.03889
+  dps: 30945.20504
+  tps: 46122.96254
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rainsong-56377"
  value: {
-  dps: 30855.04706
-  tps: 45905.03889
+  dps: 30945.20504
+  tps: 46122.96254
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rathrak,thePoisonousMind-77195"
  value: {
-  dps: 29862.76072
-  tps: 43576.74813
+  dps: 29881.59523
+  tps: 43752.11913
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rathrak,thePoisonousMind-78475"
  value: {
-  dps: 30442.24436
-  tps: 44337.50152
+  dps: 30457.03072
+  tps: 44472.47088
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Rathrak,thePoisonousMind-78484"
  value: {
-  dps: 29344.17254
-  tps: 43094.79133
+  dps: 29335.56925
+  tps: 43298.78202
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 30895.28528
-  tps: 46061.66668
+  dps: 30976.75716
+  tps: 46004.98654
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 30855.04706
-  tps: 45905.03889
+  dps: 30945.20504
+  tps: 46122.96254
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 30855.04706
-  tps: 45905.03889
+  dps: 30945.20504
+  tps: 46122.96254
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 30855.04706
-  tps: 45905.03889
+  dps: 30945.20504
+  tps: 46122.96254
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 32914.73841
-  tps: 48195.93015
+  dps: 32901.67354
+  tps: 47651.76822
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 32827.30517
-  tps: 48068.75299
+  dps: 32814.24201
+  tps: 47526.05261
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 32896.27899
-  tps: 48925.62684
+  dps: 32888.70194
+  tps: 48955.37362
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 31331.64711
-  tps: 46382.28256
+  dps: 31319.2382
+  tps: 46484.10711
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 31392.3133
-  tps: 45952.75922
+  dps: 31501.65272
+  tps: 46070.58264
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RosaryofLight-72901"
  value: {
-  dps: 32075.25087
-  tps: 46940.03894
+  dps: 32049.06865
+  tps: 47306.34802
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RottingSkull-77116"
  value: {
-  dps: 32552.95886
-  tps: 48409.98574
+  dps: 32656.42525
+  tps: 48298.79213
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuneofZeth-68998"
  value: {
-  dps: 31386.46951
-  tps: 46787.7682
+  dps: 31433.89256
+  tps: 46964.86558
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofConquest-70399"
  value: {
-  dps: 32895.14715
-  tps: 47591.08981
+  dps: 32932.69645
+  tps: 47766.46926
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofConquest-72304"
  value: {
-  dps: 33015.82752
-  tps: 47681.02558
+  dps: 33051.07329
+  tps: 47900.88579
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofDominance-70401"
  value: {
-  dps: 30890.43412
-  tps: 46190.50388
+  dps: 30975.09185
+  tps: 46454.53299
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofDominance-72448"
  value: {
-  dps: 30890.43412
-  tps: 46190.50388
+  dps: 30975.09185
+  tps: 46454.53299
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofVictory-70400"
  value: {
-  dps: 31581.57375
-  tps: 46799.16334
+  dps: 31659.79412
+  tps: 47436.03013
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sBadgeofVictory-72450"
  value: {
-  dps: 31625.45184
-  tps: 46854.86132
+  dps: 31703.18414
+  tps: 47491.53785
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofConquest-70404"
  value: {
-  dps: 32809.07248
-  tps: 47565.49708
+  dps: 32723.08011
+  tps: 47807.17173
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofConquest-72309"
  value: {
-  dps: 32994.07985
-  tps: 47187.96102
+  dps: 32869.05971
+  tps: 47447.55801
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofDominance-70402"
  value: {
-  dps: 30909.80944
-  tps: 46270.77896
+  dps: 30920.62882
+  tps: 46177.69652
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofDominance-72449"
  value: {
-  dps: 30876.26192
-  tps: 45507.78546
+  dps: 30958.45224
+  tps: 46374.67713
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofVictory-70403"
  value: {
-  dps: 31581.92613
-  tps: 46289.30234
+  dps: 31623.59355
+  tps: 46692.12932
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RuthlessGladiator'sInsigniaofVictory-72455"
  value: {
-  dps: 31543.89503
-  tps: 46438.24567
+  dps: 31564.94715
+  tps: 46227.44982
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ScalesofLife-68915"
  value: {
-  dps: 30855.04706
-  tps: 45905.03889
+  dps: 30945.20504
+  tps: 46122.96254
   hps: 315.97258
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ScalesofLife-69109"
  value: {
-  dps: 30855.04706
-  tps: 45905.03889
+  dps: 30945.20504
+  tps: 46122.96254
   hps: 356.41412
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 32167.7624
-  tps: 47137.8662
+  dps: 32099.31227
+  tps: 47770.29986
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-55256"
  value: {
-  dps: 30890.43412
-  tps: 46190.50388
+  dps: 30975.09185
+  tps: 46454.53299
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SeaStar-56290"
  value: {
-  dps: 30890.43412
-  tps: 46190.50388
+  dps: 30975.09185
+  tps: 46454.53299
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ShardofWoe-60233"
  value: {
-  dps: 31480.50668
-  tps: 46090.19946
+  dps: 31411.30813
+  tps: 46409.90159
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 31654.44425
-  tps: 46549.65593
+  dps: 31603.2209
+  tps: 46411.62769
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 30880.94297
-  tps: 45941.96485
+  dps: 30952.69392
+  tps: 46181.98074
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 32252.69499
-  tps: 47625.52429
+  dps: 32266.71484
+  tps: 48174.32931
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 32487.60802
-  tps: 48296.24365
+  dps: 32465.40974
+  tps: 48450.35108
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-55879"
  value: {
-  dps: 31190.40521
-  tps: 46392.97196
+  dps: 31281.11655
+  tps: 46951.70848
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Sorrowsong-56400"
  value: {
-  dps: 31233.25821
-  tps: 46465.13842
+  dps: 31324.08728
+  tps: 47024.77926
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 31223.03685
-  tps: 46329.68003
+  dps: 31327.88526
+  tps: 46588.06683
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulCasket-58183"
  value: {
-  dps: 31310.46193
-  tps: 46890.29325
+  dps: 31401.21743
+  tps: 47443.05555
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 31656.35274
-  tps: 46010.72525
+  dps: 31727.15866
+  tps: 46502.55664
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 31618.97434
-  tps: 47272.37999
+  dps: 31677.35726
+  tps: 47218.19637
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 31863.61792
-  tps: 46715.70883
+  dps: 31869.62418
+  tps: 46889.86296
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 31355.34121
-  tps: 46735.54669
+  dps: 31451.69731
+  tps: 47241.77734
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 31386.93961
-  tps: 47193.74161
+  dps: 31478.99532
+  tps: 47635.73382
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 33525.2635
-  tps: 48758.14086
+  dps: 33610.73565
+  tps: 48999.20989
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 33097.93
-  tps: 47531.65694
+  dps: 33157.1465
+  tps: 47712.85126
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 34130.41766
-  tps: 49350.7394
+  dps: 34096.49824
+  tps: 48964.71949
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StayofExecution-68996"
  value: {
-  dps: 30855.04706
-  tps: 45905.03889
+  dps: 30945.20504
+  tps: 46122.96254
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 30858.07875
-  tps: 45913.72515
+  dps: 30941.93355
+  tps: 46093.79499
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stormrider'sBattlegarb"
  value: {
-  dps: 28750.73717
-  tps: 40801.53562
+  dps: 28649.13376
+  tps: 40213.50492
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Stormrider'sRegalia"
  value: {
-  dps: 22445.93083
-  tps: 31184.42374
+  dps: 22425.59441
+  tps: 31186.19401
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62465"
  value: {
-  dps: 30856.024
-  tps: 45913.94935
+  dps: 30946.18198
+  tps: 46131.873
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-StumpofTime-62470"
  value: {
-  dps: 30856.024
-  tps: 45913.94935
+  dps: 30946.18198
+  tps: 46132.04091
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 30855.04706
-  tps: 45905.03889
+  dps: 30945.20504
+  tps: 46122.96254
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 30855.04706
-  tps: 45905.03889
+  dps: 30945.20504
+  tps: 46122.96254
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 30856.50864
-  tps: 46084.63083
+  dps: 30928.24067
+  tps: 46445.24632
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 31578.15042
-  tps: 46731.97459
+  dps: 31724.22845
+  tps: 47149.19565
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-55819"
  value: {
-  dps: 30855.04706
-  tps: 45904.86552
+  dps: 30945.20504
+  tps: 46122.78123
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TearofBlood-56351"
  value: {
-  dps: 30855.97517
-  tps: 45905.46803
+  dps: 30946.13315
+  tps: 46123.38116
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 31137.06476
-  tps: 46367.50912
+  dps: 31218.89723
+  tps: 46833.83586
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 31241.84289
-  tps: 46570.25718
+  dps: 31313.58647
+  tps: 47017.1465
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheHungerer-68927"
  value: {
-  dps: 32978.01861
-  tps: 47780.78314
+  dps: 32987.22289
+  tps: 48520.53422
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TheHungerer-69112"
  value: {
-  dps: 33337.8809
-  tps: 48455.84414
+  dps: 33438.57286
+  tps: 49202.45182
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 30875.95081
-  tps: 45922.40939
+  dps: 30970.73492
+  tps: 46133.15087
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 30853.89566
-  tps: 45826.34366
+  dps: 30955.17003
+  tps: 46152.10014
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 30855.04706
-  tps: 45905.03889
+  dps: 30945.20504
+  tps: 46122.96254
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 30855.04706
-  tps: 45905.03889
+  dps: 30945.20504
+  tps: 46122.96254
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-77190"
  value: {
-  dps: 33103.92692
-  tps: 48291.36132
+  dps: 33088.99883
+  tps: 47956.60753
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-78477"
  value: {
-  dps: 33078.89591
-  tps: 48104.37008
+  dps: 33048.35343
+  tps: 47896.11889
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-78486"
  value: {
-  dps: 33084.48254
-  tps: 48253.31917
+  dps: 33067.53594
+  tps: 48018.96841
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 32425.74993
-  tps: 48302.25149
+  dps: 32480.78443
+  tps: 49026.21265
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 32593.61989
-  tps: 48883.00391
+  dps: 32657.10129
+  tps: 49345.99048
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 31262.73975
-  tps: 46666.96602
+  dps: 31126.73719
+  tps: 46476.48062
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 30867.22361
-  tps: 46032.04615
+  dps: 30979.41578
+  tps: 46043.35515
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnheededWarning-59520"
  value: {
-  dps: 32883.60461
-  tps: 49181.07226
+  dps: 32775.7767
+  tps: 49069.48636
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 30890.43412
-  tps: 46190.50388
+  dps: 30975.09185
+  tps: 46454.53299
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 32813.71472
-  tps: 48042.80003
+  dps: 32872.47665
+  tps: 48159.86833
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 32813.71472
-  tps: 48042.80003
+  dps: 32872.47665
+  tps: 48159.86833
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 32813.71472
-  tps: 48042.80003
+  dps: 32872.47665
+  tps: 48159.86833
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 26865.96087
-  tps: 37701.06217
+  dps: 26869.97027
+  tps: 37674.77404
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 30857.86043
-  tps: 45914.80092
+  dps: 30948.01841
+  tps: 46132.70957
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 30857.50683
-  tps: 45909.00524
+  dps: 30947.66481
+  tps: 46126.91197
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 32107.10834
-  tps: 46623.22498
+  dps: 32074.8927
+  tps: 46246.6745
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VeilofLies-72900"
  value: {
-  dps: 30904.71153
-  tps: 46177.74673
+  dps: 30976.73046
+  tps: 46045.62173
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 32128.27592
-  tps: 48163.93275
+  dps: 32152.41272
+  tps: 48387.98511
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 32283.4224
-  tps: 48247.70717
+  dps: 32300.98569
+  tps: 48642.61251
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77207"
  value: {
-  dps: 33702.40845
-  tps: 51412.5793
+  dps: 33770.46381
+  tps: 51672.78276
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77979"
  value: {
-  dps: 33376.67136
-  tps: 50523.44114
+  dps: 33295.85382
+  tps: 50726.91251
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77999"
  value: {
-  dps: 33757.71299
-  tps: 50250.22908
+  dps: 33771.31506
+  tps: 49958.39978
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 30890.43412
-  tps: 46190.50388
+  dps: 30975.09185
+  tps: 46454.53299
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 30890.43412
-  tps: 46190.50388
+  dps: 30975.09185
+  tps: 46454.53299
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 32374.11557
-  tps: 47314.69404
+  dps: 32432.52898
+  tps: 47438.10954
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofConquest-70517"
  value: {
-  dps: 32603.2351
-  tps: 47699.4103
+  dps: 32644.37565
+  tps: 47752.55714
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 30890.43412
-  tps: 46190.50388
+  dps: 30975.09185
+  tps: 46454.53299
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofDominance-70518"
  value: {
-  dps: 30890.43412
-  tps: 46190.50388
+  dps: 30975.09185
+  tps: 46454.53299
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 31438.65825
-  tps: 46480.04228
+  dps: 31490.17435
+  tps: 46957.50029
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sBadgeofVictory-70519"
  value: {
-  dps: 31510.07966
-  tps: 46570.5402
+  dps: 31560.81274
+  tps: 47048.26801
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 30878.50925
-  tps: 46110.13076
+  dps: 30955.77445
+  tps: 46337.2492
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 31339.09345
-  tps: 45343.50443
+  dps: 31347.85055
+  tps: 44428.05649
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 31344.05371
-  tps: 46668.81232
+  dps: 31363.95731
+  tps: 46862.93979
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 30877.53231
-  tps: 46101.2203
+  dps: 30954.79751
+  tps: 46328.33874
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 31322.07451
-  tps: 46839.81146
+  dps: 31405.26998
+  tps: 47354.93125
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 30877.53231
-  tps: 46101.2203
+  dps: 30954.79751
+  tps: 46328.33874
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 32550.96811
-  tps: 47453.90507
+  dps: 32486.97383
+  tps: 47528.36267
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofConquest-70577"
  value: {
-  dps: 32725.94184
-  tps: 48254.30644
+  dps: 32691.52922
+  tps: 48744.68073
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 30793.96778
-  tps: 45953.26686
+  dps: 30876.54183
+  tps: 46296.37685
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofDominance-70578"
  value: {
-  dps: 30875.00923
-  tps: 45601.17667
+  dps: 30919.60274
+  tps: 45534.14914
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 31474.81059
-  tps: 46332.21568
+  dps: 31420.74065
+  tps: 47442.70923
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sInsigniaofVictory-70579"
  value: {
-  dps: 31502.90175
-  tps: 46311.16859
+  dps: 31503.10105
+  tps: 46512.24104
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 30855.04706
-  tps: 45907.25353
+  dps: 30945.20504
+  tps: 46125.16839
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 30855.04706
-  tps: 45906.93505
+  dps: 30945.20504
+  tps: 46124.83331
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WillofUnbinding-77995"
  value: {
-  dps: 30855.04706
-  tps: 45907.60018
+  dps: 30945.20504
+  tps: 46125.52961
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 30860.47537
-  tps: 45877.22903
+  dps: 30939.27628
+  tps: 46130.57239
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 30853.95828
-  tps: 45881.1955
+  dps: 30931.96767
+  tps: 46080.49773
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 31142.26182
-  tps: 46376.27192
+  dps: 31238.14582
+  tps: 46878.6377
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 34561.6939
-  tps: 51423.54466
+  dps: 34567.04413
+  tps: 51930.50098
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 34171.78278
-  tps: 50964.93151
+  dps: 34187.71758
+  tps: 51593.33033
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 35035.69344
-  tps: 52235.86255
+  dps: 35051.6792
+  tps: 52840.9344
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 31261.27359
-  tps: 46165.54531
+  dps: 31417.88037
+  tps: 46498.64472
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 31261.27359
-  tps: 46165.54531
+  dps: 31417.88037
+  tps: 46498.64472
  }
 }
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 33378.90178
-  tps: 48038.78132
+  dps: 33383.39687
+  tps: 48144.33668
  }
 }
 dps_results: {
@@ -2120,85 +2120,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 39331.47853
-  tps: 51042.88253
+  dps: 39360.24626
+  tps: 51328.31672
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39076.92317
-  tps: 51691.43291
+  dps: 39048.05284
+  tps: 51769.5999
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 50516.21059
-  tps: 43943.57556
+  dps: 50455.38315
+  tps: 43161.69317
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 25077.06862
-  tps: 33081.34372
+  dps: 25055.31254
+  tps: 33287.01434
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25300.65329
-  tps: 36107.98036
+  dps: 25313.9951
+  tps: 36100.23259
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 28233.01234
-  tps: 26760.23231
+  dps: 28190.16666
+  tps: 26903.98973
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38433.73843
-  tps: 27290.21492
+  dps: 38352.92932
+  tps: 27232.84045
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38066.96424
-  tps: 27027.54461
+  dps: 38118.37241
+  tps: 27064.04441
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 49864.82439
-  tps: 35404.02531
+  dps: 49740.79453
+  tps: 35315.96411
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24037.60193
-  tps: 17069.06025
+  dps: 24019.47012
+  tps: 17056.18667
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24161.25222
-  tps: 17154.69924
+  dps: 24190.13987
+  tps: 17175.20947
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27875.22467
-  tps: 19791.97751
+  dps: 27841.50702
+  tps: 19768.03798
  }
 }
 dps_results: {
@@ -2246,85 +2246,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38638.43727
-  tps: 50012.89847
+  dps: 38498.35903
+  tps: 49229.12315
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38175.64271
-  tps: 49442.40795
+  dps: 38144.38129
+  tps: 48726.93602
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 48650.95704
-  tps: 42382.00099
+  dps: 48683.78869
+  tps: 41484.40671
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24528.09756
-  tps: 32039.47093
+  dps: 24529.97483
+  tps: 32244.28671
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24676.78752
-  tps: 32674.63943
+  dps: 24680.53841
+  tps: 32446.32967
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27093.48532
-  tps: 24706.70297
+  dps: 27124.58676
+  tps: 24868.04213
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 37671.988
-  tps: 26749.37212
+  dps: 37686.00003
+  tps: 26759.32066
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37234.78705
-  tps: 26436.6988
+  dps: 37275.8464
+  tps: 26465.85094
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 48361.36508
-  tps: 34336.56921
+  dps: 48377.68065
+  tps: 34348.15326
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 23591.03494
-  tps: 16751.99769
+  dps: 23603.43675
+  tps: 16760.80297
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 23666.92377
-  tps: 16803.72603
+  dps: 23677.18868
+  tps: 16811.01412
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 26866.82914
-  tps: 19076.01669
+  dps: 26854.57624
+  tps: 19067.31713
  }
 }
 dps_results: {
@@ -2372,36 +2372,36 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 33394.82736
-  tps: 46602.0142
+  dps: 33421.02321
+  tps: 47042.89264
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 33133.20219
-  tps: 48193.22962
+  dps: 33149.28611
+  tps: 47582.65367
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 41357.49006
-  tps: 41929.35355
+  dps: 41412.68011
+  tps: 41938.56382
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 20921.70464
-  tps: 30743.72724
+  dps: 20910.18842
+  tps: 30390.9821
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 21183.10035
-  tps: 31971.26679
+  dps: 21144.82648
+  tps: 31826.73714
  }
 }
 dps_results: {
@@ -2414,36 +2414,36 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 32368.84811
-  tps: 22984.1428
+  dps: 32371.66289
+  tps: 22986.14129
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 31721.10693
-  tps: 22521.98592
+  dps: 31752.1838
+  tps: 22544.0505
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 40417.14079
-  tps: 28696.16996
+  dps: 40440.20439
+  tps: 28712.54512
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 19959.49812
-  tps: 14173.60654
+  dps: 19940.34532
+  tps: 14160.00806
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20066.06447
-  tps: 14247.11593
+  dps: 20066.65269
+  tps: 14247.53357
  }
 }
 dps_results: {
@@ -2498,15 +2498,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 32744.4925
-  tps: 46876.40931
+  dps: 32916.87371
+  tps: 47154.3542
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 32197.11604
-  tps: 45402.65812
+  dps: 32203.61274
+  tps: 45965.75615
  }
 }
 dps_results: {
@@ -2519,15 +2519,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 20373.13916
-  tps: 29002.67019
+  dps: 20295.70718
+  tps: 28921.52771
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20560.52558
-  tps: 30302.86953
+  dps: 20502.06699
+  tps: 30347.72199
  }
 }
 dps_results: {
@@ -2540,36 +2540,36 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 31677.5287
-  tps: 22493.30602
+  dps: 31703.80861
+  tps: 22511.96475
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 31152.15481
-  tps: 22118.02991
+  dps: 31130.40875
+  tps: 22102.59021
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 39897.38686
-  tps: 28327.14467
+  dps: 39898.55068
+  tps: 28327.97098
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 19446.29719
-  tps: 13809.23388
+  dps: 19433.61796
+  tps: 13800.23163
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-preraid-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 19490.76603
-  tps: 13838.65404
+  dps: 19505.21525
+  tps: 13848.91299
  }
 }
 dps_results: {
@@ -2624,36 +2624,36 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 39510.76507
-  tps: 52368.96342
+  dps: 39495.2722
+  tps: 52972.76594
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39170.16337
-  tps: 52237.12863
+  dps: 39097.0607
+  tps: 51899.5222
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 49680.333
-  tps: 44544.57168
+  dps: 49778.04677
+  tps: 44285.73108
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24970.55318
-  tps: 33367.13477
+  dps: 24975.05701
+  tps: 33565.0638
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25399.95762
-  tps: 35226.09901
+  dps: 25394.17898
+  tps: 35843.29309
  }
 }
 dps_results: {
@@ -2666,36 +2666,36 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38341.48317
-  tps: 27224.71369
+  dps: 38342.08465
+  tps: 27225.14074
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37849.06553
-  tps: 26872.83652
+  dps: 37903.99639
+  tps: 26911.83744
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 49320.54229
-  tps: 35017.58503
+  dps: 49260.74102
+  tps: 34975.12612
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24115.74126
-  tps: 17124.53918
+  dps: 24122.06499
+  tps: 17129.02902
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24224.14549
-  tps: 17199.35346
+  dps: 24238.6946
+  tps: 17209.68332
  }
 }
 dps_results: {
@@ -2750,85 +2750,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38593.50258
-  tps: 51115.9057
+  dps: 38592.52738
+  tps: 50261.6846
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38183.05067
-  tps: 49986.10539
+  dps: 38148.80757
+  tps: 50197.35442
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 48138.84938
-  tps: 42554.68903
+  dps: 48098.57458
+  tps: 42079.20521
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24299.65318
-  tps: 32557.78079
+  dps: 24315.06425
+  tps: 32218.73384
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24536.55723
-  tps: 34197.49351
+  dps: 24506.07496
+  tps: 33892.97251
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 26696.82698
-  tps: 25386.88424
+  dps: 26725.06359
+  tps: 25297.44611
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 37631.50735
-  tps: 26720.63086
+  dps: 37604.92001
+  tps: 26701.75384
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37020.3483
-  tps: 26284.4473
+  dps: 37058.34666
+  tps: 26311.42613
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 47817.37091
-  tps: 33950.33335
+  dps: 47845.80387
+  tps: 33970.52074
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 23503.83287
-  tps: 16690.08422
+  dps: 23496.76745
+  tps: 16685.06777
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 23613.1353
-  tps: 16765.53622
+  dps: 23586.41283
+  tps: 16746.56327
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 26446.02829
-  tps: 18777.24809
+  dps: 26447.78298
+  tps: 18778.49392
  }
 }
 dps_results: {
@@ -2876,36 +2876,36 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 33438.73077
-  tps: 47065.41224
+  dps: 33351.44339
+  tps: 47003.12191
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 33045.59964
-  tps: 48165.54524
+  dps: 33039.01896
+  tps: 47925.46561
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 40987.28801
-  tps: 42443.00713
+  dps: 40918.91613
+  tps: 42132.5583
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 20794.65108
-  tps: 30156.17268
+  dps: 20830.79563
+  tps: 30166.32385
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 21019.1735
-  tps: 31983.26481
+  dps: 20943.15484
+  tps: 31507.23917
  }
 }
 dps_results: {
@@ -2918,15 +2918,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 32271.36189
-  tps: 22914.92759
+  dps: 32231.03239
+  tps: 22886.29364
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 31677.94556
-  tps: 22491.34135
+  dps: 31693.72241
+  tps: 22502.54291
  }
 }
 dps_results: {
@@ -2939,15 +2939,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 19947.27587
-  tps: 14164.92875
+  dps: 19950.57448
+  tps: 14167.27076
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20016.58844
-  tps: 14211.98795
+  dps: 19992.96983
+  tps: 14195.21874
  }
 }
 dps_results: {
@@ -3002,36 +3002,36 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 32582.6374
-  tps: 45409.93938
+  dps: 32617.97455
+  tps: 45589.2227
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 32025.30577
-  tps: 45118.91553
+  dps: 32018.25831
+  tps: 45082.36252
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 39757.57722
-  tps: 40401.21536
+  dps: 39760.9316
+  tps: 40401.80493
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 20263.75729
-  tps: 28942.84489
+  dps: 20297.83841
+  tps: 29049.22276
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20479.78754
-  tps: 29932.29873
+  dps: 20418.02566
+  tps: 29973.4874
  }
 }
 dps_results: {
@@ -3044,36 +3044,36 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 31486.92598
-  tps: 22357.97808
+  dps: 31532.29716
+  tps: 22390.19163
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 30911.28915
-  tps: 21947.01529
+  dps: 30870.32492
+  tps: 21917.9307
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 39040.66451
-  tps: 27718.8718
+  dps: 39072.42468
+  tps: 27741.42152
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 19363.54128
-  tps: 13750.47719
+  dps: 19368.10438
+  tps: 13753.71699
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 19456.94031
-  tps: 13814.63778
+  dps: 19462.16591
+  tps: 13818.34796
  }
 }
 dps_results: {

--- a/sim/druid/feral/apl_values.go
+++ b/sim/druid/feral/apl_values.go
@@ -163,9 +163,15 @@ func (action *APLActionCatOptimalRotationAction) Execute(sim *core.Simulation) {
 		}
 	}
 
-	// Off-GCD Maul check.
-	if cat.BearFormAura.IsActive() && !cat.ClearcastingAura.IsActive() && cat.Maul.CanCast(sim, cat.CurrentTarget) && ((cat.CurrentRage() >= cat.Maul.DefaultCast.Cost + cat.MangleBear.DefaultCast.Cost) || (cat.AutoAttacks.NextAttackAt() < cat.NextGCDAt())) {
-		cat.Maul.Cast(sim, cat.CurrentTarget)
+	// Off-GCD bear-weave checks.
+	if cat.BearFormAura.IsActive() && !cat.ClearcastingAura.IsActive() {
+		if cat.Enrage.IsReady(sim) && !cat.readyToShift {
+			cat.Enrage.Cast(sim, nil)
+		}
+
+		if cat.Maul.CanCast(sim, cat.CurrentTarget) && ((cat.CurrentRage() >= cat.Maul.DefaultCast.Cost + cat.MangleBear.DefaultCast.Cost) || (cat.AutoAttacks.NextAttackAt() < cat.NextGCDAt())) {
+			cat.Maul.Cast(sim, cat.CurrentTarget)
+		}
 	}
 
 	// Handle movement before any rotation logic

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -731,7 +731,7 @@ func (cat *FeralDruid) doRotation(sim *core.Simulation) (bool, time.Duration) {
 			return false, 0
 		}
 		timeToNextAction = core.DurationFromSeconds((cat.CurrentMangleCatCost() - excessE) / regenRate)
-	} else if !t11RefreshNext {
+	} else if !t11RefreshNext && (isClearcast || !ripRefreshPending || !cat.tempSnapshotAura.IsActive() || (ripRefreshTime + cat.ReactionTime - sim.CurrentTime > core.GCDMin)) {
 		if excessE >= cat.CurrentShredCost() || isClearcast {
 			cat.Shred.Cast(sim, cat.CurrentTarget)
 			return false, 0

--- a/ui/druid/feral/apls/aoe.apl.json
+++ b/ui/druid/feral/apls/aoe.apl.json
@@ -3,6 +3,7 @@
       "priorityList": [
         {"action":{"autocastOtherCooldowns":{}}},
         {"action":{"condition":{"const":{"val":"false"}},"castSpell":{"spellId":{"spellId":50334}}}},
+        {"action":{"condition":{"const":{"val":"false"}},"castSpell":{"spellId":{"spellId":5229}}}},
         {"action":{"catOptimalRotationAction":{"rotationType":"Aoe","manualParams":false,"maintainFaerieFire":false,"bearWeave":true,"snekWeave":true}}},
         {"action":{"autocastOtherCooldowns":{}}}
       ]

--- a/ui/druid/feral/apls/default.apl.json
+++ b/ui/druid/feral/apls/default.apl.json
@@ -6,6 +6,7 @@
         {"action":{"condition":{"auraIsActive":{"auraId":{"spellId":50334}}},"castSpell":{"spellId":{"spellId":26297}}}},
         {"action":{"autocastOtherCooldowns":{}}},
         {"action":{"condition":{"const":{"val":"false"}},"castSpell":{"spellId":{"spellId":50334}}}},
+        {"action":{"condition":{"const":{"val":"false"}},"castSpell":{"spellId":{"spellId":5229}}}},
         {"action":{"catOptimalRotationAction":{"manualParams":false,"maintainFaerieFire":true,"meleeWeave":true,"bearWeave":true,"snekWeave":true}}},
         {"action":{"autocastOtherCooldowns":{}}}
       ]

--- a/ui/druid/feral/apls/monocat.apl.json
+++ b/ui/druid/feral/apls/monocat.apl.json
@@ -6,6 +6,7 @@
         {"action":{"condition":{"auraIsActive":{"auraId":{"spellId":50334}}},"castSpell":{"spellId":{"spellId":26297}}}},
         {"action":{"autocastOtherCooldowns":{}}},
         {"action":{"condition":{"const":{"val":"false"}},"castSpell":{"spellId":{"spellId":50334}}}},
+        {"action":{"condition":{"const":{"val":"false"}},"castSpell":{"spellId":{"spellId":5229}}}},
         {"action":{"catOptimalRotationAction":{"manualParams":false,"maintainFaerieFire":true,"meleeWeave":true,"bearWeave":false,"snekWeave":false}}},
         {"action":{"autocastOtherCooldowns":{}}}
       ]

--- a/ui/druid/feral/sim.ts
+++ b/ui/druid/feral/sim.ts
@@ -7,7 +7,7 @@ import { Player } from '../../core/player';
 import { PlayerClasses } from '../../core/player_classes';
 import { APLAction, APLListItem, APLRotation, APLRotation_Type as APLRotationType } from '../../core/proto/apl';
 import { Cooldowns, Debuffs, Faction, IndividualBuffs, PartyBuffs, PseudoStat, Race, RaidBuffs, Spec, Stat } from '../../core/proto/common';
-import { FeralDruid_Rotation as DruidRotation } from '../../core/proto/druid';
+import { FeralDruid_Rotation as DruidRotation, FeralDruid_Rotation_AplType as FeralRotationType } from '../../core/proto/druid';
 import * as AplUtils from '../../core/proto_utils/apl_utils';
 import { Stats, UnitStat } from '../../core/proto_utils/stats';
 import * as FeralInputs from './inputs';
@@ -146,7 +146,17 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFeralDruid, {
 		);
 		const autocasts = APLAction.fromJsonString(`{"autocastOtherCooldowns":{}}`);
 
-		actions.push(...([synapseSprings, potion, trollRacial, blockZerk, doRotation, autocasts].filter(a => a) as Array<APLAction>));
+		const singleTarget = (simple.rotationType == FeralRotationType.SingleTarget);
+		actions.push(
+			...([
+				singleTarget ? synapseSprings : null,
+				singleTarget ? potion : null,
+				singleTarget ? trollRacial : null,
+				blockZerk,
+				doRotation,
+				autocasts,
+			].filter(a => a) as Array<APLAction>),
+		);
 
 		return APLRotation.create({
 			prepullActions: prepullActions,

--- a/ui/druid/feral/sim.ts
+++ b/ui/druid/feral/sim.ts
@@ -135,6 +135,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFeralDruid, {
 		const potion = APLAction.fromJsonString(`{"condition":{"or":{"vals":[{"and":{"vals":[{"auraIsActive":{"auraId":{"spellId":5217}}},{"cmp":{"op":"OpLt","lhs":{"remainingTime":{}},"rhs":{"math":{"op":"OpAdd","lhs":{"spellTimeToReady":{"spellId":{"spellId":50334}}},"rhs":{"const":{"val":"26s"}}}}}}]}},{"cmp":{"op":"OpLt","lhs":{"remainingTime":{}},"rhs":{"const":{"val":"26s"}}}},{"auraIsActive":{"auraId":{"spellId":50334}}}]}},"castSpell":{"spellId":{"itemId":58145}}}`);
 		const trollRacial = APLAction.fromJsonString(`{"condition":{"auraIsActive":{"auraId":{"spellId":50334}}},"castSpell":{"spellId":{"spellId":26297}}}`);
 		const blockZerk = APLAction.fromJsonString(`{"condition":{"const":{"val":"false"}},"castSpell":{"spellId":{"spellId":50334}}}`);
+		const blockEnrage = APLAction.fromJsonString(`{"condition":{"const":{"val":"false"}},"castSpell":{"spellId":{"spellId":5229}}}`);
 		const doRotation = APLAction.fromJsonString(
 			`{"catOptimalRotationAction":{"rotationType":${simple.rotationType},"manualParams":${simple.manualParams},"maintainFaerieFire":${
 				simple.maintainFaerieFire
@@ -153,6 +154,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFeralDruid, {
 				singleTarget ? potion : null,
 				singleTarget ? trollRacial : null,
 				blockZerk,
+				blockEnrage,
 				doRotation,
 				autocasts,
 			].filter(a => a) as Array<APLAction>),
@@ -168,7 +170,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecFeralDruid, {
 		});
 	},
 
-	hiddenMCDs: [50334],
+	hiddenMCDs: [50334, 5229],
 
 	raidSimPresets: [
 		{


### PR DESCRIPTION
- Omit single-target-optimized CD timing logic from AoE APLs generated via the Simple interface.
- Turn off Enrage auto-cast, and cast it manually within the rotation code only when no Omen proc is active and we are not about to shift back to Cat Form. Adds 7-10 DPS depending on gear and talents.
- Block Shreds when a scheduled Rip clip for snapshotting will occur in less than a second. Adds 4-16 DPS depending on gear/talents/rotation config.