### PR TITLE
Fix Rogue 4pT13 to correctly add 9s to Vendetta duration

### DIFF
--- a/sim/rogue/assassination/TestAssassination.results
+++ b/sim/rogue/assassination/TestAssassination.results
@@ -174,8 +174,8 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-BlackfangBattleweave"
  value: {
-  dps: 27833.11682
-  tps: 19761.51294
+  dps: 28147.3748
+  tps: 19984.6361
  }
 }
 dps_results: {
@@ -2437,169 +2437,169 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-Assassination-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 54499.60733
-  tps: 38694.7212
+  dps: 55080.59031
+  tps: 39107.21912
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-Assassination-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 54499.60733
-  tps: 38694.7212
+  dps: 55080.59031
+  tps: 39107.21912
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-Assassination-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 69793.2058
-  tps: 49553.17612
+  dps: 70960.03037
+  tps: 50381.62156
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-Assassination-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 33205.09094
-  tps: 23575.61457
+  dps: 33575.82611
+  tps: 23838.83654
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-Assassination-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 33205.09094
-  tps: 23575.61457
+  dps: 33575.82611
+  tps: 23838.83654
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-Assassination-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 36442.0357
-  tps: 25873.84534
+  dps: 37146.99331
+  tps: 26374.36525
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 41793.6737
-  tps: 29673.50833
+  dps: 42240.29222
+  tps: 29990.60748
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 41793.6737
-  tps: 29673.50833
+  dps: 42240.29222
+  tps: 29990.60748
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 53464.88687
-  tps: 37960.06968
+  dps: 54387.48528
+  tps: 38615.11455
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 25534.59521
-  tps: 18129.5626
+  dps: 25820.56964
+  tps: 18332.60444
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 25534.59521
-  tps: 18129.5626
+  dps: 25820.56964
+  tps: 18332.60444
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 28327.09226
-  tps: 20112.2355
+  dps: 28893.4139
+  tps: 20514.32387
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 55485.05494
-  tps: 39394.389
+  dps: 56086.35515
+  tps: 39821.31215
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 55485.05494
-  tps: 39394.389
+  dps: 56086.35515
+  tps: 39821.31215
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 71209.64337
-  tps: 50558.84679
+  dps: 72391.8827
+  tps: 51398.23672
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 33753.29927
-  tps: 23964.84248
+  dps: 34132.13202
+  tps: 24233.81373
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 33753.29927
-  tps: 23964.84248
+  dps: 34132.13202
+  tps: 24233.81373
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 37029.19334
-  tps: 26290.72727
+  dps: 37750.34904
+  tps: 26802.74782
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 28199.69053
-  tps: 20021.78028
+  dps: 28460.07859
+  tps: 20206.6558
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 28199.69053
-  tps: 20021.78028
+  dps: 28460.07859
+  tps: 20206.6558
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 35994.77997
-  tps: 25556.29378
+  dps: 36445.74832
+  tps: 25876.4813
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 16517.95383
-  tps: 11727.74722
+  dps: 16660.54813
+  tps: 11828.98917
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 16517.95383
-  tps: 11727.74722
+  dps: 16660.54813
+  tps: 11828.98917
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 18812.8833
-  tps: 13357.14715
+  dps: 19077.58485
+  tps: 13545.08525
  }
 }
 dps_results: {
@@ -2941,169 +2941,169 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-Assassination-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 54878.55017
-  tps: 38963.77062
+  dps: 55459.46132
+  tps: 39376.21754
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-Assassination-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 54878.55017
-  tps: 38963.77062
+  dps: 55459.46132
+  tps: 39376.21754
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-Assassination-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 70531.55198
-  tps: 50077.40191
+  dps: 71698.23284
+  tps: 50905.74531
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-Assassination-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 33463.59075
-  tps: 23759.14943
+  dps: 33834.27785
+  tps: 24022.33728
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-Assassination-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 33463.59075
-  tps: 23759.14943
+  dps: 33834.27785
+  tps: 24022.33728
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-Assassination-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 36868.00399
-  tps: 26176.28283
+  dps: 37572.86993
+  tps: 26676.73765
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 42071.8844
-  tps: 29871.03792
+  dps: 42518.44916
+  tps: 30188.0989
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 42071.8844
-  tps: 29871.03792
+  dps: 42518.44916
+  tps: 30188.0989
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 54023.98863
-  tps: 38357.03193
+  dps: 54946.47604
+  tps: 39011.99799
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 25727.64097
-  tps: 18266.62509
+  dps: 26013.57937
+  tps: 18469.64135
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 25727.64097
-  tps: 18266.62509
+  dps: 26013.57937
+  tps: 18469.64135
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 28655.80416
-  tps: 20345.62095
+  dps: 29222.05338
+  tps: 20747.6579
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 55869.26282
-  tps: 39667.1766
+  dps: 56470.48857
+  tps: 40094.04688
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 55869.26282
-  tps: 39667.1766
+  dps: 56470.48857
+  tps: 40094.04688
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 71966.77245
-  tps: 51096.40844
+  dps: 73148.86603
+  tps: 51935.69488
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 34015.2566
-  tps: 24150.83218
+  dps: 34394.0403
+  tps: 24419.76861
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 34015.2566
-  tps: 24150.83218
+  dps: 34394.0403
+  tps: 24419.76861
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 37465.06298
-  tps: 26600.19471
+  dps: 38186.12468
+  tps: 27112.14852
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 28392.88629
-  tps: 20158.94926
+  dps: 28653.24362
+  tps: 20343.80297
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 28392.88629
-  tps: 20158.94926
+  dps: 28653.24362
+  tps: 20343.80297
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 36405.3604
-  tps: 25847.80588
+  dps: 36856.27563
+  tps: 26167.9557
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 16664.21745
-  tps: 11831.59439
+  dps: 16807.93006
+  tps: 11933.63034
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 16664.21745
-  tps: 11831.59439
+  dps: 16807.93006
+  tps: 11933.63034
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 19050.45258
-  tps: 13525.82133
+  dps: 19315.07128
+  tps: 13713.70061
  }
 }
 dps_results: {

--- a/sim/rogue/assassination/vendetta.go
+++ b/sim/rogue/assassination/vendetta.go
@@ -16,7 +16,7 @@ func (sinRogue *AssassinationRogue) registerVendetta() {
 	actionID := core.ActionID{SpellID: 79140}
 	hasGlyph := sinRogue.HasPrimeGlyph(proto.RoguePrimeGlyph_GlyphOfVendetta)
 	t13Bonus := sinRogue.HasSetBonus(rogue.Tier13, 4)
-	duration := time.Duration((30.0+core.TernaryFloat64(t13Bonus, 3.0, 0))*core.TernaryFloat64(hasGlyph, 1.2, 1.0)) * time.Second
+	duration := time.Duration((30.0+core.TernaryFloat64(t13Bonus, 9.0, 0))*core.TernaryFloat64(hasGlyph, 1.2, 1.0)) * time.Second
 
 	vendettaAura := sinRogue.NewEnemyAuraArray(func(target *core.Unit) *core.Aura {
 		return target.GetOrRegisterAura(core.Aura{


### PR DESCRIPTION
Merging separately from #1253 for a cleaner final unit test comparison in #1253 .