### PR TITLE
[UI] Always show spell tooltip instead of glyph item tooltip

### DIFF
--- a/ui/core/talents/mage.ts
+++ b/ui/core/talents/mage.ts
@@ -36,7 +36,6 @@ export const mageGlyphsConfig: GlyphsConfig = {
 			name: 'Glyph of Fireball',
 			description: 'Increases the critical strike chance of your Fireball spell by 5%.',
 			iconUrl: 'https://wow.zamimg.com/images/wow/icons/large/spell_fire_flamebolt.jpg',
-			spellIdOverride: 56368,
 		},
 		[MagePrimeGlyph.GlyphOfFrostbolt]: {
 			name: 'Glyph of Frostbolt',


### PR DESCRIPTION
Had a special case fix for Glyph of Fireball before since the item tooltip says 5% damage but the spell shows the correct 5% crit. This PR just does this for *all* glyphs across the board, to never show "empty" tooltips.

Old:
![image](https://github.com/user-attachments/assets/97d836e7-3e1c-446e-b2b1-29ce1f366936)

New:
![image](https://github.com/user-attachments/assets/4ee57db1-488e-48e7-b321-e1f811a1cb2e)
