### PR TITLE
Add Shattering Throw raid buff

### DIFF
--- a/proto/common.proto
+++ b/proto/common.proto
@@ -658,6 +658,7 @@ message IndividualBuffs {
 	int32 hand_of_sacrifice_count = 25;
 	int32 guardian_spirit_count = 26;
 	int32 rallying_cry_count = 102;
+	int32 shattering_throw_count = 103;
 	bool focus_magic = 22;
 	bool dark_intent = 27;
 

--- a/sim/core/armor_test.go
+++ b/sim/core/armor_test.go
@@ -173,7 +173,7 @@ func TestDamageReductionFromArmor(t *testing.T) {
 	}
 
 	// Major Multi
-	shatteringThrowAura := ShatteringThrowAura(&target)
+	shatteringThrowAura := ShatteringThrowAura(&target, attacker.UnitIndex)
 	shatteringThrowAura.Activate(&sim)
 	expectedDamageReduction = 0.244387
 	if !WithinToleranceFloat64(1-expectedDamageReduction, attackTable.GetArmorDamageModifier(spell), tolerance) {

--- a/sim/core/buffs.go
+++ b/sim/core/buffs.go
@@ -299,6 +299,7 @@ func applyBuffEffects(agent Agent, raidBuffs *proto.RaidBuffs, _ *proto.PartyBuf
 		registerPainSuppressionCD(agent, individualBuffs.PainSuppressionCount)
 		registerGuardianSpiritCD(agent, individualBuffs.GuardianSpiritCount)
 		registerRallyingCryCD(agent, individualBuffs.RallyingCryCount)
+		registerShatteringThrowCD(agent, individualBuffs.ShatteringThrowCount)
 
 		if individualBuffs.FocusMagic {
 			FocusMagicAura(nil, &character.Unit)
@@ -1677,30 +1678,32 @@ func RallyingCryAura(character *Character, actionTag int32) *Aura {
 
 const ShatteringThrowCD = time.Minute * 5
 
-// func registerShatteringThrowCD(agent Agent, numShatteringThrows int32) {
-// 	if numShatteringThrows == 0 {
-// 		return
-// 	}
+func registerShatteringThrowCD(agent Agent, numShatteringThrows int32) {
+	if numShatteringThrows == 0 {
+		return
+	}
 
-// 	stAura := ShatteringThrowAura(agent.GetCharacter().Env.Encounter.TargetUnits[0])
+	stAura := ShatteringThrowAura(agent.GetCharacter().Env.Encounter.TargetUnits[0], -1)
 
-// 	registerExternalConsecutiveCDApproximation(
-// 		agent,
-// 		externalConsecutiveCDApproximation{
-// 			ActionID:         ActionID{SpellID: 64382, Tag: -1},
-// 			AuraTag:          ShatteringThrowAuraTag,
-// 			CooldownPriority: CooldownPriorityDefault,
-// 			AuraDuration:     ShatteringThrowDuration,
-// 			AuraCD:           ShatteringThrowCD,
-// 			Type:             CooldownTypeDPS,
+	registerExternalConsecutiveCDApproximation(
+		agent,
+		externalConsecutiveCDApproximation{
+			ActionID:         ActionID{SpellID: 64382, Tag: -1},
+			AuraTag:          ShatteringThrowAuraTag,
+			CooldownPriority: CooldownPriorityDefault,
+			AuraDuration:     ShatteringThrowDuration,
+			AuraCD:           ShatteringThrowCD,
+			Type:             CooldownTypeDPS,
 
-// 			ShouldActivate: func(sim *Simulation, unit *Unit) bool {
-// 				return true
-// 			},
-// 			AddAura: func(sim *Simulation, unit *Unit) { stAura.Activate(sim) },
-// 		},
-// 		numShatteringThrows)
-// }
+			ShouldActivate: func(sim *Simulation, character *Character) bool {
+				return true
+			},
+			AddAura: func(sim *Simulation, character *Character) {
+				stAura.Activate(sim)
+			},
+		},
+		numShatteringThrows)
+}
 
 var InnervateAuraTag = "Innervate"
 

--- a/sim/core/debuffs.go
+++ b/sim/core/debuffs.go
@@ -121,14 +121,13 @@ func applyDebuffEffects(target *Unit, targetIdx int, debuffs *proto.Debuffs, rai
 	if debuffs.FaerieFire && targetIdx == 0 {
 		aura := FaerieFireAura(target)
 		ScheduledMajorArmorAura(aura, PeriodicActionOptions{
-			Period:          time.Millisecond * 1500,
-			NumTicks:        3,
-			TickImmediately: true,
-			Priority:        ActionPriorityDOT,
+			Period:   time.Millisecond * 1500,
+			NumTicks: 1,
+			Priority: ActionPriorityDOT,
 			OnAction: func(sim *Simulation) {
 				aura.Activate(sim)
 				if aura.IsActive() {
-					aura.AddStack(sim)
+					aura.SetStacks(sim, 3)
 				}
 			},
 		}, raid)
@@ -476,13 +475,13 @@ func ExposeArmorAura(target *Unit, hasGlyph bool) *Aura {
 var ShatteringThrowAuraTag = "ShatteringThrow"
 var ShatteringThrowDuration = time.Second * 10
 
-func ShatteringThrowAura(target *Unit) *Aura {
+func ShatteringThrowAura(target *Unit, actionTag int32) *Aura {
 	armorReduction := 0.2
 
 	return target.GetOrRegisterAura(Aura{
 		Label:    "Shattering Throw",
 		Tag:      ShatteringThrowAuraTag,
-		ActionID: ActionID{SpellID: 64382},
+		ActionID: ActionID{SpellID: 64382, Tag: actionTag},
 		Duration: ShatteringThrowDuration,
 		OnGain: func(aura *Aura, sim *Simulation) {
 			aura.Unit.PseudoStats.ArmorMultiplier *= (1.0 - armorReduction)

--- a/sim/warrior/glyphs.go
+++ b/sim/warrior/glyphs.go
@@ -69,14 +69,6 @@ func (warrior *Warrior) applyMinorGlyphs() {
 			FloatValue: 0.5,
 		})
 	}
-
-	if warrior.HasMinorGlyph(proto.WarriorMinorGlyph_GlyphOfShatteringThrow) {
-		warrior.AddStaticMod(core.SpellModConfig{
-			ClassMask:  SpellMaskShatteringThrow,
-			Kind:       core.SpellMod_CastTime_Pct,
-			FloatValue: -1.0,
-		})
-	}
 }
 
 func (warrior *Warrior) ApplyGlyphs() {

--- a/ui/core/components/inputs/buffs_debuffs.ts
+++ b/ui/core/components/inputs/buffs_debuffs.ts
@@ -183,9 +183,14 @@ export const ManaTideTotem = makeMultistateRaidBuffInput({ actionId: ActionId.fr
 export const Innervate = makeMultistateIndividualBuffInput({ actionId: ActionId.fromSpellId(29166), numStates: 11, fieldName: 'innervateCount' });
 export const PowerInfusion = makeMultistateIndividualBuffInput({ actionId: ActionId.fromSpellId(10060), numStates: 11, fieldName: 'powerInfusionCount' });
 export const FocusMagic = makeBooleanIndividualBuffInput({ actionId: ActionId.fromSpellId(54648), fieldName: 'focusMagic' });
-export const TricksOfTheTrade = makeTristateIndividualBuffInput({ actionId: ActionId.fromItemId(45767), impId: ActionId.fromSpellId(57933), fieldName: 'tricksOfTheTrade' });
+export const TricksOfTheTrade = makeTristateIndividualBuffInput({
+	actionId: ActionId.fromItemId(45767),
+	impId: ActionId.fromSpellId(57933),
+	fieldName: 'tricksOfTheTrade',
+});
 export const UnholyFrenzy = makeMultistateIndividualBuffInput({ actionId: ActionId.fromSpellId(49016), numStates: 11, fieldName: 'unholyFrenzyCount' });
 export const DarkIntent = makeBooleanIndividualBuffInput({ actionId: ActionId.fromSpellId(85759), fieldName: 'darkIntent' });
+export const ShatteringThrow = makeMultistateIndividualBuffInput({ actionId: ActionId.fromSpellId(64382), numStates: 11, fieldName: 'shatteringThrowCount' });
 
 ///////////////////////////////////////////////////////////////////////////
 //                                 DEBUFFS
@@ -388,6 +393,11 @@ export const RAID_BUFFS_MISC_CONFIG = [
 	},
 	{
 		config: UnholyFrenzy,
+		picker: IconPicker,
+		stats: [Stat.StatAttackPower, Stat.StatRangedAttackPower],
+	},
+	{
+		config: ShatteringThrow,
 		picker: IconPicker,
 		stats: [Stat.StatAttackPower, Stat.StatRangedAttackPower],
 	},

--- a/ui/core/proto_utils/action_id.ts
+++ b/ui/core/proto_utils/action_id.ts
@@ -345,7 +345,9 @@ export class ActionId {
 				}
 				break;
 			case 'Shattering Throw':
-				if (tag === playerIndex) {
+				if (tag === -1) {
+					name += ' (raid)';
+				} else {
 					name += ` (self)`;
 				}
 				break;

--- a/ui/core/talents/warrior.ts
+++ b/ui/core/talents/warrior.ts
@@ -180,11 +180,6 @@ export const warriorGlyphsConfig: GlyphsConfig = {
 			name: 'Glyph of Intimidating Shout',
 			description: 'All targets of your Intimidating Shout now tremble in place instead of fleeing in fear.',
 			iconUrl: 'https://wow.zamimg.com/images/wow/icons/large/ability_golemthunderclap.jpg',
-		},
-		[WarriorMinorGlyph.GlyphOfShatteringThrow]: {
-			name: 'Glyph of Shattering Throw',
-			description: 'Your Shattering Throw is now instant and can be used in any stance, but it no longer removes invulnerabilities and cannot be used on players or player-controlled targets.',
-			iconUrl: 'https://wow.zamimg.com/images/wow/icons/large/inv_misc_questionmark.jpg',
-		},
+		}
 	},
 };

--- a/ui/scss/core/components/_icon_picker.scss
+++ b/ui/scss/core/components/_icon_picker.scss
@@ -33,7 +33,7 @@
 			left: 0;
 			right: 0;
 			text-align: center;
-			background: var(--black-alpha-30);
+			background: var(--bs-black-alpha-50);
 			color: var(--bs-success);
 			font-size: 0.625rem;
 			font-weight: bold;


### PR DESCRIPTION
- Add (enable) Shattering Throw as Buff (external)
- Added Shattering Throw Missile Speed
- Modified Action ID for self and raid casts
- Modified Faerie Fire (external) to always apply 3 stacks as if it's cast by a Feral Druid
- Removed Glyph of Shattering Throw