### PR TITLE
Feature/add trinket swapping aura icd

### DIFF
--- a/sim/common/shared/shared_utils.go
+++ b/sim/common/shared/shared_utils.go
@@ -171,11 +171,12 @@ func factory_StatBonusEffect(config ProcStatBonusEffect, extraSpell func(agent c
 			procAura.Icd = triggerAura.Icd
 		}
 
-		triggerAura.ApplyOnGain(func(_ *core.Aura, _ *core.Simulation) {
-			procAura.Enable()
+		triggerAura.ApplyOnGain(func(aura *core.Aura, sim *core.Simulation) {
+			procAura.Enable(sim)
 		})
-		triggerAura.ApplyOnExpire(func(_ *core.Aura, _ *core.Simulation) {
-			procAura.Disable()
+
+		triggerAura.ApplyOnExpire(func(aura *core.Aura, sim *core.Simulation) {
+			procAura.Disable(sim)
 		})
 
 		if isEnchant {

--- a/sim/common/shared/shared_utils.go
+++ b/sim/common/shared/shared_utils.go
@@ -171,6 +171,13 @@ func factory_StatBonusEffect(config ProcStatBonusEffect, extraSpell func(agent c
 			procAura.Icd = triggerAura.Icd
 		}
 
+		triggerAura.ApplyOnGain(func(_ *core.Aura, _ *core.Simulation) {
+			procAura.Enable()
+		})
+		triggerAura.ApplyOnExpire(func(_ *core.Aura, _ *core.Simulation) {
+			procAura.Disable()
+		})
+
 		if isEnchant {
 			character.ItemSwap.RegisterEnchantProc(effectID, triggerAura)
 		} else {

--- a/sim/core/apl_actions_misc.go
+++ b/sim/core/apl_actions_misc.go
@@ -86,6 +86,13 @@ func (action *APLActionActivateAura) Execute(sim *Simulation) {
 	if sim.Log != nil {
 		action.aura.Unit.Log(sim, "Activating aura %s", action.aura.ActionID)
 	}
+	if action.aura.ActionID.SpellID == 109789 {
+		fmt.Println("APLActionActivateAura.Execute", action.aura.ActionID, sim.CurrentTime, action.aura.Icd.Duration, action.aura.Icd.ReadyAt(), action.aura.Icd.IsReady(sim))
+	}
+	if action.aura.Icd != nil && !action.aura.Icd.IsReady(sim) {
+		return
+	}
+
 	action.aura.Activate(sim)
 	if action.aura.Icd != nil {
 		action.aura.Icd.Use(sim)

--- a/sim/core/apl_actions_misc.go
+++ b/sim/core/apl_actions_misc.go
@@ -87,6 +87,9 @@ func (action *APLActionActivateAura) Execute(sim *Simulation) {
 		action.aura.Unit.Log(sim, "Activating aura %s", action.aura.ActionID)
 	}
 
+	if action.aura.Icd != nil {
+		fmt.Println("Aura ready", action.aura.ActionID, action.aura.Icd.IsReady(sim), action.aura)
+	}
 	if action.aura.Icd != nil && !action.aura.Icd.IsReady(sim) {
 		return
 	}

--- a/sim/core/apl_actions_misc.go
+++ b/sim/core/apl_actions_misc.go
@@ -83,15 +83,21 @@ func (action *APLActionActivateAura) IsReady(sim *Simulation) bool {
 }
 
 func (action *APLActionActivateAura) Execute(sim *Simulation) {
-	if sim.Log != nil {
-		action.aura.Unit.Log(sim, "Activating aura %s", action.aura.ActionID)
-	}
-
-	if action.aura.Icd != nil {
-		fmt.Println("Aura ready", action.aura.ActionID, action.aura.Icd.IsReady(sim), action.aura)
+	if !action.aura.IsEnabled() {
+		if sim.Log != nil {
+			action.aura.Unit.Log(sim, "Could not activate disabled aura %s", action.aura.ActionID)
+		}
+		return
 	}
 	if action.aura.Icd != nil && !action.aura.Icd.IsReady(sim) {
+		if sim.Log != nil {
+			action.aura.Unit.Log(sim, "Could not activate aura %s because it's on ICD for %s", action.aura.ActionID, action.aura.Icd.TimeToReady(sim))
+		}
 		return
+	}
+
+	if sim.Log != nil {
+		action.aura.Unit.Log(sim, "Activating aura %s", action.aura.ActionID)
 	}
 
 	action.aura.Activate(sim)
@@ -128,12 +134,21 @@ func (action *APLActionActivateAuraWithStacks) IsReady(sim *Simulation) bool {
 	return true
 }
 func (action *APLActionActivateAuraWithStacks) Execute(sim *Simulation) {
-	if sim.Log != nil {
-		action.aura.Unit.Log(sim, "Activating aura %s (%d stacks)", action.aura.ActionID, action.numStacks)
+	if !action.aura.IsEnabled() {
+		if sim.Log != nil {
+			action.aura.Unit.Log(sim, "Could not activate disabled aura %s (%d stacks)", action.aura.ActionID, action.numStacks)
+		}
+		return
+	}
+	if action.aura.Icd != nil && !action.aura.Icd.IsReady(sim) {
+		if sim.Log != nil {
+			action.aura.Unit.Log(sim, "Could not activate aura %s (%d stacks) because it's on ICD for %s", action.aura.ActionID, action.numStacks, action.aura.Icd.TimeToReady(sim))
+		}
+		return
 	}
 
-	if action.aura.Icd != nil && !action.aura.Icd.IsReady(sim) {
-		return
+	if sim.Log != nil {
+		action.aura.Unit.Log(sim, "Activating aura %s (%d stacks)", action.aura.ActionID, action.numStacks)
 	}
 
 	action.aura.Activate(sim)

--- a/sim/core/apl_actions_misc.go
+++ b/sim/core/apl_actions_misc.go
@@ -86,9 +86,7 @@ func (action *APLActionActivateAura) Execute(sim *Simulation) {
 	if sim.Log != nil {
 		action.aura.Unit.Log(sim, "Activating aura %s", action.aura.ActionID)
 	}
-	if action.aura.ActionID.SpellID == 109789 {
-		fmt.Println("APLActionActivateAura.Execute", action.aura.ActionID, sim.CurrentTime, action.aura.Icd.Duration, action.aura.Icd.ReadyAt(), action.aura.Icd.IsReady(sim))
-	}
+
 	if action.aura.Icd != nil && !action.aura.Icd.IsReady(sim) {
 		return
 	}
@@ -130,6 +128,11 @@ func (action *APLActionActivateAuraWithStacks) Execute(sim *Simulation) {
 	if sim.Log != nil {
 		action.aura.Unit.Log(sim, "Activating aura %s (%d stacks)", action.aura.ActionID, action.numStacks)
 	}
+
+	if action.aura.Icd != nil && !action.aura.Icd.IsReady(sim) {
+		return
+	}
+
 	action.aura.Activate(sim)
 	action.aura.SetStacks(sim, action.numStacks)
 }

--- a/sim/core/item_swaps.go
+++ b/sim/core/item_swaps.go
@@ -1,7 +1,6 @@
 package core
 
 import (
-	"fmt"
 	"slices"
 	"time"
 
@@ -169,14 +168,9 @@ func (swap *ItemSwap) registerProcInternal(config ItemSwapProcConfig) {
 		} else {
 			config.Aura.Deactivate(sim)
 		}
-
 		// Enchant effects such as Weapon/Back do not trigger an ICD
 		if isItemProc && config.Aura.Icd != nil {
 			config.Aura.Icd.Use(sim)
-		}
-
-		if config.Aura.Icd != nil {
-			fmt.Println("registerProcInternal", sim.CurrentTime, config.ItemID, isItemSlotMatch, config.Aura.ActionID, config.Aura.Icd.ReadyAt())
 		}
 	})
 }
@@ -198,7 +192,6 @@ func (swap *ItemSwap) RegisterActive(itemID int32) {
 				aura.Deactivate(sim)
 			}
 			if !hasItemEquipped {
-				fmt.Println("Item not equipped", itemID)
 				spell.Flags |= SpellFlagSwapped
 				return
 			}
@@ -293,11 +286,9 @@ func (swap *ItemSwap) EligibleSlotsForEffect(effectID int32) []proto.ItemSlot {
 }
 
 func (swap *ItemSwap) SwapItems(sim *Simulation, swapSet proto.APLActionItemSwap_SwapSet, isReset bool) {
-	fmt.Println("SwapItems", sim.CurrentTime, swap.swapSet, swapSet, isReset)
-	if !swap.IsEnabled() || !isReset && !swap.IsValidSwap(swapSet) {
+	if !swap.IsEnabled() || !swap.IsValidSwap(swapSet) && !isReset {
 		return
 	}
-	fmt.Println("Swapping", sim.CurrentTime, swap.swapSet, swapSet, isReset)
 
 	character := swap.character
 
@@ -315,6 +306,10 @@ func (swap *ItemSwap) SwapItems(sim *Simulation, swapSet proto.APLActionItemSwap
 		for _, onSwap := range swap.onSwapCallbacks[slot] {
 			onSwap(sim, slot)
 		}
+	}
+
+	if !swap.IsValidSwap(swapSet) && isReset {
+		return
 	}
 
 	statsToSwap := Ternary(isPrepull, swap.equipmentStats.allSlots, swap.equipmentStats.weaponSlots)

--- a/sim/core/item_swaps.go
+++ b/sim/core/item_swaps.go
@@ -176,7 +176,7 @@ func (swap *ItemSwap) registerProcInternal(config ItemSwapProcConfig) {
 		}
 
 		if config.Aura.Icd != nil {
-			fmt.Println("registerProcInternal", sim.CurrentTime, config.ItemID, config.Aura.Icd.ReadyAt())
+			fmt.Println("registerProcInternal", sim.CurrentTime, config.ItemID, isItemSlotMatch, config.Aura.ActionID, config.Aura.Icd.ReadyAt())
 		}
 	})
 }
@@ -184,7 +184,7 @@ func (swap *ItemSwap) registerProcInternal(config ItemSwapProcConfig) {
 // Helper for handling Item On Use effects to set a 30s cd on the related spell.
 func (swap *ItemSwap) RegisterActive(itemID int32) {
 	slots := swap.EligibleSlotsForItem(itemID)
-	if !swap.ItemExistsInSwapSet(itemID, slots) {
+	if !swap.CanRegisterItemCallback(itemID, slots) {
 		return
 	}
 
@@ -250,11 +250,15 @@ func (swap *ItemSwap) GetUnequippedItemBySlot(slot proto.ItemSlot) *Item {
 	return &swap.unEquippedItems[slot]
 }
 
+func (swap *ItemSwap) CanRegisterItemCallback(itemID int32, possibleSlots []proto.ItemSlot) bool {
+	return swap.ItemExistsInMainEquip(itemID, possibleSlots) || swap.ItemExistsInSwapEquip(itemID, possibleSlots)
+}
+
 func (swap *ItemSwap) ItemExistsInMainEquip(itemID int32, possibleSlots []proto.ItemSlot) bool {
 	return swap.originalEquip.containsItemInSlots(itemID, possibleSlots)
 }
 
-func (swap *ItemSwap) ItemExistsInSwapSet(itemID int32, possibleSlots []proto.ItemSlot) bool {
+func (swap *ItemSwap) ItemExistsInSwapEquip(itemID int32, possibleSlots []proto.ItemSlot) bool {
 	return swap.swapEquip.containsItemInSlots(itemID, possibleSlots)
 }
 

--- a/sim/death_knight/frost/TestFrost.results
+++ b/sim/death_knight/frost/TestFrost.results
@@ -2380,291 +2380,99 @@ dps_results: {
  }
 }
 dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-DefaultTalents-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
+ key: "TestFrost-Settings-Orc-p3.masterfrost-Basic-item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 132833.53464
-  tps: 130451.14991
-  hps: 580.99232
+  dps: 132809.95817
+  tps: 130442.07202
+  hps: 574.34903
  }
 }
 dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-DefaultTalents-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
+ key: "TestFrost-Settings-Orc-p3.masterfrost-Basic-item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 40764.14516
-  tps: 38397.7855
-  hps: 521.10422
+  dps: 40049.87009
+  tps: 37726.55542
+  hps: 515.32293
  }
 }
 dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-DefaultTalents-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
+ key: "TestFrost-Settings-Orc-p3.masterfrost-Basic-item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 51497.02687
-  tps: 44705.57238
-  hps: 614.43632
+  dps: 48836.62103
+  tps: 42372.73047
+  hps: 596.56462
  }
 }
 dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-DefaultTalents-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
+ key: "TestFrost-Settings-Orc-p3.masterfrost-Basic-item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 87666.19576
-  tps: 86010.24476
-  hps: 472.19948
+  dps: 85936.16598
+  tps: 84260.44939
+  hps: 490.12197
  }
 }
 dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-DefaultTalents-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
+ key: "TestFrost-Settings-Orc-p3.masterfrost-Basic-item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 27303.75763
-  tps: 25650.08347
-  hps: 419.4201
+  dps: 27097.43483
+  tps: 25423.80302
+  hps: 439.5741
  }
 }
 dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-DefaultTalents-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
+ key: "TestFrost-Settings-Orc-p3.masterfrost-Basic-item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 32462.32721
-  tps: 27584.49845
-  hps: 467.97712
+  dps: 31197.39654
+  tps: 26342.39016
+  hps: 479.37762
  }
 }
 dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-DualWield-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
+ key: "TestFrost-Settings-Worgen-p3.masterfrost-Basic-item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 127185.79675
-  tps: 124811.06596
-  hps: 577.88125
+  dps: 130812.70026
+  tps: 128535.12025
+  hps: 575.17067
  }
 }
 dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-DualWield-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
+ key: "TestFrost-Settings-Worgen-p3.masterfrost-Basic-item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 40378.99222
-  tps: 38012.46869
-  hps: 527.32637
+  dps: 40002.96304
+  tps: 37737.18759
+  hps: 521.3694
  }
 }
 dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-DualWield-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
+ key: "TestFrost-Settings-Worgen-p3.masterfrost-Basic-item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 51257.76297
-  tps: 44304.87616
-  hps: 629.99168
+  dps: 48108.33202
+  tps: 41809.87066
+  hps: 603.93401
  }
 }
 dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-DualWield-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
+ key: "TestFrost-Settings-Worgen-p3.masterfrost-Basic-item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 84492.69883
-  tps: 82839.90885
-  hps: 468.68085
+  dps: 86049.93039
+  tps: 84408.7583
+  hps: 492.7942
  }
 }
 dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-DualWield-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
+ key: "TestFrost-Settings-Worgen-p3.masterfrost-Basic-item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26938.41312
-  tps: 25268.34255
-  hps: 423.64245
+  dps: 27038.67695
+  tps: 25393.44493
+  hps: 446.44656
  }
 }
 dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-DualWield-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
+ key: "TestFrost-Settings-Worgen-p3.masterfrost-Basic-item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 32066.15655
-  tps: 27205.6691
-  hps: 485.57025
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-TwoHand-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 117208.5077
-  tps: 114939.62599
-  hps: 247.33006
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-TwoHand-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 30160.66129
-  tps: 27849.67166
-  hps: 251.99667
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-TwoHand-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 38764.68304
-  tps: 32601.29536
-  hps: 268.32979
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-TwoHand-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 78118.76028
-  tps: 76476.51131
-  hps: 192.11692
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-TwoHand-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 20116.30781
-  tps: 18481.85577
-  hps: 192.11692
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Orc-p3.masterfrost-TwoHand-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 24540.25144
-  tps: 19953.3313
-  hps: 165.37537
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Worgen-p3.masterfrost-DefaultTalents-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 131651.87299
-  tps: 129353.91411
-  hps: 584.82589
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Worgen-p3.masterfrost-DefaultTalents-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 40456.61886
-  tps: 38161.76936
-  hps: 527.27653
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Worgen-p3.masterfrost-DefaultTalents-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 50831.24106
-  tps: 44191.31023
-  hps: 622.1552
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Worgen-p3.masterfrost-DefaultTalents-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 87583.84892
-  tps: 85949.49318
-  hps: 478.4854
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Worgen-p3.masterfrost-DefaultTalents-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 27090.51977
-  tps: 25454.56503
-  hps: 424.30396
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Worgen-p3.masterfrost-DefaultTalents-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 32069.74508
-  tps: 27254.84668
-  hps: 474.96713
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Worgen-p3.masterfrost-DualWield-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 126011.19167
-  tps: 123682.56316
-  hps: 584.82589
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Worgen-p3.masterfrost-DualWield-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 40225.56588
-  tps: 37919.13214
-  hps: 532.72039
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Worgen-p3.masterfrost-DualWield-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 50587.18375
-  tps: 43853.45815
-  hps: 637.70908
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Worgen-p3.masterfrost-DualWield-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 84302.7102
-  tps: 82675.18596
-  hps: 474.96712
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Worgen-p3.masterfrost-DualWield-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 26936.15814
-  tps: 25316.25637
-  hps: 427.11858
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Worgen-p3.masterfrost-DualWield-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 32033.1213
-  tps: 27258.8418
-  hps: 492.5585
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Worgen-p3.masterfrost-TwoHand-Basic-masterfrost-FullBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 117246.8602
-  tps: 115017.52841
-  hps: 248.86208
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Worgen-p3.masterfrost-TwoHand-Basic-masterfrost-FullBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 30058.53322
-  tps: 27815.9021
-  hps: 250.41747
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Worgen-p3.masterfrost-TwoHand-Basic-masterfrost-FullBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 38335.16838
-  tps: 32284.54322
-  hps: 264.41596
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Worgen-p3.masterfrost-TwoHand-Basic-masterfrost-NoBuffs-0.0yards-LongMultiTarget"
- value: {
-  dps: 78115.20334
-  tps: 76515.8076
-  hps: 198.43071
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Worgen-p3.masterfrost-TwoHand-Basic-masterfrost-NoBuffs-0.0yards-LongSingleTarget"
- value: {
-  dps: 19981.7618
-  tps: 18384.03753
-  hps: 193.50513
- }
-}
-dps_results: {
- key: "TestFrost-Settings-Worgen-p3.masterfrost-TwoHand-Basic-masterfrost-NoBuffs-0.0yards-ShortSingleTarget"
- value: {
-  dps: 24115.07134
-  tps: 19596.47159
-  hps: 165.35893
+  dps: 30676.35245
+  tps: 25904.38384
+  hps: 472.56053
  }
 }
 dps_results: {

--- a/sim/warlock/demonology/TestDemonology.results
+++ b/sim/warlock/demonology/TestDemonology.results
@@ -1994,673 +1994,673 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 56255.92196
-  tps: 47924.1349
+  dps: 57812.84551
+  tps: 49971.08112
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39453.36455
-  tps: 19740.98775
+  dps: 40895.50581
+  tps: 20701.76493
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 58596.21242
-  tps: 27017.15095
+  dps: 60401.4096
+  tps: 28113.69125
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 48479.95459
-  tps: 44508.82953
+  dps: 49882.05215
+  tps: 45919.55801
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28742.13451
-  tps: 14167.71598
+  dps: 29439.33182
+  tps: 14612.51565
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 40023.59617
-  tps: 18061.89648
+  dps: 40352.22892
+  tps: 18348.04247
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 56041.21316
-  tps: 47002.65867
+  dps: 57655.92977
+  tps: 48560.85268
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39931.34828
-  tps: 20926.03998
+  dps: 41175.13462
+  tps: 21853.60326
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 60135.5683
-  tps: 29769.26682
+  dps: 61126.09466
+  tps: 30100.83901
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 48911.69345
-  tps: 42772.84701
+  dps: 49450.71064
+  tps: 43280.46471
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29173.44782
-  tps: 14959.02566
+  dps: 29790.47976
+  tps: 15409.3956
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 39942.14495
-  tps: 19271.48121
+  dps: 40539.91694
+  tps: 19714.81905
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 56717.21013
-  tps: 48374.71517
+  dps: 58254.48877
+  tps: 49819.76466
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 40234.57586
-  tps: 20294.14472
+  dps: 41534.37046
+  tps: 21217.27477
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 59636.10327
-  tps: 27833.37046
+  dps: 61076.34906
+  tps: 28874.74658
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 49201.61324
-  tps: 44625.99305
+  dps: 50182.55337
+  tps: 46263.72769
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29122.6198
-  tps: 14532.4756
+  dps: 30060.67252
+  tps: 15046.58402
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 39698.8897
-  tps: 18428.08553
+  dps: 40897.37186
+  tps: 18903.94496
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 50613.10989
-  tps: 40800.65709
+  dps: 51658.05368
+  tps: 42415.78948
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 36249.37416
-  tps: 17851.79818
+  dps: 37029.43921
+  tps: 18329.7128
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 56624.22006
-  tps: 26253.08575
+  dps: 56690.30343
+  tps: 26195.77935
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 43855.13974
-  tps: 37176.71595
+  dps: 44490.33844
+  tps: 37684.2896
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 26516.68718
-  tps: 12949.14265
+  dps: 27033.3258
+  tps: 13239.11222
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 37596.15052
-  tps: 17237.78039
+  dps: 38549.41606
+  tps: 17827.91762
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 55604.06884
-  tps: 47545.77407
+  dps: 57045.88832
+  tps: 48960.73794
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39004.76575
-  tps: 19432.34692
+  dps: 40511.95277
+  tps: 20297.94048
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 58033.60332
-  tps: 26559.21562
+  dps: 59870.13768
+  tps: 27597.37913
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 47029.99871
-  tps: 43318.5175
+  dps: 49671.72849
+  tps: 45736.82433
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28068.08806
-  tps: 13936.60774
+  dps: 29418.51313
+  tps: 14553.37638
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 39334.51806
-  tps: 18137.04983
+  dps: 40727.50225
+  tps: 18600.21429
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 55953.45648
-  tps: 46572.81616
+  dps: 56722.49477
+  tps: 47377.45087
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39521.26382
-  tps: 20693.41643
+  dps: 40816.34034
+  tps: 21339.05607
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 59558.7354
-  tps: 28615.9067
+  dps: 61018.01583
+  tps: 29763.10255
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 47605.52379
-  tps: 41685.67889
+  dps: 49745.42103
+  tps: 43429.07507
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28069.66394
-  tps: 14596.45723
+  dps: 29597.66048
+  tps: 15303.42917
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 38884.3189
-  tps: 18887.09456
+  dps: 40624.78481
+  tps: 19533.08094
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 56157.14173
-  tps: 47368.71093
+  dps: 57699.3758
+  tps: 49410.06904
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39663.98807
-  tps: 19969.85737
+  dps: 41125.08084
+  tps: 20805.10784
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 59266.81126
-  tps: 27527.48379
+  dps: 60545.3961
+  tps: 28336.53968
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 47708.59171
-  tps: 43668.88869
+  dps: 49842.68753
+  tps: 45607.8322
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28345.75913
-  tps: 14216.69085
+  dps: 29862.24074
+  tps: 14909.41783
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 39127.84205
-  tps: 18378.57428
+  dps: 41361.45932
+  tps: 19054.43631
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 50197.72105
-  tps: 40809.69727
+  dps: 51028.48525
+  tps: 41737.88151
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 35806.67379
-  tps: 17616.85145
+  dps: 36980.14131
+  tps: 18201.88956
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 55699.24754
-  tps: 25806.07549
+  dps: 56590.16432
+  tps: 26291.17038
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 43602.31234
-  tps: 37887.53754
+  dps: 45263.94421
+  tps: 38529.85302
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 26168.11321
-  tps: 12734.75802
+  dps: 27022.59222
+  tps: 13272.36287
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 37419.37323
-  tps: 17110.76839
+  dps: 38496.122
+  tps: 17518.02535
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 56784.57577
-  tps: 47463.07761
+  dps: 58264.48952
+  tps: 49207.72527
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39870.81005
-  tps: 19545.48918
+  dps: 41438.16231
+  tps: 20466.03366
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 59892.39502
-  tps: 26944.9983
+  dps: 61765.52383
+  tps: 27995.25506
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 48215.86234
-  tps: 43727.40401
+  dps: 51010.83183
+  tps: 46253.49543
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28783.06468
-  tps: 14071.24539
+  dps: 30101.60042
+  tps: 14651.15738
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 40786.0213
-  tps: 18452.47938
+  dps: 42176.07614
+  tps: 18889.3594
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 57082.8632
-  tps: 46585.44943
+  dps: 57734.55903
+  tps: 47503.48206
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 40466.79328
-  tps: 20842.38501
+  dps: 41848.4793
+  tps: 21582.78429
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 61516.43964
-  tps: 29059.64921
+  dps: 62952.31519
+  tps: 30202.11984
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 48815.83904
-  tps: 42185.51659
+  dps: 51110.94872
+  tps: 44035.19639
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28841.20953
-  tps: 14761.25597
+  dps: 30316.42186
+  tps: 15439.87349
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 40344.14808
-  tps: 19206.40868
+  dps: 42091.83655
+  tps: 19837.40953
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 57241.51673
-  tps: 47677.42508
+  dps: 58882.75298
+  tps: 49620.72559
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 40648.22302
-  tps: 20167.04023
+  dps: 42047.22757
+  tps: 20973.66677
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 61142.38149
-  tps: 27927.23729
+  dps: 62446.58674
+  tps: 28746.46454
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 48856.69446
-  tps: 43978.7077
+  dps: 50936.56231
+  tps: 45918.78301
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29184.07206
-  tps: 14434.95985
+  dps: 30618.59908
+  tps: 15097.01133
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 40563.44624
-  tps: 18696.90898
+  dps: 42821.18788
+  tps: 19347.9078
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 51236.31296
-  tps: 40914.88008
+  dps: 52157.92744
+  tps: 41886.83509
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 36666.07909
-  tps: 17731.6063
+  dps: 37903.41505
+  tps: 18426.41755
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 57559.74177
-  tps: 26210.55349
+  dps: 58464.72927
+  tps: 26698.22646
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 44798.63054
-  tps: 38426.79677
+  dps: 46434.2234
+  tps: 38961.55594
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 26935.14746
-  tps: 12873.21232
+  dps: 27762.34223
+  tps: 13408.5345
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 38897.04814
-  tps: 17415.15241
+  dps: 39968.49931
+  tps: 17809.42566
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 56708.98264
-  tps: 47834.81401
+  dps: 57658.71708
+  tps: 49433.74784
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39404.89986
-  tps: 19846.98519
+  dps: 40865.91046
+  tps: 20444.69152
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 60321.44083
-  tps: 28143.60658
+  dps: 62052.56368
+  tps: 28117.17296
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 48495.71112
-  tps: 45184.26465
+  dps: 51159.73308
+  tps: 47528.31617
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28549.30761
-  tps: 14245.4831
+  dps: 29869.77013
+  tps: 14880.78257
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 41517.13548
-  tps: 19039.75874
+  dps: 43007.54612
+  tps: 19906.17839
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 56848.35818
-  tps: 47336.23874
+  dps: 57486.61356
+  tps: 48053.1366
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39781.12797
-  tps: 20860.43308
+  dps: 41109.13836
+  tps: 21607.25965
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 60681.6755
-  tps: 29567.46537
+  dps: 62564.10196
+  tps: 30673.95549
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 49413.69622
-  tps: 43743.02781
+  dps: 51384.01832
+  tps: 45103.84509
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 28881.62753
-  tps: 14967.31282
+  dps: 30269.19173
+  tps: 15670.25833
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 41209.04808
-  tps: 20107.05997
+  dps: 42345.07901
+  tps: 20538.41175
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 57378.18714
-  tps: 49003.98434
+  dps: 58283.00849
+  tps: 49582.25753
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 40261.27684
-  tps: 20456.47076
+  dps: 41661.7154
+  tps: 21032.51916
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 61241.86061
-  tps: 28918.16013
+  dps: 63051.516
+  tps: 29015.27723
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 49116.8107
-  tps: 45141.52137
+  dps: 51747.13294
+  tps: 47188.0655
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29025.83531
-  tps: 14585.56636
+  dps: 30131.51419
+  tps: 15201.15742
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 41633.19795
-  tps: 19488.89265
+  dps: 42320.84018
+  tps: 20131.33894
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 51513.97232
-  tps: 41348.115
+  dps: 52601.32501
+  tps: 43275.70668
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 36115.62314
-  tps: 17862.00607
+  dps: 37659.42405
+  tps: 18580.75364
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 57641.88682
-  tps: 26727.68957
+  dps: 59205.83046
+  tps: 27719.30492
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 44672.80767
-  tps: 37655.74146
+  dps: 46537.12384
+  tps: 39588.13578
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 26412.0499
-  tps: 12927.46779
+  dps: 27423.91703
+  tps: 13480.36248
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 38781.54277
-  tps: 18054.06941
+  dps: 39351.68911
+  tps: 18606.18382
  }
 }
 dps_results: {

--- a/sim/warlock/demonology/TestDemonology.results
+++ b/sim/warlock/demonology/TestDemonology.results
@@ -1994,673 +1994,673 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 57765.88701
-  tps: 49792.4927
+  dps: 56255.92196
+  tps: 47924.1349
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 40908.21782
-  tps: 20705.48793
+  dps: 39453.36455
+  tps: 19740.98775
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 60401.4096
-  tps: 28113.69125
+  dps: 58596.21242
+  tps: 27017.15095
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 49904.74084
-  tps: 45796.37965
+  dps: 48479.95459
+  tps: 44508.82953
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29472.35206
-  tps: 14626.37927
+  dps: 28742.13451
+  tps: 14167.71598
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 40296.28548
-  tps: 18345.90653
+  dps: 40023.59617
+  tps: 18061.89648
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 57656.40418
-  tps: 48487.33858
+  dps: 56041.21316
+  tps: 47002.65867
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 41174.50984
-  tps: 21849.59062
+  dps: 39931.34828
+  tps: 20926.03998
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 61126.09466
-  tps: 30098.63735
+  dps: 60135.5683
+  tps: 29769.26682
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 49597.44949
-  tps: 43532.11453
+  dps: 48911.69345
+  tps: 42772.84701
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29788.67387
-  tps: 15371.54402
+  dps: 29173.44782
+  tps: 14959.02566
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 40570.72497
-  tps: 19719.27074
+  dps: 39942.14495
+  tps: 19271.48121
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 58252.93329
-  tps: 49883.74084
+  dps: 56717.21013
+  tps: 48374.71517
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 41523.84962
-  tps: 21190.00805
+  dps: 40234.57586
+  tps: 20294.14472
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 61076.34906
-  tps: 28874.70842
+  dps: 59636.10327
+  tps: 27833.37046
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 49999.66112
-  tps: 45994.83411
+  dps: 49201.61324
+  tps: 44625.99305
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29993.63826
-  tps: 14994.71272
+  dps: 29122.6198
+  tps: 14532.4756
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 40854.69771
-  tps: 18897.58625
+  dps: 39698.8897
+  tps: 18428.08553
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 51678.9612
-  tps: 42548.1271
+  dps: 50613.10989
+  tps: 40800.65709
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37035.70292
-  tps: 18338.80142
+  dps: 36249.37416
+  tps: 17851.79818
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 56690.30343
-  tps: 26195.66293
+  dps: 56624.22006
+  tps: 26253.08575
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 44545.4666
-  tps: 37635.72865
+  dps: 43855.13974
+  tps: 37176.71595
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 27090.99889
-  tps: 13248.55627
+  dps: 26516.68718
+  tps: 12949.14265
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Goblin-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 38561.45311
-  tps: 17828.7083
+  dps: 37596.15052
+  tps: 17237.78039
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 57064.0856
-  tps: 48953.38395
+  dps: 55604.06884
+  tps: 47545.77407
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 40468.82037
-  tps: 20309.88101
+  dps: 39004.76575
+  tps: 19432.34692
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 59870.13768
-  tps: 27596.99226
+  dps: 58033.60332
+  tps: 26559.21562
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 49473.13125
-  tps: 45546.97853
+  dps: 47029.99871
+  tps: 43318.5175
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29397.62168
-  tps: 14529.294
+  dps: 28068.08806
+  tps: 13936.60774
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 40719.26373
-  tps: 18594.76947
+  dps: 39334.51806
+  tps: 18137.04983
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 56722.49477
-  tps: 47316.16661
+  dps: 55953.45648
+  tps: 46572.81616
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 40816.34034
-  tps: 21334.96243
+  dps: 39521.26382
+  tps: 20693.41643
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 61018.01583
-  tps: 29761.60303
+  dps: 59558.7354
+  tps: 28615.9067
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 49778.92884
-  tps: 43425.66188
+  dps: 47605.52379
+  tps: 41685.67889
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29572.68422
-  tps: 15281.11621
+  dps: 28069.66394
+  tps: 14596.45723
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 40624.78481
-  tps: 19532.65536
+  dps: 38884.3189
+  tps: 18887.09456
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 57681.90435
-  tps: 49434.29467
+  dps: 56157.14173
+  tps: 47368.71093
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 41151.20164
-  tps: 20855.41552
+  dps: 39663.98807
+  tps: 19969.85737
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 60545.3961
-  tps: 28336.5022
+  dps: 59266.81126
+  tps: 27527.48379
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 49868.24618
-  tps: 45698.32984
+  dps: 47708.59171
+  tps: 43668.88869
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29853.47669
-  tps: 14905.18765
+  dps: 28345.75913
+  tps: 14216.69085
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 41352.80713
-  tps: 19048.33811
+  dps: 39127.84205
+  tps: 18378.57428
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 51067.03507
-  tps: 41929.68671
+  dps: 50197.72105
+  tps: 40809.69727
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 36980.04861
-  tps: 18224.29481
+  dps: 35806.67379
+  tps: 17616.85145
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 56590.16432
-  tps: 26291.01051
+  dps: 55699.24754
+  tps: 25806.07549
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 45258.58089
-  tps: 38547.26106
+  dps: 43602.31234
+  tps: 37887.53754
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 27037.2704
-  tps: 13280.92026
+  dps: 26168.11321
+  tps: 12734.75802
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Human-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 38496.122
-  tps: 17518.02535
+  dps: 37419.37323
+  tps: 17110.76839
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 58242.81239
-  tps: 49160.40691
+  dps: 56784.57577
+  tps: 47463.07761
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 41457.56479
-  tps: 20526.33066
+  dps: 39870.81005
+  tps: 19545.48918
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 61765.52383
-  tps: 27994.86908
+  dps: 59892.39502
+  tps: 26944.9983
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 50768.65209
-  tps: 45955.84828
+  dps: 48215.86234
+  tps: 43727.40401
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 30016.32147
-  tps: 14657.81809
+  dps: 28783.06468
+  tps: 14071.24539
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 42167.84008
-  tps: 18883.9162
+  dps: 40786.0213
+  tps: 18452.47938
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 57734.55903
-  tps: 47433.34344
+  dps: 57082.8632
+  tps: 46585.44943
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 41848.4793
-  tps: 21578.76053
+  dps: 40466.79328
+  tps: 20842.38501
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 62952.31519
-  tps: 30200.62387
+  dps: 61516.43964
+  tps: 29059.64921
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 51112.67651
-  tps: 43930.44594
+  dps: 48815.83904
+  tps: 42185.51659
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 30320.50448
-  tps: 15445.28885
+  dps: 28841.20953
+  tps: 14761.25597
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 42091.83655
-  tps: 19836.9855
+  dps: 40344.14808
+  tps: 19206.40868
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 58870.65659
-  tps: 49662.58554
+  dps: 57241.51673
+  tps: 47677.42508
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 42051.47941
-  tps: 20997.36883
+  dps: 40648.22302
+  tps: 20167.04023
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 62446.58674
-  tps: 28746.4279
+  dps: 61142.38149
+  tps: 27927.23729
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 50879.87334
-  tps: 45820.35208
+  dps: 48856.69446
+  tps: 43978.7077
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 30598.26474
-  tps: 15089.48209
+  dps: 29184.07206
+  tps: 14434.95985
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 42812.53827
-  tps: 19341.81142
+  dps: 40563.44624
+  tps: 18696.90898
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 52157.92744
-  tps: 41998.01088
+  dps: 51236.31296
+  tps: 40914.88008
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37903.41505
-  tps: 18430.87171
+  dps: 36666.07909
+  tps: 17731.6063
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 58464.72927
-  tps: 26698.06997
+  dps: 57559.74177
+  tps: 26210.55349
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 46430.45786
-  tps: 38980.22529
+  dps: 44798.63054
+  tps: 38426.79677
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 27802.83179
-  tps: 13425.54157
+  dps: 26935.14746
+  tps: 12873.21232
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Orc-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 39968.49931
-  tps: 17809.42566
+  dps: 38897.04814
+  tps: 17415.15241
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 57652.98962
-  tps: 49334.9296
+  dps: 56708.98264
+  tps: 47834.81401
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 40882.42312
-  tps: 20471.37614
+  dps: 39404.89986
+  tps: 19846.98519
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-incinerate-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 62052.56368
-  tps: 28115.63794
+  dps: 60321.44083
+  tps: 28143.60658
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 50958.26796
-  tps: 47182.23916
+  dps: 48495.71112
+  tps: 45184.26465
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 29963.06196
-  tps: 14908.80513
+  dps: 28549.30761
+  tps: 14245.4831
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-incinerate-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 43035.50532
-  tps: 19917.66528
+  dps: 41517.13548
+  tps: 19039.75874
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 57497.06379
-  tps: 47964.38055
+  dps: 56848.35818
+  tps: 47336.23874
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 41109.13836
-  tps: 21602.80258
+  dps: 39781.12797
+  tps: 20860.43308
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 62564.10196
-  tps: 30673.51739
+  dps: 60681.6755
+  tps: 29567.46537
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 51414.33664
-  tps: 45141.81581
+  dps: 49413.69622
+  tps: 43743.02781
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 30229.39702
-  tps: 15672.38856
+  dps: 28881.62753
+  tps: 14967.31282
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-DefaultTalents-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 42345.07901
-  tps: 20538.19996
+  dps: 41209.04808
+  tps: 20107.05997
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 58304.62597
-  tps: 49576.08756
+  dps: 57378.18714
+  tps: 49003.98434
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 41726.51177
-  tps: 21036.30322
+  dps: 40261.27684
+  tps: 20456.47076
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-incinerate-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 63051.516
-  tps: 29015.81874
+  dps: 61241.86061
+  tps: 28918.16013
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 51802.61958
-  tps: 47176.76997
+  dps: 49116.8107
+  tps: 45141.52137
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 30119.01256
-  tps: 15201.19683
+  dps: 29025.83531
+  tps: 14585.56636
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-incinerate-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 42333.13142
-  tps: 20131.58886
+  dps: 41633.19795
+  tps: 19488.89265
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 52601.32501
-  tps: 43383.51909
+  dps: 51513.97232
+  tps: 41348.115
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37659.42405
-  tps: 18584.64563
+  dps: 36115.62314
+  tps: 17862.00607
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-shadow-bolt-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 59205.83046
-  tps: 27719.39096
+  dps: 57641.88682
+  tps: 26727.68957
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 46500.25328
-  tps: 39562.77697
+  dps: 44672.80767
+  tps: 37655.74146
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 27429.99684
-  tps: 13476.269
+  dps: 26412.0499
+  tps: 12927.46779
  }
 }
 dps_results: {
  key: "TestDemonology-Settings-Troll-p3-Incinerate-Demonology Warlock-shadow-bolt-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 39351.68911
-  tps: 18605.97203
+  dps: 38781.54277
+  tps: 18054.06941
  }
 }
 dps_results: {

--- a/sim/warrior/fury/TestFury.results
+++ b/sim/warrior/fury/TestFury.results
@@ -2169,1345 +2169,1345 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 98949.58737
-  tps: 107121.31103
+  dps: 95069.68415
+  tps: 102802.56607
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 38837.31151
-  tps: 32838.3516
+  dps: 36892.7545
+  tps: 30723.28533
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 51460.43208
-  tps: 42476.49406
+  dps: 48733.57161
+  tps: 39983.54231
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 67145.6191
-  tps: 73608.9278
+  dps: 64207.02533
+  tps: 70380.40255
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 24128.70401
-  tps: 19945.98196
+  dps: 22822.74308
+  tps: 18704.79296
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 28034.81089
-  tps: 22065.24622
+  dps: 26637.46164
+  tps: 21008.36832
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 99167.3007
-  tps: 107358.02957
+  dps: 106926.62183
+  tps: 115326.45192
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 38919.88094
-  tps: 32911.90612
+  dps: 41991.46609
+  tps: 34919.55819
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 51827.40981
-  tps: 42805.26407
+  dps: 55987.78656
+  tps: 45794.37607
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 67270.45531
-  tps: 73746.67078
+  dps: 72794.04268
+  tps: 79746.40304
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 24169.07647
-  tps: 19980.29007
+  dps: 26218.7139
+  tps: 21553.13808
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 28216.69655
-  tps: 22221.5636
+  dps: 30252.33889
+  tps: 23781.0842
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 98949.58737
-  tps: 107121.31103
+  dps: 95069.68415
+  tps: 102802.56607
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 38294.37441
-  tps: 31854.92695
+  dps: 36200.12225
+  tps: 29700.35846
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 50310.80958
-  tps: 41435.83952
+  dps: 47823.84755
+  tps: 38736.54673
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 67145.6191
-  tps: 73608.9278
+  dps: 64207.02533
+  tps: 70380.40255
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 23761.89209
-  tps: 19285.03085
+  dps: 22556.28185
+  tps: 18107.77862
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 28060.4489
-  tps: 21816.56485
+  dps: 26195.12148
+  tps: 20129.89669
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 99167.3007
-  tps: 107358.02957
+  dps: 106926.62183
+  tps: 115326.45192
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 38376.75927
-  tps: 31927.70383
+  dps: 41471.5712
+  tps: 34061.47307
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 50672.68761
-  tps: 41758.0038
+  dps: 55345.44524
+  tps: 44659.20768
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 67270.45531
-  tps: 73746.67078
+  dps: 72794.04268
+  tps: 79746.40304
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 23802.09299
-  tps: 19318.97785
+  dps: 26102.30468
+  tps: 20930.17631
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 28241.72296
-  tps: 21970.98634
+  dps: 30236.29548
+  tps: 23206.87062
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 82111.42544
-  tps: 89541.70663
+  dps: 78862.42492
+  tps: 85753.92658
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 31286.68646
-  tps: 27067.40349
+  dps: 29650.71527
+  tps: 25365.42513
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 41696.93811
-  tps: 35395.30239
+  dps: 39572.79534
+  tps: 33190.96781
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 55687.9054
-  tps: 61549.90212
+  dps: 53237.2925
+  tps: 58880.53009
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 19280.02073
-  tps: 16485.81767
+  dps: 18385.37249
+  tps: 15578.06849
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 22514.03432
-  tps: 18094.10603
+  dps: 21356.16216
+  tps: 17086.12116
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 82293.05351
-  tps: 89740.17001
+  dps: 88534.70722
+  tps: 96166.74027
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 31354.43076
-  tps: 27129.14537
+  dps: 33755.02866
+  tps: 28928.92215
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 41995.74705
-  tps: 35668.96464
+  dps: 45774.57718
+  tps: 38321.09969
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 55790.96511
-  tps: 61664.49042
+  dps: 59822.41092
+  tps: 65987.29472
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 19312.69562
-  tps: 16514.32972
+  dps: 21104.43345
+  tps: 17860.65079
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 22658.00673
-  tps: 18220.6202
+  dps: 24631.35056
+  tps: 19640.17384
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 82111.42544
-  tps: 89541.70663
+  dps: 78862.42492
+  tps: 85753.92658
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 31110.68099
-  tps: 26300.37335
+  dps: 29730.26157
+  tps: 24894.87237
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 41201.5275
-  tps: 34450.03066
+  dps: 39253.43679
+  tps: 32583.17853
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 55687.9054
-  tps: 61549.90212
+  dps: 53237.2925
+  tps: 58880.53009
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 19280.8582
-  tps: 15998.6057
+  dps: 18450.4652
+  tps: 15136.78811
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 22422.66881
-  tps: 17740.68092
+  dps: 21357.48025
+  tps: 16754.22328
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 82293.05351
-  tps: 89740.17001
+  dps: 88534.70722
+  tps: 96166.74027
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 31178.71285
-  tps: 26361.57521
+  dps: 33960.2413
+  tps: 28386.42968
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 41495.55542
-  tps: 34715.64659
+  dps: 45654.51668
+  tps: 37583.50445
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 55790.96511
-  tps: 61664.49042
+  dps: 59822.41092
+  tps: 65987.29472
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 19313.27529
-  tps: 16026.51444
+  dps: 21076.02173
+  tps: 17243.99034
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 22566.62461
-  tps: 17865.25088
+  dps: 24315.70492
+  tps: 19028.4618
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 149906.71851
-  tps: 164780.91961
+  dps: 129530.05177
+  tps: 142995.49494
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 49817.23078
-  tps: 40959.86834
+  dps: 42509.42521
+  tps: 34593.2294
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 65165.07046
-  tps: 52517.80122
+  dps: 55422.34341
+  tps: 44255.18448
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 105758.01773
-  tps: 117859.11427
+  dps: 93035.22695
+  tps: 104097.53057
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 31957.13478
-  tps: 25512.25535
+  dps: 27347.84259
+  tps: 21634.05223
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 36779.59912
-  tps: 27960.05924
+  dps: 31951.07251
+  tps: 24027.85883
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 150234.38112
-  tps: 165141.03629
+  dps: 144029.12906
+  tps: 158437.18719
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 49924.90371
-  tps: 41051.64155
+  dps: 48539.67643
+  tps: 39609.5608
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 65631.18121
-  tps: 52917.33387
+  dps: 63184.64134
+  tps: 50299.97799
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 105955.48631
-  tps: 118079.45873
+  dps: 103304.83679
+  tps: 114982.89356
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 32012.27747
-  tps: 25556.41628
+  dps: 30742.00045
+  tps: 24333.94715
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 37022.36511
-  tps: 28155.28437
+  dps: 36429.13437
+  tps: 27534.40518
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 149906.71851
-  tps: 164780.91961
+  dps: 129530.05177
+  tps: 142995.49494
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 49915.17092
-  tps: 40051.00327
+  dps: 42690.01438
+  tps: 33791.98816
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 64681.16513
-  tps: 51470.78666
+  dps: 55905.58696
+  tps: 43753.30564
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 105758.01773
-  tps: 117859.11427
+  dps: 93035.22695
+  tps: 104097.53057
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 31968.63156
-  tps: 24939.13148
+  dps: 27304.84305
+  tps: 20877.11241
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 36614.31302
-  tps: 27130.48319
+  dps: 32103.72398
+  tps: 23634.18973
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 150234.38112
-  tps: 165141.03629
+  dps: 144029.12906
+  tps: 158437.18719
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 50021.66575
-  tps: 40140.88139
+  dps: 48564.40332
+  tps: 38382.13083
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 65143.65737
-  tps: 51864.01013
+  dps: 63466.75911
+  tps: 49710.13157
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 105955.48631
-  tps: 118079.45873
+  dps: 103304.83679
+  tps: 114982.89356
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 32023.17947
-  tps: 24981.85439
+  dps: 31423.83091
+  tps: 24176.39159
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 36853.80047
-  tps: 27320.07802
+  dps: 36903.50257
+  tps: 27162.13153
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 123235.1684
-  tps: 136531.80883
+  dps: 108506.29478
+  tps: 120725.97215
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 39914.83038
-  tps: 33818.96114
+  dps: 34069.23604
+  tps: 28676.05368
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 52371.3802
-  tps: 43612.82869
+  dps: 44396.72561
+  tps: 36715.34716
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 87643.43916
-  tps: 98383.75587
+  dps: 76649.53831
+  tps: 86368.22084
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 25251.16521
-  tps: 20940.09682
+  dps: 21572.9737
+  tps: 17736.75813
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 29638.57389
-  tps: 23534.38315
+  dps: 25231.49032
+  tps: 19878.61809
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 123504.5959
-  tps: 136829.65305
+  dps: 120141.72003
+  tps: 133146.16985
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 40000.17138
-  tps: 33893.25919
+  dps: 38795.60959
+  tps: 32549.71345
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 52750.24202
-  tps: 43945.80431
+  dps: 51361.72205
+  tps: 42331.57482
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 87807.56591
-  tps: 98568.49093
+  dps: 85209.87434
+  tps: 95703.65472
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 25295.19005
-  tps: 20976.60793
+  dps: 24663.9654
+  tps: 20305.82229
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 29833.47313
-  tps: 23697.50685
+  dps: 29139.81101
+  tps: 22830.37521
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 123235.1684
-  tps: 136531.80883
+  dps: 108506.29478
+  tps: 120725.97215
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 40255.42749
-  tps: 32886.98131
+  dps: 34317.99551
+  tps: 27840.65254
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 52634.55444
-  tps: 42495.15244
+  dps: 44976.58547
+  tps: 36076.92433
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 87643.43916
-  tps: 98383.75587
+  dps: 76649.53831
+  tps: 86368.22084
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 25576.38566
-  tps: 20508.43464
+  dps: 22065.37147
+  tps: 17461.95537
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 29863.38572
-  tps: 22901.23997
+  dps: 25191.48666
+  tps: 19043.4976
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 123504.5959
-  tps: 136829.65305
+  dps: 120141.72003
+  tps: 133146.16985
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 40340.64637
-  tps: 32959.97037
+  dps: 39095.49557
+  tps: 31558.099
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 53014.30499
-  tps: 42823.07515
+  dps: 51630.14692
+  tps: 41270.91658
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 87807.56591
-  tps: 98568.49093
+  dps: 85209.87434
+  tps: 95703.65472
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 25620.63493
-  tps: 20544.30976
+  dps: 24941.60896
+  tps: 19588.49312
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 30056.99407
-  tps: 23059.48596
+  dps: 29270.42774
+  tps: 22142.31527
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 99284.62616
-  tps: 107527.11992
+  dps: 94832.11176
+  tps: 102583.73099
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 38797.28869
-  tps: 32534.01027
+  dps: 36583.64847
+  tps: 30560.90824
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 50576.26905
-  tps: 41633.85003
+  dps: 48288.24299
+  tps: 39518.90554
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 68126.44053
-  tps: 74746.5713
+  dps: 64551.91325
+  tps: 70815.01326
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 24090.43076
-  tps: 19895.02957
+  dps: 22811.2388
+  tps: 18697.77596
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 27699.05965
-  tps: 21818.6416
+  dps: 26093.36838
+  tps: 20466.61877
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 99498.38738
-  tps: 107759.92875
+  dps: 107204.98909
+  tps: 115856.57382
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 38877.08226
-  tps: 32604.99612
+  dps: 42130.40633
+  tps: 35110.292
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 50931.82417
-  tps: 41951.48147
+  dps: 55347.15423
+  tps: 45366.8058
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 68247.32426
-  tps: 74880.05571
+  dps: 72570.47246
+  tps: 79393.4981
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 24129.38495
-  tps: 19928.14345
+  dps: 26295.64265
+  tps: 21520.88036
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 27875.27675
-  tps: 21970.29092
+  dps: 30117.2385
+  tps: 23477.85932
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 99284.62616
-  tps: 107527.11992
+  dps: 94832.11176
+  tps: 102583.73099
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 38118.37479
-  tps: 31528.99958
+  dps: 36498.8125
+  tps: 30107.83858
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 49810.05069
-  tps: 40835.65477
+  dps: 47276.40953
+  tps: 38374.00372
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 68126.44053
-  tps: 74746.5713
+  dps: 64551.91325
+  tps: 70815.01326
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 23944.21388
-  tps: 19439.32126
+  dps: 22579.60533
+  tps: 18108.01771
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 26950.41436
-  tps: 20812.54791
+  dps: 25991.51857
+  tps: 19669.24141
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 99498.38738
-  tps: 107759.92875
+  dps: 107204.98909
+  tps: 115856.57382
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 38196.95499
-  tps: 31598.28416
+  dps: 41746.62778
+  tps: 34344.72372
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 50158.31636
-  tps: 41144.20646
+  dps: 54499.7125
+  tps: 44213.5575
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 68247.32426
-  tps: 74880.05571
+  dps: 72570.47246
+  tps: 79393.4981
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 23982.56571
-  tps: 19471.51837
+  dps: 25892.39253
+  tps: 20640.68384
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 27121.41242
-  tps: 20957.12264
+  dps: 29499.74333
+  tps: 22435.2133
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 82630.29522
-  tps: 89953.06088
+  dps: 78956.75623
+  tps: 85975.91533
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 31197.40563
-  tps: 26868.77994
+  dps: 29470.33719
+  tps: 25130.63893
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 40912.89789
-  tps: 34583.41518
+  dps: 39387.34208
+  tps: 32936.05662
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 55887.35599
-  tps: 61827.07531
+  dps: 53106.60539
+  tps: 58690.88565
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 19519.77691
-  tps: 16661.11458
+  dps: 18311.82156
+  tps: 15468.99
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 22448.38595
-  tps: 17975.87654
+  dps: 21174.48406
+  tps: 16825.72989
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 82807.24429
-  tps: 90146.76848
+  dps: 89470.56867
+  tps: 97404.07835
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 31261.97291
-  tps: 26927.4127
+  dps: 34125.08442
+  tps: 29118.33584
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 41201.71572
-  tps: 34847.52668
+  dps: 44579.98095
+  tps: 37166.48519
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 55987.59192
-  tps: 61938.58409
+  dps: 59609.27051
+  tps: 65741.01738
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 19551.47664
-  tps: 16688.78238
+  dps: 21173.22667
+  tps: 17832.06701
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 22589.32385
-  tps: 18100.00024
+  dps: 24486.91888
+  tps: 19482.44603
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 82630.29522
-  tps: 89953.06088
+  dps: 78956.75623
+  tps: 85975.91533
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 30888.83638
-  tps: 26022.84457
+  dps: 29424.41355
+  tps: 24558.56535
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 41002.82975
-  tps: 34341.72235
+  dps: 38805.00803
+  tps: 32053.28227
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 55887.35599
-  tps: 61827.07531
+  dps: 53106.60539
+  tps: 58690.88565
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 19438.56898
-  tps: 16044.95485
+  dps: 18225.95078
+  tps: 14923.49773
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 22280.49271
-  tps: 17512.72817
+  dps: 20866.51899
+  tps: 16224.33948
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 82807.24429
-  tps: 90146.76848
+  dps: 89470.56867
+  tps: 97404.07835
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 30954.37682
-  tps: 26081.66849
+  dps: 33737.19514
+  tps: 28256.51484
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 41289.98776
-  tps: 34600.72988
+  dps: 44499.28055
+  tps: 36556.00922
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 55987.59192
-  tps: 61938.58409
+  dps: 59609.27051
+  tps: 65741.01738
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 19469.65676
-  tps: 16071.47839
+  dps: 20948.84756
+  tps: 17072.63094
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 22420.21094
-  tps: 17633.92058
+  dps: 24111.23778
+  tps: 18642.06251
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 147866.00819
-  tps: 162739.83049
+  dps: 131212.7762
+  tps: 145101.55093
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 49319.45713
-  tps: 40347.8773
+  dps: 42732.50353
+  tps: 34566.89599
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 64200.71621
-  tps: 51402.65594
+  dps: 55077.76135
+  tps: 43985.35588
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 105965.51434
-  tps: 117997.13688
+  dps: 92648.8568
+  tps: 103530.98034
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 31966.61586
-  tps: 25550.56045
+  dps: 27390.74222
+  tps: 21669.44707
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 36332.31719
-  tps: 27726.67966
+  dps: 31470.04792
+  tps: 23635.77334
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 148182.59425
-  tps: 163088.77576
+  dps: 145132.75256
+  tps: 159897.49113
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 49420.06194
-  tps: 40432.37284
+  dps: 48298.28452
+  tps: 39178.40094
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 64648.53098
-  tps: 51782.29888
+  dps: 63331.72763
+  tps: 50650.63669
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 106160.14386
-  tps: 118214.72583
+  dps: 103425.13202
+  tps: 115023.65725
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 32020.22687
-  tps: 25593.2213
+  dps: 31241.75544
+  tps: 24668.91866
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 36566.8042
-  tps: 27914.87461
+  dps: 35710.13603
+  tps: 26787.23776
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 147866.00819
-  tps: 162739.83049
+  dps: 131212.7762
+  tps: 145101.55093
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 49745.41018
-  tps: 39722.09752
+  dps: 42431.37384
+  tps: 33342.61366
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 63748.30056
-  tps: 50043.23353
+  dps: 54815.43338
+  tps: 42908.93123
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 105965.51434
-  tps: 117997.13688
+  dps: 92648.8568
+  tps: 103530.98034
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 32176.93207
-  tps: 25015.88947
+  dps: 27226.53506
+  tps: 20863.54238
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 36370.25406
-  tps: 27090.84006
+  dps: 31448.1671
+  tps: 23066.84869
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 148182.59425
-  tps: 163088.77576
+  dps: 145132.75256
+  tps: 159897.49113
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 49846.21503
-  tps: 39805.841
+  dps: 48439.17371
+  tps: 38210.68552
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 64196.48289
-  tps: 50418.58389
+  dps: 62616.98351
+  tps: 48660.34487
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 106160.14386
-  tps: 118214.72583
+  dps: 103425.13202
+  tps: 115023.65725
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 32230.23389
-  tps: 25057.60663
+  dps: 31287.96171
+  tps: 23984.36877
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 36602.64948
-  tps: 27274.86959
+  dps: 35664.40585
+  tps: 26014.38137
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 123526.76619
-  tps: 136914.32338
+  dps: 107481.16887
+  tps: 119506.97335
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 39389.0227
-  tps: 33240.97143
+  dps: 34036.01709
+  tps: 28600.46814
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 52043.0382
-  tps: 43224.07867
+  dps: 44594.82556
+  tps: 36692.28721
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 87979.75774
-  tps: 98783.92063
+  dps: 76872.18116
+  tps: 86627.83318
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 25108.71593
-  tps: 20685.62676
+  dps: 21673.23534
+  tps: 17832.36629
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 29132.02888
-  tps: 22588.94592
+  dps: 24945.81696
+  tps: 19266.16793
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 123789.30248
-  tps: 137205.04389
+  dps: 120589.3743
+  tps: 133727.54279
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 39470.09113
-  tps: 33311.10212
+  dps: 38802.91271
+  tps: 32418.60825
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 52413.49809
-  tps: 43549.49437
+  dps: 50597.89316
+  tps: 41521.40348
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 88140.57861
-  tps: 98964.99817
+  dps: 85369.96405
+  tps: 95727.38186
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 25152.27477
-  tps: 20721.22069
+  dps: 24740.00598
+  tps: 20279.06033
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 29319.28562
-  tps: 22742.65075
+  dps: 28621.58992
+  tps: 22096.96503
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 123526.76619
-  tps: 136914.32338
+  dps: 107481.16887
+  tps: 119506.97335
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 40014.72178
-  tps: 32771.59868
+  dps: 34464.43326
+  tps: 27859.01345
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 51384.25484
-  tps: 41532.52632
+  dps: 44491.21853
+  tps: 35718.37177
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 87979.75774
-  tps: 98783.92063
+  dps: 76872.18116
+  tps: 86627.83318
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 25841.50351
-  tps: 20624.43602
+  dps: 21985.06922
+  tps: 17317.97873
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 28988.02234
-  tps: 21879.56831
+  dps: 25622.09776
+  tps: 19260.51224
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 123789.30248
-  tps: 137205.04389
+  dps: 120589.3743
+  tps: 133727.54279
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 40095.95862
-  tps: 32840.5451
+  dps: 39376.65842
+  tps: 31692.48938
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 51742.12028
-  tps: 41839.75091
+  dps: 51210.76081
+  tps: 40874.65621
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 88140.57861
-  tps: 98964.99817
+  dps: 85369.96405
+  tps: 95727.38186
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 25884.55312
-  tps: 20658.95595
+  dps: 25309.76093
+  tps: 20032.66887
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 29174.61619
-  tps: 22030.04428
+  dps: 29339.4139
+  tps: 22074.98005
  }
 }
 dps_results: {

--- a/sim/warrior/fury/TestFury.results
+++ b/sim/warrior/fury/TestFury.results
@@ -2169,1345 +2169,1345 @@ dps_results: {
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 95069.68415
-  tps: 102802.56607
+  dps: 99086.5715
+  tps: 107201.19328
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 36892.7545
-  tps: 30723.28533
+  dps: 38991.63829
+  tps: 32930.69538
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 48733.57161
-  tps: 39983.54231
+  dps: 50786.19029
+  tps: 41946.88095
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 64207.02533
-  tps: 70380.40255
+  dps: 67169.7269
+  tps: 73666.72154
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 22822.74308
-  tps: 18704.79296
+  dps: 24302.8068
+  tps: 20017.23413
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 26637.46164
-  tps: 21008.36832
+  dps: 27615.17647
+  tps: 21822.10327
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 106926.62183
-  tps: 115326.45192
+  dps: 99311.77041
+  tps: 107450.57969
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 41991.46609
-  tps: 34919.55819
+  dps: 39086.65236
+  tps: 33012.77052
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 55987.78656
-  tps: 45794.37607
+  dps: 51236.61205
+  tps: 42348.576
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 72794.04268
-  tps: 79746.40304
+  dps: 67298.46915
+  tps: 73807.74422
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26218.7139
-  tps: 21553.13808
+  dps: 24337.01953
+  tps: 20045.38985
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 30252.33889
-  tps: 23781.0842
+  dps: 27786.34725
+  tps: 21960.59526
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 95069.68415
-  tps: 102802.56607
+  dps: 99086.5715
+  tps: 107201.19328
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 36200.12225
-  tps: 29700.35846
+  dps: 38176.28177
+  tps: 31709.97498
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 47823.84755
-  tps: 38736.54673
+  dps: 50140.07391
+  tps: 41141.41624
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 64207.02533
-  tps: 70380.40255
+  dps: 67169.7269
+  tps: 73666.72154
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 22556.28185
-  tps: 18107.77862
+  dps: 23748.96152
+  tps: 19326.11727
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 26195.12148
-  tps: 20129.89669
+  dps: 27160.9062
+  tps: 21023.48378
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 106926.62183
-  tps: 115326.45192
+  dps: 99311.77041
+  tps: 107450.57969
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 41471.5712
-  tps: 34061.47307
+  dps: 38314.86011
+  tps: 31828.8794
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 55345.44524
-  tps: 44659.20768
+  dps: 50589.08475
+  tps: 41559.65929
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 72794.04268
-  tps: 79746.40304
+  dps: 67298.46915
+  tps: 73807.74422
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26102.30468
-  tps: 20930.17631
+  dps: 23807.94809
+  tps: 19375.897
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 30236.29548
-  tps: 23206.87062
+  dps: 27357.78213
+  tps: 21196.8807
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 78862.42492
-  tps: 85753.92658
+  dps: 82296.86937
+  tps: 89694.95126
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 29650.71527
-  tps: 25365.42513
+  dps: 31203.14425
+  tps: 26971.61546
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 39572.79534
-  tps: 33190.96781
+  dps: 41756.0408
+  tps: 35445.79804
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 53237.2925
-  tps: 58880.53009
+  dps: 56149.60171
+  tps: 62082.2483
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 18385.37249
-  tps: 15578.06849
+  dps: 19444.73625
+  tps: 16501.24898
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 21356.16216
-  tps: 17086.12116
+  dps: 22818.67865
+  tps: 18510.25666
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 88534.70722
-  tps: 96166.74027
+  dps: 82515.58676
+  tps: 89935.7203
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 33755.02866
-  tps: 28928.92215
+  dps: 31280.39356
+  tps: 27041.01884
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 45774.57718
-  tps: 38321.09969
+  dps: 42060.07123
+  tps: 35718.59756
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 59822.41092
-  tps: 65987.29472
+  dps: 56289.85448
+  tps: 62237.17142
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 21104.43345
-  tps: 17860.65079
+  dps: 19473.2393
+  tps: 16529.20022
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 24631.35056
-  tps: 19640.17384
+  dps: 22988.36156
+  tps: 18661.63297
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 78862.42492
-  tps: 85753.92658
+  dps: 82296.86937
+  tps: 89694.95126
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 29730.26157
-  tps: 24894.87237
+  dps: 31150.09613
+  tps: 26408.66903
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 39253.43679
-  tps: 32583.17853
+  dps: 41529.25046
+  tps: 34857.65744
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 53237.2925
-  tps: 58880.53009
+  dps: 56149.60171
+  tps: 62082.2483
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 18450.4652
-  tps: 15136.78811
+  dps: 19317.88028
+  tps: 16031.41008
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 21357.48025
-  tps: 16754.22328
+  dps: 22454.84805
+  tps: 17808.16067
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 88534.70722
-  tps: 96166.74027
+  dps: 82515.58676
+  tps: 89935.7203
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 33960.2413
-  tps: 28386.42968
+  dps: 31247.56905
+  tps: 26490.54991
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 45654.51668
-  tps: 37583.50445
+  dps: 41851.93541
+  tps: 35146.28735
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 59822.41092
-  tps: 65987.29472
+  dps: 56289.85448
+  tps: 62237.17142
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 21076.02173
-  tps: 17243.99034
+  dps: 19362.63957
+  tps: 16068.62741
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 24315.70492
-  tps: 19028.4618
+  dps: 22593.74603
+  tps: 17932.80281
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 129530.05177
-  tps: 142995.49494
+  dps: 149035.89804
+  tps: 164092.76921
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 42509.42521
-  tps: 34593.2294
+  dps: 49868.9297
+  tps: 40872.99123
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 55422.34341
-  tps: 44255.18448
+  dps: 64629.93218
+  tps: 51880.31564
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 93035.22695
-  tps: 104097.53057
+  dps: 105717.59653
+  tps: 117855.4861
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 27347.84259
-  tps: 21634.05223
+  dps: 31935.69818
+  tps: 25564.82884
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 31951.07251
-  tps: 24027.85883
+  dps: 37150.47504
+  tps: 28433.21374
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 144029.12906
-  tps: 158437.18719
+  dps: 149394.64102
+  tps: 164486.12723
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 48539.67643
-  tps: 39609.5608
+  dps: 50025.05228
+  tps: 41007.20361
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 63184.64134
-  tps: 50299.97799
+  dps: 65071.39269
+  tps: 52251.9225
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 103304.83679
-  tps: 114982.89356
+  dps: 105915.48119
+  tps: 118078.86269
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 30742.00045
-  tps: 24333.94715
+  dps: 32001.22775
+  tps: 25613.59376
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 36429.13437
-  tps: 27534.40518
+  dps: 37361.61201
+  tps: 28606.60569
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 129530.05177
-  tps: 142995.49494
+  dps: 149035.89804
+  tps: 164092.76921
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 42690.01438
-  tps: 33791.98816
+  dps: 49464.9414
+  tps: 39806.13919
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 55905.58696
-  tps: 43753.30564
+  dps: 64626.11482
+  tps: 51035.40573
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 93035.22695
-  tps: 104097.53057
+  dps: 105717.59653
+  tps: 117855.4861
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 27304.84305
-  tps: 20877.11241
+  dps: 32009.1266
+  tps: 24860.15426
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 32103.72398
-  tps: 23634.18973
+  dps: 36955.00697
+  tps: 27604.10414
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 144029.12906
-  tps: 158437.18719
+  dps: 149394.64102
+  tps: 164486.12723
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 48564.40332
-  tps: 38382.13083
+  dps: 49606.09051
+  tps: 39926.72338
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 63466.75911
-  tps: 49710.13157
+  dps: 65082.86608
+  tps: 51419.18811
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 103304.83679
-  tps: 114982.89356
+  dps: 105915.48119
+  tps: 118078.86269
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 31423.83091
-  tps: 24176.39159
+  dps: 32069.57302
+  tps: 24904.5051
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 36903.50257
-  tps: 27162.13153
+  dps: 37174.09107
+  tps: 27793.45552
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 108506.29478
-  tps: 120725.97215
+  dps: 123784.03897
+  tps: 137302.09263
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 34069.23604
-  tps: 28676.05368
+  dps: 39793.10921
+  tps: 33617.66626
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 44396.72561
-  tps: 36715.34716
+  dps: 52538.67128
+  tps: 43533.76633
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 76649.53831
-  tps: 86368.22084
+  dps: 88227.05534
+  tps: 99156.30868
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 21572.9737
-  tps: 17736.75813
+  dps: 25085.20939
+  tps: 20785.96417
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 25231.49032
-  tps: 19878.61809
+  dps: 29366.22353
+  tps: 23100.85975
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 120141.72003
-  tps: 133146.16985
+  dps: 124065.40132
+  tps: 137607.76073
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 38795.60959
-  tps: 32549.71345
+  dps: 39855.90726
+  tps: 33674.93045
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 51361.72205
-  tps: 42331.57482
+  dps: 52953.65087
+  tps: 43905.93002
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 85209.87434
-  tps: 95703.65472
+  dps: 88423.48219
+  tps: 99377.34254
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 24663.9654
-  tps: 20305.82229
+  dps: 25142.60514
+  tps: 20834.30771
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 29139.81101
-  tps: 22830.37521
+  dps: 29586.52786
+  tps: 23289.92199
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 108506.29478
-  tps: 120725.97215
+  dps: 123784.03897
+  tps: 137302.09263
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 34317.99551
-  tps: 27840.65254
+  dps: 40052.0863
+  tps: 32753.15569
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 44976.58547
-  tps: 36076.92433
+  dps: 52530.7137
+  tps: 42690.94644
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 76649.53831
-  tps: 86368.22084
+  dps: 88227.05534
+  tps: 99156.30868
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 22065.37147
-  tps: 17461.95537
+  dps: 25798.93016
+  tps: 20562.30037
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 25191.48666
-  tps: 19043.4976
+  dps: 29262.27751
+  tps: 22336.35327
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 120141.72003
-  tps: 133146.16985
+  dps: 124065.40132
+  tps: 137607.76073
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 39095.49557
-  tps: 31558.099
+  dps: 40159.53364
+  tps: 32852.53764
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 51630.14692
-  tps: 41270.91658
+  dps: 52966.34015
+  tps: 43082.79455
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 85209.87434
-  tps: 95703.65472
+  dps: 88423.48219
+  tps: 99377.34254
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 24941.60896
-  tps: 19588.49312
+  dps: 25869.1676
+  tps: 20620.69079
  }
 }
 dps_results: {
  key: "TestFury-Settings-Troll-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 29270.42774
-  tps: 22142.31527
+  dps: 29449.11158
+  tps: 22494.443
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 94832.11176
-  tps: 102583.73099
+  dps: 98692.66401
+  tps: 106739.88549
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 36583.64847
-  tps: 30560.90824
+  dps: 38635.05185
+  tps: 32505.62589
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 48288.24299
-  tps: 39518.90554
+  dps: 50614.56538
+  tps: 41626.79323
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 64551.91325
-  tps: 70815.01326
+  dps: 67532.47754
+  tps: 74100.28555
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 22811.2388
-  tps: 18697.77596
+  dps: 24184.35367
+  tps: 20059.83085
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 26093.36838
-  tps: 20466.61877
+  dps: 27641.31905
+  tps: 21603.97954
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 107204.98909
-  tps: 115856.57382
+  dps: 98927.22969
+  tps: 106997.95268
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 42130.40633
-  tps: 35110.292
+  dps: 38753.26721
+  tps: 32609.66768
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 55347.15423
-  tps: 45366.8058
+  dps: 51041.99936
+  tps: 42005.80969
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 72570.47246
-  tps: 79393.4981
+  dps: 67701.61432
+  tps: 74281.58653
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26295.64265
-  tps: 21520.88036
+  dps: 24245.50916
+  tps: 20112.76926
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 30117.2385
-  tps: 23477.85932
+  dps: 27832.27848
+  tps: 21773.09034
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 94832.11176
-  tps: 102583.73099
+  dps: 98692.66401
+  tps: 106739.88549
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 36498.8125
-  tps: 30107.83858
+  dps: 38161.7307
+  tps: 31521.43942
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 47276.40953
-  tps: 38374.00372
+  dps: 50236.67315
+  tps: 41336.04921
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 64551.91325
-  tps: 70815.01326
+  dps: 67532.47754
+  tps: 74100.28555
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 22579.60533
-  tps: 18108.01771
+  dps: 23993.39194
+  tps: 19451.45204
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 25991.51857
-  tps: 19669.24141
+  dps: 26955.82144
+  tps: 20891.95836
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 107204.98909
-  tps: 115856.57382
+  dps: 98927.22969
+  tps: 106997.95268
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 41746.62778
-  tps: 34344.72372
+  dps: 38230.34143
+  tps: 31583.02016
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 54499.7125
-  tps: 44213.5575
+  dps: 50687.65355
+  tps: 41720.42914
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 72570.47246
-  tps: 79393.4981
+  dps: 67701.61432
+  tps: 74281.58653
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 25892.39253
-  tps: 20640.68384
+  dps: 24046.47414
+  tps: 19496.02497
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 29499.74333
-  tps: 22435.2133
+  dps: 27185.06435
+  tps: 21082.38277
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 78956.75623
-  tps: 85975.91533
+  dps: 82785.26228
+  tps: 90391.80245
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 29470.33719
-  tps: 25130.63893
+  dps: 31367.8661
+  tps: 27117.6777
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 39387.34208
-  tps: 32936.05662
+  dps: 41351.22324
+  tps: 34994.67294
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 53106.60539
-  tps: 58690.88565
+  dps: 55957.01057
+  tps: 61887.00173
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 18311.82156
-  tps: 15468.99
+  dps: 19496.59383
+  tps: 16606.1579
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 21174.48406
-  tps: 16825.72989
+  dps: 22307.93834
+  tps: 17889.02173
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 89470.56867
-  tps: 97404.07835
+  dps: 82968.35534
+  tps: 90596.7307
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 34125.08442
-  tps: 29118.33584
+  dps: 31445.91447
+  tps: 27184.76553
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 44579.98095
-  tps: 37166.48519
+  dps: 41742.55074
+  tps: 35347.50156
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 59609.27051
-  tps: 65741.01738
+  dps: 56107.04771
+  tps: 62052.26618
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 21173.22667
-  tps: 17832.06701
+  dps: 19549.4686
+  tps: 16654.68572
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 24486.91888
-  tps: 19482.44603
+  dps: 22483.41447
+  tps: 18047.74174
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 78956.75623
-  tps: 85975.91533
+  dps: 82785.26228
+  tps: 90391.80245
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 29424.41355
-  tps: 24558.56535
+  dps: 31221.14552
+  tps: 26381.30553
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 38805.00803
-  tps: 32053.28227
+  dps: 41595.50668
+  tps: 34768.16206
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 53106.60539
-  tps: 58690.88565
+  dps: 55957.01057
+  tps: 61887.00173
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 18225.95078
-  tps: 14923.49773
+  dps: 19444.44589
+  tps: 16060.98185
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 20866.51899
-  tps: 16224.33948
+  dps: 22182.77062
+  tps: 17367.27056
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 89470.56867
-  tps: 97404.07835
+  dps: 82968.35534
+  tps: 90596.7307
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 33737.19514
-  tps: 28256.51484
+  dps: 31299.39996
+  tps: 26445.14173
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 44499.28055
-  tps: 36556.00922
+  dps: 41914.79739
+  tps: 35063.25629
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 59609.27051
-  tps: 65741.01738
+  dps: 56107.04771
+  tps: 62052.26618
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 20948.84756
-  tps: 17072.63094
+  dps: 19472.58462
+  tps: 16084.71351
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_smf-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 24111.23778
-  tps: 18642.06251
+  dps: 22346.84805
+  tps: 17513.61389
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 131212.7762
-  tps: 145101.55093
+  dps: 149953.17254
+  tps: 165098.63373
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 42732.50353
-  tps: 34566.89599
+  dps: 49897.59087
+  tps: 40916.69191
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 55077.76135
-  tps: 43985.35588
+  dps: 64455.40187
+  tps: 51759.33083
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 92648.8568
-  tps: 103530.98034
+  dps: 105977.97424
+  tps: 117961.55726
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 27390.74222
-  tps: 21669.44707
+  dps: 31793.32536
+  tps: 25447.47668
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 31470.04792
-  tps: 23635.77334
+  dps: 36471.11816
+  tps: 27607.00833
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 145132.75256
-  tps: 159897.49113
+  dps: 150287.50861
+  tps: 165462.11833
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 48298.28452
-  tps: 39178.40094
+  dps: 50003.41396
+  tps: 41003.50374
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 63331.72763
-  tps: 50650.63669
+  dps: 64898.76113
+  tps: 52155.52969
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 103425.13202
-  tps: 115023.65725
+  dps: 106163.90034
+  tps: 118168.3742
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 31241.75544
-  tps: 24668.91866
+  dps: 31872.57162
+  tps: 25507.87654
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 35710.13603
-  tps: 26787.23776
+  dps: 36764.8022
+  tps: 27842.88487
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 131212.7762
-  tps: 145101.55093
+  dps: 149953.17254
+  tps: 165098.63373
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 42431.37384
-  tps: 33342.61366
+  dps: 49801.48631
+  tps: 39883.82049
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 54815.43338
-  tps: 42908.93123
+  dps: 63353.0053
+  tps: 49465.25794
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 92648.8568
-  tps: 103530.98034
+  dps: 105977.97424
+  tps: 117961.55726
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 27226.53506
-  tps: 20863.54238
+  dps: 32318.12609
+  tps: 25223.19923
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 31448.1671
-  tps: 23066.84869
+  dps: 35852.05383
+  tps: 26608.91257
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 145132.75256
-  tps: 159897.49113
+  dps: 150287.50861
+  tps: 165462.11833
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 48439.17371
-  tps: 38210.68552
+  dps: 49915.83525
+  tps: 39970.39006
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 62616.98351
-  tps: 48660.34487
+  dps: 63766.13194
+  tps: 49826.92632
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 103425.13202
-  tps: 115023.65725
+  dps: 106163.90034
+  tps: 118168.3742
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 31287.96171
-  tps: 23984.36877
+  dps: 32348.75237
+  tps: 25250.32873
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-DefaultTalents-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 35664.40585
-  tps: 26014.38137
+  dps: 36091.86449
+  tps: 26806.14157
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 107481.16887
-  tps: 119506.97335
+  dps: 123667.88904
+  tps: 137149.59679
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 34036.01709
-  tps: 28600.46814
+  dps: 39875.39596
+  tps: 33830.50037
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 44594.82556
-  tps: 36692.28721
+  dps: 52127.37163
+  tps: 43363.06099
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 76872.18116
-  tps: 86627.83318
+  dps: 88370.628
+  tps: 99291.43961
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 21673.23534
-  tps: 17832.36629
+  dps: 25551.4182
+  tps: 21114.45442
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_smf_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 24945.81696
-  tps: 19266.16793
+  dps: 29185.41403
+  tps: 22651.13298
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 120589.3743
-  tps: 133727.54279
+  dps: 123969.88968
+  tps: 137478.49594
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 38802.91271
-  tps: 32418.60825
+  dps: 39950.05917
+  tps: 33891.2677
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 50597.89316
-  tps: 41521.40348
+  dps: 52539.31127
+  tps: 43736.89969
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 85369.96405
-  tps: 95727.38186
+  dps: 88553.22625
+  tps: 99496.06365
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 24740.00598
-  tps: 20279.06033
+  dps: 25577.39316
+  tps: 21137.43017
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-smf-p3_fury_tg_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 28621.58992
-  tps: 22096.96503
+  dps: 29428.941
+  tps: 22859.23113
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 107481.16887
-  tps: 119506.97335
+  dps: 123667.88904
+  tps: 137149.59679
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 34464.43326
-  tps: 27859.01345
+  dps: 40221.06685
+  tps: 32934.84366
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 44491.21853
-  tps: 35718.37177
+  dps: 51601.78675
+  tps: 41427.56797
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 76872.18116
-  tps: 86627.83318
+  dps: 88370.628
+  tps: 99291.43961
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 21985.06922
-  tps: 17317.97873
+  dps: 25464.22586
+  tps: 20260.34284
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_smf_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 25622.09776
-  tps: 19260.51224
+  dps: 29844.71972
+  tps: 22867.75488
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 120589.3743
-  tps: 133727.54279
+  dps: 123969.88968
+  tps: 137478.49594
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 39376.65842
-  tps: 31692.48938
+  dps: 40293.16136
+  tps: 32994.91379
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 51210.76081
-  tps: 40874.65621
+  dps: 52027.85419
+  tps: 41791.70747
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 85369.96405
-  tps: 95727.38186
+  dps: 88553.22625
+  tps: 99496.06365
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 25309.76093
-  tps: 20032.66887
+  dps: 25495.36958
+  tps: 20285.62778
  }
 }
 dps_results: {
  key: "TestFury-Settings-Worgen-p3_fury_tg-Titan's Grip-Basic-tg-p3_fury_tg_item_swap-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 29339.4139
-  tps: 22074.98005
+  dps: 29981.52983
+  tps: 22979.74849
  }
 }
 dps_results: {

--- a/ui/shaman/elemental/apls/aoe.apl.json
+++ b/ui/shaman/elemental/apls/aoe.apl.json
@@ -1,7 +1,7 @@
 {
 	"type": "TypeAPL",
 	"prepullActions": [
-		{"action":{"itemSwap":{"swapSet":"Swap1"}},"doAtValue":{"const":{"val":"-54s"}}},
+		{"action":{"itemSwap":{"swapSet":"Swap1"}},"doAtValue":{"const":{"val":"-124s"}}},
         {"action":{"castSpell":{"spellId":{"spellId":66842}}},"doAtValue":{"const":{"val":"-3s"}}},
         {"action":{"castSpell":{"spellId":{"spellId":79206}}},"doAtValue":{"const":{"val":"-1s"}},"hide":true},
         {"action":{"activateAura":{"auraId":{"spellId":74221,"tag":1}}},"doAtValue":{"const":{"val":"-1s"}}},

--- a/ui/shaman/elemental/apls/default.apl.json
+++ b/ui/shaman/elemental/apls/default.apl.json
@@ -1,7 +1,7 @@
 {
 	"type": "TypeAPL",
 	"prepullActions":  [
-		{"action":{"itemSwap":{"swapSet":"Swap1"}},"doAtValue":{"const":{"val":"-54s"}}},
+		{"action":{"itemSwap":{"swapSet":"Swap1"}},"doAtValue":{"const":{"val":"-124s"}}},
         {"action":{"castSpell":{"spellId":{"spellId":66842}}},"doAtValue":{"const":{"val":"-3s"}}},
         {"action":{"castSpell":{"spellId":{"spellId":79206}}},"doAtValue":{"const":{"val":"-1s"}},"hide":true},
         {"action":{"activateAura":{"auraId":{"spellId":74221,"tag":1}}},"doAtValue":{"const":{"val":"-1s"}}},

--- a/ui/warlock/demonology/apls/incinerate.apl.json
+++ b/ui/warlock/demonology/apls/incinerate.apl.json
@@ -1,7 +1,7 @@
 {
 	"type": "TypeAPL",
 	"prepullActions": [
-		{"action":{"itemSwap":{"swapSet":"Swap1"}},"doAtValue":{"const":{"val":"-60s"}}},
+		{"action":{"itemSwap":{"swapSet":"Swap1"}},"doAtValue":{"const":{"val":"-145s"}}},
 		{"action":{"castSpell":{"spellId":{"itemId":70142}}},"doAtValue":{"const":{"val":"-22.5"}}},
 		{"action":{"castSpell":{"spellId":{"spellId":30146}}},"doAtValue":{"const":{"val":"-10s"}}},
 		{"action":{"castSpell":{"spellId":{"spellId":77801}}},"doAtValue":{"const":{"val":"-4.01s"}},"hide":true},

--- a/ui/warlock/demonology/apls/shadow-bolt.apl.json
+++ b/ui/warlock/demonology/apls/shadow-bolt.apl.json
@@ -1,7 +1,7 @@
 {
 	"type": "TypeAPL",
 	"prepullActions": [
-		{"action":{"itemSwap":{"swapSet":"Swap1"}},"doAtValue":{"const":{"val":"-60s"}}},
+		{"action":{"itemSwap":{"swapSet":"Swap1"}},"doAtValue":{"const":{"val":"-145s"}}},
 		{"action":{"castSpell":{"spellId":{"itemId":70142}}},"doAtValue":{"const":{"val":"-22.5"}}},
 		{"action":{"castSpell":{"spellId":{"spellId":30146}}},"doAtValue":{"const":{"val":"-10s"}}},
 		{"action":{"castSpell":{"spellId":{"spellId":77801}}},"doAtValue":{"const":{"val":"-4.01s"}},"hide":true},

--- a/ui/warrior/fury/apls/smf.apl.json
+++ b/ui/warrior/fury/apls/smf.apl.json
@@ -1,7 +1,7 @@
 {
 	"type": "TypeAPL",
 	"prepullActions": [
-		{"action":{"itemSwap":{"swapSet":"Swap1"}},"doAtValue":{"const":{"val":"-70s"}}},
+		{"action":{"itemSwap":{"swapSet":"Swap1"}},"doAtValue":{"const":{"val":"-150s"}}},
 		{"action":{"castSpell":{"spellId":{"itemId":70142}}},"doAtValue":{"const":{"val":"-20.1s"}}},
 		{"action":{"castSpell":{"spellId":{"spellId":2458}}},"doAtValue":{"const":{"val":"-2s"}}},
 		{"action":{"castSpell":{"spellId":{"spellId":6673}}},"doAtValue":{"const":{"val":"-1.7s"}}},

--- a/ui/warrior/fury/apls/tg.apl.json
+++ b/ui/warrior/fury/apls/tg.apl.json
@@ -1,7 +1,7 @@
 {
 	"type": "TypeAPL",
 	"prepullActions": [
-		{"action":{"itemSwap":{"swapSet":"Swap1"}},"doAtValue":{"const":{"val":"-70s"}}},
+		{"action":{"itemSwap":{"swapSet":"Swap1"}},"doAtValue":{"const":{"val":"-150s"}}},
 		{"action":{"castSpell":{"spellId":{"itemId":70142}}},"doAtValue":{"const":{"val":"-20.1s"}}},
 		{"action":{"castSpell":{"spellId":{"spellId":2458}}},"doAtValue":{"const":{"val":"-2s"}}},
 		{"action":{"castSpell":{"spellId":{"spellId":6673}}},"doAtValue":{"const":{"val":"-1.7s"}}},


### PR DESCRIPTION
WIP for allowing a Aura to be Enabled/Disabled. Needed for when Item Swapping combined with "Activate Aura" APL for example. Aura's can falsefully be Activated whilst not being equipped (Enabled).