### PR TITLE
[UI] Improve drag-and-drop support in APL editor

### DIFF
--- a/ui/core/components/individual_sim_ui/apl_values.ts
+++ b/ui/core/components/individual_sim_ui/apl_values.ts
@@ -474,7 +474,7 @@ export function valueListFieldConfig(field: string): AplHelpers.APLPickerBuilder
 					index: number,
 					config: ListItemPickerConfig<Player<any>, APLValue | undefined>,
 				) => new APLValuePicker(parent, player, config),
-				allowedActions: ['create', 'delete'],
+				allowedActions: ['copy', 'create', 'delete', 'move'],
 				actions: {
 					create: {
 						useIcon: true,

--- a/ui/scss/core/components/_list_picker.scss
+++ b/ui/scss/core/components/_list_picker.scss
@@ -20,11 +20,15 @@
 
 		.list-picker-item-container {
 			border: var(--border-default);
+			
+			&.dragfrom {
+				background-color: color-mix(in srgb, var(--bs-body-bg) 80%, transparent);
+				filter: opacity(0.5);
+				cursor: move;
+			}
 
-			&.draggable:has(> .list-picker-item-header .list-picker-item-move.hover),
-			&.draggable.value:has(> .list-picker-item-header .list-picker-item-copy.hover),
-			&.draggable.value:has(> .list-picker-item-header .list-picker-item-delete.hover) {
-				filter: drop-shadow(-1px 1px 1px rgba(255, 255, 255, 0.45)) drop-shadow(1px -1px 1px rgba(255, 255, 255, 0.45));
+			&.draggable:has(> .list-picker-item-header .list-picker-item-popover.hover) {
+				background-color: color-mix(in srgb, var(--bs-primary) 5%, transparent);
 			}
 
 			&:not(:last-child) {
@@ -65,6 +69,19 @@
 
 				.list-picker-item-action {
 					margin-left: var(--spacer-2);
+					
+					&.list-picker-item-move {
+						cursor: move;
+					}
+				}
+
+				.list-picker-item-popover:popover-open {
+					inset: unset;
+					position: relative;
+					background-color: color-mix(in srgb, var(--bs-body-bg) 80%, transparent);
+					border: 1px solid black;
+					border-radius: 5px;
+					padding: 5px 10px;
 				}
 			}
 		}

--- a/ui/scss/core/components/_list_picker.scss
+++ b/ui/scss/core/components/_list_picker.scss
@@ -21,6 +21,12 @@
 		.list-picker-item-container {
 			border: var(--border-default);
 
+			&.draggable:has(> .list-picker-item-header .list-picker-item-move.hover),
+			&.draggable.value:has(> .list-picker-item-header .list-picker-item-copy.hover),
+			&.draggable.value:has(> .list-picker-item-header .list-picker-item-delete.hover) {
+				filter: drop-shadow(-1px 1px 1px rgba(255, 255, 255, 0.45)) drop-shadow(1px -1px 1px rgba(255, 255, 255, 0.45));
+			}
+
 			&:not(:last-child) {
 				margin-bottom: var(--spacer-3);
 			}
@@ -32,7 +38,6 @@
 					padding: 0;
 					border: 0;
 					margin: 0;
-					flex: 0;
 				}
 			}
 

--- a/ui/scss/core/components/individual_sim_ui/_apl_rotation_picker.scss
+++ b/ui/scss/core/components/individual_sim_ui/_apl_rotation_picker.scss
@@ -25,6 +25,7 @@
 
 			.list-picker-item-header {
 				align-items: flex-start;
+				justify-content: flex-end;
 			}
 
 			& > .list-picker-item {

--- a/ui/scss/shared/_global.scss
+++ b/ui/scss/shared/_global.scss
@@ -123,7 +123,7 @@ kbd {
 }
 
 .dragto:not(.dragfrom) {
-	filter: brightness(0.75);
+	filter: brightness(0.5);
 }
 
 .interactive {


### PR DESCRIPTION
Doing a ton of APL editing highlighted a few missing features that would really speed things up, so I added them!

* Drag and drop APL values inside an `Any of` / `All of`
  * Not restricted to the same list, can be moved in/out any number of levels **and even between different APL actions**
* Being able to copy an APL value inside an `Any of` / `All of`
* Clearer indication of what block will be deleted inside nested `Any of` / `All of`
* Having the whole block show up as the drag-placeholder instead of just the move-button

Any feedback is appreciated!

https://github.com/user-attachments/assets/20f6edd3-4b19-4cfd-bee7-7a4b00f79ddf


