### PR TITLE
[Warrior] Fix Rend damage formula

### DIFF
--- a/sim/warrior/arms/TestArms.results
+++ b/sim/warrior/arms/TestArms.results
@@ -38,2246 +38,2246 @@ character_stats_results: {
 dps_results: {
  key: "TestArms-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 33790.3758
-  tps: 22673.70261
+  dps: 33318.18084
+  tps: 22201.50765
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 32947.54657
-  tps: 22230.6263
+  dps: 32493.44531
+  tps: 21776.52505
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 34201.68934
-  tps: 22993.98914
+  dps: 33727.41836
+  tps: 22519.71816
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 34474.55465
-  tps: 23180.43011
+  dps: 33995.53437
+  tps: 22701.40983
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ArrowofTime-72897"
  value: {
-  dps: 33057.5975
-  tps: 22346.54425
+  dps: 32602.41896
+  tps: 21891.36571
  }
 }
 dps_results: {
  key: "TestArms-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 33201.10995
-  tps: 22302.19995
+  dps: 32734.59349
+  tps: 21835.68349
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
   hps: 96.7093
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 32486.28547
-  tps: 21850.37501
+  dps: 32030.4179
+  tps: 21394.50744
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 32593.09322
-  tps: 21916.3252
+  dps: 32135.78837
+  tps: 21459.02035
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BindingPromise-67037"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 32656.19697
-  tps: 22029.77928
+  dps: 32207.1612
+  tps: 21580.74351
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 32350.50089
-  tps: 21735.06977
+  dps: 31904.01466
+  tps: 21288.58354
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 32308.02574
-  tps: 21761.52214
+  dps: 31860.90521
+  tps: 21314.40161
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 32296.10518
-  tps: 21804.4158
+  dps: 31841.25754
+  tps: 21349.56816
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 31766.36409
-  tps: 21353.61841
+  dps: 31320.00212
+  tps: 20907.25644
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 32928.09525
-  tps: 22102.76624
+  dps: 32467.60371
+  tps: 21642.27471
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 32481.54874
-  tps: 21853.15726
+  dps: 32025.85016
+  tps: 21397.45868
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 32307.02352
-  tps: 21750.7899
+  dps: 31851.93448
+  tps: 21295.70086
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 32800.20308
-  tps: 22072.90176
+  dps: 32339.48716
+  tps: 21612.18585
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 34439.42199
-  tps: 23567.654
+  dps: 33973.7449
+  tps: 23101.9769
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 33974.73017
-  tps: 23117.73128
+  dps: 33511.11098
+  tps: 22654.1121
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 34501.31928
-  tps: 23680.0571
+  dps: 34033.90021
+  tps: 23212.63802
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BottledLightning-66879"
  value: {
-  dps: 31972.38849
-  tps: 21472.61673
+  dps: 31522.9595
+  tps: 21023.18774
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BottledWishes-77114"
  value: {
-  dps: 32098.37548
-  tps: 21630.6547
+  dps: 31651.75879
+  tps: 21184.03801
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 33201.10995
-  tps: 21856.2895
+  dps: 32734.59349
+  tps: 21399.10338
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Bryntroll,theBoneArbiter-50709"
  value: {
-  dps: 34433.68059
-  tps: 23107.07131
+  dps: 33952.63977
+  tps: 22626.03049
  }
 }
 dps_results: {
  key: "TestArms-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 33680.16083
-  tps: 22605.80937
+  dps: 33209.43179
+  tps: 22135.08034
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CataclysmicGladiator'sBadgeofConquest-73648"
  value: {
-  dps: 32691.07387
-  tps: 21985.79074
+  dps: 32233.87881
+  tps: 21528.59568
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CataclysmicGladiator'sBadgeofDominance-73498"
  value: {
-  dps: 31766.36409
-  tps: 21353.61841
+  dps: 31320.00212
+  tps: 20907.25644
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CataclysmicGladiator'sBadgeofVictory-73496"
  value: {
-  dps: 33615.19808
-  tps: 22545.84776
+  dps: 33146.34965
+  tps: 22076.99932
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CataclysmicGladiator'sInsigniaofConquest-73643"
  value: {
-  dps: 32668.76258
-  tps: 22003.25068
+  dps: 32210.02846
+  tps: 21544.51656
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CataclysmicGladiator'sInsigniaofDominance-73497"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CataclysmicGladiator'sInsigniaofVictory-73491"
  value: {
-  dps: 33425.54187
-  tps: 22500.61765
+  dps: 32956.26988
+  tps: 22031.34566
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 33797.84332
-  tps: 22681.17013
+  dps: 33325.50013
+  tps: 22208.82694
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ColossalDragonplateArmor"
  value: {
-  dps: 27910.05376
-  tps: 19049.45036
+  dps: 27513.21235
+  tps: 18652.60895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ColossalDragonplateBattlegear"
  value: {
-  dps: 31846.77879
-  tps: 21753.00997
+  dps: 31414.21822
+  tps: 21320.4494
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 33227.22973
-  tps: 22361.37003
+  dps: 32761.29022
+  tps: 21895.43051
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 31766.36409
-  tps: 21353.61841
+  dps: 31320.00212
+  tps: 20907.25644
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 34740.71951
-  tps: 23455.32328
+  dps: 34253.62264
+  tps: 22968.2264
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 34441.52302
-  tps: 23185.089
+  dps: 33959.97798
+  tps: 22703.54395
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 35161.30137
-  tps: 23678.85308
+  dps: 34671.43688
+  tps: 23188.98858
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CrushingWeight-59506"
  value: {
-  dps: 33185.77518
-  tps: 22494.3428
+  dps: 32725.64994
+  tps: 22034.21755
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CrushingWeight-65118"
  value: {
-  dps: 33445.1594
-  tps: 22573.90279
+  dps: 32981.54091
+  tps: 22110.2843
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-CunningoftheCruel-78000"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 33597.73584
-  tps: 22818.20805
+  dps: 33136.24113
+  tps: 22356.71335
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 33094.10823
-  tps: 22482.66185
+  dps: 32639.54858
+  tps: 22028.10221
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 32385.66261
-  tps: 21884.03135
+  dps: 31938.24209
+  tps: 21436.61083
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 32588.41429
-  tps: 22020.81801
+  dps: 32132.24524
+  tps: 21564.64895
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 33314.09695
-  tps: 22374.97509
+  dps: 32846.04746
+  tps: 21906.9256
  }
 }
 dps_results: {
  key: "TestArms-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 31920.60498
-  tps: 21358.81638
+  dps: 31474.09668
+  tps: 20912.30808
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 33566.40805
-  tps: 22615.13509
+  dps: 33095.2436
+  tps: 22143.97063
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EarthenBattleplate"
  value: {
-  dps: 27346.53784
-  tps: 18476.06639
+  dps: 26944.41076
+  tps: 18073.93931
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EarthenWarplate"
  value: {
-  dps: 30117.20834
-  tps: 20331.27693
+  dps: 29693.6261
+  tps: 19907.69468
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 33201.10995
-  tps: 22302.19995
+  dps: 32734.59349
+  tps: 21835.68349
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 31766.36409
-  tps: 21353.61841
+  dps: 31320.00212
+  tps: 20907.25644
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 33201.10995
-  tps: 22302.19995
+  dps: 32734.59349
+  tps: 21835.68349
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 33314.09695
-  tps: 22374.97509
+  dps: 32846.04746
+  tps: 21906.9256
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 33133.65014
-  tps: 22290.26299
+  dps: 32670.59836
+  tps: 21827.21121
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 33229.2943
-  tps: 22362.36818
+  dps: 32762.67804
+  tps: 21895.75192
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 33581.2646
-  tps: 22665.90574
+  dps: 33120.75333
+  tps: 22205.39448
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 33201.10995
-  tps: 22302.19995
+  dps: 32734.59349
+  tps: 21835.68349
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 34484.43426
-  tps: 23178.00818
+  dps: 34000.2439
+  tps: 22693.81782
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 34179.04285
-  tps: 22974.80926
+  dps: 33699.03323
+  tps: 22494.79964
  }
 }
 dps_results: {
  key: "TestArms-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 34820.3648
-  tps: 23401.52699
+  dps: 34331.57563
+  tps: 22912.73783
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FallofMortality-59500"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FallofMortality-65124"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 31750.77288
-  tps: 21355.33532
+  dps: 31304.23677
+  tps: 20908.79922
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 32256.28192
-  tps: 21712.97388
+  dps: 31802.75887
+  tps: 21259.45083
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 31766.36409
-  tps: 21353.61841
+  dps: 31320.00212
+  tps: 20907.25644
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 31766.36409
-  tps: 21353.61841
+  dps: 31320.00212
+  tps: 20907.25644
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 33403.85373
-  tps: 22466.94228
+  dps: 32944.47597
+  tps: 22007.56452
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 32338.40929
-  tps: 22088.41028
+  dps: 31893.2789
+  tps: 21643.27989
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 33331.52692
-  tps: 22447.11427
+  dps: 32866.09627
+  tps: 21981.68362
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FluidDeath-58181"
  value: {
-  dps: 32463.24423
-  tps: 21834.85275
+  dps: 32007.54565
+  tps: 21379.15417
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 33201.10995
-  tps: 22302.19995
+  dps: 32734.59349
+  tps: 21835.68349
  }
 }
 dps_results: {
  key: "TestArms-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-GaleofShadows-56138"
  value: {
-  dps: 32051.67202
-  tps: 21663.70668
+  dps: 31602.92971
+  tps: 21214.96437
  }
 }
 dps_results: {
  key: "TestArms-AllItems-GaleofShadows-56462"
  value: {
-  dps: 32182.86685
-  tps: 21734.3093
+  dps: 31734.38802
+  tps: 21285.83046
  }
 }
 dps_results: {
  key: "TestArms-AllItems-GearDetector-61462"
  value: {
-  dps: 32368.71454
-  tps: 21852.99439
+  dps: 31921.20094
+  tps: 21405.48079
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Gladiator'sBattlegear"
  value: {
-  dps: 26988.2729
-  tps: 18151.38976
+  dps: 26589.24628
+  tps: 17752.36314
  }
 }
 dps_results: {
  key: "TestArms-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 32270.45805
-  tps: 21730.33057
+  dps: 31817.16938
+  tps: 21277.04191
  }
 }
 dps_results: {
  key: "TestArms-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 32530.29582
-  tps: 21957.98691
+  dps: 32071.65188
+  tps: 21499.34297
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Gurthalak,VoiceoftheDeeps-77191"
  value: {
-  dps: 36355.97696
-  tps: 23725.77463
+  dps: 35861.09005
+  tps: 23230.88771
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Gurthalak,VoiceoftheDeeps-78478"
  value: {
-  dps: 36551.79636
-  tps: 23937.9586
+  dps: 36053.61997
+  tps: 23439.78221
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Gurthalak,VoiceoftheDeeps-78487"
  value: {
-  dps: 35768.20582
-  tps: 23657.41661
+  dps: 35275.67562
+  tps: 23164.88641
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HarmlightToken-63839"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 33130.62416
-  tps: 22424.92558
+  dps: 32674.17203
+  tps: 21968.47344
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartofRage-59224"
  value: {
-  dps: 33034.08688
-  tps: 22280.16798
+  dps: 32569.93454
+  tps: 21816.01565
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartofSolace-55868"
  value: {
-  dps: 33028.04698
-  tps: 22391.62043
+  dps: 32566.1978
+  tps: 21929.77124
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartofSolace-56393"
  value: {
-  dps: 33308.45969
-  tps: 22551.08576
+  dps: 32845.05692
+  tps: 22087.683
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartofThunder-55845"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartofThunder-56370"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 32378.39751
-  tps: 21805.97618
+  dps: 31923.49143
+  tps: 21351.07011
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 33314.09695
-  tps: 22374.97509
+  dps: 32846.04746
+  tps: 21906.9256
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 33668.70173
-  tps: 22728.924
+  dps: 33207.351
+  tps: 22267.57327
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 33668.70173
-  tps: 22728.924
+  dps: 33207.351
+  tps: 22267.57327
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 32350.50089
-  tps: 21735.06977
+  dps: 31904.01466
+  tps: 21288.58354
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 32308.02574
-  tps: 21761.52214
+  dps: 31860.90521
+  tps: 21314.40161
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IndomitablePride-77211"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IndomitablePride-77983"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-IndomitablePride-78003"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 32351.85726
-  tps: 21943.69197
+  dps: 31905.92716
+  tps: 21497.76187
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 32298.52177
-  tps: 21857.58753
+  dps: 31851.1687
+  tps: 21410.23446
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 32469.15601
-  tps: 21914.72678
+  dps: 32022.48082
+  tps: 21468.05159
  }
 }
 dps_results: {
  key: "TestArms-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 32443.60441
-  tps: 21960.62064
+  dps: 31997.46389
+  tps: 21514.48012
  }
 }
 dps_results: {
  key: "TestArms-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 32656.19697
-  tps: 22029.77928
+  dps: 32207.1612
+  tps: 21580.74351
  }
 }
 dps_results: {
  key: "TestArms-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 32280.57807
-  tps: 21695.73182
+  dps: 31827.63178
+  tps: 21242.78553
  }
 }
 dps_results: {
  key: "TestArms-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 32376.29811
-  tps: 21770.11336
+  dps: 31921.48306
+  tps: 21315.2983
  }
 }
 dps_results: {
  key: "TestArms-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 32524.46981
-  tps: 22017.75629
+  dps: 32069.19791
+  tps: 21562.48439
  }
 }
 dps_results: {
  key: "TestArms-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 32438.93961
-  tps: 21677.92026
+  dps: 31986.00436
+  tps: 21224.98501
  }
 }
 dps_results: {
  key: "TestArms-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 32438.93961
-  tps: 21677.92026
+  dps: 31986.00436
+  tps: 21224.98501
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 31995.03444
-  tps: 21403.66804
+  dps: 31548.9392
+  tps: 20957.5728
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LastWord-50708"
  value: {
-  dps: 34210.72976
-  tps: 22958.72282
+  dps: 33732.75375
+  tps: 22480.7468
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LeadenDespair-55816"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LeadenDespair-56347"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 32219.03706
-  tps: 21705.12614
+  dps: 31766.39322
+  tps: 21252.48229
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 32225.32841
-  tps: 21727.60004
+  dps: 31771.80973
+  tps: 21274.08136
  }
 }
 dps_results: {
  key: "TestArms-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 32957.47723
-  tps: 22162.01357
+  dps: 32494.19055
+  tps: 21698.72689
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 32481.00834
-  tps: 21849.37444
+  dps: 32024.95818
+  tps: 21393.32428
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 32710.77614
-  tps: 22005.07279
+  dps: 32251.70064
+  tps: 21545.99729
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 32990.82762
-  tps: 22287.06561
+  dps: 32534.03163
+  tps: 21830.26962
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 33061.02228
-  tps: 22456.6623
+  dps: 32602.71203
+  tps: 21998.35204
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 33639.14921
-  tps: 22683.31064
+  dps: 33169.51891
+  tps: 22213.68034
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 33805.09706
-  tps: 22875.80449
+  dps: 33332.44367
+  tps: 22403.15111
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 32277.49972
-  tps: 21711.47019
+  dps: 31824.12914
+  tps: 21258.0996
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 32710.77614
-  tps: 22005.07279
+  dps: 32251.70064
+  tps: 21545.99729
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 32385.66261
-  tps: 21884.03135
+  dps: 31938.24209
+  tps: 21436.61083
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 32385.66261
-  tps: 21884.03135
+  dps: 31938.24209
+  tps: 21436.61083
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 32481.54874
-  tps: 21853.15726
+  dps: 32025.85016
+  tps: 21397.45868
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MoltenGiantBattleplate"
  value: {
-  dps: 28311.78972
-  tps: 19449.99272
+  dps: 27904.38376
+  tps: 19042.58675
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MoltenGiantWarplate"
  value: {
-  dps: 32837.99202
-  tps: 22521.68321
+  dps: 32388.14151
+  tps: 22071.8327
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 32121.41441
-  tps: 21794.78716
+  dps: 31677.8776
+  tps: 21351.25034
  }
 }
 dps_results: {
  key: "TestArms-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-No'Kaled,theElementsofDeath-77188"
  value: {
-  dps: 34477.80325
-  tps: 23231.50707
+  dps: 34000.79159
+  tps: 22754.49542
  }
 }
 dps_results: {
  key: "TestArms-AllItems-No'Kaled,theElementsofDeath-78472"
  value: {
-  dps: 34551.61688
-  tps: 23298.0207
+  dps: 34073.6108
+  tps: 22820.01461
  }
 }
 dps_results: {
  key: "TestArms-AllItems-No'Kaled,theElementsofDeath-78481"
  value: {
-  dps: 34399.55961
-  tps: 23166.21112
+  dps: 33923.14832
+  tps: 22689.79983
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 32836.764
-  tps: 22058.47908
+  dps: 32376.68343
+  tps: 21598.39852
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 32137.42216
-  tps: 21612.50278
+  dps: 31685.52471
+  tps: 21160.60532
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 31981.21965
-  tps: 21625.51808
+  dps: 31535.98477
+  tps: 21180.28321
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 32198.53484
-  tps: 21674.66764
+  dps: 31754.51174
+  tps: 21230.64454
  }
 }
 dps_results: {
  key: "TestArms-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 33201.10995
-  tps: 22302.19995
+  dps: 32734.59349
+  tps: 21835.68349
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 32604.23532
-  tps: 22054.98105
+  dps: 32153.00714
+  tps: 21603.75287
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 32781.85195
-  tps: 22318.00483
+  dps: 32327.71722
+  tps: 21863.8701
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Rainsong-55854"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Rainsong-56377"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 31775.29297
-  tps: 21371.15808
+  dps: 31328.5349
+  tps: 20924.40001
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 33850.41216
-  tps: 22719.06521
+  dps: 33377.35326
+  tps: 22246.00631
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 33680.16083
-  tps: 22605.80937
+  dps: 33209.43179
+  tps: 22135.08034
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 33165.18293
-  tps: 22347.75933
+  dps: 32702.05165
+  tps: 21884.62804
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 32700.19015
-  tps: 22009.55643
+  dps: 32239.67721
+  tps: 21549.04349
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 32852.86192
-  tps: 22117.23977
+  dps: 32390.69814
+  tps: 21655.07599
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RosaryofLight-72901"
  value: {
-  dps: 33944.89946
-  tps: 22850.16465
+  dps: 33467.75648
+  tps: 22373.02167
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RottingSkull-77116"
  value: {
-  dps: 34289.77632
-  tps: 23076.55614
+  dps: 33810.27293
+  tps: 22597.05275
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RuneofZeth-68998"
  value: {
-  dps: 32625.52196
-  tps: 21931.45265
+  dps: 32168.93966
+  tps: 21474.87034
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RuthlessGladiator'sBadgeofConquest-70399"
  value: {
-  dps: 32492.71832
-  tps: 21862.91166
+  dps: 32037.95863
+  tps: 21408.15197
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RuthlessGladiator'sBadgeofConquest-72304"
  value: {
-  dps: 32557.03587
-  tps: 21890.88177
+  dps: 32101.02146
+  tps: 21434.86736
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RuthlessGladiator'sBadgeofDominance-70401"
  value: {
-  dps: 31766.36409
-  tps: 21353.61841
+  dps: 31320.00212
+  tps: 20907.25644
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RuthlessGladiator'sBadgeofDominance-72448"
  value: {
-  dps: 31766.36409
-  tps: 21353.61841
+  dps: 31320.00212
+  tps: 20907.25644
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RuthlessGladiator'sBadgeofVictory-70400"
  value: {
-  dps: 33317.12233
-  tps: 22353.63219
+  dps: 32851.89924
+  tps: 21888.40911
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RuthlessGladiator'sBadgeofVictory-72450"
  value: {
-  dps: 33405.01646
-  tps: 22410.31114
+  dps: 32938.72436
+  tps: 21944.01905
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RuthlessGladiator'sInsigniaofConquest-70404"
  value: {
-  dps: 32522.10861
-  tps: 21908.13492
+  dps: 32064.91239
+  tps: 21450.9387
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RuthlessGladiator'sInsigniaofConquest-72309"
  value: {
-  dps: 32492.86678
-  tps: 21878.71302
+  dps: 32037.36803
+  tps: 21423.21427
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RuthlessGladiator'sInsigniaofDominance-70402"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RuthlessGladiator'sInsigniaofDominance-72449"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RuthlessGladiator'sInsigniaofVictory-70403"
  value: {
-  dps: 33167.19778
-  tps: 22312.85761
+  dps: 32701.9303
+  tps: 21847.59013
  }
 }
 dps_results: {
  key: "TestArms-AllItems-RuthlessGladiator'sInsigniaofVictory-72455"
  value: {
-  dps: 33263.30526
-  tps: 22378.25529
+  dps: 32796.00733
+  tps: 21910.95735
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ScalesofLife-68915"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
   hps: 315.97258
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ScalesofLife-69109"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
   hps: 356.41412
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 32751.30999
-  tps: 22169.9753
+  dps: 32300.99075
+  tps: 21719.65606
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SeaStar-55256"
  value: {
-  dps: 31766.36409
-  tps: 21353.61841
+  dps: 31320.00212
+  tps: 20907.25644
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SeaStar-56290"
  value: {
-  dps: 31766.36409
-  tps: 21353.61841
+  dps: 31320.00212
+  tps: 20907.25644
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Shadowmourne-49623"
  value: {
-  dps: 35726.03698
-  tps: 23932.91835
+  dps: 35232.75742
+  tps: 23439.63879
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ShardofWoe-60233"
  value: {
-  dps: 32286.91543
-  tps: 21810.58481
+  dps: 31840.45705
+  tps: 21364.12642
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 32744.90551
-  tps: 22137.43491
+  dps: 32286.96952
+  tps: 21679.49892
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 32495.58498
-  tps: 21901.37583
+  dps: 32045.75913
+  tps: 21451.54999
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 32820.38353
-  tps: 22201.54341
+  dps: 32369.75838
+  tps: 21750.91826
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Sorrowsong-55879"
  value: {
-  dps: 32350.50089
-  tps: 21735.06977
+  dps: 31904.01466
+  tps: 21288.58354
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Sorrowsong-56400"
  value: {
-  dps: 32308.02574
-  tps: 21761.52214
+  dps: 31860.90521
+  tps: 21314.40161
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 32277.49972
-  tps: 21711.47019
+  dps: 31824.12914
+  tps: 21258.0996
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SoulCasket-58183"
  value: {
-  dps: 32364.16039
-  tps: 21881.90943
+  dps: 31917.57632
+  tps: 21435.32536
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Souldrinker-77193"
  value: {
-  dps: 34690.77274
-  tps: 23327.22194
+  dps: 34208.22183
+  tps: 22844.67103
   hps: 293.48815
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Souldrinker-78479"
  value: {
-  dps: 34802.47071
-  tps: 23408.31122
+  dps: 34318.66858
+  tps: 22924.50909
   hps: 334.02155
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Souldrinker-78488"
  value: {
-  dps: 34591.90192
-  tps: 23254.73793
+  dps: 34110.42965
+  tps: 22773.26565
   hps: 253.38663
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 32802.09626
-  tps: 22370.63311
+  dps: 32357.00751
+  tps: 21925.54436
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 32680.75451
-  tps: 22156.95072
+  dps: 32235.59505
+  tps: 21711.79126
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 32748.14391
-  tps: 22370.83372
+  dps: 32302.7629
+  tps: 21925.45271
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 32464.53139
-  tps: 21908.92349
+  dps: 32017.73504
+  tps: 21462.12714
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 32472.20327
-  tps: 22026.82657
+  dps: 32025.73406
+  tps: 21580.35736
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 33111.37356
-  tps: 22376.1049
+  dps: 32656.4752
+  tps: 21921.20654
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 32796.55801
-  tps: 22177.29956
+  dps: 32341.66829
+  tps: 21722.40984
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 33418.61216
-  tps: 22475.68563
+  dps: 32961.09456
+  tps: 22018.16803
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StayofExecution-68996"
  value: {
-  dps: 31766.54733
-  tps: 21354.58534
+  dps: 31320.1833
+  tps: 20908.22131
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StumpofTime-62465"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-StumpofTime-62470"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 32935.21684
-  tps: 22062.54953
+  dps: 32477.85268
+  tps: 21605.18536
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TearofBlood-55819"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TearofBlood-56351"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 32178.61788
-  tps: 21735.59357
+  dps: 31733.16489
+  tps: 21290.14058
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 32308.02574
-  tps: 21761.52214
+  dps: 31860.90521
+  tps: 21314.40161
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheHungerer-68927"
  value: {
-  dps: 32833.41665
-  tps: 22138.47544
+  dps: 32379.41287
+  tps: 21684.47166
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TheHungerer-69112"
  value: {
-  dps: 32933.01535
-  tps: 22287.84031
+  dps: 32478.26879
+  tps: 21833.09376
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 32788.45034
-  tps: 22064.51893
+  dps: 32335.86578
+  tps: 21611.93436
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 32833.87596
-  tps: 22123.10678
+  dps: 32379.56821
+  tps: 21668.79903
  }
 }
 dps_results: {
  key: "TestArms-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 32509.69233
-  tps: 22069.96232
+  dps: 32064.98334
+  tps: 21625.25333
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 31551.36955
-  tps: 21192.12566
+  dps: 31107.82931
+  tps: 20748.58542
  }
 }
 dps_results: {
  key: "TestArms-AllItems-UnheededWarning-59520"
  value: {
-  dps: 32867.67083
-  tps: 22116.46135
+  dps: 32405.2649
+  tps: 21654.05543
  }
 }
 dps_results: {
  key: "TestArms-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 31766.36409
-  tps: 21353.61841
+  dps: 31320.00212
+  tps: 20907.25644
  }
 }
 dps_results: {
  key: "TestArms-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 32818.56289
-  tps: 22190.58761
+  dps: 32364.09208
+  tps: 21736.11681
  }
 }
 dps_results: {
  key: "TestArms-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 32818.56289
-  tps: 22190.58761
+  dps: 32364.09208
+  tps: 21736.11681
  }
 }
 dps_results: {
  key: "TestArms-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 32818.56289
-  tps: 22190.58761
+  dps: 32364.09208
+  tps: 21736.11681
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 18633.79726
-  tps: 12151.8626
+  dps: 18478.50521
+  tps: 11996.57054
  }
 }
 dps_results: {
  key: "TestArms-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 33850.27449
-  tps: 22857.36448
+  dps: 33387.68615
+  tps: 22394.77614
  }
 }
 dps_results: {
  key: "TestArms-AllItems-VeilofLies-72900"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 33984.28676
-  tps: 22850.27095
+  dps: 33508.32488
+  tps: 22374.30906
  }
 }
 dps_results: {
  key: "TestArms-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 34220.88994
-  tps: 23015.14129
+  dps: 33741.6393
+  tps: 22535.89066
  }
 }
 dps_results: {
  key: "TestArms-AllItems-VialofShadows-77207"
  value: {
-  dps: 32881.36177
-  tps: 22311.53162
+  dps: 32427.71714
+  tps: 21857.88699
  }
 }
 dps_results: {
  key: "TestArms-AllItems-VialofShadows-77979"
  value: {
-  dps: 32781.67366
-  tps: 22308.46652
+  dps: 32329.84131
+  tps: 21856.63418
  }
 }
 dps_results: {
  key: "TestArms-AllItems-VialofShadows-77999"
  value: {
-  dps: 33145.38494
-  tps: 22641.19117
+  dps: 32689.9783
+  tps: 22185.78454
  }
 }
 dps_results: {
  key: "TestArms-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 32340.37383
-  tps: 21755.3839
+  dps: 31886.28444
+  tps: 21301.2945
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sBadgeofConquest-70517"
  value: {
-  dps: 32382.97502
-  tps: 21787.09907
+  dps: 31929.10159
+  tps: 21333.22564
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 31766.36409
-  tps: 21353.61841
+  dps: 31320.00212
+  tps: 20907.25644
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sBadgeofDominance-70518"
  value: {
-  dps: 31766.36409
-  tps: 21353.61841
+  dps: 31320.00212
+  tps: 20907.25644
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 32993.06048
-  tps: 22144.65938
+  dps: 32531.7788
+  tps: 21683.3777
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sBadgeofVictory-70519"
  value: {
-  dps: 33137.51257
-  tps: 22237.81
+  dps: 32674.474
+  tps: 21774.77142
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 32054.37033
-  tps: 21640.33813
+  dps: 31607.94443
+  tps: 21193.91222
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 32536.55888
-  tps: 21880.34863
+  dps: 32080.22454
+  tps: 21424.01428
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 32531.48874
-  tps: 21942.69873
+  dps: 32084.63903
+  tps: 21495.84902
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 32353.03709
-  tps: 21752.08433
+  dps: 31899.02419
+  tps: 21298.07143
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sInsigniaofConquest-70577"
  value: {
-  dps: 32402.38046
-  tps: 21774.41019
+  dps: 31947.03569
+  tps: 21319.06541
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sInsigniaofDominance-70578"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 32908.0251
-  tps: 22140.97055
+  dps: 32445.98777
+  tps: 21678.93321
  }
 }
 dps_results: {
  key: "TestArms-AllItems-ViciousGladiator'sInsigniaofVictory-70579"
  value: {
-  dps: 33000.85341
-  tps: 22203.61339
+  dps: 32537.56207
+  tps: 21740.32205
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Vishanka,JawsoftheEarth-78359"
  value: {
-  dps: 33391.59844
-  tps: 22441.85395
+  dps: 32924.56426
+  tps: 21974.81976
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Vishanka,JawsoftheEarth-78471"
  value: {
-  dps: 33424.93109
-  tps: 22464.89346
+  dps: 32957.59807
+  tps: 21997.56044
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Vishanka,JawsoftheEarth-78480"
  value: {
-  dps: 33360.69505
-  tps: 22421.54612
+  dps: 32893.78121
+  tps: 21954.63228
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WillofUnbinding-77995"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 31796.98989
-  tps: 21389.85767
+  dps: 31349.59001
+  tps: 20942.45779
  }
 }
 dps_results: {
  key: "TestArms-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 32252.08427
-  tps: 21780.91593
+  dps: 31807.53862
+  tps: 21336.37027
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 33116.81699
-  tps: 22293.64778
+  dps: 32652.87044
+  tps: 21829.70123
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 32996.48134
-  tps: 22207.53018
+  dps: 32534.01044
+  tps: 21745.05928
  }
 }
 dps_results: {
  key: "TestArms-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 33247.06293
-  tps: 22387.28521
+  dps: 32781.93192
+  tps: 21922.15419
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 32042.53657
-  tps: 21730.77081
+  dps: 31597.78468
+  tps: 21286.01892
  }
 }
 dps_results: {
  key: "TestArms-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 32042.53657
-  tps: 21730.77081
+  dps: 31597.78468
+  tps: 21286.01892
  }
 }
 dps_results: {
  key: "TestArms-Average-Default"
  value: {
-  dps: 33816.50388
-  tps: 22702.06121
+  dps: 33345.1784
+  tps: 22230.73574
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p1_arms_bis-Basic-arms-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 69704.87702
-  tps: 37227.38285
+  dps: 69255.75856
+  tps: 36778.26439
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p1_arms_bis-Basic-arms-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 33850.41216
-  tps: 22719.06521
+  dps: 33377.35326
+  tps: 22246.00631
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p1_arms_bis-Basic-arms-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 41186.69888
-  tps: 26639.37681
+  dps: 40688.48459
+  tps: 26141.16252
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p1_arms_bis-Basic-arms-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 48136.06716
-  tps: 24158.03766
+  dps: 47805.04876
+  tps: 23827.01926
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p1_arms_bis-Basic-arms-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 23062.96975
-  tps: 15351.08717
+  dps: 22715.95
+  tps: 15004.06742
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p1_arms_bis-Basic-arms-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 25242.48633
-  tps: 15842.81478
+  dps: 24886.63914
+  tps: 15486.96758
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p3_arms_bis-Basic-arms-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 87335.88753
-  tps: 46141.07743
+  dps: 86790.47048
+  tps: 45595.66038
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p3_arms_bis-Basic-arms-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 42049.15923
-  tps: 28814.77014
+  dps: 41473.10359
+  tps: 28238.7145
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p3_arms_bis-Basic-arms-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 47607.75126
-  tps: 31488.73131
+  dps: 47021.17219
+  tps: 30902.15224
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p3_arms_bis-Basic-arms-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 61545.89993
-  tps: 31140.73398
+  dps: 61130.57326
+  tps: 30725.40731
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p3_arms_bis-Basic-arms-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 29569.55892
-  tps: 20059.51223
+  dps: 29133.68335
+  tps: 19623.63666
  }
 }
 dps_results: {
  key: "TestArms-Settings-Orc-p3_arms_bis-Basic-arms-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 30997.74768
-  tps: 19867.21827
+  dps: 30559.43558
+  tps: 19428.90617
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p1_arms_bis-Basic-arms-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 69836.63261
-  tps: 37142.53993
+  dps: 69386.57535
+  tps: 36692.48266
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p1_arms_bis-Basic-arms-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 33916.55996
-  tps: 22766.33304
+  dps: 33442.51582
+  tps: 22292.2889
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p1_arms_bis-Basic-arms-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 40826.99654
-  tps: 26364.52488
+  dps: 40331.75204
+  tps: 25869.28038
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p1_arms_bis-Basic-arms-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 48288.32482
-  tps: 24108.32799
+  dps: 47957.12317
+  tps: 23777.12635
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p1_arms_bis-Basic-arms-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 23212.22874
-  tps: 15502.56209
+  dps: 22864.90474
+  tps: 15155.23809
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p1_arms_bis-Basic-arms-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 25248.44492
-  tps: 15904.30802
+  dps: 24895.22535
+  tps: 15551.08845
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p3_arms_bis-Basic-arms-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 87578.60384
-  tps: 46158.13288
+  dps: 87032.76215
+  tps: 45612.29118
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p3_arms_bis-Basic-arms-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 42139.83845
-  tps: 28863.71833
+  dps: 41563.74577
+  tps: 28287.62564
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p3_arms_bis-Basic-arms-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 47527.59926
-  tps: 31348.15486
+  dps: 46941.69186
+  tps: 30762.24746
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p3_arms_bis-Basic-arms-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 61762.67916
-  tps: 31252.21345
+  dps: 61346.42677
+  tps: 30835.96107
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p3_arms_bis-Basic-arms-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 29623.74961
-  tps: 20147.11201
+  dps: 29187.6952
+  tps: 19711.0576
  }
 }
 dps_results: {
  key: "TestArms-Settings-Worgen-p3_arms_bis-Basic-arms-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 30711.97776
-  tps: 19673.53322
+  dps: 30275.9306
+  tps: 19237.48605
  }
 }
 dps_results: {
  key: "TestArms-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 30918.82972
-  tps: 20951.01196
+  dps: 30462.50668
+  tps: 20494.68892
  }
 }

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -38,2333 +38,2333 @@ character_stats_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 4732.71755
-  tps: 28849.17142
+  dps: 4604.49911
+  tps: 28208.07922
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AgonyandTorment"
  value: {
-  dps: 4084.74884
-  tps: 24072.55212
+  dps: 3962.47949
+  tps: 23461.20537
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 4804.6615
-  tps: 29325.93142
+  dps: 4676.31475
+  tps: 28684.1977
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 4815.04381
-  tps: 29353.58984
+  dps: 4686.39158
+  tps: 28710.3287
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 4968.70943
-  tps: 30318.44262
+  dps: 4834.74922
+  tps: 29648.64159
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 5005.31317
-  tps: 30543.09911
+  dps: 4870.51189
+  tps: 29869.09271
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ArrowofTime-72897"
  value: {
-  dps: 4875.28805
-  tps: 29644.86942
+  dps: 4744.97749
+  tps: 28993.31659
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 4804.23789
-  tps: 29232.02381
+  dps: 4674.23281
+  tps: 28581.99839
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 4815.0551
-  tps: 29291.75692
+  dps: 4684.74453
+  tps: 28640.20408
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BindingPromise-67037"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BlackBruise-50692"
  value: {
-  dps: 4183.85134
-  tps: 25977.37649
+  dps: 4084.24903
+  tps: 25479.36491
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 4797.36195
-  tps: 29193.95412
+  dps: 4667.61871
+  tps: 28545.23792
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 4773.52649
-  tps: 29064.95768
+  dps: 4644.17602
+  tps: 28418.2053
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 4912.77208
-  tps: 29972.34308
+  dps: 4780.13027
+  tps: 29309.13403
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 5459.06466
-  tps: 32804.47855
+  dps: 5323.84284
+  tps: 32128.36946
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 5371.61164
-  tps: 32364.59925
+  dps: 5237.26454
+  tps: 31692.86375
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 5597.63451
-  tps: 33572.76562
+  dps: 5461.42022
+  tps: 32891.69418
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BottledLightning-66879"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BottledWishes-77114"
  value: {
-  dps: 4740.67009
-  tps: 28860.96402
+  dps: 4613.32708
+  tps: 28224.24896
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 4688.32477
-  tps: 28025.62909
+  dps: 4560.8072
+  tps: 27400.79298
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 4711.86249
-  tps: 28731.39556
+  dps: 4584.10664
+  tps: 28092.61631
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CataclysmicGladiator'sBadgeofConquest-73648"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CataclysmicGladiator'sBadgeofDominance-73498"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CataclysmicGladiator'sBadgeofVictory-73496"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CataclysmicGladiator'sInsigniaofConquest-73643"
  value: {
-  dps: 4824.07974
-  tps: 29350.90468
+  dps: 4693.68189
+  tps: 28698.91544
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CataclysmicGladiator'sInsigniaofDominance-73497"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CataclysmicGladiator'sInsigniaofVictory-73491"
  value: {
-  dps: 5045.62069
-  tps: 30784.62672
+  dps: 4909.41819
+  tps: 30103.61418
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 4736.57086
-  tps: 28870.53834
+  dps: 4608.30616
+  tps: 28229.21484
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ColossalDragonplateArmor"
  value: {
-  dps: 4661.54971
-  tps: 28327.16681
+  dps: 4535.41426
+  tps: 27696.48957
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ColossalDragonplateBattlegear"
  value: {
-  dps: 5577.46678
-  tps: 33880.33334
+  dps: 5440.92681
+  tps: 33197.63352
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 4878.0978
-  tps: 29678.42943
+  dps: 4746.67381
+  tps: 29021.30946
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 5273.54432
-  tps: 32052.92304
+  dps: 5134.29639
+  tps: 31356.68339
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 5212.99959
-  tps: 31697.74505
+  dps: 5075.526
+  tps: 31010.37709
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 5349.42718
-  tps: 32499.24119
+  dps: 5208.7843
+  tps: 31796.02677
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CrushingWeight-59506"
  value: {
-  dps: 4999.50435
-  tps: 30414.83441
+  dps: 4866.17768
+  tps: 29748.20106
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CrushingWeight-65118"
  value: {
-  dps: 5040.47063
-  tps: 30656.20595
+  dps: 4905.61213
+  tps: 29981.91348
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-CunningoftheCruel-78000"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 5095.44543
-  tps: 30846.88276
+  dps: 4962.71011
+  tps: 30183.20617
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 4952.83279
-  tps: 29913.92518
+  dps: 4823.61324
+  tps: 29267.82741
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 4872.75732
-  tps: 29610.37176
+  dps: 4742.32145
+  tps: 28958.19245
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 4712.05955
-  tps: 28730.96565
+  dps: 4584.06193
+  tps: 28090.97755
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 4709.61979
-  tps: 28717.87137
+  dps: 4581.57853
+  tps: 28077.66508
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 5081.73431
-  tps: 30925.83577
+  dps: 4945.76156
+  tps: 30245.97201
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EarthenBattleplate"
  value: {
-  dps: 4750.29819
-  tps: 28957.53779
+  dps: 4622.88434
+  tps: 28320.46855
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EarthenWarplate"
  value: {
-  dps: 5197.19222
-  tps: 31488.59318
+  dps: 5066.63497
+  tps: 30835.80693
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 4712.05955
-  tps: 28730.96565
+  dps: 4584.06193
+  tps: 28090.97755
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 4888.27938
-  tps: 29688.04747
+  dps: 4757.05236
+  tps: 29031.91238
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 4947.36213
-  tps: 30032.60453
+  dps: 4815.21866
+  tps: 29371.88719
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 5319.90929
-  tps: 32470.6009
+  dps: 5177.90999
+  tps: 31760.60438
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 5248.13833
-  tps: 32030.48419
+  dps: 5107.78467
+  tps: 31328.71593
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 5398.85736
-  tps: 32954.72927
+  dps: 5255.04784
+  tps: 32235.68167
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FallofMortality-59500"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FallofMortality-65124"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 4815.04381
-  tps: 29353.58984
+  dps: 4686.39158
+  tps: 28710.3287
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FluidDeath-58181"
  value: {
-  dps: 4987.17282
-  tps: 30372.16253
+  dps: 4855.98944
+  tps: 29716.24565
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 4804.23789
-  tps: 29232.02381
+  dps: 4674.23281
+  tps: 28581.99839
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GaleofShadows-56138"
  value: {
-  dps: 4750.81567
-  tps: 28938.47158
+  dps: 4622.99261
+  tps: 28299.35629
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GaleofShadows-56462"
  value: {
-  dps: 4721.87255
-  tps: 28827.70342
+  dps: 4594.18042
+  tps: 28189.24274
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GearDetector-61462"
  value: {
-  dps: 4752.695
-  tps: 28955.81262
+  dps: 4623.91185
+  tps: 28311.89687
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Gladiator'sBattlegear"
  value: {
-  dps: 4779.12772
-  tps: 29076.17754
+  dps: 4652.71411
+  tps: 28444.10948
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 4792.69375
-  tps: 29181.88003
+  dps: 4663.03779
+  tps: 28533.60024
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 4833.07831
-  tps: 29398.81285
+  dps: 4702.54954
+  tps: 28746.169
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HarmlightToken-63839"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 4859.63028
-  tps: 29648.96628
+  dps: 4728.17648
+  tps: 28991.69726
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HeartofRage-59224"
  value: {
-  dps: 5190.11175
-  tps: 31776.30129
+  dps: 5055.99417
+  tps: 31105.71337
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HeartofRage-65072"
  value: {
-  dps: 5253.18334
-  tps: 32120.57998
+  dps: 5118.51041
+  tps: 31447.21534
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HeartofSolace-55868"
  value: {
-  dps: 4982.75856
-  tps: 30347.46199
+  dps: 4849.67808
+  tps: 29682.05958
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HeartofSolace-56393"
  value: {
-  dps: 4982.51498
-  tps: 30409.63748
+  dps: 4848.89663
+  tps: 29741.54576
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HeartofThunder-55845"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HeartofThunder-56370"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 4794.61158
-  tps: 29186.08443
+  dps: 4664.91198
+  tps: 28537.58644
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Heartpierce-50641"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 4712.05955
-  tps: 28730.96565
+  dps: 4584.06193
+  tps: 28090.97755
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IndomitablePride-77211"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IndomitablePride-77983"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-IndomitablePride-78003"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 4818.20991
-  tps: 29265.57363
+  dps: 4690.16865
+  tps: 28625.36733
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 4782.15874
-  tps: 29036.00406
+  dps: 4654.29204
+  tps: 28396.67057
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 4851.3632
-  tps: 29393.6781
+  dps: 4723.67107
+  tps: 28755.21742
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 4842.43163
-  tps: 29517.70079
+  dps: 4712.16471
+  tps: 28866.36616
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 4910.32559
-  tps: 29894.28084
+  dps: 4780.18959
+  tps: 29243.60082
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 4740.67009
-  tps: 28860.96402
+  dps: 4613.32708
+  tps: 28224.24896
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 4706.84604
-  tps: 28723.84275
+  dps: 4578.89206
+  tps: 28084.07286
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 4706.84604
-  tps: 28723.84275
+  dps: 4578.89206
+  tps: 28084.07286
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-LastWord-50708"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-LeadenDespair-55816"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-LeadenDespair-56347"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 4898.87627
-  tps: 29913.71448
+  dps: 4770.44224
+  tps: 29271.54435
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 4952.05442
-  tps: 30288.06473
+  dps: 4823.35855
+  tps: 29644.58539
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 5158.16969
-  tps: 31499.80829
+  dps: 5022.76272
+  tps: 30822.77344
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 4811.78559
-  tps: 29342.04311
+  dps: 4683.56977
+  tps: 28700.964
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 4865.76016
-  tps: 29806.27873
+  dps: 4738.50443
+  tps: 29170.00007
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 4872.80763
-  tps: 29729.84262
+  dps: 4741.05104
+  tps: 29071.05966
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 4896.9661
-  tps: 29878.1159
+  dps: 4764.6544
+  tps: 29216.5574
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 4800.6767
-  tps: 29212.24178
+  dps: 4670.80254
+  tps: 28562.87097
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 4813.09585
-  tps: 29281.96071
+  dps: 4682.95985
+  tps: 28631.28069
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 4772.60511
-  tps: 29145.32335
+  dps: 4644.25836
+  tps: 28503.58964
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 4815.04381
-  tps: 29353.58984
+  dps: 4686.39158
+  tps: 28710.3287
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 4798.45811
-  tps: 29199.43495
+  dps: 4668.67123
+  tps: 28550.50055
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MoltenGiantBattleplate"
  value: {
-  dps: 5127.91698
-  tps: 31084.45259
+  dps: 4997.98816
+  tps: 30434.80844
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MoltenGiantWarplate"
  value: {
-  dps: 5793.02769
-  tps: 35155.03865
+  dps: 5651.683
+  tps: 34448.31519
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-No'Kaled,theElementsofDeath-77188"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-No'Kaled,theElementsofDeath-78472"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-No'Kaled,theElementsofDeath-78481"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 4830.34729
-  tps: 29469.24109
+  dps: 4699.56634
+  tps: 28815.33637
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 4752.35147
-  tps: 28949.03416
+  dps: 4623.6556
+  tps: 28305.55483
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 4853.97792
-  tps: 29429.21016
+  dps: 4723.9292
+  tps: 28778.96654
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 4875.8885
-  tps: 29548.77137
+  dps: 4746.14526
+  tps: 28900.05517
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Rainsong-55854"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Rainsong-56377"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Rathrak,thePoisonousMind-77195"
  value: {
-  dps: 4209.73897
-  tps: 26147.07239
+  dps: 4128.43356
+  tps: 25740.54537
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Rathrak,thePoisonousMind-78475"
  value: {
-  dps: 4328.12217
-  tps: 26738.9884
+  dps: 4241.98734
+  tps: 26308.31428
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Rathrak,thePoisonousMind-78484"
  value: {
-  dps: 4104.55548
-  tps: 25621.15495
+  dps: 4027.54089
+  tps: 25236.08203
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 4751.59561
-  tps: 28975.18346
+  dps: 4622.9297
+  tps: 28331.85392
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 4711.86249
-  tps: 28731.39556
+  dps: 4584.10664
+  tps: 28092.61631
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 4784.33575
-  tps: 29124.88407
+  dps: 4654.76707
+  tps: 28477.04068
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 4967.41206
-  tps: 30294.36802
+  dps: 4835.24411
+  tps: 29633.52827
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 4996.25855
-  tps: 30450.65948
+  dps: 4863.1469
+  tps: 29785.10123
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RosaryofLight-72901"
  value: {
-  dps: 5126.67585
-  tps: 31203.95488
+  dps: 4989.32308
+  tps: 30517.19106
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RottingSkull-77116"
  value: {
-  dps: 4852.13867
-  tps: 29505.54048
+  dps: 4721.12986
+  tps: 28850.49641
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RuneofZeth-68998"
  value: {
-  dps: 4823.326
-  tps: 29340.23173
+  dps: 4692.92815
+  tps: 28688.24249
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RuthlessGladiator'sBadgeofConquest-70399"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RuthlessGladiator'sBadgeofConquest-72304"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RuthlessGladiator'sBadgeofDominance-70401"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RuthlessGladiator'sBadgeofDominance-72448"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RuthlessGladiator'sBadgeofVictory-70400"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RuthlessGladiator'sBadgeofVictory-72450"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RuthlessGladiator'sInsigniaofConquest-70404"
  value: {
-  dps: 4798.63716
-  tps: 29195.53656
+  dps: 4669.02484
+  tps: 28547.47497
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RuthlessGladiator'sInsigniaofConquest-72309"
  value: {
-  dps: 4807.99237
-  tps: 29255.66345
+  dps: 4678.72917
+  tps: 28609.34748
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RuthlessGladiator'sInsigniaofDominance-70402"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RuthlessGladiator'sInsigniaofDominance-72449"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RuthlessGladiator'sInsigniaofVictory-70403"
  value: {
-  dps: 4988.59152
-  tps: 30442.31011
+  dps: 4854.07613
+  tps: 29769.73319
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-RuthlessGladiator'sInsigniaofVictory-72455"
  value: {
-  dps: 5000.48574
-  tps: 30506.31952
+  dps: 4865.75915
+  tps: 29832.68659
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ScalesofLife-68915"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ScalesofLife-69109"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 4756.60014
-  tps: 28973.7053
+  dps: 4627.77335
+  tps: 28329.57135
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SeaStar-55256"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SeaStar-56290"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ShardofWoe-60233"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 4870.11744
-  tps: 29633.2635
+  dps: 4739.23027
+  tps: 28978.82764
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 4760.10151
-  tps: 28991.21216
+  dps: 4631.1438
+  tps: 28346.42361
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 4768.07454
-  tps: 29032.79119
+  dps: 4638.81134
+  tps: 28386.47522
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Sorrowsong-55879"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Sorrowsong-56400"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 4804.6615
-  tps: 29325.93142
+  dps: 4676.31475
+  tps: 28684.1977
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SoulCasket-58183"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Souldrinker-77193"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Souldrinker-78479"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Souldrinker-78488"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 4972.11702
-  tps: 30106.75393
+  dps: 4841.58825
+  tps: 29454.11009
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 4924.4473
-  tps: 29852.08163
+  dps: 4793.96217
+  tps: 29199.65599
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 4995.075
-  tps: 30226.80796
+  dps: 4863.67342
+  tps: 29569.80007
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StayofExecution-68996"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StumpofTime-62465"
  value: {
-  dps: 4873.20697
-  tps: 29752.0107
+  dps: 4744.16198
+  tps: 29106.78575
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-StumpofTime-62470"
  value: {
-  dps: 4873.20697
-  tps: 29752.0107
+  dps: 4744.16198
+  tps: 29106.78575
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 4915.11834
-  tps: 29989.63675
+  dps: 4783.55765
+  tps: 29331.8333
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TearofBlood-55819"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TearofBlood-56351"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheHungerer-68927"
  value: {
-  dps: 4885.1322
-  tps: 29636.2158
+  dps: 4754.90891
+  tps: 28985.09938
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheHungerer-69112"
  value: {
-  dps: 4909.26684
-  tps: 29807.92193
+  dps: 4778.78171
+  tps: 29155.49629
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 4768.74047
-  tps: 29037.90093
+  dps: 4639.43364
+  tps: 28391.36675
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 4782.3845
-  tps: 29113.22543
+  dps: 4652.85946
+  tps: 28465.60025
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 4727.01334
-  tps: 28849.46012
+  dps: 4598.75388
+  tps: 28208.16281
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-UnheededWarning-59520"
  value: {
-  dps: 4898.59656
-  tps: 29821.1131
+  dps: 4766.36717
+  tps: 29159.96613
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 3806.98606
-  tps: 24236.92466
+  dps: 3739.62261
+  tps: 23900.1074
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 4968.70943
-  tps: 30318.44262
+  dps: 4834.74922
+  tps: 29648.64159
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-VeilofLies-72900"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 5068.64267
-  tps: 30876.0232
+  dps: 4932.31852
+  tps: 30194.40247
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 5118.68647
-  tps: 31177.36399
+  dps: 4981.24335
+  tps: 30490.14838
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-VialofShadows-77207"
  value: {
-  dps: 5173.50145
-  tps: 31075.82959
+  dps: 5043.36544
+  tps: 30425.14957
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-VialofShadows-77979"
  value: {
-  dps: 5102.38769
-  tps: 30714.01503
+  dps: 4972.51353
+  tps: 30064.64423
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-VialofShadows-77999"
  value: {
-  dps: 5235.29779
-  tps: 31410.19811
+  dps: 5104.76902
+  tps: 30757.55427
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sBadgeofConquest-70517"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sBadgeofDominance-70518"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sBadgeofVictory-70519"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 4889.09714
-  tps: 29823.63918
+  dps: 4759.83395
+  tps: 29177.32321
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 4766.50982
-  tps: 28999.04261
+  dps: 4638.81768
+  tps: 28360.58193
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 4806.91864
-  tps: 29245.42751
+  dps: 4676.82627
+  tps: 28594.96569
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 4901.6378
-  tps: 30001.88947
+  dps: 4774.29479
+  tps: 29365.17442
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 4770.30777
-  tps: 29040.91761
+  dps: 4640.73909
+  tps: 28393.07422
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sInsigniaofConquest-70577"
  value: {
-  dps: 4797.61413
-  tps: 29200.71884
+  dps: 4668.04545
+  tps: 28552.87545
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sInsigniaofDominance-70578"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 4925.105
-  tps: 30051.21194
+  dps: 4792.0325
+  tps: 29385.84944
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ViciousGladiator'sInsigniaofVictory-70579"
  value: {
-  dps: 4953.89904
-  tps: 30231.54253
+  dps: 4819.95814
+  tps: 29561.83804
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Vishanka,JawsoftheEarth-78359"
  value: {
-  dps: 4627.62545
-  tps: 28216.06568
+  dps: 4500.74612
+  tps: 27581.669
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Vishanka,JawsoftheEarth-78471"
  value: {
-  dps: 4674.97149
-  tps: 28392.92566
+  dps: 4548.04913
+  tps: 27758.31386
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Vishanka,JawsoftheEarth-78480"
  value: {
-  dps: 4594.87911
-  tps: 28045.80854
+  dps: 4468.43002
+  tps: 27413.56308
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WillofUnbinding-77995"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 4919.28535
-  tps: 29862.8408
+  dps: 4786.66184
+  tps: 29199.72324
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 4897.89075
-  tps: 29746.27836
+  dps: 4765.57272
+  tps: 29084.68821
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 4949.82466
-  tps: 30028.05607
+  dps: 4816.59018
+  tps: 29361.88367
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 4688.32477
-  tps: 28597.5739
+  dps: 4560.8072
+  tps: 27959.98603
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Average-Default"
  value: {
-  dps: 14775.43321
-  tps: 85099.02566
+  dps: 14516.29907
+  tps: 83803.35496
   dtps: 14800.16653
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p1_bis-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 24264.91791
-  tps: 139053.44774
+  dps: 22231.50857
+  tps: 128886.40103
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p1_bis-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 5271.05018
-  tps: 32261.53542
+  dps: 5143.53945
+  tps: 31623.98176
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p1_bis-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 5765.25271
-  tps: 34900.62565
+  dps: 5635.9098
+  tps: 34253.91111
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p1_bis-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17528.2548
-  tps: 100605.46506
+  dps: 16002.19763
+  tps: 92975.17924
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p1_bis-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 3455.09741
-  tps: 21378.4644
+  dps: 3379.73036
+  tps: 21001.62915
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p1_bis-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 3297.165
-  tps: 20517.29332
+  dps: 3220.85995
+  tps: 20135.76806
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p3_bis-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 25605.66527
-  tps: 145803.96636
+  dps: 23457.28142
+  tps: 135062.04709
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p3_bis-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 5785.51853
-  tps: 34794.13652
+  dps: 5651.48755
+  tps: 34123.98162
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p3_bis-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 6250.91917
-  tps: 37247.68465
+  dps: 6117.88538
+  tps: 36582.51568
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p3_bis-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 18313.87458
-  tps: 104208.17508
+  dps: 16708.96327
+  tps: 96183.61851
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p3_bis-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 3822.36274
-  tps: 23231.29509
+  dps: 3742.10092
+  tps: 22829.98594
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-p3_bis-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 3637.92645
-  tps: 22242.00207
+  dps: 3557.39184
+  tps: 21839.32902
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-preraid-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 23573.79485
-  tps: 134997.17692
+  dps: 21623.82034
+  tps: 125247.30435
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-preraid-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 5247.6378
-  tps: 31894.62084
+  dps: 5125.73439
+  tps: 31285.10376
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-preraid-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 5727.35544
-  tps: 34446.68445
+  dps: 5603.87479
+  tps: 33829.28121
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-preraid-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 16887.08099
-  tps: 96872.51812
+  dps: 15440.93232
+  tps: 89641.77478
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-preraid-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 3437.55582
-  tps: 21112.50425
+  dps: 3366.22375
+  tps: 20755.84393
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Human-preraid-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 3297.99839
-  tps: 20365.18955
+  dps: 3225.53802
+  tps: 20002.88769
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p1_bis-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 24278.9745
-  tps: 139166.16025
+  dps: 22239.69525
+  tps: 128969.76398
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p1_bis-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 5268.83745
-  tps: 32270.28808
+  dps: 5141.58172
+  tps: 31634.00943
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p1_bis-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 5725.99151
-  tps: 34694.376
+  dps: 5597.252
+  tps: 34050.67846
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p1_bis-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17512.87869
-  tps: 100483.53922
+  dps: 15987.20473
+  tps: 92855.16947
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p1_bis-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 3451.32686
-  tps: 21312.17133
+  dps: 3376.20308
+  tps: 20936.55239
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p1_bis-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 3268.15258
-  tps: 20335.23638
+  dps: 3191.95511
+  tps: 19954.24905
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p3_bis-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 25546.85907
-  tps: 145455.82305
+  dps: 23398.51066
+  tps: 134714.08097
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p3_bis-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 5763.93175
-  tps: 34582.12463
+  dps: 5629.89504
+  tps: 33911.9411
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p3_bis-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 6235.29311
-  tps: 37143.55364
+  dps: 6101.98191
+  tps: 36476.99763
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p3_bis-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 18304.53384
-  tps: 104252.07318
+  dps: 16694.64779
+  tps: 96202.6429
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p3_bis-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 3802.93533
-  tps: 23115.13501
+  dps: 3722.5086
+  tps: 22713.00136
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-p3_bis-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 3594.07413
-  tps: 21969.85196
+  dps: 3513.36913
+  tps: 21566.32694
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-preraid-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 23553.99325
-  tps: 134858.44962
+  dps: 21602.79385
+  tps: 125102.45261
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-preraid-Basic-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 5226.39416
-  tps: 31735.51033
+  dps: 5104.60612
+  tps: 31126.5701
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-preraid-Basic-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 5682.83686
-  tps: 34167.25405
+  dps: 5559.92769
+  tps: 33552.70816
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-preraid-Basic-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 16877.15557
-  tps: 96789.77658
+  dps: 15429.76876
+  tps: 89552.8425
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-preraid-Basic-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 3436.30448
-  tps: 21063.89509
+  dps: 3365.15072
+  tps: 20708.1263
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-Settings-Orc-preraid-Basic-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 3267.26215
-  tps: 20161.14939
+  dps: 3195.15959
+  tps: 19800.63662
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 16847.87634
-  tps: 96817.31458
+  dps: 16589.92682
+  tps: 95527.56697
   dtps: 14847.84825
  }
 }

--- a/sim/warrior/rend.go
+++ b/sim/warrior/rend.go
@@ -6,9 +6,8 @@ import (
 	"github.com/wowsims/cata/sim/core"
 )
 
-// TODO (maybe) https://github.com/magey/wotlk-warrior/issues/23 - Rend is not benefitting from Two-Handed Weapon Specialization
 func (warrior *Warrior) RegisterRendSpell() {
-	dotTicks := int32(5)
+	baseTickDamage := warrior.ClassSpellScaling * 0.0939999968
 
 	warrior.Rend = warrior.RegisterSpell(core.SpellConfig{
 		ActionID:       core.ActionID{SpellID: 772},
@@ -43,14 +42,14 @@ func (warrior *Warrior) RegisterRendSpell() {
 				ActionID: core.ActionID{SpellID: 94009},
 				Tag:      "Rend",
 			},
-			NumberOfTicks: dotTicks,
+			NumberOfTicks: 5,
 			TickLength:    time.Second * 3,
 
 			OnSnapshot: func(sim *core.Simulation, target *core.Unit, dot *core.Dot, _ bool) {
 				weaponMH := warrior.AutoAttacks.MH()
 				avgMHDamage := weaponMH.CalculateAverageWeaponDamage(dot.Spell.MeleeAttackPower())
 
-				dot.SnapshotPhysical(target, (529+(0.25*6*(avgMHDamage)))/float64(dot.BaseTickCount))
+				dot.SnapshotPhysical(target, baseTickDamage+0.25*avgMHDamage)
 			},
 			OnTick: func(sim *core.Simulation, target *core.Unit, dot *core.Dot) {
 				dot.CalcAndDealPeriodicSnapshotDamage(sim, target, dot.OutcomeSnapshotCrit)


### PR DESCRIPTION
<img width="1087" alt="image" src="https://github.com/user-attachments/assets/e7640d9d-aa13-4948-92ef-199f203c27b4" />

The damage formula for Rend was a bit off, it was copied from the tooltip which has a 6x multiplier in it that shouldn't be there. In this case, that `*6` in the tooltip should in fact be a 5 since it's the tick count (tooltip does show total damage over 15sec).
Sim also used the rounded, final value from the tooltip instead of using the class scaling coefficient and spell effect avg.

Compared from a guildies log and his exact gear imported to the sim with the same buffs and found a place where no extra AP modifiers or other stuff was active.

Sorry for nerfing but all is as it should be 😆 