### PR TITLE
Set bonus RNG seed labeling change

### DIFF
--- a/sim/common/cata/stat_bonus_procs.go
+++ b/sim/common/cata/stat_bonus_procs.go
@@ -1285,7 +1285,7 @@ var ItemSetAgonyAndTorment = core.NewItemSet(core.ItemSet{
 				ActionID: core.ActionID{SpellID: 95763},
 				Handler: func(sim *core.Simulation, _ *core.Spell, _ *core.SpellResult) {
 					// This set uses raw chance, NOT PPM
-					if icd.IsReady(sim) && sim.Proc(.10, "Agony and Torment Proc") {
+					if icd.IsReady(sim) && sim.Proc(.10, "Agony and Torment Trigger") {
 						icd.Use(sim)
 						procAura.Activate(sim)
 					}

--- a/sim/death_knight/unholy/TestUnholy.results
+++ b/sim/death_knight/unholy/TestUnholy.results
@@ -304,7 +304,7 @@ dps_results: {
  value: {
   dps: 43120.17978
   tps: 32013.58168
-  hps: 601.25406
+  hps: 601.25407
  }
 }
 dps_results: {

--- a/sim/hunter/beast_mastery/TestBM.results
+++ b/sim/hunter/beast_mastery/TestBM.results
@@ -45,8 +45,8 @@ dps_results: {
 dps_results: {
  key: "TestBM-AllItems-AgonyandTorment"
  value: {
-  dps: 24729.17074
-  tps: 15561.62994
+  dps: 24774.58485
+  tps: 15652.29344
  }
 }
 dps_results: {
@@ -641,8 +641,8 @@ dps_results: {
 dps_results: {
  key: "TestBM-AllItems-Flamewaker'sBattlegear"
  value: {
-  dps: 26321.21677
-  tps: 16578.24976
+  dps: 26276.20431
+  tps: 16504.95023
  }
 }
 dps_results: {

--- a/sim/hunter/cata_items.go
+++ b/sim/hunter/cata_items.go
@@ -49,7 +49,7 @@ var ItemSetFlameWakersBattleGear = core.NewItemSet(core.ItemSet{
 						return
 					}
 					procChance := 0.1
-					if sim.RandomFloat("Flaming Arrow") < procChance {
+					if sim.RandomFloat("T12 2-set") < procChance {
 						if spell == hunter.SteadyShot {
 							flamingArrowSpellForSteadyShot.Cast(sim, result.Target)
 						} else {

--- a/sim/hunter/marksmanship/TestMM.results
+++ b/sim/hunter/marksmanship/TestMM.results
@@ -45,8 +45,8 @@ dps_results: {
 dps_results: {
  key: "TestMM-AllItems-AgonyandTorment"
  value: {
-  dps: 23626.3959
-  tps: 21256.05288
+  dps: 23590.04647
+  tps: 21226.66864
  }
 }
 dps_results: {
@@ -641,8 +641,8 @@ dps_results: {
 dps_results: {
  key: "TestMM-AllItems-Flamewaker'sBattlegear"
  value: {
-  dps: 24941.63332
-  tps: 22473.27177
+  dps: 25140.4034
+  tps: 22640.61989
  }
 }
 dps_results: {

--- a/sim/hunter/survival/TestSV.results
+++ b/sim/hunter/survival/TestSV.results
@@ -45,8 +45,8 @@ dps_results: {
 dps_results: {
  key: "TestSV-AllItems-AgonyandTorment"
  value: {
-  dps: 28835.22024
-  tps: 26056.09185
+  dps: 28920.01029
+  tps: 26141.33582
  }
 }
 dps_results: {
@@ -627,8 +627,8 @@ dps_results: {
 dps_results: {
  key: "TestSV-AllItems-Flamewaker'sBattlegear"
  value: {
-  dps: 29262.74951
-  tps: 26380.52812
+  dps: 29323.33223
+  tps: 26450.21775
  }
 }
 dps_results: {

--- a/sim/rogue/combat/TestCombat.results
+++ b/sim/rogue/combat/TestCombat.results
@@ -45,8 +45,8 @@ dps_results: {
 dps_results: {
  key: "TestCombat-AllItems-AgonyandTorment"
  value: {
-  dps: 25876.28121
-  tps: 18372.15966
+  dps: 25809.92133
+  tps: 18325.04414
  }
 }
 dps_results: {

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -45,8 +45,8 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-AgonyandTorment"
  value: {
-  dps: 33535.21661
-  tps: 20880.87531
+  dps: 33474.71356
+  tps: 20891.5129
  }
 }
 dps_results: {

--- a/sim/warlock/affliction/TestAffliction.results
+++ b/sim/warlock/affliction/TestAffliction.results
@@ -38,625 +38,625 @@ character_stats_results: {
 dps_results: {
  key: "TestAffliction-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 38084.95153
-  tps: 26570.52772
+  dps: 38075.37796
+  tps: 26688.5452
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 36363.45836
-  tps: 25431.90863
+  dps: 36422.56514
+  tps: 25578.34903
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 36380.89251
-  tps: 25460.16279
+  dps: 36162.68093
+  tps: 25392.89794
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 36677.15454
-  tps: 25631.54406
+  dps: 36579.92532
+  tps: 25641.25576
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 36689.1798
-  tps: 25639.6595
+  dps: 36580.63366
+  tps: 25642.34355
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ArrowofTime-72897"
  value: {
-  dps: 36291.31517
-  tps: 25468.76725
+  dps: 36531.02581
+  tps: 25629.259
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 37552.29955
-  tps: 26146.03344
+  dps: 37613.40017
+  tps: 26229.03873
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Balespider'sBurningVestments"
  value: {
-  dps: 35084.10229
-  tps: 24558.07422
+  dps: 35012.22945
+  tps: 24461.383
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 35749.34307
-  tps: 24989.25932
-  hps: 102.469
+  dps: 35608.85567
+  tps: 24955.06695
+  hps: 102.53611
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 37664.14804
-  tps: 26199.25099
+  dps: 37482.68868
+  tps: 26216.49566
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 37856.53086
-  tps: 26352.83264
+  dps: 37645.11854
+  tps: 26412.82102
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BindingPromise-67037"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 36073.7266
-  tps: 25341.89273
+  dps: 35948.99704
+  tps: 25281.1884
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 36108.16723
-  tps: 25277.92138
+  dps: 35993.16021
+  tps: 25280.80634
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 36148.60464
-  tps: 25314.66401
+  dps: 36033.69343
+  tps: 25317.60045
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 35799.88207
-  tps: 25021.1133
+  dps: 35690.17532
+  tps: 25074.02753
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 36807.03901
-  tps: 25690.70799
+  dps: 36649.19081
+  tps: 25763.22702
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 35803.94881
-  tps: 25014.61598
+  dps: 35653.65604
+  tps: 25082.0604
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 36262.7632
-  tps: 25395.82399
+  dps: 36227.77935
+  tps: 25473.53329
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 35745.44442
-  tps: 25026.02567
+  dps: 35802.36244
+  tps: 25098.69232
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 35716.12547
-  tps: 24993.96091
+  dps: 35675.26636
+  tps: 25080.10945
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 36674.58903
-  tps: 25596.63359
+  dps: 36538.37354
+  tps: 25581.65211
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 35928.48079
-  tps: 25129.36802
+  dps: 35807.89849
+  tps: 25121.92788
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 35910.96381
-  tps: 25107.51319
+  dps: 35793.18477
+  tps: 25108.26336
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 35953.79075
-  tps: 25151.53749
+  dps: 35834.66108
+  tps: 25146.76422
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BottledLightning-66879"
  value: {
-  dps: 36535.5101
-  tps: 25503.4425
+  dps: 36673.97708
+  tps: 25729.36819
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BottledWishes-77114"
  value: {
-  dps: 37770.36306
-  tps: 26355.90319
+  dps: 37781.95362
+  tps: 26548.70457
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 37806.26761
-  tps: 25671.19102
+  dps: 37749.86365
+  tps: 25783.917
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 38237.66409
-  tps: 26567.92871
+  dps: 38185.39703
+  tps: 26687.40888
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CataclysmicGladiator'sBadgeofConquest-73648"
  value: {
-  dps: 35803.94881
-  tps: 25014.61598
+  dps: 35653.65604
+  tps: 25082.0604
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CataclysmicGladiator'sBadgeofDominance-73498"
  value: {
-  dps: 37400.31407
-  tps: 26090.58083
+  dps: 37237.99723
+  tps: 26166.10123
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CataclysmicGladiator'sBadgeofVictory-73496"
  value: {
-  dps: 35803.94881
-  tps: 25014.61598
+  dps: 35653.65604
+  tps: 25082.0604
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CataclysmicGladiator'sInsigniaofConquest-73643"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CataclysmicGladiator'sInsigniaofDominance-73497"
  value: {
-  dps: 37143.05363
-  tps: 25897.66774
+  dps: 37021.13288
+  tps: 25894.05379
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CataclysmicGladiator'sInsigniaofVictory-73491"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 38141.7576
-  tps: 26598.1559
+  dps: 38165.62683
+  tps: 26721.69226
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 36385.74091
-  tps: 25373.64998
+  dps: 36207.86317
+  tps: 25386.50213
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 36711.17875
-  tps: 25660.71256
+  dps: 36925.65343
+  tps: 25939.95496
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 36364.40218
-  tps: 25432.24051
+  dps: 36340.89418
+  tps: 25455.73855
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 36454.09154
-  tps: 25440.76587
+  dps: 36270.72015
+  tps: 25436.95872
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 36373.22695
-  tps: 25371.93782
+  dps: 36324.00059
+  tps: 25515.93756
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CrushingWeight-59506"
  value: {
-  dps: 36095.74091
-  tps: 25166.30662
+  dps: 36083.23968
+  tps: 25340.17062
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CrushingWeight-65118"
  value: {
-  dps: 36181.04035
-  tps: 25254.5719
+  dps: 36085.01687
+  tps: 25291.62873
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 38688.1291
-  tps: 27545.091
+  dps: 38705.3417
+  tps: 27629.07902
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 38275.5836
-  tps: 27242.41163
+  dps: 38307.37624
+  tps: 27223.63466
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CunningoftheCruel-78000"
  value: {
-  dps: 39034.1512
-  tps: 27849.72143
+  dps: 39187.5601
+  tps: 28086.30487
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 35716.73582
-  tps: 24995.23556
+  dps: 35675.26636
+  tps: 25080.16939
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 36808.27213
-  tps: 25820.82635
+  dps: 36841.95089
+  tps: 25865.98398
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 36063.49759
-  tps: 25172.76447
+  dps: 35977.68706
+  tps: 25221.26813
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 37700.67298
-  tps: 26210.48746
+  dps: 37719.33456
+  tps: 26328.80781
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 36781.12357
-  tps: 25670.08434
+  dps: 36672.40311
+  tps: 25706.83119
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 36323.07622
-  tps: 25312.90053
+  dps: 36187.68291
+  tps: 25376.09218
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 37552.29955
-  tps: 26146.03344
+  dps: 37613.40017
+  tps: 26229.03873
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 36338.60223
-  tps: 25406.62619
+  dps: 36183.24913
+  tps: 25383.31984
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 37748.02681
-  tps: 26279.33383
+  dps: 37809.73495
+  tps: 26339.39598
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 37700.67298
-  tps: 26210.48746
+  dps: 37719.33456
+  tps: 26328.80781
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 36380.89251
-  tps: 25460.16279
+  dps: 36162.68093
+  tps: 25392.89794
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 37552.29955
-  tps: 26146.03344
+  dps: 37613.40017
+  tps: 26229.03873
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FallofMortality-59500"
  value: {
-  dps: 36808.27213
-  tps: 25820.82635
+  dps: 36841.95089
+  tps: 25865.98398
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FallofMortality-65124"
  value: {
-  dps: 37034.2298
-  tps: 25993.89905
+  dps: 37055.08981
+  tps: 26031.89247
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 37145.58702
-  tps: 25899.29611
+  dps: 36998.24022
+  tps: 25846.77958
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 36177.56075
-  tps: 25159.67353
+  dps: 35990.22407
+  tps: 25199.62158
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 36713.94269
-  tps: 25688.97261
+  dps: 36756.78616
+  tps: 25833.69845
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 35832.32269
-  tps: 25059.2279
+  dps: 35786.91291
+  tps: 25109.94773
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 37646.22336
-  tps: 26317.97889
+  dps: 37684.32331
+  tps: 26472.99638
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 36153.88555
-  tps: 25332.70882
+  dps: 36002.70584
+  tps: 25399.90806
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 36401.00218
-  tps: 25534.96252
+  dps: 36294.84638
+  tps: 25545.05699
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 37714.58303
-  tps: 26246.87906
+  dps: 37700.41463
+  tps: 26360.10401
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FluidDeath-58181"
  value: {
-  dps: 36065.43271
-  tps: 25231.11621
+  dps: 35963.79622
+  tps: 25230.97816
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 37806.26761
-  tps: 26188.29155
+  dps: 37749.86365
+  tps: 26303.31806
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 37701.0791
-  tps: 26583.53364
+  dps: 37727.66949
+  tps: 26624.88921
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 36411.87723
-  tps: 25393.54029
+  dps: 36234.17766
+  tps: 25402.51367
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GaleofShadows-56138"
  value: {
-  dps: 36939.45195
-  tps: 25903.69225
+  dps: 36764.46434
+  tps: 25824.10221
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GaleofShadows-56462"
  value: {
-  dps: 37349.89102
-  tps: 26040.53158
+  dps: 36935.1041
+  tps: 25862.61672
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GearDetector-61462"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
@@ -669,1053 +669,1053 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 36389.74624
-  tps: 25454.71516
+  dps: 36353.27992
+  tps: 25515.7391
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HarmlightToken-63839"
  value: {
-  dps: 37144.51304
-  tps: 25794.2502
+  dps: 36856.15362
+  tps: 25783.9954
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 37250.24309
-  tps: 26002.70848
+  dps: 37178.90497
+  tps: 26074.77378
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 37398.46574
-  tps: 26178.11541
+  dps: 37477.51035
+  tps: 26339.61572
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofRage-59224"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofRage-65072"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofSolace-55868"
  value: {
-  dps: 36172.05068
-  tps: 25359.4687
+  dps: 35998.17624
+  tps: 25281.03828
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofSolace-56393"
  value: {
-  dps: 36470.12987
-  tps: 25421.06942
+  dps: 36065.14386
+  tps: 25248.41771
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofThunder-55845"
  value: {
-  dps: 35809.75671
-  tps: 25015.20199
+  dps: 35693.8221
+  tps: 25007.07744
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofThunder-56370"
  value: {
-  dps: 35809.75362
-  tps: 25015.55079
+  dps: 35698.41155
+  tps: 25005.11267
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 37700.67298
-  tps: 26210.48746
+  dps: 37719.33456
+  tps: 26328.80781
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 36198.08808
-  tps: 25372.88896
+  dps: 36046.79635
+  tps: 25440.05724
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 36198.08808
-  tps: 25372.88896
+  dps: 36046.79635
+  tps: 25440.05724
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 36115.41032
-  tps: 25278.49216
+  dps: 36048.20933
+  tps: 25319.9735
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 36155.86375
-  tps: 25315.2518
+  dps: 36088.84764
+  tps: 25356.8613
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-IndomitablePride-77211"
  value: {
-  dps: 35775.64041
-  tps: 25034.13826
+  dps: 35633.83678
+  tps: 25024.88949
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-IndomitablePride-77983"
  value: {
-  dps: 35823.92124
-  tps: 25036.63143
+  dps: 35784.46572
+  tps: 25091.74098
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-IndomitablePride-78003"
  value: {
-  dps: 35780.92363
-  tps: 25077.82788
+  dps: 35745.85223
+  tps: 25100.18041
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 35809.75671
-  tps: 25015.07968
+  dps: 35693.8221
+  tps: 25006.94154
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 38720.25263
-  tps: 27105.00723
+  dps: 38577.35035
+  tps: 27035.53796
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 38072.62789
-  tps: 26678.40473
+  dps: 38183.80229
+  tps: 26816.67345
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 39287.48593
-  tps: 27474.9662
+  dps: 39072.08779
+  tps: 27485.13699
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 36639.19807
-  tps: 25711.27624
+  dps: 36500.72654
+  tps: 25641.55972
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 35589.49225
-  tps: 24831.81693
+  dps: 35596.69027
+  tps: 24982.36255
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 35828.11393
-  tps: 25009.93984
+  dps: 35713.67548
+  tps: 25122.06805
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 37079.43329
-  tps: 25825.83224
+  dps: 37114.9784
+  tps: 26041.35054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 37338.17961
-  tps: 26030.51814
+  dps: 37377.02967
+  tps: 26187.04243
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 36073.7266
-  tps: 25341.89273
+  dps: 35948.99704
+  tps: 25281.1884
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 36065.43271
-  tps: 25231.11621
+  dps: 35963.79622
+  tps: 25230.97816
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 36065.43271
-  tps: 25231.11621
+  dps: 35963.79622
+  tps: 25230.97816
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 36381.34181
-  tps: 25434.52497
+  dps: 36410.34718
+  tps: 25631.72584
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 36120.70156
-  tps: 25212.9177
+  dps: 35908.27244
+  tps: 25252.97054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 36120.70156
-  tps: 25212.9177
+  dps: 35908.27244
+  tps: 25252.97054
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 36356.50832
-  tps: 25267.59725
+  dps: 36128.57114
+  tps: 25254.29082
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LeadenDespair-55816"
  value: {
-  dps: 35790.95036
-  tps: 25036.67108
+  dps: 35823.52018
+  tps: 25137.94825
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LeadenDespair-56347"
  value: {
-  dps: 35832.32269
-  tps: 25059.2279
+  dps: 35786.92399
+  tps: 25109.94773
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 36065.43271
-  tps: 25231.11621
+  dps: 35963.79622
+  tps: 25230.97816
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 35804.62424
-  tps: 25096.95409
+  dps: 35679.60069
+  tps: 25036.60937
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 35804.62424
-  tps: 25096.95409
+  dps: 35679.60069
+  tps: 25036.60937
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 35803.97662
-  tps: 24994.9571
+  dps: 35748.58862
+  tps: 24990.10144
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 35803.97662
-  tps: 24994.9571
+  dps: 35748.58862
+  tps: 24990.10144
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 36137.63492
-  tps: 25400.68145
+  dps: 36007.31091
+  tps: 25334.41027
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 36181.24346
-  tps: 25440.45528
+  dps: 36050.22535
+  tps: 25373.40801
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 36305.55603
-  tps: 25173.70925
+  dps: 36168.06462
+  tps: 25228.5432
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 36305.55603
-  tps: 25173.70925
+  dps: 36168.06462
+  tps: 25228.5432
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 36199.99477
-  tps: 25355.35323
+  dps: 36133.18035
+  tps: 25397.10253
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 36199.99477
-  tps: 25355.35323
+  dps: 36133.18035
+  tps: 25397.10253
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 37483.46626
-  tps: 26114.91993
+  dps: 37315.66653
+  tps: 26145.88295
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 37312.88919
-  tps: 26188.68126
+  dps: 37492.05254
+  tps: 26456.69068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 35745.98748
-  tps: 25025.52862
+  dps: 35690.05011
+  tps: 25084.19795
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 37521.99904
-  tps: 26417.44095
+  dps: 37550.99642
+  tps: 26460.94661
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 37950.31476
-  tps: 26685.41254
+  dps: 37838.55918
+  tps: 26698.04533
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 36114.8089
-  tps: 25253.05614
+  dps: 36178.52836
+  tps: 25445.87642
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 36793.24637
-  tps: 25743.55982
+  dps: 36757.51561
+  tps: 25808.10628
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 36774.92983
-  tps: 25639.34679
+  dps: 36688.09507
+  tps: 25696.78762
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 37552.29955
-  tps: 26146.03344
+  dps: 37613.40017
+  tps: 26229.03873
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Rainsong-55854"
  value: {
-  dps: 35792.90336
-  tps: 24973.11091
+  dps: 35686.38791
+  tps: 25003.1708
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Rainsong-56377"
  value: {
-  dps: 35803.97662
-  tps: 24994.9571
+  dps: 35748.58862
+  tps: 24990.10144
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 37164.47743
-  tps: 25973.36627
+  dps: 36966.41288
+  tps: 25827.00093
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 38084.95153
-  tps: 26570.52772
+  dps: 38075.37796
+  tps: 26688.5452
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 38078.54242
-  tps: 26561.5635
+  dps: 38066.77773
+  tps: 26676.81157
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 36504.69354
-  tps: 25550.53143
+  dps: 36488.88269
+  tps: 25664.81883
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 36065.43271
-  tps: 25231.11621
+  dps: 35963.79622
+  tps: 25230.97816
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 36065.43271
-  tps: 25231.11621
+  dps: 35963.79622
+  tps: 25230.97816
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RosaryofLight-72901"
  value: {
-  dps: 36211.35376
-  tps: 25271.00745
+  dps: 35959.25043
+  tps: 25203.96152
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RottingSkull-77116"
  value: {
-  dps: 36571.73034
-  tps: 25560.6237
+  dps: 36382.55306
+  tps: 25610.51502
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuneofZeth-68998"
  value: {
-  dps: 37585.09576
-  tps: 26189.17129
+  dps: 37492.96573
+  tps: 26193.12298
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuthlessGladiator'sBadgeofConquest-70399"
  value: {
-  dps: 35803.94881
-  tps: 25014.61598
+  dps: 35653.65604
+  tps: 25082.0604
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuthlessGladiator'sBadgeofConquest-72304"
  value: {
-  dps: 35803.94881
-  tps: 25014.61598
+  dps: 35653.65604
+  tps: 25082.0604
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuthlessGladiator'sBadgeofDominance-70401"
  value: {
-  dps: 37142.94224
-  tps: 25917.10986
+  dps: 36982.56397
+  tps: 25991.32822
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuthlessGladiator'sBadgeofDominance-72448"
  value: {
-  dps: 37218.83394
-  tps: 25968.26156
+  dps: 37057.88403
+  tps: 26042.86385
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuthlessGladiator'sBadgeofVictory-70400"
  value: {
-  dps: 35803.94881
-  tps: 25014.61598
+  dps: 35653.65604
+  tps: 25082.0604
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuthlessGladiator'sBadgeofVictory-72450"
  value: {
-  dps: 35803.94881
-  tps: 25014.61598
+  dps: 35653.65604
+  tps: 25082.0604
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuthlessGladiator'sInsigniaofConquest-70404"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuthlessGladiator'sInsigniaofConquest-72309"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuthlessGladiator'sInsigniaofDominance-70402"
  value: {
-  dps: 36905.86236
-  tps: 25735.83731
+  dps: 36769.7843
+  tps: 25733.3372
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuthlessGladiator'sInsigniaofDominance-72449"
  value: {
-  dps: 36981.68527
-  tps: 25792.86946
+  dps: 36863.81613
+  tps: 25796.45519
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuthlessGladiator'sInsigniaofVictory-70403"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuthlessGladiator'sInsigniaofVictory-72455"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ScalesofLife-68915"
  value: {
-  dps: 35805.84967
-  tps: 25048.60183
+  dps: 35706.06141
+  tps: 25029.67715
   hps: 357.04731
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ScalesofLife-69109"
  value: {
-  dps: 35783.81374
-  tps: 25040.30268
+  dps: 35690.77273
+  tps: 25044.85856
   hps: 402.74602
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SeaStar-55256"
  value: {
-  dps: 36300.94625
-  tps: 25356.10343
+  dps: 36143.9543
+  tps: 25409.43871
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SeaStar-56290"
  value: {
-  dps: 36737.23374
-  tps: 25650.40492
+  dps: 36576.12285
+  tps: 25705.79252
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ShadowflameRegalia"
  value: {
-  dps: 32128.93916
-  tps: 22802.35482
+  dps: 32340.39214
+  tps: 22869.50713
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ShardofWoe-60233"
  value: {
-  dps: 36573.19849
-  tps: 25534.68961
+  dps: 36425.46954
+  tps: 25567.44071
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 35880.39903
-  tps: 25002.89743
+  dps: 35748.61925
+  tps: 25081.14549
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 36170.32456
-  tps: 25349.87884
+  dps: 36019.68728
+  tps: 25417.22033
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 36218.30234
-  tps: 25393.78231
+  dps: 36067.61994
+  tps: 25461.11032
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Sorrowsong-55879"
  value: {
-  dps: 36818.40117
-  tps: 25781.22733
+  dps: 36700.02286
+  tps: 25785.60765
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Sorrowsong-56400"
  value: {
-  dps: 36952.99218
-  tps: 25884.91758
+  dps: 36834.26871
+  tps: 25889.55913
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 36305.55603
-  tps: 25173.70925
+  dps: 36168.06462
+  tps: 25228.5432
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SoulCasket-58183"
  value: {
-  dps: 37483.42517
-  tps: 26242.67083
+  dps: 37322.54975
+  tps: 26316.24686
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 36435.70289
-  tps: 25639.39415
+  dps: 36337.52276
+  tps: 25664.89283
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 36406.40702
-  tps: 25567.60195
+  dps: 36364.20039
+  tps: 25621.26079
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 36569.23617
-  tps: 25803.78638
+  dps: 36553.72845
+  tps: 25838.44365
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 36268.69149
-  tps: 25423.77851
+  dps: 36154.06482
+  tps: 25426.86782
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 36329.96029
-  tps: 25479.44918
+  dps: 36215.4788
+  tps: 25482.61648
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 36938.10339
-  tps: 25775.24853
+  dps: 36890.96067
+  tps: 25992.0877
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 36644.35449
-  tps: 25700.10177
+  dps: 36429.3763
+  tps: 25599.20114
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 37223.31282
-  tps: 26151.66218
+  dps: 36977.0315
+  tps: 26025.09204
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StayofExecution-68996"
  value: {
-  dps: 35803.94881
-  tps: 25014.61598
+  dps: 35653.65604
+  tps: 25082.0604
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 36844.55071
-  tps: 25785.23283
+  dps: 36836.96707
+  tps: 25839.63345
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StumpofTime-62465"
  value: {
-  dps: 37207.82804
-  tps: 26035.90572
+  dps: 37092.1873
+  tps: 26034.26226
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StumpofTime-62470"
  value: {
-  dps: 37260.21125
-  tps: 26041.40435
+  dps: 37135.16997
+  tps: 26028.49215
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 35796.81046
-  tps: 25059.36075
+  dps: 35715.90925
+  tps: 25092.23903
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 35819.74261
-  tps: 25058.15627
+  dps: 35708.34888
+  tps: 25061.01556
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 36877.21313
-  tps: 25788.18587
+  dps: 36833.40602
+  tps: 25900.55873
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TearofBlood-55819"
  value: {
-  dps: 36504.31981
-  tps: 25518.62314
+  dps: 36549.03303
+  tps: 25657.56014
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TearofBlood-56351"
  value: {
-  dps: 36731.25813
-  tps: 25656.18683
+  dps: 36686.41923
+  tps: 25731.18032
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 36632.51909
-  tps: 25613.65616
+  dps: 36513.86375
+  tps: 25614.80154
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 36862.81422
-  tps: 25778.9371
+  dps: 36740.12523
+  tps: 25784.01558
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TheHungerer-68927"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TheHungerer-69112"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 37236.47093
-  tps: 26209.76507
+  dps: 37291.01074
+  tps: 26277.56254
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 37525.49825
-  tps: 26440.77542
+  dps: 37556.05981
+  tps: 26492.55765
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 36108.16723
-  tps: 25277.92138
+  dps: 35993.16021
+  tps: 25280.80634
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 36148.60464
-  tps: 25314.66401
+  dps: 36033.69343
+  tps: 25317.60045
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 36076.90653
-  tps: 25244.82444
+  dps: 35861.14536
+  tps: 25174.90449
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 36964.87239
-  tps: 25904.13291
+  dps: 36819.5486
+  tps: 25745.70203
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnheededWarning-59520"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 35795.24938
-  tps: 25014.98126
+  dps: 35643.03165
+  tps: 25065.9377
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 36198.08808
-  tps: 25372.88896
+  dps: 36046.79635
+  tps: 25440.05724
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 36198.08808
-  tps: 25372.88896
+  dps: 36046.79635
+  tps: 25440.05724
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 36198.08808
-  tps: 25372.88896
+  dps: 36046.79635
+  tps: 25440.05724
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 36865.60804
-  tps: 25738.38333
+  dps: 37055.14642
+  tps: 25903.1393
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 36132.72468
-  tps: 25294.94721
+  dps: 35987.72994
+  tps: 25275.33174
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VeilofLies-72900"
  value: {
-  dps: 35811.93002
-  tps: 25050.72892
+  dps: 35740.37516
+  tps: 25092.69507
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 35958.37418
-  tps: 25118.60272
+  dps: 35801.64439
+  tps: 25127.11025
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 35956.8828
-  tps: 25112.12253
+  dps: 35832.53872
+  tps: 25132.87844
  }
 }
 dps_results: {
@@ -1728,420 +1728,420 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-VialofShadows-77207"
  value: {
-  dps: 35979.98765
-  tps: 25180.88848
+  dps: 35859.22723
+  tps: 25172.00508
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VialofShadows-77979"
  value: {
-  dps: 35952.66181
-  tps: 25155.40845
+  dps: 35843.68153
+  tps: 25157.086
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VialofShadows-77999"
  value: {
-  dps: 35983.14688
-  tps: 25184.33555
+  dps: 35860.68298
+  tps: 25175.31593
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 35796.81046
-  tps: 25059.36075
+  dps: 35715.89818
+  tps: 25092.23903
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 35819.74261
-  tps: 25058.15627
+  dps: 35708.33781
+  tps: 25061.01556
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 35803.94881
-  tps: 25014.61598
+  dps: 35653.65604
+  tps: 25082.0604
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sBadgeofConquest-70517"
  value: {
-  dps: 35803.94881
-  tps: 25014.61598
+  dps: 35653.65604
+  tps: 25082.0604
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 36863.13287
-  tps: 25728.51577
+  dps: 36704.86216
+  tps: 25801.31858
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sBadgeofDominance-70518"
  value: {
-  dps: 36987.85922
-  tps: 25812.58247
+  dps: 36828.64905
+  tps: 25886.01627
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 35803.94881
-  tps: 25014.61598
+  dps: 35653.65604
+  tps: 25082.0604
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sBadgeofVictory-70519"
  value: {
-  dps: 35803.94881
-  tps: 25014.61598
+  dps: 35653.65604
+  tps: 25082.0604
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 36094.79607
-  tps: 25245.36921
+  dps: 35942.07975
+  tps: 25243.4259
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 36281.92905
-  tps: 25411.59492
+  dps: 36166.0464
+  tps: 25366.61347
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 36307.48231
-  tps: 25431.46571
+  dps: 36290.86848
+  tps: 25492.42436
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 35739.12169
-  tps: 25005.7394
+  dps: 35705.92688
+  tps: 25075.74399
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 36154.51842
-  tps: 25384.36629
+  dps: 36125.1229
+  tps: 25455.31121
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 35739.12169
-  tps: 25005.7394
+  dps: 35705.92688
+  tps: 25075.74399
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sInsigniaofConquest-70577"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 36673.86069
-  tps: 25585.04025
+  dps: 36534.93643
+  tps: 25565.25128
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sInsigniaofDominance-70578"
  value: {
-  dps: 36756.92018
-  tps: 25643.95262
+  dps: 36656.13277
+  tps: 25663.05154
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sInsigniaofVictory-70579"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 38521.14598
-  tps: 26822.06182
+  dps: 38282.51469
+  tps: 26838.55513
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 38197.0471
-  tps: 26613.37999
+  dps: 37953.35796
+  tps: 26606.01722
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WillofUnbinding-77995"
  value: {
-  dps: 38809.73221
-  tps: 27003.01427
+  dps: 38645.75951
+  tps: 27079.13828
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 36822.21049
-  tps: 25724.9896
+  dps: 36653.07427
+  tps: 25654.40162
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 37187.41752
-  tps: 25964.52405
+  dps: 37322.31764
+  tps: 26233.37138
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 36072.84756
-  tps: 25259.04521
+  dps: 35921.87326
+  tps: 25326.30124
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 35799.37247
-  tps: 24997.34123
+  dps: 35683.63378
+  tps: 24999.83309
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 35898.49836
-  tps: 25142.28682
+  dps: 36049.72097
+  tps: 25373.54434
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 35898.49836
-  tps: 25142.28682
+  dps: 36049.72097
+  tps: 25373.54434
  }
 }
 dps_results: {
  key: "TestAffliction-Average-Default"
  value: {
-  dps: 38585.68763
-  tps: 26986.40457
+  dps: 38588.3039
+  tps: 26987.64674
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p3-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 39007.36069
-  tps: 34138.45669
+  dps: 38956.22067
+  tps: 34098.92963
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p3-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37844.84438
-  tps: 26679.42675
+  dps: 37822.03434
+  tps: 26626.40477
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p3-Affliction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 46297.09379
-  tps: 29827.53787
+  dps: 46204.94357
+  tps: 29762.10756
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p3-Affliction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 25383.92023
-  tps: 25277.29592
+  dps: 25281.05133
+  tps: 25198.93387
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p3-Affliction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25383.92023
-  tps: 17655.67544
+  dps: 25281.05133
+  tps: 17577.31339
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p3-Affliction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 28128.93913
-  tps: 17436.90164
+  dps: 27967.90829
+  tps: 17148.48851
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p3-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38554.58894
-  tps: 33789.0105
+  dps: 38600.41651
+  tps: 33837.88884
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p3-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37547.48034
-  tps: 26375.47272
+  dps: 37497.31622
+  tps: 26488.09508
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p3-Affliction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 45925.32118
-  tps: 29596.36276
+  dps: 45710.56658
+  tps: 29581.38701
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p3-Affliction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 25248.83476
-  tps: 25039.30692
+  dps: 25185.26723
+  tps: 25001.43085
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p3-Affliction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25248.83476
-  tps: 17560.59183
+  dps: 25185.26723
+  tps: 17522.71575
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p3-Affliction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27425.59262
-  tps: 16803.38146
+  dps: 27299.21561
+  tps: 16755.03989
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p3-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 39239.49319
-  tps: 33989.57338
+  dps: 39285.27622
+  tps: 34037.08082
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p3-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38237.66409
-  tps: 26567.92871
+  dps: 38185.39703
+  tps: 26687.40888
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p3-Affliction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 45698.7195
-  tps: 30007.62743
+  dps: 45843.71178
+  tps: 30025.89851
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p3-Affliction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 25724.00024
-  tps: 25154.72762
+  dps: 25675.51717
+  tps: 25124.84027
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p3-Affliction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25724.00024
-  tps: 17675.2608
+  dps: 25675.51717
+  tps: 17645.37346
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p3-Affliction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27792.34666
-  tps: 17098.99538
+  dps: 27671.84345
+  tps: 17114.01593
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p3-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38912.66742
-  tps: 34047.30369
+  dps: 38781.29963
+  tps: 34075.96365
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p3-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37891.74459
-  tps: 26736.13884
+  dps: 37778.50173
+  tps: 26702.94262
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p3-Affliction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 47214.37437
-  tps: 30775.93289
+  dps: 47157.75955
+  tps: 30656.31156
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p3-Affliction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 25412.54903
-  tps: 25387.37212
+  dps: 25352.73702
+  tps: 25310.71698
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p3-Affliction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25412.54903
-  tps: 17765.75164
+  dps: 25352.73702
+  tps: 17689.0965
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p3-Affliction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 28800.27225
-  tps: 17813.07169
+  dps: 28745.13145
+  tps: 17658.28505
  }
 }
 dps_results: {
  key: "TestAffliction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 38105.61707
-  tps: 26567.92871
+  dps: 38053.35001
+  tps: 26687.40888
  }
 }

--- a/sim/warlock/demonology/TestDemonology.results
+++ b/sim/warlock/demonology/TestDemonology.results
@@ -38,625 +38,625 @@ character_stats_results: {
 dps_results: {
  key: "TestDemonology-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 39451.94317
-  tps: 19979.30645
+  dps: 39459.91338
+  tps: 20068.14531
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 37349.42456
-  tps: 19022.63477
+  dps: 37356.51893
+  tps: 19011.15066
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 37655.42921
-  tps: 19081.50478
+  dps: 37608.42358
+  tps: 19111.93397
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 38008.62917
-  tps: 19258.04791
+  dps: 38041.71999
+  tps: 19244.29242
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 38085.92843
-  tps: 19295.62944
+  dps: 38105.53953
+  tps: 19277.65478
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ArrowofTime-72897"
  value: {
-  dps: 37433.02631
-  tps: 19136.87015
+  dps: 37291.57092
+  tps: 18996.02402
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 39132.97057
-  tps: 19760.52099
+  dps: 39137.08925
+  tps: 19845.05164
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Balespider'sBurningVestments"
  value: {
-  dps: 36663.59277
-  tps: 18491.86778
+  dps: 36606.81657
+  tps: 18633.23526
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 36780.4328
-  tps: 18742.29622
-  hps: 101.6345
+  dps: 36728.22584
+  tps: 18760.56611
+  hps: 101.27642
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 38809.46772
-  tps: 19710.66106
+  dps: 38782.08103
+  tps: 19696.14489
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 38918.98771
-  tps: 19688.31597
+  dps: 39033.33333
+  tps: 19789.82301
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BindingPromise-67037"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 37287.75247
-  tps: 18931.23347
+  dps: 37241.08768
+  tps: 18961.64884
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 37331.05749
-  tps: 18961.47099
+  dps: 37284.27104
+  tps: 18991.88914
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 37450.59446
-  tps: 18991.70851
+  dps: 37403.81824
+  tps: 19022.12944
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 36842.1336
-  tps: 18762.95389
+  dps: 36865.30838
+  tps: 18795.69374
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 37617.71959
-  tps: 19180.86328
+  dps: 37572.07872
+  tps: 19211.46919
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 37359.97334
-  tps: 19062.25467
+  dps: 37378.09083
+  tps: 19064.63907
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 36771.66874
-  tps: 18730.25596
+  dps: 36725.41567
+  tps: 18760.53477
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 37762.02419
-  tps: 19213.43935
+  dps: 37716.47046
+  tps: 19242.64075
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 36941.68521
-  tps: 18900.94435
+  dps: 36883.32806
+  tps: 18918.35675
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 36904.8896
-  tps: 18862.99034
+  dps: 36855.90843
+  tps: 18889.70772
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 36950.8098
-  tps: 18913.14207
+  dps: 36886.38492
+  tps: 18921.70675
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BottledLightning-66879"
  value: {
-  dps: 37593.82812
-  tps: 19170.45151
+  dps: 37573.81344
+  tps: 19117.1992
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BottledWishes-77114"
  value: {
-  dps: 39123.06953
-  tps: 20120.82736
+  dps: 39162.94124
+  tps: 20166.3547
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 39339.66205
-  tps: 19464.72797
+  dps: 39323.88779
+  tps: 19569.17458
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 39660.76602
-  tps: 20069.36608
+  dps: 39648.43337
+  tps: 20180.59086
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CataclysmicGladiator'sBadgeofConquest-73648"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CataclysmicGladiator'sBadgeofDominance-73498"
  value: {
-  dps: 38118.11414
-  tps: 19447.19024
+  dps: 38072.83536
+  tps: 19477.91976
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CataclysmicGladiator'sBadgeofVictory-73496"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CataclysmicGladiator'sInsigniaofConquest-73643"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CataclysmicGladiator'sInsigniaofDominance-73497"
  value: {
-  dps: 38434.2924
-  tps: 19508.70163
+  dps: 38408.34896
+  tps: 19550.33805
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CataclysmicGladiator'sInsigniaofVictory-73491"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 39661.25027
-  tps: 20067.05019
+  dps: 39545.15118
+  tps: 20121.49531
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 37361.76658
-  tps: 19062.25467
+  dps: 37380.26276
+  tps: 19064.63907
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 37836.66198
-  tps: 19254.1448
+  dps: 37895.4403
+  tps: 19353.15315
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 37298.12275
-  tps: 19073.25977
+  dps: 37360.27581
+  tps: 19100.53092
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 37451.20574
-  tps: 19042.27353
+  dps: 37438.14892
+  tps: 19141.04758
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 37527.56393
-  tps: 19081.49332
+  dps: 37553.40637
+  tps: 19128.59728
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CrushingWeight-59506"
  value: {
-  dps: 37059.98617
-  tps: 18940.2288
+  dps: 37094.51732
+  tps: 19055.50024
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CrushingWeight-65118"
  value: {
-  dps: 37143.38776
-  tps: 19075.47081
+  dps: 37287.18716
+  tps: 19053.85471
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 40030.96981
-  tps: 21098.88747
+  dps: 40055.58101
+  tps: 21309.92892
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 39731.0859
-  tps: 20995.35737
+  dps: 39524.96863
+  tps: 20799.52216
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-CunningoftheCruel-78000"
  value: {
-  dps: 40619.73896
-  tps: 21623.48238
+  dps: 40412.81262
+  tps: 21517.89685
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 37836.66198
-  tps: 19254.1448
+  dps: 37895.4403
+  tps: 19353.15315
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 36981.25725
-  tps: 18837.30677
+  dps: 37075.77822
+  tps: 18893.24948
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 39336.30716
-  tps: 19844.50843
+  dps: 39219.73671
+  tps: 19896.67802
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 38079.35254
-  tps: 19650.89151
+  dps: 37747.44273
+  tps: 19462.90199
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 37531.0213
-  tps: 19159.82393
+  dps: 37416.49296
+  tps: 19155.9928
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 39132.97057
-  tps: 19760.52099
+  dps: 39137.08925
+  tps: 19845.05164
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 37198.49813
-  tps: 18964.51558
+  dps: 37148.4957
+  tps: 18957.39705
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 39343.32688
-  tps: 19859.02475
+  dps: 39323.88779
+  tps: 19962.59608
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 39336.30716
-  tps: 19844.50843
+  dps: 39219.73671
+  tps: 19896.67802
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 37655.42921
-  tps: 19081.50478
+  dps: 37608.42358
+  tps: 19111.93397
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 39132.97057
-  tps: 19760.52099
+  dps: 39137.08925
+  tps: 19845.05164
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FallofMortality-59500"
  value: {
-  dps: 37836.66198
-  tps: 19254.1448
+  dps: 37895.4403
+  tps: 19353.15315
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FallofMortality-65124"
  value: {
-  dps: 38002.31064
-  tps: 19321.51583
+  dps: 38017.08226
+  tps: 19410.42307
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 37995.49072
-  tps: 19467.19708
+  dps: 37942.97092
+  tps: 19453.36089
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 37236.64586
-  tps: 18919.1032
+  dps: 37259.52729
+  tps: 18901.98417
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 37715.28688
-  tps: 19159.79761
+  dps: 37760.7113
+  tps: 19286.41369
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 36771.66874
-  tps: 18730.66986
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 38507.38777
-  tps: 19579.39014
+  dps: 38557.39885
+  tps: 19706.81976
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 37450.59446
-  tps: 18991.70851
+  dps: 37403.81824
+  tps: 19022.12944
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 37830.08167
-  tps: 19150.22642
+  dps: 37782.93142
+  tps: 19180.66193
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 39206.71955
-  tps: 19812.10031
+  dps: 39210.79265
+  tps: 19896.78382
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FluidDeath-58181"
  value: {
-  dps: 37236.64586
-  tps: 18919.1032
+  dps: 37259.29654
+  tps: 18901.86879
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 39339.66205
-  tps: 19849.45506
+  dps: 39323.88779
+  tps: 19955.66684
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 39032.83587
-  tps: 19627.77276
+  dps: 39025.62064
+  tps: 19701.60115
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 37383.17646
-  tps: 19073.64827
+  dps: 37345.21215
+  tps: 19053.57732
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GaleofShadows-56138"
  value: {
-  dps: 38204.21255
-  tps: 19669.59665
+  dps: 38191.83099
+  tps: 19711.24762
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GaleofShadows-56462"
  value: {
-  dps: 38168.67487
-  tps: 19746.00619
+  dps: 38184.76445
+  tps: 19629.57064
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GearDetector-61462"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
@@ -669,1053 +669,1053 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 37391.50076
-  tps: 19046.47965
+  dps: 37396.21317
+  tps: 19032.44638
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HarmlightToken-63839"
  value: {
-  dps: 38326.02468
-  tps: 19428.09091
+  dps: 38127.50236
+  tps: 19389.79481
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 38414.71515
-  tps: 19674.65404
+  dps: 38227.65755
+  tps: 19609.97043
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 38849.91995
-  tps: 19959.19213
+  dps: 38672.18233
+  tps: 19797.18854
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofRage-59224"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofRage-65072"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofSolace-55868"
  value: {
-  dps: 37460.29402
-  tps: 19296.47175
+  dps: 37449.80126
+  tps: 19338.56715
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofSolace-56393"
  value: {
-  dps: 37329.69089
-  tps: 19322.29526
+  dps: 37345.71826
+  tps: 19209.98734
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofThunder-55845"
  value: {
-  dps: 36771.66874
-  tps: 18730.68239
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartofThunder-56370"
  value: {
-  dps: 36771.66874
-  tps: 18730.72019
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 39336.30716
-  tps: 19844.50843
+  dps: 39219.73671
+  tps: 19896.67802
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 37497.83631
-  tps: 19024.6949
+  dps: 37450.92736
+  tps: 19055.11886
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 37497.83631
-  tps: 19024.6949
+  dps: 37450.92736
+  tps: 19055.11886
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 37331.05749
-  tps: 18961.47099
+  dps: 37284.27104
+  tps: 18991.88914
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 37450.59446
-  tps: 18991.70851
+  dps: 37403.81824
+  tps: 19022.12944
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-IndomitablePride-77211"
  value: {
-  dps: 36771.66874
-  tps: 18730.73293
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-IndomitablePride-77983"
  value: {
-  dps: 36771.66874
-  tps: 18730.71401
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-IndomitablePride-78003"
  value: {
-  dps: 36771.66874
-  tps: 18730.75427
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 36771.66874
-  tps: 18730.67107
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 39790.41327
-  tps: 20370.31384
+  dps: 39771.26124
+  tps: 20465.82607
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 39478.93682
-  tps: 20134.46653
+  dps: 39447.61621
+  tps: 20077.37329
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 40378.73544
-  tps: 20565.24956
+  dps: 40457.00151
+  tps: 20587.65512
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 37799.46427
-  tps: 19181.5787
+  dps: 37748.22013
+  tps: 19212.51729
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 36770.47169
-  tps: 18750.56781
+  dps: 36725.41567
+  tps: 18771.39333
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 36770.47169
-  tps: 18752.1746
+  dps: 36725.41567
+  tps: 18772.75648
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 38075.70134
-  tps: 19363.59404
+  dps: 38079.44054
+  tps: 19439.92108
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 38196.77774
-  tps: 19412.71703
+  dps: 38292.70204
+  tps: 19500.32729
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 37287.75247
-  tps: 18931.23347
+  dps: 37241.08768
+  tps: 18961.64884
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 37236.64586
-  tps: 18919.1032
+  dps: 37259.29654
+  tps: 18901.86879
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 37236.64586
-  tps: 18919.1032
+  dps: 37259.29654
+  tps: 18901.86879
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 37855.76674
-  tps: 19452.20439
+  dps: 37878.57662
+  tps: 19488.362
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 37337.14681
-  tps: 19293.26629
+  dps: 37039.78056
+  tps: 19112.04157
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 37337.14681
-  tps: 19293.26629
+  dps: 37039.78056
+  tps: 19112.04157
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 37215.61072
-  tps: 19027.24388
+  dps: 37128.12006
+  tps: 18989.68204
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-LeadenDespair-55816"
  value: {
-  dps: 36771.66874
-  tps: 18730.64464
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-LeadenDespair-56347"
  value: {
-  dps: 36771.66874
-  tps: 18730.66986
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 37236.64586
-  tps: 18919.1032
+  dps: 37259.29654
+  tps: 18901.86879
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 36771.66874
-  tps: 18730.23645
+  dps: 36725.41567
+  tps: 18760.50745
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 36771.66874
-  tps: 18730.23645
+  dps: 36725.41567
+  tps: 18760.50745
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 37084.38872
-  tps: 18806.19656
+  dps: 37038.80587
+  tps: 18837.94119
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 37124.07536
-  tps: 18816.10052
+  dps: 37078.58913
+  tps: 18848.02164
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 37236.64586
-  tps: 18919.1032
+  dps: 37259.29654
+  tps: 18901.86879
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 37236.64586
-  tps: 18919.1032
+  dps: 37259.29654
+  tps: 18901.86879
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 37497.83631
-  tps: 19024.6949
+  dps: 37450.92736
+  tps: 19055.11886
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 37497.83631
-  tps: 19024.6949
+  dps: 37450.92736
+  tps: 19055.11886
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 38558.49273
-  tps: 19593.70794
+  dps: 38582.13873
+  tps: 19601.23338
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 38091.83368
-  tps: 19336.13089
+  dps: 38078.54391
+  tps: 19372.61171
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 36771.66874
-  tps: 18730.68999
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 38806.73859
-  tps: 19620.99377
+  dps: 38808.78927
+  tps: 19695.91386
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 39038.36982
-  tps: 19702.45653
+  dps: 39138.23106
+  tps: 19789.71834
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 37167.66494
-  tps: 18983.68171
+  dps: 37136.92913
+  tps: 18960.73022
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 37769.42227
-  tps: 19219.36186
+  dps: 37832.65082
+  tps: 19325.95649
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 37889.45718
-  tps: 19241.67355
+  dps: 37985.22381
+  tps: 19303.05049
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 39132.97057
-  tps: 19760.52099
+  dps: 39137.08925
+  tps: 19845.05164
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Rainsong-55854"
  value: {
-  dps: 36771.66874
-  tps: 18730.33986
+  dps: 36725.41567
+  tps: 18760.65223
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Rainsong-56377"
  value: {
-  dps: 36771.66874
-  tps: 18730.27157
+  dps: 36725.41567
+  tps: 18760.55662
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 38037.87744
-  tps: 19367.1462
+  dps: 37980.86125
+  tps: 19398.63962
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 39451.94317
-  tps: 19979.30645
+  dps: 39459.91338
+  tps: 20068.14531
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 39451.94317
-  tps: 19979.23823
+  dps: 39459.91338
+  tps: 20068.06659
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 37403.00052
-  tps: 19127.11893
+  dps: 37458.89601
+  tps: 19115.8659
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 37236.64586
-  tps: 18919.1032
+  dps: 37259.29654
+  tps: 18901.86879
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 37236.64586
-  tps: 18919.1032
+  dps: 37259.29654
+  tps: 18901.86879
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RosaryofLight-72901"
  value: {
-  dps: 37033.79336
-  tps: 18841.98119
+  dps: 36982.49521
+  tps: 18938.33003
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RottingSkull-77116"
  value: {
-  dps: 37649.04872
-  tps: 19231.81215
+  dps: 37556.63689
+  tps: 19253.89402
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RuneofZeth-68998"
  value: {
-  dps: 38649.47905
-  tps: 19808.59061
+  dps: 38638.72286
+  tps: 19816.80567
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RuthlessGladiator'sBadgeofConquest-70399"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RuthlessGladiator'sBadgeofConquest-72304"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RuthlessGladiator'sBadgeofDominance-70401"
  value: {
-  dps: 37901.03531
-  tps: 19331.65352
+  dps: 37855.59944
+  tps: 19362.32941
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RuthlessGladiator'sBadgeofDominance-72448"
  value: {
-  dps: 37965.04573
-  tps: 19365.72204
+  dps: 37919.65619
+  tps: 19396.41374
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RuthlessGladiator'sBadgeofVictory-70400"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RuthlessGladiator'sBadgeofVictory-72450"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RuthlessGladiator'sInsigniaofConquest-70404"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RuthlessGladiator'sInsigniaofConquest-72309"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RuthlessGladiator'sInsigniaofDominance-70402"
  value: {
-  dps: 38108.82485
-  tps: 19361.44377
+  dps: 38055.53293
+  tps: 19384.03334
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RuthlessGladiator'sInsigniaofDominance-72449"
  value: {
-  dps: 38184.61891
-  tps: 19405.68634
+  dps: 38129.26888
+  tps: 19433.81974
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RuthlessGladiator'sInsigniaofVictory-70403"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-RuthlessGladiator'sInsigniaofVictory-72455"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ScalesofLife-68915"
  value: {
-  dps: 36775.92435
-  tps: 18734.80654
+  dps: 36735.13789
+  tps: 18765.49996
   hps: 354.04187
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ScalesofLife-69109"
  value: {
-  dps: 36775.92435
-  tps: 18734.82473
+  dps: 36735.13789
+  tps: 18765.49996
   hps: 399.35591
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SeaStar-55256"
  value: {
-  dps: 37197.47723
-  tps: 18956.98423
+  dps: 37151.53227
+  tps: 18987.40763
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SeaStar-56290"
  value: {
-  dps: 37564.84141
-  tps: 19152.42499
+  dps: 37519.16228
+  tps: 19182.90596
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ShadowflameRegalia"
  value: {
-  dps: 33912.5186
-  tps: 17409.05312
+  dps: 33661.338
+  tps: 17359.48496
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ShardofWoe-60233"
  value: {
-  dps: 37519.03873
-  tps: 19181.14158
+  dps: 37574.39503
+  tps: 19203.72678
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 36771.66874
-  tps: 18730.62887
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 37197.45423
-  tps: 18883.80372
+  dps: 37171.56148
+  tps: 18927.50352
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 37251.94537
-  tps: 18903.87052
+  dps: 37228.70044
+  tps: 18949.31237
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Sorrowsong-55879"
  value: {
-  dps: 38029.29788
-  tps: 19305.68504
+  dps: 37969.63031
+  tps: 19330.26949
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Sorrowsong-56400"
  value: {
-  dps: 38242.72942
-  tps: 19381.6014
+  dps: 38181.37285
+  tps: 19405.42822
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 37236.64586
-  tps: 18919.1032
+  dps: 37259.29654
+  tps: 18901.86879
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SoulCasket-58183"
  value: {
-  dps: 38592.98971
-  tps: 19606.07893
+  dps: 38547.07299
+  tps: 19636.85023
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 37918.93868
-  tps: 18967.32238
+  dps: 37913.05767
+  tps: 19031.97122
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 37985.79618
-  tps: 19071.34513
+  dps: 37930.56843
+  tps: 19104.91552
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 37963.78597
-  tps: 19003.56214
+  dps: 37935.35481
+  tps: 19053.59413
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 37655.42921
-  tps: 19081.50478
+  dps: 37608.42358
+  tps: 19111.93397
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 37797.27483
-  tps: 19127.3192
+  dps: 37750.21676
+  tps: 19157.75261
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 38235.49887
-  tps: 19432.79343
+  dps: 38047.70491
+  tps: 19463.58994
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 38140.42802
-  tps: 19437.36374
+  dps: 38045.42128
+  tps: 19433.04904
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 38483.34965
-  tps: 19673.99666
+  dps: 38394.27926
+  tps: 19574.18466
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-StayofExecution-68996"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 37885.66188
-  tps: 19302.22917
+  dps: 37920.14234
+  tps: 19289.24934
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-StumpofTime-62465"
  value: {
-  dps: 38496.74956
-  tps: 19524.05635
+  dps: 38520.95641
+  tps: 19501.28363
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-StumpofTime-62470"
  value: {
-  dps: 38611.70495
-  tps: 19534.51402
+  dps: 38631.07779
+  tps: 19512.483
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 36771.66874
-  tps: 18730.6832
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 36771.66874
-  tps: 18730.69824
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 37904.64422
-  tps: 19138.50702
+  dps: 37908.2876
+  tps: 19199.591
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TearofBlood-55819"
  value: {
-  dps: 37482.45527
-  tps: 19068.68614
+  dps: 37507.31143
+  tps: 19104.39284
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TearofBlood-56351"
  value: {
-  dps: 37715.28688
-  tps: 19159.79761
+  dps: 37760.7113
+  tps: 19286.41369
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 38005.90411
-  tps: 19263.28539
+  dps: 37978.13846
+  tps: 19301.69117
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 38495.5939
-  tps: 19462.11328
+  dps: 38446.01296
+  tps: 19497.81882
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TheHungerer-68927"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TheHungerer-69112"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 38478.59424
-  tps: 19411.4087
+  dps: 38582.57541
+  tps: 19536.53396
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 38863.36525
-  tps: 19583.6929
+  dps: 38905.25314
+  tps: 19696.34805
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 37331.05749
-  tps: 18961.47099
+  dps: 37284.27104
+  tps: 18991.88914
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 37450.59446
-  tps: 18991.70851
+  dps: 37403.81824
+  tps: 19022.12944
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 37166.63378
-  tps: 18869.91033
+  dps: 37025.95768
+  tps: 18862.50686
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 38011.69794
-  tps: 19481.06206
+  dps: 37809.78834
+  tps: 19431.74245
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-UnheededWarning-59520"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 36771.66874
-  tps: 18730.38181
+  dps: 36725.41567
+  tps: 18760.71096
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 37497.83631
-  tps: 19024.6949
+  dps: 37450.92736
+  tps: 19055.11886
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 37497.83631
-  tps: 19024.6949
+  dps: 37450.92736
+  tps: 19055.11886
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 37497.83631
-  tps: 19024.6949
+  dps: 37450.92736
+  tps: 19055.11886
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 38146.25293
-  tps: 19288.79347
+  dps: 38060.56663
+  tps: 19262.02376
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 37068.74265
-  tps: 18791.35809
+  dps: 37088.03952
+  tps: 18860.9333
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VeilofLies-72900"
  value: {
-  dps: 36771.66874
-  tps: 18730.70576
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 36845.286
-  tps: 18799.73212
+  dps: 36881.08868
+  tps: 18820.29305
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 36875.82687
-  tps: 18809.21691
+  dps: 36888.11112
+  tps: 18826.51269
  }
 }
 dps_results: {
@@ -1728,924 +1728,924 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-VialofShadows-77207"
  value: {
-  dps: 36974.00737
-  tps: 18931.59147
+  dps: 36917.66775
+  tps: 18952.44568
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VialofShadows-77979"
  value: {
-  dps: 36948.79987
-  tps: 18908.54726
+  dps: 36889.74838
+  tps: 18924.66608
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VialofShadows-77999"
  value: {
-  dps: 36982.474
-  tps: 18944.14121
+  dps: 36921.75687
+  tps: 18955.75029
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 36771.66874
-  tps: 18730.6832
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 36771.66874
-  tps: 18730.69824
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sBadgeofConquest-70517"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 37665.03165
-  tps: 19206.04436
+  dps: 37619.42501
+  tps: 19236.66195
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sBadgeofDominance-70518"
  value: {
-  dps: 37770.23139
-  tps: 19262.03523
+  dps: 37724.70088
+  tps: 19292.67881
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sBadgeofVictory-70519"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 37236.64586
-  tps: 18919.1032
+  dps: 37259.29654
+  tps: 18901.86879
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 37575.93618
-  tps: 19362.03537
+  dps: 37486.68684
+  tps: 19231.36338
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 37448.06435
-  tps: 19104.0903
+  dps: 37318.63251
+  tps: 19062.95151
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 37599.00145
-  tps: 19042.10438
+  dps: 37552.15436
+  tps: 19072.52994
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sInsigniaofConquest-70577"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 37812.98752
-  tps: 19223.96835
+  dps: 37782.75948
+  tps: 19266.73724
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sInsigniaofDominance-70578"
  value: {
-  dps: 37962.10151
-  tps: 19294.33076
+  dps: 37922.97596
+  tps: 19326.87889
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-ViciousGladiator'sInsigniaofVictory-70579"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 39670.82473
-  tps: 20175.00195
+  dps: 39741.67875
+  tps: 20299.13444
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 39380.33272
-  tps: 20068.92708
+  dps: 39396.36863
+  tps: 20131.57496
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-WillofUnbinding-77995"
  value: {
-  dps: 40063.86144
-  tps: 20431.58505
+  dps: 40124.74566
+  tps: 20465.96725
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 37766.36129
-  tps: 19299.58176
+  dps: 37796.55766
+  tps: 19303.87373
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 38623.62352
-  tps: 19818.08271
+  dps: 38629.74941
+  tps: 19823.24759
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 37287.75247
-  tps: 18931.23347
+  dps: 37241.08768
+  tps: 18961.64884
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 36771.66874
-  tps: 18730.56629
+  dps: 36725.41567
+  tps: 18760.96322
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 37044.70208
-  tps: 18796.37239
+  dps: 36999.02262
+  tps: 18827.86074
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 37044.70208
-  tps: 18796.37239
+  dps: 36999.02262
+  tps: 18827.86074
  }
 }
 dps_results: {
  key: "TestDemonology-Average-Default"
  value: {
-  dps: 40180.88723
-  tps: 20371.0101
+  dps: 40219.87173
+  tps: 20393.63287
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 55748.7927
-  tps: 47457.78426
+  dps: 55474.61166
+  tps: 46945.7794
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39084.75267
-  tps: 19388.29946
+  dps: 39017.38544
+  tps: 19434.37557
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 51004.71943
-  tps: 22105.34758
+  dps: 50982.39568
+  tps: 22186.72612
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 47074.24252
-  tps: 42901.87293
+  dps: 46346.45051
+  tps: 41989.26962
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28245.30254
-  tps: 13653.61115
+  dps: 28145.30493
+  tps: 13768.7337
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 34587.37168
-  tps: 14653.74364
+  dps: 34540.06267
+  tps: 14808.58533
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 55600.09056
-  tps: 46261.31968
+  dps: 55362.03939
+  tps: 45878.12553
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39372.784
-  tps: 20456.50798
+  dps: 39218.22319
+  tps: 20436.38569
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 51426.9584
-  tps: 23706.81113
+  dps: 51259.91081
+  tps: 23632.40412
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 47048.45968
-  tps: 40611.64752
+  dps: 47002.69593
+  tps: 40367.30212
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28754.64597
-  tps: 14470.83077
+  dps: 28492.22803
+  tps: 14455.32359
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 35141.47841
-  tps: 15716.20616
+  dps: 34990.80929
+  tps: 15709.28551
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 56161.92744
-  tps: 47435.6272
+  dps: 56078.64291
+  tps: 47761.78797
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39728.52117
-  tps: 19937.75085
+  dps: 39670.81761
+  tps: 19955.94985
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 51707.55705
-  tps: 22735.35341
+  dps: 51691.90373
+  tps: 22823.209
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 46983.51424
-  tps: 42502.72809
+  dps: 47294.34195
+  tps: 42859.99077
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28730.84014
-  tps: 13977.77441
+  dps: 28626.64716
+  tps: 14081.8007
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 35022.08314
-  tps: 14992.55039
+  dps: 34918.11196
+  tps: 15126.34897
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 49893.78101
-  tps: 40216.19731
+  dps: 49861.16212
+  tps: 40400.15761
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 35171.86258
-  tps: 17113.05781
+  dps: 35281.3488
+  tps: 17118.95367
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 48186.43703
-  tps: 20901.56805
+  dps: 47898.49843
+  tps: 20682.16536
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 42180.89808
-  tps: 35199.14981
+  dps: 42037.04531
+  tps: 34840.16775
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 26030.08087
-  tps: 12411.79015
+  dps: 25911.85856
+  tps: 12317.24498
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 33021.20703
-  tps: 13881.67668
+  dps: 33114.8164
+  tps: 14025.35289
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 54940.99063
-  tps: 46815.84857
+  dps: 54882.03498
+  tps: 46371.15181
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38518.83911
-  tps: 19070.9852
+  dps: 38453.85498
+  tps: 18976.54992
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 50695.337
-  tps: 21875.87785
+  dps: 50598.12506
+  tps: 21888.4896
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 46759.62204
-  tps: 42355.18007
+  dps: 46437.62732
+  tps: 42271.3675
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28425.28671
-  tps: 13718.35597
+  dps: 28291.04874
+  tps: 13828.58977
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 34853.90901
-  tps: 14598.40337
+  dps: 34599.61982
+  tps: 14705.83233
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 55102.73502
-  tps: 45258.66333
+  dps: 54797.35059
+  tps: 44590.67967
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38818.88209
-  tps: 19949.68119
+  dps: 38767.05462
+  tps: 20049.2243
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 51217.30551
-  tps: 23244.69884
+  dps: 51628.47638
+  tps: 23716.19848
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 47187.31301
-  tps: 40623.29889
+  dps: 46953.28399
+  tps: 40345.69825
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28527.28609
-  tps: 14446.19258
+  dps: 28489.72309
+  tps: 14448.74322
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 34634.4314
-  tps: 15354.90669
+  dps: 34524.61978
+  tps: 15457.02086
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 55633.56262
-  tps: 47882.14442
+  dps: 55395.07607
+  tps: 47153.09097
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39228.39531
-  tps: 19549.90316
+  dps: 39064.93153
+  tps: 19470.00327
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 51484.60255
-  tps: 22538.81089
+  dps: 51422.32154
+  tps: 22555.86641
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 46973.95164
-  tps: 42246.09859
+  dps: 47035.50283
+  tps: 42577.0434
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28785.63631
-  tps: 14029.05565
+  dps: 28510.56383
+  tps: 14036.36564
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 35259.23067
-  tps: 14998.30758
+  dps: 34933.29242
+  tps: 15041.17152
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 49203.92616
-  tps: 39552.67295
+  dps: 49297.22752
+  tps: 39838.84511
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 34984.06584
-  tps: 17057.9117
+  dps: 34880.75448
+  tps: 16957.33055
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 48272.3456
-  tps: 21162.76538
+  dps: 48025.07576
+  tps: 20909.52264
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 42876.71724
-  tps: 36527.15244
+  dps: 42737.42609
+  tps: 36002.81956
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 26078.72991
-  tps: 12461.36538
+  dps: 25936.16965
+  tps: 12450.85972
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 33155.96343
-  tps: 13946.61549
+  dps: 33123.61811
+  tps: 14081.0992
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 56080.50609
-  tps: 47245.55726
+  dps: 55930.78938
+  tps: 46517.58984
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39358.10047
-  tps: 19162.7078
+  dps: 39348.58229
+  tps: 19128.94312
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 52418.70649
-  tps: 22160.22765
+  dps: 52305.18181
+  tps: 22172.35164
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 47787.73848
-  tps: 42791.36686
+  dps: 47524.50049
+  tps: 42485.30574
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29215.90401
-  tps: 13870.26088
+  dps: 29004.35586
+  tps: 13945.69689
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 36183.9915
-  tps: 14804.63701
+  dps: 35905.86155
+  tps: 14917.39552
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 56164.84253
-  tps: 45411.37329
+  dps: 55961.06439
+  tps: 45132.54632
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39660.76602
-  tps: 20069.36608
+  dps: 39648.43337
+  tps: 20180.59086
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 52953.47752
-  tps: 23555.50598
+  dps: 53365.83049
+  tps: 24035.97982
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 48190.08588
-  tps: 40727.75716
+  dps: 48096.14958
+  tps: 40957.8709
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29287.29802
-  tps: 14564.64821
+  dps: 29253.28993
+  tps: 14545.05227
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 35969.26603
-  tps: 15572.77142
+  dps: 35849.8277
+  tps: 15681.37094
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 56737.21368
-  tps: 48067.13438
+  dps: 56494.77983
+  tps: 47408.38116
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 40114.50589
-  tps: 19712.7136
+  dps: 40014.28787
+  tps: 19630.96676
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 53218.77813
-  tps: 22831.20481
+  dps: 53141.67345
+  tps: 22847.80438
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 48177.86938
-  tps: 42720.02576
+  dps: 48077.89001
+  tps: 42821.24155
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29608.14442
-  tps: 14217.26934
+  dps: 29261.71983
+  tps: 14196.85002
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 36589.70169
-  tps: 15208.23183
+  dps: 36237.12338
+  tps: 15255.78436
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 50307.8578
-  tps: 39674.27249
+  dps: 50376.79376
+  tps: 40063.69921
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 35962.60165
-  tps: 17224.79629
+  dps: 35825.16544
+  tps: 17140.95719
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 49986.0079
-  tps: 21455.71666
+  dps: 49739.13042
+  tps: 21205.67248
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 44001.86393
-  tps: 36840.69697
+  dps: 43865.69629
+  tps: 36363.1245
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 26813.44051
-  tps: 12592.00735
+  dps: 26656.29708
+  tps: 12591.20811
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 34494.36907
-  tps: 14154.44553
+  dps: 34452.92999
+  tps: 14293.74114
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 55853.44828
-  tps: 47390.17943
+  dps: 55361.87792
+  tps: 46294.42932
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39007.07555
-  tps: 19274.11384
+  dps: 39043.98081
+  tps: 19385.35031
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 51916.19183
-  tps: 22353.044
+  dps: 52390.17319
+  tps: 22553.77805
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 47764.32217
-  tps: 43642.58243
+  dps: 47725.5598
+  tps: 43760.62496
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28653.2259
-  tps: 13903.5541
+  dps: 28747.75389
+  tps: 14024.03467
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 36664.26457
-  tps: 15405.59358
+  dps: 36591.07931
+  tps: 15526.11974
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 55737.22285
-  tps: 46317.35219
+  dps: 55477.40651
+  tps: 45989.51049
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39388.46385
-  tps: 20292.40481
+  dps: 39344.91323
+  tps: 20328.13889
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 52075.46284
-  tps: 23584.6296
+  dps: 52578.17831
+  tps: 24002.91312
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 48456.58266
-  tps: 41798.12848
+  dps: 48178.38432
+  tps: 41698.92282
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28882.18367
-  tps: 14731.22839
+  dps: 28743.93275
+  tps: 14726.89006
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 36164.4213
-  tps: 16177.87309
+  dps: 35934.31145
+  tps: 16197.97574
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 56543.60599
-  tps: 47691.61348
+  dps: 56193.24905
+  tps: 47499.60025
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39694.72093
-  tps: 19815.6555
+  dps: 39767.49132
+  tps: 19909.40397
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 52808.12817
-  tps: 23170.01345
+  dps: 53304.84227
+  tps: 23373.75795
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 48635.18112
-  tps: 43857.48528
+  dps: 48438.0864
+  tps: 43935.3227
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29108.3498
-  tps: 14372.82314
+  dps: 28923.68874
+  tps: 14310.30228
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 36359.87803
-  tps: 15780.29529
+  dps: 36235.08674
+  tps: 15893.94225
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 50098.39305
-  tps: 40610.06953
+  dps: 50065.31563
+  tps: 40846.54033
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 35635.74293
-  tps: 17254.53941
+  dps: 35507.94429
+  tps: 17263.83751
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 49273.03358
-  tps: 21108.34497
+  dps: 49340.03941
+  tps: 21279.26219
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 43455.00409
-  tps: 36469.16848
+  dps: 43330.02963
+  tps: 36154.44562
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 26217.11053
-  tps: 12587.52131
+  dps: 26099.20333
+  tps: 12563.35341
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 33892.16048
-  tps: 14471.31324
+  dps: 33881.09328
+  tps: 14744.71468
  }
 }
 dps_results: {
  key: "TestDemonology-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 39477.40934
-  tps: 20069.36608
+  dps: 39465.12928
+  tps: 20180.59086
  }
 }

--- a/sim/warlock/destruction/TestDestruction.results
+++ b/sim/warlock/destruction/TestDestruction.results
@@ -38,625 +38,625 @@ character_stats_results: {
 dps_results: {
  key: "TestDestruction-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 40223.65458
-  tps: 23815.38906
+  dps: 40384.73187
+  tps: 23922.57373
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 38618.09021
-  tps: 22790.80886
+  dps: 38625.86691
+  tps: 22870.97614
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 38613.22519
-  tps: 22832.88195
+  dps: 38564.09092
+  tps: 22853.24563
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 38813.61858
-  tps: 22890.19443
+  dps: 38779.83976
+  tps: 22943.70128
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 38851.2684
-  tps: 22922.84555
+  dps: 38818.64934
+  tps: 22968.60763
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ArrowofTime-72897"
  value: {
-  dps: 38682.51939
-  tps: 22827.76551
+  dps: 38643.46024
+  tps: 22858.60886
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 39803.9954
-  tps: 23533.93425
+  dps: 39958.6156
+  tps: 23635.85692
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Balespider'sBurningVestments"
  value: {
-  dps: 37078.56714
-  tps: 21829.18695
+  dps: 37159.72343
+  tps: 22082.62325
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 37904.19624
-  tps: 22379.29581
-  hps: 100.99448
+  dps: 37979.46945
+  tps: 22540.91773
+  hps: 101.14686
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 39850.58424
-  tps: 23497.00322
+  dps: 39753.14723
+  tps: 23420.37122
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 40114.0151
-  tps: 23663.60802
+  dps: 39976.2355
+  tps: 23548.86997
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BindingPromise-67037"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 38365.18187
-  tps: 22681.36228
+  dps: 38306.59407
+  tps: 22700.23726
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 38428.31636
-  tps: 22707.31604
+  dps: 38398.14718
+  tps: 22755.424
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 38478.86518
-  tps: 22738.81197
+  dps: 38448.66885
+  tps: 22786.96892
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 37991.63812
-  tps: 22428.2138
+  dps: 37967.76745
+  tps: 22503.98081
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 39074.3486
-  tps: 22981.47386
+  dps: 39057.2499
+  tps: 23069.44831
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 37994.36195
-  tps: 22426.55276
+  dps: 37975.68447
+  tps: 22507.6043
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 38568.68711
-  tps: 22781.45899
+  dps: 38462.41449
+  tps: 22735.28375
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 38042.30725
-  tps: 22467.16212
+  dps: 38012.34534
+  tps: 22514.89597
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 38042.30725
-  tps: 22467.26115
+  dps: 38012.34534
+  tps: 22514.995
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 39054.2969
-  tps: 23034.46334
+  dps: 39018.32561
+  tps: 23078.04511
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 38164.02181
-  tps: 22588.30681
+  dps: 38138.27489
+  tps: 22640.57257
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 38148.36839
-  tps: 22574.5455
+  dps: 38123.09346
+  tps: 22624.01845
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 38181.36255
-  tps: 22610.56469
+  dps: 38165.37981
+  tps: 22665.27575
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BottledLightning-66879"
  value: {
-  dps: 38789.98095
-  tps: 22910.25201
+  dps: 38751.4835
+  tps: 22933.83353
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BottledWishes-77114"
  value: {
-  dps: 40123.99619
-  tps: 23682.01173
+  dps: 40343.53859
+  tps: 23888.39425
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 40016.70864
-  tps: 23193.76972
+  dps: 40152.41398
+  tps: 23290.16951
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 40439.94755
-  tps: 23933.1579
+  dps: 40581.30779
+  tps: 24036.45451
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CataclysmicGladiator'sBadgeofConquest-73648"
  value: {
-  dps: 37994.36195
-  tps: 22426.55276
+  dps: 37975.68447
+  tps: 22507.6043
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CataclysmicGladiator'sBadgeofDominance-73498"
  value: {
-  dps: 39713.10386
-  tps: 23309.68048
+  dps: 39696.93893
+  tps: 23401.74948
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CataclysmicGladiator'sBadgeofVictory-73496"
  value: {
-  dps: 37994.36195
-  tps: 22426.55276
+  dps: 37975.68447
+  tps: 22507.6043
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CataclysmicGladiator'sInsigniaofConquest-73643"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CataclysmicGladiator'sInsigniaofDominance-73497"
  value: {
-  dps: 39594.7557
-  tps: 23314.70263
+  dps: 39557.27743
+  tps: 23359.56562
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CataclysmicGladiator'sInsigniaofVictory-73491"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 40281.46039
-  tps: 23860.39968
+  dps: 40443.63781
+  tps: 23949.03178
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 38565.90273
-  tps: 22788.76551
+  dps: 38464.69437
+  tps: 22735.51605
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 39109.36052
-  tps: 23098.58915
+  dps: 39146.39792
+  tps: 23190.23155
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 38612.87504
-  tps: 22825.01971
+  dps: 38638.82351
+  tps: 22891.53039
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 38730.18468
-  tps: 22926.14874
+  dps: 38581.48189
+  tps: 22845.54118
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 38622.7187
-  tps: 22782.63378
+  dps: 38636.61335
+  tps: 22859.3526
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CrushingWeight-59506"
  value: {
-  dps: 38377.06895
-  tps: 22667.80189
+  dps: 38401.76659
+  tps: 22691.39782
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CrushingWeight-65118"
  value: {
-  dps: 38570.37967
-  tps: 22787.62827
+  dps: 38572.47072
+  tps: 22851.97528
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 40809.794
-  tps: 24605.60939
+  dps: 40942.90269
+  tps: 24750.78367
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 40581.74746
-  tps: 24453.66947
+  dps: 40601.98946
+  tps: 24436.82902
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-CunningoftheCruel-78000"
  value: {
-  dps: 41182.24473
-  tps: 24896.38034
+  dps: 41321.30784
+  tps: 24999.91216
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 38042.30725
-  tps: 22467.2667
+  dps: 38012.34534
+  tps: 22515.00055
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 39165.69674
-  tps: 23125.72029
+  dps: 39176.73337
+  tps: 23206.11624
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 38302.63266
-  tps: 22620.12336
+  dps: 38213.90567
+  tps: 22640.69965
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 39858.78229
-  tps: 23576.52068
+  dps: 40015.02048
+  tps: 23661.07605
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 39036.94361
-  tps: 22972.30192
+  dps: 39096.57471
+  tps: 23075.86374
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 38557.64298
-  tps: 22735.62663
+  dps: 38698.15962
+  tps: 22893.74662
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 39803.9954
-  tps: 23533.93425
+  dps: 39958.6156
+  tps: 23635.85692
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 38524.73068
-  tps: 22727.18908
+  dps: 38453.81267
+  tps: 22759.0779
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 40010.621
-  tps: 23661.6201
+  dps: 40152.41398
+  tps: 23762.31773
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 39858.78229
-  tps: 23576.52068
+  dps: 40015.02048
+  tps: 23661.07605
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 38613.22519
-  tps: 22832.88195
+  dps: 38564.09092
+  tps: 22853.24563
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 39803.9954
-  tps: 23533.93425
+  dps: 39958.6156
+  tps: 23635.85692
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FallofMortality-59500"
  value: {
-  dps: 39165.69674
-  tps: 23125.72029
+  dps: 39176.73337
+  tps: 23206.11624
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FallofMortality-65124"
  value: {
-  dps: 39316.2664
-  tps: 23211.96732
+  dps: 39320.2104
+  tps: 23288.20412
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 39258.26766
-  tps: 23147.38741
+  dps: 39302.16207
+  tps: 23225.63032
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 37994.36195
-  tps: 22426.55276
+  dps: 37975.68447
+  tps: 22507.6043
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 39023.68035
-  tps: 23042.51528
+  dps: 39015.78327
+  tps: 23111.98377
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 38019.98205
-  tps: 22453.22969
+  dps: 38012.34534
+  tps: 22515.00632
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 40041.24082
-  tps: 23568.66491
+  dps: 40033.32405
+  tps: 23639.42662
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 38430.75122
-  tps: 22698.01198
+  dps: 38411.52592
+  tps: 22779.88458
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 38743.86349
-  tps: 22903.92697
+  dps: 38713.52488
+  tps: 22952.34075
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 39889.98085
-  tps: 23587.73179
+  dps: 40045.04021
+  tps: 23689.92113
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FluidDeath-58181"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 40016.70864
-  tps: 23649.43762
+  dps: 40152.41398
+  tps: 23748.03945
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 40158.90644
-  tps: 23734.22606
+  dps: 40147.07868
+  tps: 23792.82701
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 38571.98193
-  tps: 22803.5844
+  dps: 38470.03844
+  tps: 22723.7645
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GaleofShadows-56138"
  value: {
-  dps: 39101.03151
-  tps: 23092.13686
+  dps: 39160.08902
+  tps: 23208.06561
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GaleofShadows-56462"
  value: {
-  dps: 39522.20961
-  tps: 23373.57175
+  dps: 39542.54235
+  tps: 23437.51476
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GearDetector-61462"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
@@ -669,1053 +669,1053 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 38673.01308
-  tps: 22841.69146
+  dps: 38661.27267
+  tps: 22899.51851
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HarmlightToken-63839"
  value: {
-  dps: 38977.7888
-  tps: 23021.78822
+  dps: 39056.87119
+  tps: 23039.02622
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 39603.13687
-  tps: 23416.39323
+  dps: 39638.59996
+  tps: 23473.33294
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 39930.40692
-  tps: 23664.91023
+  dps: 39849.29299
+  tps: 23563.17211
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofRage-59224"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofRage-65072"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofSolace-55868"
  value: {
-  dps: 38285.80219
-  tps: 22624.18938
+  dps: 38343.34022
+  tps: 22737.65339
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofSolace-56393"
  value: {
-  dps: 38594.60361
-  tps: 22840.10058
+  dps: 38614.88586
+  tps: 22903.29054
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofThunder-55845"
  value: {
-  dps: 38024.31429
-  tps: 22448.99903
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartofThunder-56370"
  value: {
-  dps: 38024.04876
-  tps: 22449.87582
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 39858.78229
-  tps: 23576.52068
+  dps: 40015.02048
+  tps: 23661.07605
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 38485.87407
-  tps: 22732.30156
+  dps: 38466.57957
+  tps: 22814.27788
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 38485.87407
-  tps: 22732.30156
+  dps: 38466.57957
+  tps: 22814.27788
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 38428.31636
-  tps: 22707.31604
+  dps: 38398.14718
+  tps: 22755.424
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 38478.86518
-  tps: 22738.81197
+  dps: 38448.66885
+  tps: 22786.96892
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-IndomitablePride-77211"
  value: {
-  dps: 38036.77637
-  tps: 22457.0101
+  dps: 38012.34534
+  tps: 22515.29297
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-IndomitablePride-77983"
  value: {
-  dps: 38033.63613
-  tps: 22461.50351
+  dps: 38012.34534
+  tps: 22515.20697
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-IndomitablePride-78003"
  value: {
-  dps: 38033.76429
-  tps: 22454.07563
+  dps: 38012.34534
+  tps: 22515.38999
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 38024.31429
-  tps: 22448.98771
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 41023.41259
-  tps: 24148.80384
+  dps: 41131.63573
+  tps: 24411.23901
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 40857.54612
-  tps: 24039.95375
+  dps: 40830.78786
+  tps: 24050.34536
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 41659.75251
-  tps: 24646.32643
+  dps: 41613.81727
+  tps: 24542.33662
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 38956.19927
-  tps: 22976.47035
+  dps: 38900.55582
+  tps: 22997.8782
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 38021.2871
-  tps: 22471.11108
+  dps: 38012.19613
+  tps: 22527.60088
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 38001.70401
-  tps: 22458.00065
+  dps: 38016.78052
+  tps: 22535.24632
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 39367.90038
-  tps: 23275.72517
+  dps: 39351.44444
+  tps: 23304.44424
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 39545.74005
-  tps: 23373.62812
+  dps: 39528.79885
+  tps: 23406.61678
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 38365.18187
-  tps: 22681.36228
+  dps: 38306.59407
+  tps: 22700.23726
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 38627.32994
-  tps: 22919.10804
+  dps: 38829.70896
+  tps: 23107.91608
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 38305.7279
-  tps: 22615.84269
+  dps: 38308.98486
+  tps: 22640.05022
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 38305.7279
-  tps: 22615.84269
+  dps: 38308.98486
+  tps: 22640.05022
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 38475.62264
-  tps: 22776.38947
+  dps: 38545.47775
+  tps: 22789.02184
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LeadenDespair-55816"
  value: {
-  dps: 38051.89462
-  tps: 22478.33919
+  dps: 38012.34534
+  tps: 22514.89166
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LeadenDespair-56347"
  value: {
-  dps: 38019.98205
-  tps: 22453.22969
+  dps: 38012.34534
+  tps: 22515.00632
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 38029.39979
-  tps: 22472.19964
+  dps: 37971.62227
+  tps: 22491.16784
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 38029.39979
-  tps: 22472.19964
+  dps: 37971.62227
+  tps: 22491.16784
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 38042.30725
-  tps: 22466.69609
+  dps: 38012.34534
+  tps: 22514.42994
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 38042.30725
-  tps: 22466.69609
+  dps: 38012.34534
+  tps: 22514.42994
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 38465.22228
-  tps: 22728.68692
+  dps: 38408.72534
+  tps: 22748.68296
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 38522.29427
-  tps: 22762.27454
+  dps: 38465.96503
+  tps: 22782.40518
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 38029.39979
-  tps: 22472.19964
+  dps: 37971.62227
+  tps: 22491.16784
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 38029.39979
-  tps: 22472.19964
+  dps: 37971.62227
+  tps: 22491.16784
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 38534.00933
-  tps: 22773.17116
+  dps: 38503.7834
+  tps: 22821.38156
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 38534.00933
-  tps: 22773.17116
+  dps: 38503.7834
+  tps: 22821.38156
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 39749.16147
-  tps: 23463.60152
+  dps: 39651.5938
+  tps: 23404.75306
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 39926.43358
-  tps: 23597.41539
+  dps: 39914.17415
+  tps: 23651.05026
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 38033.90166
-  tps: 22460.55538
+  dps: 38012.34534
+  tps: 22515.09783
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 40003.52061
-  tps: 23648.7406
+  dps: 39983.02137
+  tps: 23698.22811
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 40343.5681
-  tps: 23871.23005
+  dps: 40242.75154
+  tps: 23850.1709
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 38275.33646
-  tps: 22548.02172
+  dps: 38311.50527
+  tps: 22614.36583
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 39092.66128
-  tps: 23083.55059
+  dps: 39113.29861
+  tps: 23164.90555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 39094.18496
-  tps: 23063.08433
+  dps: 39005.66808
+  tps: 23086.71506
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 39803.9954
-  tps: 23533.93425
+  dps: 39958.6156
+  tps: 23635.85692
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Rainsong-55854"
  value: {
-  dps: 38042.30725
-  tps: 22466.73096
+  dps: 38012.34534
+  tps: 22514.46481
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Rainsong-56377"
  value: {
-  dps: 38042.30725
-  tps: 22466.70793
+  dps: 38012.34534
+  tps: 22514.44178
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 39503.90258
-  tps: 23218.51714
+  dps: 39472.05078
+  tps: 23243.93924
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 40223.65458
-  tps: 23815.38906
+  dps: 40384.73187
+  tps: 23922.57373
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 40223.65458
-  tps: 23815.36379
+  dps: 40384.73187
+  tps: 23922.55857
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 38578.91258
-  tps: 22707.02293
+  dps: 38603.9467
+  tps: 22816.82832
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RosaryofLight-72901"
  value: {
-  dps: 38358.07378
-  tps: 22649.74392
+  dps: 38356.79956
+  tps: 22741.39292
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RottingSkull-77116"
  value: {
-  dps: 38745.07691
-  tps: 22919.13467
+  dps: 38674.6293
+  tps: 22859.87236
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RuneofZeth-68998"
  value: {
-  dps: 39983.79553
-  tps: 23580.38458
+  dps: 39835.60262
+  tps: 23467.6877
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RuthlessGladiator'sBadgeofConquest-70399"
  value: {
-  dps: 37994.36195
-  tps: 22426.55276
+  dps: 37975.68447
+  tps: 22507.6043
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RuthlessGladiator'sBadgeofConquest-72304"
  value: {
-  dps: 37994.36195
-  tps: 22426.55276
+  dps: 37975.68447
+  tps: 22507.6043
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RuthlessGladiator'sBadgeofDominance-70401"
  value: {
-  dps: 39436.00202
-  tps: 23167.29941
+  dps: 39419.43201
+  tps: 23257.59213
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RuthlessGladiator'sBadgeofDominance-72448"
  value: {
-  dps: 39517.71154
-  tps: 23209.28357
+  dps: 39501.26098
+  tps: 23300.10007
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RuthlessGladiator'sBadgeofVictory-70400"
  value: {
-  dps: 37994.36195
-  tps: 22426.55276
+  dps: 37975.68447
+  tps: 22507.6043
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RuthlessGladiator'sBadgeofVictory-72450"
  value: {
-  dps: 37994.36195
-  tps: 22426.55276
+  dps: 37975.68447
+  tps: 22507.6043
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RuthlessGladiator'sInsigniaofConquest-70404"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RuthlessGladiator'sInsigniaofConquest-72309"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RuthlessGladiator'sInsigniaofDominance-70402"
  value: {
-  dps: 39309.56083
-  tps: 23162.65602
+  dps: 39277.0776
+  tps: 23206.50643
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RuthlessGladiator'sInsigniaofDominance-72449"
  value: {
-  dps: 39382.98665
-  tps: 23211.25153
+  dps: 39336.07672
+  tps: 23245.97106
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RuthlessGladiator'sInsigniaofVictory-70403"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-RuthlessGladiator'sInsigniaofVictory-72455"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ScalesofLife-68915"
  value: {
-  dps: 37874.70409
-  tps: 22368.04975
+  dps: 37972.72762
+  tps: 22539.83699
   hps: 354.04187
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ScalesofLife-69109"
  value: {
-  dps: 37888.31713
-  tps: 22375.21895
+  dps: 37972.72762
+  tps: 22539.91967
   hps: 399.35591
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SeaStar-55256"
  value: {
-  dps: 38537.90786
-  tps: 22705.76351
+  dps: 38520.02497
+  tps: 22790.30868
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SeaStar-56290"
  value: {
-  dps: 39006.84943
-  tps: 22946.68413
+  dps: 38989.65206
+  tps: 23034.23929
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ShadowflameRegalia"
  value: {
-  dps: 33806.41574
-  tps: 20286.00681
+  dps: 33842.47526
+  tps: 20400.29611
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ShardofWoe-60233"
  value: {
-  dps: 39018.50201
-  tps: 23053.00093
+  dps: 38972.28039
+  tps: 23085.228
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 38051.89462
-  tps: 22478.2532
+  dps: 38012.34534
+  tps: 22514.82
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 38506.43971
-  tps: 22731.61329
+  dps: 38488.94286
+  tps: 22817.34835
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 38573.49751
-  tps: 22771.56169
+  dps: 38556.15527
+  tps: 22857.91007
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Sorrowsong-55879"
  value: {
-  dps: 39139.58219
-  tps: 23106.95308
+  dps: 39115.8645
+  tps: 23158.86466
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Sorrowsong-56400"
  value: {
-  dps: 39284.49078
-  tps: 23191.55914
+  dps: 39261.60778
+  tps: 23244.02788
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 38029.39979
-  tps: 22472.19964
+  dps: 37971.62227
+  tps: 22491.16784
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SoulCasket-58183"
  value: {
-  dps: 39872.67272
-  tps: 23446.29601
+  dps: 39855.42013
+  tps: 23537.22085
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 39157.39888
-  tps: 23139.71223
+  dps: 39133.25561
+  tps: 23200.7355
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 38995.63419
-  tps: 23048.2664
+  dps: 38977.16524
+  tps: 23109.11577
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 39257.56527
-  tps: 23207.24253
+  dps: 39240.9926
+  tps: 23271.6341
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 38628.97983
-  tps: 22832.34532
+  dps: 38598.7029
+  tps: 22880.64776
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 38705.56894
-  tps: 22880.06642
+  dps: 38675.25088
+  tps: 22928.44309
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 39258.56132
-  tps: 23138.34595
+  dps: 39398.60009
+  tps: 23345.88486
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 39185.48013
-  tps: 23223.82012
+  dps: 39060.22978
+  tps: 23212.88718
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 39629.30677
-  tps: 23552.82373
+  dps: 39510.50111
+  tps: 23405.40554
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-StayofExecution-68996"
  value: {
-  dps: 37994.36195
-  tps: 22426.55276
+  dps: 37975.68447
+  tps: 22507.6043
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 39095.7533
-  tps: 23060.95284
+  dps: 39185.20217
+  tps: 23203.65167
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-StumpofTime-62465"
  value: {
-  dps: 39210.54823
-  tps: 23128.14914
+  dps: 39183.95406
+  tps: 23178.79921
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-StumpofTime-62470"
  value: {
-  dps: 39255.6866
-  tps: 23130.32036
+  dps: 39231.47803
+  tps: 23185.26912
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 38033.90166
-  tps: 22460.52451
+  dps: 38012.34534
+  tps: 22515.06696
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 38033.90166
-  tps: 22460.59286
+  dps: 38012.34534
+  tps: 22515.13531
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 39211.8546
-  tps: 23147.70937
+  dps: 39180.17742
+  tps: 23210.45963
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TearofBlood-55819"
  value: {
-  dps: 38800.99668
-  tps: 22896.78222
+  dps: 38779.55819
+  tps: 22983.02569
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TearofBlood-56351"
  value: {
-  dps: 39022.50025
-  tps: 23042.31802
+  dps: 39051.35007
+  tps: 23131.86185
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 39093.32174
-  tps: 23076.37634
+  dps: 39069.2753
+  tps: 23132.00031
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 39457.97503
-  tps: 23275.50252
+  dps: 39435.93153
+  tps: 23329.23347
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TheHungerer-68927"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TheHungerer-69112"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 39828.06899
-  tps: 23533.08179
+  dps: 39837.54164
+  tps: 23615.69044
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 40073.04459
-  tps: 23675.72044
+  dps: 40085.54353
+  tps: 23761.05063
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 38428.31636
-  tps: 22707.31604
+  dps: 38398.14718
+  tps: 22755.424
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 38478.86518
-  tps: 22738.81197
+  dps: 38448.66885
+  tps: 22786.96892
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 39040.26565
-  tps: 23206.1395
+  dps: 38906.72117
+  tps: 23039.96595
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-UnheededWarning-59520"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 37994.36195
-  tps: 22426.48809
+  dps: 37975.68447
+  tps: 22507.54771
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 38485.87407
-  tps: 22732.30156
+  dps: 38466.57957
+  tps: 22814.27788
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 38485.87407
-  tps: 22732.30156
+  dps: 38466.57957
+  tps: 22814.27788
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 38485.87407
-  tps: 22732.30156
+  dps: 38466.57957
+  tps: 22814.27788
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 39553.06607
-  tps: 23372.00576
+  dps: 39388.13751
+  tps: 23335.38689
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 38441.18138
-  tps: 22713.39458
+  dps: 38397.34218
+  tps: 22754.47369
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VeilofLies-72900"
  value: {
-  dps: 38020.02309
-  tps: 22454.39605
+  dps: 38012.34534
+  tps: 22515.16949
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 38142.62039
-  tps: 22506.42476
+  dps: 38085.8308
+  tps: 22573.86875
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 38144.84803
-  tps: 22518.4744
+  dps: 38086.48117
+  tps: 22567.28087
  }
 }
 dps_results: {
@@ -1728,420 +1728,420 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-VialofShadows-77207"
  value: {
-  dps: 38208.49533
-  tps: 22636.28899
+  dps: 38182.89937
+  tps: 22687.90215
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VialofShadows-77979"
  value: {
-  dps: 38191.92852
-  tps: 22620.10526
+  dps: 38153.11514
+  tps: 22655.96503
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VialofShadows-77999"
  value: {
-  dps: 38216.14322
-  tps: 22641.56735
+  dps: 38184.99149
+  tps: 22688.63259
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 38033.90166
-  tps: 22460.52451
+  dps: 38012.34534
+  tps: 22515.06696
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 38033.90166
-  tps: 22460.59286
+  dps: 38012.34534
+  tps: 22515.13531
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 37994.36195
-  tps: 22426.55276
+  dps: 37975.68447
+  tps: 22507.6043
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sBadgeofConquest-70517"
  value: {
-  dps: 37994.36195
-  tps: 22426.55276
+  dps: 37975.68447
+  tps: 22507.6043
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 39134.74259
-  tps: 23012.50563
+  dps: 39117.73218
+  tps: 23100.86722
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sBadgeofDominance-70518"
  value: {
-  dps: 39269.0304
-  tps: 23081.50569
+  dps: 39252.2163
+  tps: 23170.72809
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 37994.36195
-  tps: 22426.55276
+  dps: 37975.68447
+  tps: 22507.6043
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sBadgeofVictory-70519"
  value: {
-  dps: 37994.36195
-  tps: 22426.55276
+  dps: 37975.68447
+  tps: 22507.6043
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 38042.30725
-  tps: 22467.28758
+  dps: 38012.34534
+  tps: 22515.02143
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 38540.99733
-  tps: 22710.34268
+  dps: 38689.62307
+  tps: 22888.6644
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 38622.8216
-  tps: 22841.16984
+  dps: 38499.43768
+  tps: 22740.22468
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 38042.30725
-  tps: 22467.28758
+  dps: 38012.34534
+  tps: 22515.02143
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 38563.1132
-  tps: 22791.79106
+  dps: 38532.87163
+  tps: 22840.02966
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 38042.30725
-  tps: 22467.28758
+  dps: 38012.34534
+  tps: 22515.02143
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sInsigniaofConquest-70577"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 39055.65618
-  tps: 23017.03929
+  dps: 39013.93756
+  tps: 23061.49154
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sInsigniaofDominance-70578"
  value: {
-  dps: 39169.3674
-  tps: 23093.8671
+  dps: 39138.80249
+  tps: 23140.4116
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-ViciousGladiator'sInsigniaofVictory-70579"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 41151.68444
-  tps: 24360.63569
+  dps: 41088.35323
+  tps: 24337.77154
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 40766.84464
-  tps: 24118.99253
+  dps: 40716.76206
+  tps: 24111.05596
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WillofUnbinding-77995"
  value: {
-  dps: 41539.43331
-  tps: 24575.54107
+  dps: 41506.93081
+  tps: 24572.56331
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 39338.32715
-  tps: 23345.2139
+  dps: 39201.5547
+  tps: 23180.39146
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 39795.72593
-  tps: 23655.79378
+  dps: 39841.97794
+  tps: 23707.76778
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 38329.69265
-  tps: 22635.14774
+  dps: 38310.59421
+  tps: 22716.8302
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 38042.30725
-  tps: 22466.8017
+  dps: 38012.34534
+  tps: 22514.53555
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 38412.97848
-  tps: 22702.72981
+  dps: 38363.6237
+  tps: 22718.30646
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 38412.97848
-  tps: 22702.72981
+  dps: 38363.6237
+  tps: 22718.30646
  }
 }
 dps_results: {
  key: "TestDestruction-Average-Default"
  value: {
-  dps: 41082.55381
-  tps: 24262.44965
+  dps: 41111.19848
+  tps: 24289.79909
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Goblin-p3-Destruction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 41864.92935
-  tps: 42105.90851
+  dps: 41802.26693
+  tps: 42313.17909
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Goblin-p3-Destruction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 40031.20265
-  tps: 23943.78893
+  dps: 40079.62114
+  tps: 24028.62833
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Goblin-p3-Destruction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 50419.71466
-  tps: 28741.59809
+  dps: 50657.95733
+  tps: 28966.88087
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Goblin-p3-Destruction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 26214.48301
-  tps: 30138.44154
+  dps: 26032.18127
+  tps: 29881.0243
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Goblin-p3-Destruction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 26214.48301
-  tps: 15626.42597
+  dps: 26032.18127
+  tps: 15459.43191
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Goblin-p3-Destruction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 29047.15886
-  tps: 16008.59796
+  dps: 28792.01484
+  tps: 15868.25505
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p3-Destruction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 41787.23971
-  tps: 41991.24163
+  dps: 41710.38411
+  tps: 42074.84233
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p3-Destruction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39785.19165
-  tps: 23771.24223
+  dps: 39926.11202
+  tps: 23875.30217
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p3-Destruction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 50507.4534
-  tps: 28586.63525
+  dps: 50807.51416
+  tps: 28832.69877
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p3-Destruction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 26034.19234
-  tps: 29782.97466
+  dps: 25905.31371
+  tps: 29667.11218
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p3-Destruction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 26034.19234
-  tps: 15405.86088
+  dps: 25905.31371
+  tps: 15344.41136
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Human-p3-Destruction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 28756.09889
-  tps: 15763.87397
+  dps: 28417.72007
+  tps: 15437.79289
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p3-Destruction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 42439.69792
-  tps: 42147.27435
+  dps: 42364.42119
+  tps: 42223.4028
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p3-Destruction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 40439.94755
-  tps: 23933.1579
+  dps: 40581.30779
+  tps: 24036.45451
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p3-Destruction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 51796.63467
-  tps: 28910.28009
+  dps: 52102.90691
+  tps: 29154.89079
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p3-Destruction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 26498.86624
-  tps: 30001.32797
+  dps: 26366.30081
+  tps: 29759.15083
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p3-Destruction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 26498.86624
-  tps: 15517.57679
+  dps: 26366.30081
+  tps: 15452.31958
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Orc-p3-Destruction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 29568.80944
-  tps: 15934.33507
+  dps: 29236.47179
+  tps: 15604.65691
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p3-Destruction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 42134.2922
-  tps: 42384.79575
+  dps: 42119.67466
+  tps: 42250.33165
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p3-Destruction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 40367.40146
-  tps: 24190.57611
+  dps: 40355.69861
+  tps: 24215.02543
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p3-Destruction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 52013.38851
-  tps: 29526.12647
+  dps: 51612.35402
+  tps: 29184.03934
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p3-Destruction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 26287.98385
-  tps: 30183.70785
+  dps: 26085.9926
+  tps: 30069.74331
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p3-Destruction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 26287.98385
-  tps: 15616.17596
+  dps: 26085.9926
+  tps: 15599.41586
  }
 }
 dps_results: {
  key: "TestDestruction-Settings-Troll-p3-Destruction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 29630.53286
-  tps: 16430.73634
+  dps: 29671.09025
+  tps: 16495.3215
  }
 }
 dps_results: {
  key: "TestDestruction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 40430.22634
-  tps: 23933.1579
+  dps: 40571.58659
+  tps: 24036.45451
  }
 }

--- a/sim/warlock/items.go
+++ b/sim/warlock/items.go
@@ -52,7 +52,7 @@ var ItemSetMaleficRaiment = core.NewItemSet(core.ItemSet{
 				ActionIDForProc: aura.ActionID,
 				OnPeriodicDamageDealt: func(_ *core.Aura, sim *core.Simulation, spell *core.Spell, _ *core.SpellResult) {
 					if spell.Matches(WarlockSpellImmolateDot|WarlockSpellUnstableAffliction) &&
-						sim.Proc(0.02, "Warlock 4pT11") {
+						sim.Proc(0.02, "Item - Warlock T11 4P Bonus") {
 						aura.Activate(sim)
 						aura.SetStacks(sim, 2)
 					}
@@ -153,7 +153,7 @@ var ItemSetBalespidersBurningVestments = core.NewItemSet(core.ItemSet{
 					Duration: 45 * time.Second,
 				},
 				OnPeriodicDamageDealt: func(aura *core.Aura, sim *core.Simulation, _ *core.Spell, _ *core.SpellResult) {
-					if aura.Icd.IsReady(sim) && sim.Proc(0.05, "Warlock 2pT12") {
+					if aura.Icd.IsReady(sim) && sim.Proc(0.05, "Item - Warlock T12 2P Bonus") {
 						warlock.FieryImp.EnableWithTimeout(sim, warlock.FieryImp, 15*time.Second)
 						aura.Icd.Use(sim)
 					}
@@ -187,7 +187,7 @@ var ItemSetBalespidersBurningVestments = core.NewItemSet(core.ItemSet{
 				ActionIDForProc: aura.ActionID,
 				OnCastComplete: func(_ *core.Aura, sim *core.Simulation, spell *core.Spell) {
 					if spell.Matches(WarlockSpellShadowBolt|WarlockSpellIncinerate|WarlockSpellSoulFire|WarlockSpellDrainSoul) &&
-						sim.Proc(0.05, "Warlock 4pT12") {
+						sim.Proc(0.05, "Item - Warlock T12 4P Bonus") {
 						aura.Activate(sim)
 					}
 				},

--- a/sim/warrior/fury/TestFury.results
+++ b/sim/warrior/fury/TestFury.results
@@ -45,8 +45,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-AgonyandTorment"
  value: {
-  dps: 29508.98861
-  tps: 24665.74146
+  dps: 29386.65237
+  tps: 24468.34123
  }
 }
 dps_results: {

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -45,8 +45,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-AgonyandTorment"
  value: {
-  dps: 3962.47949
-  tps: 23461.20537
+  dps: 3972.65632
+  tps: 23497.12073
  }
 }
 dps_results: {


### PR DESCRIPTION
This is a benign PR that simply changes a few RNG seed labels for set bonuses to match the refactors in #1253 , so that we can more clearly assess any true results changes caused by #1253 .