### PR TITLE
[Feral] Talents Code Refactor

### DIFF
--- a/sim/core/aura_helpers.go
+++ b/sim/core/aura_helpers.go
@@ -391,6 +391,10 @@ func (parentAura *Aura) AttachStatsBuff(stats stats.Stats) {
 	parentAura.ApplyOnExpire(func(aura *Aura, sim *Simulation) {
 		aura.Unit.AddStatsDynamic(sim, stats.Invert())
 	})
+
+	if parentAura.IsActive() {
+		parentAura.Unit.AddStats(stats)
+	}
 }
 
 // Adds a Stat to a parent Aura
@@ -398,6 +402,21 @@ func (parentAura *Aura) AttachStatBuff(stat stats.Stat, value float64) {
 	statsToAdd := stats.Stats{}
 	statsToAdd[stat] = value
 	parentAura.AttachStatsBuff(statsToAdd)
+}
+
+// Attaches a multiplicative PseudoStat buff to a parent Aura
+func (parentAura *Aura) AttachMultiplicativePseudoStatBuff(fieldPointer *float64, multiplier float64) {
+	parentAura.ApplyOnGain(func(_ *Aura, _ *Simulation) {
+		*fieldPointer *= multiplier
+	})
+
+	parentAura.ApplyOnExpire(func(_ *Aura, _ *Simulation) {
+		*fieldPointer /= multiplier
+	})
+
+	if parentAura.IsActive() {
+		*fieldPointer *= multiplier
+	}
 }
 
 type ShieldStrengthCalculator func(unit *Unit) float64

--- a/sim/core/aura_helpers.go
+++ b/sim/core/aura_helpers.go
@@ -419,6 +419,21 @@ func (parentAura *Aura) AttachMultiplicativePseudoStatBuff(fieldPointer *float64
 	}
 }
 
+// Attaches an additive PseudoStat buff to a parent Aura
+func (parentAura *Aura) AttachAdditivePseudoStatBuff(fieldPointer *float64, bonus float64) {
+	parentAura.ApplyOnGain(func(_ *Aura, _ *Simulation) {
+		*fieldPointer += bonus
+	})
+
+	parentAura.ApplyOnExpire(func(_ *Aura, _ *Simulation) {
+		*fieldPointer -= bonus
+	})
+
+	if parentAura.IsActive() {
+		*fieldPointer += bonus
+	}
+}
+
 type ShieldStrengthCalculator func(unit *Unit) float64
 
 type DamageAbsorptionAura struct {

--- a/sim/core/character.go
+++ b/sim/core/character.go
@@ -793,7 +793,7 @@ func (character *Character) MeetsArmorSpecializationRequirement(armorType proto.
 	return true
 }
 
-func (character *Character) ApplyArmorSpecializationEffect(primaryStat stats.Stat, armorType proto.ArmorType, spellID int32) {
+func (character *Character) ApplyArmorSpecializationEffect(primaryStat stats.Stat, armorType proto.ArmorType, spellID int32) *Aura {
 	armorSpecializationDependency := character.NewDynamicMultiplyStat(primaryStat, 1.05)
 	isEnabled := character.MeetsArmorSpecializationRequirement(armorType)
 
@@ -829,4 +829,6 @@ func (character *Character) ApplyArmorSpecializationEffect(primaryStat stats.Sta
 				aura.Deactivate(sim)
 			}
 		})
+
+	return aura
 }

--- a/sim/core/character.go
+++ b/sim/core/character.go
@@ -218,6 +218,14 @@ func (character *Character) ApplyDynamicEquipScaling(sim *Simulation, stat stats
 	character.AddStatDynamic(sim, stat, statDiff)
 }
 
+func (character *Character) ApplyBuildPhaseEquipScaling(sim *Simulation, stat stats.Stat, multiplier float64) {
+	if character.Env.MeasuringStats && (character.Env.State != Finalized) {
+		character.ApplyEquipScaling(stat, multiplier)
+	} else {
+		character.ApplyDynamicEquipScaling(sim, stat, multiplier)
+	}
+}
+
 func (character *Character) RemoveEquipScaling(stat stats.Stat, multiplier float64) {
 	var statDiff stats.Stats
 	statDiff[stat] = character.applyEquipScaling(stat, 1/multiplier)
@@ -231,6 +239,14 @@ func (character *Character) RemoveEquipScaling(stat stats.Stat, multiplier float
 func (character *Character) RemoveDynamicEquipScaling(sim *Simulation, stat stats.Stat, multiplier float64) {
 	statDiff := character.applyEquipScaling(stat, 1/multiplier)
 	character.AddStatDynamic(sim, stat, statDiff)
+}
+
+func (character *Character) RemoveBuildPhaseEquipScaling(sim *Simulation, stat stats.Stat, multiplier float64) {
+	if character.Env.MeasuringStats && (character.Env.State != Finalized) {
+		character.RemoveEquipScaling(stat, multiplier)
+	} else {
+		character.RemoveDynamicEquipScaling(sim, stat, multiplier)
+	}
 }
 
 func (character *Character) EquipStats() stats.Stats {

--- a/sim/druid/druid.go
+++ b/sim/druid/druid.go
@@ -32,8 +32,10 @@ type Druid struct {
 	BleedsActive      int
 	AssumeBleedActive bool
 
-	MHAutoSpell       *core.Spell
-	ReplaceBearMHFunc core.ReplaceMHSwing
+	MHAutoSpell *core.Spell
+
+	HotWCatDep  *stats.StatDependency
+	HotWBearDep *stats.StatDependency
 
 	Barkskin              *DruidSpell
 	Berserk               *DruidSpell

--- a/sim/druid/druid.go
+++ b/sim/druid/druid.go
@@ -323,8 +323,8 @@ func (druid *Druid) RegisterFeralCatSpells() {
 
 func (druid *Druid) RegisterFeralTankSpells() {
 	druid.registerBarkskinCD()
-	druid.registerBerserkCD()
 	druid.registerBearFormSpell()
+	druid.registerBerserkCD()
 	druid.registerDemoralizingRoarSpell()
 	druid.registerEnrageSpell()
 	druid.registerFrenziedRegenerationCD()

--- a/sim/druid/druid.go
+++ b/sim/druid/druid.go
@@ -266,6 +266,7 @@ func (druid *Druid) RegisterSpell(formMask DruidForm, config core.SpellConfig) *
 }
 
 func (druid *Druid) Initialize() {
+	druid.form = druid.StartingForm
 	druid.LeatherSpecActive = druid.MeetsArmorSpecializationRequirement(proto.ArmorType_ArmorTypeLeather)
 	druid.BleedCategories = druid.GetEnemyExclusiveCategories(core.BleedEffectCategory)
 

--- a/sim/druid/druid.go
+++ b/sim/druid/druid.go
@@ -31,7 +31,6 @@ type Druid struct {
 	RebirthTiming     float64
 	BleedsActive      int
 	AssumeBleedActive bool
-	LeatherSpecActive bool
 
 	MHAutoSpell       *core.Spell
 	ReplaceBearMHFunc core.ReplaceMHSwing
@@ -123,6 +122,9 @@ type Druid struct {
 
 	form         DruidForm
 	disabledMCDs []*core.MajorCooldown
+
+	// Leather specialization tracker
+	LeatherSpec *core.Aura
 
 	// Item sets
 	T11Feral2pBonus *core.Aura
@@ -267,18 +269,12 @@ func (druid *Druid) RegisterSpell(formMask DruidForm, config core.SpellConfig) *
 
 func (druid *Druid) Initialize() {
 	druid.form = druid.StartingForm
-	druid.LeatherSpecActive = druid.MeetsArmorSpecializationRequirement(proto.ArmorType_ArmorTypeLeather)
 	druid.BleedCategories = druid.GetEnemyExclusiveCategories(core.BleedEffectCategory)
 
 	druid.Env.RegisterPostFinalizeEffect(func() {
 		druid.MHAutoSpell = druid.AutoAttacks.MHAuto()
 		druid.BlazeOfGloryAura = druid.GetAura("Blaze of Glory")
 	})
-
-	// Leather spec would always provide 5% intellect regardless of the Druid spec or form
-	if druid.LeatherSpecActive {
-		druid.MultiplyStat(stats.Intellect, 1.05)
-	}
 
 	druid.registerFaerieFireSpell()
 	// druid.registerRebirthSpell()
@@ -341,6 +337,18 @@ func (druid *Druid) RegisterFeralTankSpells() {
 	druid.registerThrashBearSpell()
 }
 
+func (druid *Druid) RegisterLeatherSpecialization() {
+	// Druid armor spec behaves differently from other classes because the boosted stats are linked to form rather
+	// than talents. For this reason, we modify the default tracker Aura to activate at BuildPhaseGear rather than
+	// BuildPhaseTalents, and also add custom handlers for the cat Agi bonus and the bear Stam bonus in forms.go (the
+	// Int bonus applies in all forms).
+	druid.LeatherSpec = druid.ApplyArmorSpecializationEffect(stats.Intellect, proto.ArmorType_ArmorTypeLeather, 87505)
+
+	if druid.LeatherSpec.BuildPhase == core.CharacterBuildPhaseTalents {
+		druid.LeatherSpec.BuildPhase = core.CharacterBuildPhaseGear
+	}
+}
+
 func (druid *Druid) Reset(_ *core.Simulation) {
 	druid.eclipseEnergyBar.reset()
 	druid.BleedsActive = 0
@@ -371,6 +379,8 @@ func New(char *core.Character, form DruidForm, selfBuffs SelfBuffs, talents stri
 
 	// Base dodge is unaffected by Diminishing Returns
 	druid.PseudoStats.BaseDodgeChance += 0.04951
+
+	druid.RegisterLeatherSpecialization()
 
 	if druid.Talents.ForceOfNature {
 		druid.Treants = &Treants{

--- a/sim/druid/feral/feral.go
+++ b/sim/druid/feral/feral.go
@@ -53,9 +53,9 @@ func NewFeralDruid(character *core.Character, options *proto.Player) *FeralDruid
 		MainHand:       cat.GetCatWeapon(),
 		AutoSwingMelee: true,
 	})
-	// cat.ReplaceBearMHFunc = func(sim *core.Simulation, mhSwingSpell *core.Spell) *core.Spell {
-	// 	return cat.checkReplaceMaul(sim, mhSwingSpell)
-	// }
+
+	cat.RegisterCatFormAura()
+	cat.RegisterBearFormAura()
 
 	return cat
 }

--- a/sim/druid/forms.go
+++ b/sim/druid/forms.go
@@ -82,12 +82,6 @@ func (druid *Druid) RegisterCatFormAura() {
 	}
 
 	agiApDep := druid.NewDynamicStatDependency(stats.Agility, stats.AttackPower, 2)
-
-	var hotwDep *stats.StatDependency
-	if druid.Talents.HeartOfTheWild > 0 {
-		hotwDep = druid.NewDynamicMultiplyStat(stats.AttackPower, []float64{1.0, 1.03, 1.07, 1.1}[druid.Talents.HeartOfTheWild])
-	}
-
 	leatherSpecDep := druid.NewDynamicMultiplyStat(stats.Agility, 1.05)
 
 	// Need redundant enabling/disabling of the dep both here and below
@@ -125,8 +119,8 @@ func (druid *Druid) RegisterCatFormAura() {
 
 			druid.AddStatsDynamic(sim, statBonus)
 			druid.EnableBuildPhaseStatDep(sim, agiApDep)
-			if hotwDep != nil {
-				druid.EnableBuildPhaseStatDep(sim, hotwDep)
+			if druid.HotWCatDep != nil {
+				druid.EnableBuildPhaseStatDep(sim, druid.HotWCatDep)
 			}
 			if druid.LeatherSpec.IsActive() {
 				druid.EnableBuildPhaseStatDep(sim, leatherSpecDep)
@@ -156,8 +150,8 @@ func (druid *Druid) RegisterCatFormAura() {
 
 			druid.AddStatsDynamic(sim, statBonus.Invert())
 			druid.DisableBuildPhaseStatDep(sim, agiApDep)
-			if hotwDep != nil {
-				druid.DisableBuildPhaseStatDep(sim, hotwDep)
+			if druid.HotWCatDep != nil {
+				druid.DisableBuildPhaseStatDep(sim, druid.HotWCatDep)
 			}
 			if druid.LeatherSpec.IsActive() {
 				druid.DisableBuildPhaseStatDep(sim, leatherSpecDep)
@@ -233,12 +227,6 @@ func (druid *Druid) RegisterBearFormAura() {
 
 	agiApDep := druid.NewDynamicStatDependency(stats.Agility, stats.AttackPower, 2)
 	stamDep := druid.NewDynamicMultiplyStat(stats.Stamina, 1.2)
-
-	var hotwDep *stats.StatDependency
-	if druid.Talents.HeartOfTheWild > 0 {
-		hotwDep = druid.NewDynamicMultiplyStat(stats.Stamina, 1.0+0.02*float64(druid.Talents.HeartOfTheWild))
-	}
-
 	leatherSpecDep := druid.NewDynamicMultiplyStat(stats.Stamina, 1.05)
 
 	// Need redundant enabling/disabling of the dep both here and below
@@ -284,8 +272,8 @@ func (druid *Druid) RegisterBearFormAura() {
 			// Preserve fraction of max health when shifting
 			healthFrac := druid.CurrentHealth() / druid.MaxHealth()
 			druid.EnableBuildPhaseStatDep(sim, stamDep)
-			if hotwDep != nil {
-				druid.EnableBuildPhaseStatDep(sim, hotwDep)
+			if druid.HotWBearDep != nil {
+				druid.EnableBuildPhaseStatDep(sim, druid.HotWBearDep)
 			}
 			if druid.LeatherSpec.IsActive() {
 				druid.EnableBuildPhaseStatDep(sim, leatherSpecDep)
@@ -312,8 +300,8 @@ func (druid *Druid) RegisterBearFormAura() {
 
 			healthFrac := druid.CurrentHealth() / druid.MaxHealth()
 			druid.DisableBuildPhaseStatDep(sim, stamDep)
-			if hotwDep != nil {
-				druid.DisableBuildPhaseStatDep(sim, hotwDep)
+			if druid.HotWBearDep != nil {
+				druid.DisableBuildPhaseStatDep(sim, druid.HotWBearDep)
 			}
 			if druid.LeatherSpec.IsActive() {
 				druid.DisableBuildPhaseStatDep(sim, leatherSpecDep)

--- a/sim/druid/forms.go
+++ b/sim/druid/forms.go
@@ -115,7 +115,6 @@ func (druid *Druid) RegisterCatFormAura() {
 
 			druid.PseudoStats.ThreatMultiplier *= 0.71
 			druid.PseudoStats.SpiritRegenMultiplier *= AnimalSpiritRegenSuppression
-			druid.PseudoStats.BaseDodgeChance += 0.02 * float64(druid.Talents.FeralSwiftness)
 
 			druid.AddStatsDynamic(sim, statBonus)
 			druid.EnableBuildPhaseStatDep(sim, agiApDep)
@@ -146,7 +145,6 @@ func (druid *Druid) RegisterCatFormAura() {
 
 			druid.PseudoStats.ThreatMultiplier /= 0.71
 			druid.PseudoStats.SpiritRegenMultiplier /= AnimalSpiritRegenSuppression
-			druid.PseudoStats.BaseDodgeChance -= 0.02 * float64(druid.Talents.FeralSwiftness)
 
 			druid.AddStatsDynamic(sim, statBonus.Invert())
 			druid.DisableBuildPhaseStatDep(sim, agiApDep)
@@ -263,7 +261,7 @@ func (druid *Druid) RegisterBearFormAura() {
 			druid.PseudoStats.ThreatMultiplier *= 5
 			druid.PseudoStats.DamageTakenMultiplier *= nrdtm
 			druid.PseudoStats.SpiritRegenMultiplier *= AnimalSpiritRegenSuppression
-			druid.PseudoStats.BaseDodgeChance += 0.02*float64(druid.Talents.FeralSwiftness) + 0.03*float64(druid.Talents.NaturalReaction)
+			druid.PseudoStats.BaseDodgeChance += 0.03*float64(druid.Talents.NaturalReaction)
 
 			druid.AddStatsDynamic(sim, statBonus)
 			druid.ApplyBuildPhaseEquipScaling(sim, stats.Armor, druid.BearArmorMultiplier())
@@ -292,7 +290,7 @@ func (druid *Druid) RegisterBearFormAura() {
 			druid.PseudoStats.ThreatMultiplier /= 5
 			druid.PseudoStats.DamageTakenMultiplier /= nrdtm
 			druid.PseudoStats.SpiritRegenMultiplier /= AnimalSpiritRegenSuppression
-			druid.PseudoStats.BaseDodgeChance -= 0.02*float64(druid.Talents.FeralSwiftness) + 0.03*float64(druid.Talents.NaturalReaction)
+			druid.PseudoStats.BaseDodgeChance -= 0.03*float64(druid.Talents.NaturalReaction)
 
 			druid.AddStatsDynamic(sim, statBonus.Invert())
 			druid.RemoveBuildPhaseEquipScaling(sim, stats.Armor, druid.BearArmorMultiplier())

--- a/sim/druid/forms.go
+++ b/sim/druid/forms.go
@@ -79,7 +79,6 @@ func (druid *Druid) RegisterCatFormAura() {
 
 	statBonus := stats.Stats{
 		stats.AttackPower:         -20, // This offset is needed because the first 10 points of Agility do not contribute any Attack Power.
-		stats.PhysicalCritPercent: core.TernaryFloat64(druid.Talents.MasterShapeshifter, 4, 0),
 	}
 
 	agiApDep := druid.NewDynamicStatDependency(stats.Agility, stats.AttackPower, 2)
@@ -274,7 +273,6 @@ func (druid *Druid) RegisterBearFormAura() {
 			druid.SetCurrentPowerBar(core.RageBar)
 
 			druid.PseudoStats.ThreatMultiplier *= 5
-			druid.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexPhysical] *= core.TernaryFloat64(druid.Talents.MasterShapeshifter, 1.04, 1.0)
 			druid.PseudoStats.DamageTakenMultiplier *= nrdtm
 			druid.PseudoStats.SpiritRegenMultiplier *= AnimalSpiritRegenSuppression
 			druid.PseudoStats.BaseDodgeChance += 0.02*float64(druid.Talents.FeralSwiftness) + 0.03*float64(druid.Talents.NaturalReaction)
@@ -304,7 +302,6 @@ func (druid *Druid) RegisterBearFormAura() {
 			druid.form = Humanoid
 
 			druid.PseudoStats.ThreatMultiplier /= 5
-			druid.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexPhysical] /= core.TernaryFloat64(druid.Talents.MasterShapeshifter, 1.04, 1.0)
 			druid.PseudoStats.DamageTakenMultiplier /= nrdtm
 			druid.PseudoStats.SpiritRegenMultiplier /= AnimalSpiritRegenSuppression
 			druid.PseudoStats.BaseDodgeChance -= 0.02*float64(druid.Talents.FeralSwiftness) + 0.03*float64(druid.Talents.NaturalReaction)

--- a/sim/druid/forms.go
+++ b/sim/druid/forms.go
@@ -243,6 +243,7 @@ func (druid *Druid) RegisterBearFormAura() {
 	})
 
 	clawWeapon := druid.GetBearWeapon()
+	baseBearArmorMulti := 2.2 // Thick Hide contribution handled separately in talents code for cleanliness and UI stats display.
 
 	druid.BearFormAura = druid.RegisterAura(core.Aura{
 		Label:      "Bear Form",
@@ -260,7 +261,7 @@ func (druid *Druid) RegisterBearFormAura() {
 			druid.PseudoStats.SpiritRegenMultiplier *= AnimalSpiritRegenSuppression
 
 			druid.AddStatsDynamic(sim, statBonus)
-			druid.ApplyBuildPhaseEquipScaling(sim, stats.Armor, druid.BearArmorMultiplier())
+			druid.ApplyBuildPhaseEquipScaling(sim, stats.Armor, baseBearArmorMulti)
 			druid.EnableBuildPhaseStatDep(sim, agiApDep)
 
 			// Preserve fraction of max health when shifting
@@ -287,7 +288,7 @@ func (druid *Druid) RegisterBearFormAura() {
 			druid.PseudoStats.SpiritRegenMultiplier /= AnimalSpiritRegenSuppression
 
 			druid.AddStatsDynamic(sim, statBonus.Invert())
-			druid.RemoveBuildPhaseEquipScaling(sim, stats.Armor, druid.BearArmorMultiplier())
+			druid.RemoveBuildPhaseEquipScaling(sim, stats.Armor, baseBearArmorMulti)
 			druid.DisableBuildPhaseStatDep(sim, agiApDep)
 
 			healthFrac := druid.CurrentHealth() / druid.MaxHealth()

--- a/sim/druid/forms.go
+++ b/sim/druid/forms.go
@@ -242,8 +242,6 @@ func (druid *Druid) RegisterBearFormAura() {
 		}
 	})
 
-	nrdtm := 1 - 0.09*float64(druid.Talents.NaturalReaction)
-
 	clawWeapon := druid.GetBearWeapon()
 
 	druid.BearFormAura = druid.RegisterAura(core.Aura{
@@ -259,9 +257,7 @@ func (druid *Druid) RegisterBearFormAura() {
 			druid.SetCurrentPowerBar(core.RageBar)
 
 			druid.PseudoStats.ThreatMultiplier *= 5
-			druid.PseudoStats.DamageTakenMultiplier *= nrdtm
 			druid.PseudoStats.SpiritRegenMultiplier *= AnimalSpiritRegenSuppression
-			druid.PseudoStats.BaseDodgeChance += 0.03*float64(druid.Talents.NaturalReaction)
 
 			druid.AddStatsDynamic(sim, statBonus)
 			druid.ApplyBuildPhaseEquipScaling(sim, stats.Armor, druid.BearArmorMultiplier())
@@ -288,9 +284,7 @@ func (druid *Druid) RegisterBearFormAura() {
 			druid.form = Humanoid
 
 			druid.PseudoStats.ThreatMultiplier /= 5
-			druid.PseudoStats.DamageTakenMultiplier /= nrdtm
 			druid.PseudoStats.SpiritRegenMultiplier /= AnimalSpiritRegenSuppression
-			druid.PseudoStats.BaseDodgeChance -= 0.03*float64(druid.Talents.NaturalReaction)
 
 			druid.AddStatsDynamic(sim, statBonus.Invert())
 			druid.RemoveBuildPhaseEquipScaling(sim, stats.Armor, druid.BearArmorMultiplier())

--- a/sim/druid/forms.go
+++ b/sim/druid/forms.go
@@ -91,6 +91,21 @@ func (druid *Druid) RegisterCatFormAura() {
 
 	leatherSpecDep := druid.NewDynamicMultiplyStat(stats.Agility, 1.05)
 
+	// Need redundant enabling/disabling of the dep both here and below
+	// because we don't know whether the leather spec tracker or Cat Form will
+	// activate first.
+	druid.LeatherSpec.ApplyOnGain(func(_ *core.Aura, sim *core.Simulation) {
+		if druid.InForm(Cat) {
+			druid.EnableBuildPhaseStatDep(sim, leatherSpecDep)
+		}
+	})
+
+	druid.LeatherSpec.ApplyOnExpire(func(_ *core.Aura, sim *core.Simulation) {
+		if druid.InForm(Cat) {
+			druid.DisableBuildPhaseStatDep(sim, leatherSpecDep)
+		}
+	})
+
 	clawWeapon := druid.GetCatWeapon()
 
 	druid.CatFormAura = druid.RegisterAura(core.Aura{
@@ -114,7 +129,7 @@ func (druid *Druid) RegisterCatFormAura() {
 			if hotwDep != nil {
 				druid.EnableBuildPhaseStatDep(sim, hotwDep)
 			}
-			if druid.LeatherSpecActive {
+			if druid.LeatherSpec.IsActive() {
 				druid.EnableBuildPhaseStatDep(sim, leatherSpecDep)
 			}
 
@@ -145,7 +160,7 @@ func (druid *Druid) RegisterCatFormAura() {
 			if hotwDep != nil {
 				druid.DisableBuildPhaseStatDep(sim, hotwDep)
 			}
-			if druid.LeatherSpecActive {
+			if druid.LeatherSpec.IsActive() {
 				druid.DisableBuildPhaseStatDep(sim, leatherSpecDep)
 			}
 
@@ -227,6 +242,21 @@ func (druid *Druid) RegisterBearFormAura() {
 
 	leatherSpecDep := druid.NewDynamicMultiplyStat(stats.Stamina, 1.05)
 
+	// Need redundant enabling/disabling of the dep both here and below
+	// because we don't know whether the leather spec tracker or Bear Form
+	// will activate first.
+	druid.LeatherSpec.ApplyOnGain(func(_ *core.Aura, sim *core.Simulation) {
+		if druid.InForm(Bear) {
+			druid.EnableBuildPhaseStatDep(sim, leatherSpecDep)
+		}
+	})
+
+	druid.LeatherSpec.ApplyOnExpire(func(_ *core.Aura, sim *core.Simulation) {
+		if druid.InForm(Bear) {
+			druid.DisableBuildPhaseStatDep(sim, leatherSpecDep)
+		}
+	})
+
 	nrdtm := 1 - 0.09*float64(druid.Talents.NaturalReaction)
 
 	clawWeapon := druid.GetBearWeapon()
@@ -259,7 +289,7 @@ func (druid *Druid) RegisterBearFormAura() {
 			if hotwDep != nil {
 				druid.EnableBuildPhaseStatDep(sim, hotwDep)
 			}
-			if druid.LeatherSpecActive {
+			if druid.LeatherSpec.IsActive() {
 				druid.EnableBuildPhaseStatDep(sim, leatherSpecDep)
 			}
 
@@ -288,7 +318,7 @@ func (druid *Druid) RegisterBearFormAura() {
 			if hotwDep != nil {
 				druid.DisableBuildPhaseStatDep(sim, hotwDep)
 			}
-			if druid.LeatherSpecActive {
+			if druid.LeatherSpec.IsActive() {
 				druid.DisableBuildPhaseStatDep(sim, leatherSpecDep)
 			}
 

--- a/sim/druid/guardian/tank.go
+++ b/sim/druid/guardian/tank.go
@@ -52,6 +52,8 @@ func NewGuardianDruid(character *core.Character, options *proto.Player) *Guardia
 		}
 	}
 
+	bear.RegisterBearFormAura()
+
 	return bear
 }
 

--- a/sim/druid/talents.go
+++ b/sim/druid/talents.go
@@ -37,6 +37,7 @@ func (druid *Druid) ApplyTalents() {
 	druid.MultiplyStat(stats.Mana, 1.0+0.05*float64(druid.Talents.Furor))
 	druid.ApplyEquipScaling(stats.Armor, druid.ThickHideMultiplier())
 	druid.PseudoStats.ReducedCritTakenChance += 0.02 * float64(druid.Talents.ThickHide)
+	druid.applyMasterShapeshifter()
 
 	if druid.Talents.HeartOfTheWild > 0 {
 		bonus := 0.02 * float64(druid.Talents.HeartOfTheWild)
@@ -235,13 +236,27 @@ func (druid *Druid) applyMoonkinForm() {
 		FloatValue: 0.1,
 		Kind:       core.SpellMod_DamageDone_Pct,
 	})
+}
 
-	if druid.Talents.MasterShapeshifter {
+func (druid *Druid) applyMasterShapeshifter() {
+	if !druid.Talents.MasterShapeshifter {
+		return
+	}
+
+	if druid.InForm(Moonkin) {
 		druid.AddStaticMod(core.SpellModConfig{
 			School:     core.SpellSchoolArcane | core.SpellSchoolFire | core.SpellSchoolFrost | core.SpellSchoolHoly | core.SpellSchoolNature | core.SpellSchoolShadow,
 			FloatValue: 0.04,
 			Kind:       core.SpellMod_DamageDone_Pct,
 		})
+	}
+
+	if druid.CatFormAura != nil {
+		druid.CatFormAura.AttachStatBuff(stats.PhysicalCritPercent, 4)
+	}
+
+	if druid.BearFormAura != nil {
+		druid.BearFormAura.AttachMultiplicativePseudoStatBuff(&druid.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexPhysical], 1.04)
 	}
 }
 

--- a/sim/druid/talents.go
+++ b/sim/druid/talents.go
@@ -73,6 +73,7 @@ func (druid *Druid) ApplyTalents() {
 	}
 
 	// druid.registerNaturesSwiftnessCD()
+	druid.applyFeralSwiftness()
 	druid.applyPrimalFury()
 	druid.applyLotp()
 	// druid.applyPredatoryInstincts()
@@ -183,7 +184,7 @@ func (druid *Druid) applyNaturesMajesty() {
 func (druid *Druid) applyMoonglow() {
 	if druid.Talents.Moonglow > 0 {
 		druid.AddStaticMod(core.SpellModConfig{
-			ClassMask:  DruidDamagingSpells | DruidHealingSpells,
+	ClassMask:  DruidDamagingSpells | DruidHealingSpells,
 			FloatValue: -0.03 * float64(druid.Talents.Moonglow),
 			Kind:       core.SpellMod_PowerCost_Pct,
 		})
@@ -278,6 +279,22 @@ func (druid *Druid) applyMasterShapeshifter() {
 
 	if druid.BearFormAura != nil {
 		druid.BearFormAura.AttachMultiplicativePseudoStatBuff(&druid.PseudoStats.SchoolDamageDealtMultiplier[stats.SchoolIndexPhysical], 1.04)
+	}
+}
+
+func (druid *Druid) applyFeralSwiftness() {
+	if druid.Talents.FeralSwiftness == 0 {
+		return
+	}
+
+	dodgeBonus := 0.02 * float64(druid.Talents.FeralSwiftness)
+
+	if druid.CatFormAura != nil {
+		druid.CatFormAura.AttachAdditivePseudoStatBuff(&druid.PseudoStats.BaseDodgeChance, dodgeBonus)
+	}
+
+	if druid.BearFormAura != nil {
+		druid.BearFormAura.AttachAdditivePseudoStatBuff(&druid.PseudoStats.BaseDodgeChance, dodgeBonus)
 	}
 }
 

--- a/sim/druid/talents.go
+++ b/sim/druid/talents.go
@@ -38,11 +38,7 @@ func (druid *Druid) ApplyTalents() {
 	druid.ApplyEquipScaling(stats.Armor, druid.ThickHideMultiplier())
 	druid.PseudoStats.ReducedCritTakenChance += 0.02 * float64(druid.Talents.ThickHide)
 	druid.applyMasterShapeshifter()
-
-	if druid.Talents.HeartOfTheWild > 0 {
-		bonus := 0.02 * float64(druid.Talents.HeartOfTheWild)
-		druid.MultiplyStat(stats.Intellect, 1.0+bonus)
-	}
+	druid.applyHeartOfTheWild()
 
 	// Balance
 	druid.applyNaturesGrace()
@@ -87,6 +83,31 @@ func (druid *Druid) ApplyTalents() {
 	druid.applyPrimalMadness()
 	druid.applyStampede()
 	druid.ApplyGlyphs()
+}
+
+func (druid *Druid) applyHeartOfTheWild() {
+	if druid.Talents.HeartOfTheWild == 0 {
+		return
+	}
+
+	multiplier := 1.0 + 0.02*float64(druid.Talents.HeartOfTheWild)
+	druid.MultiplyStat(stats.Intellect, multiplier)
+
+	if druid.CatFormAura != nil {
+		druid.HotWCatDep = druid.NewDynamicMultiplyStat(stats.AttackPower, []float64{1.0, 1.03, 1.07, 1.1}[druid.Talents.HeartOfTheWild])
+
+		if druid.InForm(Cat) {
+			druid.StatDependencyManager.EnableDynamicStatDep(druid.HotWCatDep)
+		}
+	}
+
+	if druid.BearFormAura != nil {
+		druid.HotWBearDep = druid.NewDynamicMultiplyStat(stats.Stamina, multiplier)
+
+		if druid.InForm(Bear) {
+			druid.StatDependencyManager.EnableDynamicStatDep(druid.HotWBearDep)
+		}
+	}
 }
 
 func (druid *Druid) applyNaturesGrace() {

--- a/sim/druid/talents.go
+++ b/sim/druid/talents.go
@@ -884,13 +884,14 @@ func (druid *Druid) applyLotp() {
 // }
 
 func (druid *Druid) applyNaturalReaction() {
-	if druid.Talents.NaturalReaction == 0 {
+	if (druid.Talents.NaturalReaction == 0) || (druid.BearFormAura == nil) {
 		return
 	}
 
 	actionID := core.ActionID{SpellID: 59071}
 	rageMetrics := druid.NewRageMetrics(actionID)
-	rageAdded := 1.0 + 2.0*float64(druid.Talents.NaturalReaction-1)
+	numPoints := float64(druid.Talents.NaturalReaction)
+	rageAdded := 1.0 + 2.0*(numPoints - 1.0)
 
 	core.MakeProcTriggerAura(&druid.Unit, core.ProcTrigger{
 		Name:     "Natural Reaction Trigger",
@@ -902,6 +903,9 @@ func (druid *Druid) applyNaturalReaction() {
 			}
 		},
 	})
+
+	druid.BearFormAura.AttachMultiplicativePseudoStatBuff(&druid.PseudoStats.DamageTakenMultiplier, 1.0 - 0.09*numPoints)
+	druid.BearFormAura.AttachAdditivePseudoStatBuff(&druid.PseudoStats.BaseDodgeChance, 0.03*numPoints)
 }
 
 func (druid *Druid) applyInfectedWounds() {


### PR DESCRIPTION
I finally figured out how to refactor things so that stat buffs + stat dependencies associated with a Druid form Aura can be applied during the appropriate character build phase for each effect. As a result, stat contributions in the UI stats display for the Feral and Guardian sims finally add up to the total value. This does come at a small performance cost due to chaining multiple callbacks for the form Auras vs. evaluating all effects in one function.