### PR TITLE
Add AP scaling to Vial of Shadows based on PTR testing

### DIFF
--- a/sim/death_knight/blood/TestBlood.results
+++ b/sim/death_knight/blood/TestBlood.results
@@ -2038,24 +2038,24 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-VialofShadows-77207"
  value: {
-  dps: 22511.25277
-  tps: 113457.28617
+  dps: 22977.23712
+  tps: 115995.4492
   hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-VialofShadows-77979"
  value: {
-  dps: 22457.44814
-  tps: 113101.43254
+  dps: 22859.7073
+  tps: 115272.72303
   hps: 5300.29889
  }
 }
 dps_results: {
  key: "TestBlood-AllItems-VialofShadows-77999"
  value: {
-  dps: 22572.89795
-  tps: 113802.40503
+  dps: 23088.00119
+  tps: 116597.59656
   hps: 5300.29889
  }
 }

--- a/sim/death_knight/frost/TestFrost.results
+++ b/sim/death_knight/frost/TestFrost.results
@@ -2102,24 +2102,24 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-VialofShadows-77207"
  value: {
-  dps: 39123.82984
-  tps: 36950.59212
+  dps: 39762.4396
+  tps: 37589.20188
   hps: 523.43753
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-VialofShadows-77979"
  value: {
-  dps: 39061.69576
-  tps: 36893.4726
+  dps: 39627.19631
+  tps: 37458.97315
   hps: 523.43753
  }
 }
 dps_results: {
  key: "TestFrost-AllItems-VialofShadows-77999"
  value: {
-  dps: 39249.03958
-  tps: 37066.42465
+  dps: 39950.23787
+  tps: 37767.62294
   hps: 523.43753
  }
 }

--- a/sim/death_knight/unholy/TestUnholy.results
+++ b/sim/death_knight/unholy/TestUnholy.results
@@ -2038,24 +2038,24 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-VialofShadows-77207"
  value: {
-  dps: 40404.61572
-  tps: 30081.7196
+  dps: 41128.77754
+  tps: 30805.88142
   hps: 646.50919
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-VialofShadows-77979"
  value: {
-  dps: 40204.66684
-  tps: 29919.87992
+  dps: 40857.08762
+  tps: 30572.3007
   hps: 646.50919
  }
 }
 dps_results: {
  key: "TestUnholy-AllItems-VialofShadows-77999"
  value: {
-  dps: 40470.38532
-  tps: 30125.39149
+  dps: 41256.41299
+  tps: 30911.41916
   hps: 646.50919
  }
 }

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -1854,22 +1854,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77207"
  value: {
-  dps: 33773.18634
-  tps: 51682.60914
+  dps: 34707.26511
+  tps: 53208.79528
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77979"
  value: {
-  dps: 33291.8186
-  tps: 50558.93838
+  dps: 34115.61711
+  tps: 51908.19622
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-VialofShadows-77999"
  value: {
-  dps: 33801.8041
-  tps: 49740.96919
+  dps: 34845.08564
+  tps: 51299.84382
  }
 }
 dps_results: {

--- a/sim/druid/guardian/TestGuardian.results
+++ b/sim/druid/guardian/TestGuardian.results
@@ -2118,24 +2118,24 @@ dps_results: {
 dps_results: {
  key: "TestGuardian-AllItems-VialofShadows-77207"
  value: {
-  dps: 10664.29328
-  tps: 53390.5564
+  dps: 11275.66134
+  tps: 56447.39669
   hps: 319.10667
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-VialofShadows-77979"
  value: {
-  dps: 10578.24573
-  tps: 52960.56385
+  dps: 11098.63629
+  tps: 55562.51664
   hps: 319.10667
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-VialofShadows-77999"
  value: {
-  dps: 10808.42224
-  tps: 54111.19764
+  dps: 11478.94928
+  tps: 57463.83285
   hps: 319.10667
  }
 }

--- a/sim/hunter/beast_mastery/TestBM.results
+++ b/sim/hunter/beast_mastery/TestBM.results
@@ -1934,22 +1934,22 @@ dps_results: {
 dps_results: {
  key: "TestBM-AllItems-VialofShadows-77207"
  value: {
-  dps: 25882.49711
-  tps: 16440.60206
+  dps: 26803.791
+  tps: 17361.89595
  }
 }
 dps_results: {
  key: "TestBM-AllItems-VialofShadows-77979"
  value: {
-  dps: 25698.62854
-  tps: 16310.52449
+  dps: 26506.16221
+  tps: 17118.05817
  }
 }
 dps_results: {
  key: "TestBM-AllItems-VialofShadows-77999"
  value: {
-  dps: 26223.21869
-  tps: 16622.31078
+  dps: 27249.52538
+  tps: 17648.61747
  }
 }
 dps_results: {

--- a/sim/hunter/marksmanship/TestMM.results
+++ b/sim/hunter/marksmanship/TestMM.results
@@ -1934,22 +1934,22 @@ dps_results: {
 dps_results: {
  key: "TestMM-AllItems-VialofShadows-77207"
  value: {
-  dps: 24459.42891
-  tps: 22047.21119
+  dps: 25081.69566
+  tps: 22669.47794
  }
 }
 dps_results: {
  key: "TestMM-AllItems-VialofShadows-77979"
  value: {
-  dps: 24273.31468
-  tps: 21872.39296
+  dps: 24798.44888
+  tps: 22397.52716
  }
 }
 dps_results: {
  key: "TestMM-AllItems-VialofShadows-77999"
  value: {
-  dps: 24693.51133
-  tps: 22246.3968
+  dps: 25390.22997
+  tps: 22943.11544
  }
 }
 dps_results: {

--- a/sim/hunter/survival/TestSV.results
+++ b/sim/hunter/survival/TestSV.results
@@ -1934,22 +1934,22 @@ dps_results: {
 dps_results: {
  key: "TestSV-AllItems-VialofShadows-77207"
  value: {
-  dps: 30564.4296
-  tps: 27663.71075
+  dps: 31357.13181
+  tps: 28456.41296
  }
 }
 dps_results: {
  key: "TestSV-AllItems-VialofShadows-77979"
  value: {
-  dps: 30331.61925
-  tps: 27458.66763
+  dps: 31035.51914
+  tps: 28162.56752
  }
 }
 dps_results: {
  key: "TestSV-AllItems-VialofShadows-77999"
  value: {
-  dps: 30860.46032
-  tps: 27938.22588
+  dps: 31759.66907
+  tps: 28837.43463
  }
 }
 dps_results: {

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -1823,22 +1823,22 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-VialofShadows-77207"
  value: {
-  dps: 11332.70027
-  tps: 56966.32293
+  dps: 11636.58289
+  tps: 58485.73605
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-VialofShadows-77979"
  value: {
-  dps: 11312.59001
-  tps: 56865.77166
+  dps: 11573.5821
+  tps: 58170.73212
  }
 }
 dps_results: {
  key: "TestProtection-AllItems-VialofShadows-77999"
  value: {
-  dps: 11392.76785
-  tps: 57266.66088
+  dps: 11721.69378
+  tps: 58911.29052
  }
 }
 dps_results: {

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -1826,22 +1826,22 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-VialofShadows-77207"
  value: {
-  dps: 37690.32454
-  tps: 37690.13796
+  dps: 38398.44335
+  tps: 38398.25676
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-VialofShadows-77979"
  value: {
-  dps: 37735.019
-  tps: 37731.90526
+  dps: 38347.22595
+  tps: 38344.1122
  }
 }
 dps_results: {
  key: "TestRetribution-AllItems-VialofShadows-77999"
  value: {
-  dps: 37762.02965
-  tps: 37760.24764
+  dps: 38554.47306
+  tps: 38552.69105
  }
 }
 dps_results: {

--- a/sim/rogue/assassination/TestAssassination.results
+++ b/sim/rogue/assassination/TestAssassination.results
@@ -1856,22 +1856,22 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-VialofShadows-77207"
  value: {
-  dps: 29861.85026
-  tps: 21201.91368
+  dps: 30594.34099
+  tps: 21721.98211
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VialofShadows-77979"
  value: {
-  dps: 29492.84624
-  tps: 20939.92083
+  dps: 30146.27363
+  tps: 21403.85428
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VialofShadows-77999"
  value: {
-  dps: 30073.60105
-  tps: 21352.25674
+  dps: 30893.60572
+  tps: 21934.46006
  }
 }
 dps_results: {

--- a/sim/rogue/combat/TestCombat.results
+++ b/sim/rogue/combat/TestCombat.results
@@ -1889,22 +1889,22 @@ dps_results: {
 dps_results: {
  key: "TestCombat-AllItems-VialofShadows-77207"
  value: {
-  dps: 30369.5304
-  tps: 21562.36658
+  dps: 31315.82782
+  tps: 22234.23775
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-VialofShadows-77979"
  value: {
-  dps: 30120.31532
-  tps: 21385.42387
+  dps: 30959.03429
+  tps: 21980.91434
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-VialofShadows-77999"
  value: {
-  dps: 30652.87498
-  tps: 21763.54124
+  dps: 31716.68318
+  tps: 22518.84506
  }
 }
 dps_results: {

--- a/sim/rogue/subtlety/TestSubtlety.results
+++ b/sim/rogue/subtlety/TestSubtlety.results
@@ -1819,22 +1819,22 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-VialofShadows-77207"
  value: {
-  dps: 26391.27815
-  tps: 18737.80749
+  dps: 27382.03785
+  tps: 19441.24687
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-VialofShadows-77979"
  value: {
-  dps: 26197.00382
-  tps: 18599.87271
+  dps: 27043.25067
+  tps: 19200.70798
  }
 }
 dps_results: {
  key: "TestSubtlety-AllItems-VialofShadows-77999"
  value: {
-  dps: 26895.60029
-  tps: 19095.87621
+  dps: 28000.09261
+  tps: 19880.06575
  }
 }
 dps_results: {

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -1882,22 +1882,22 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-VialofShadows-77207"
  value: {
-  dps: 36999.81936
-  tps: 23987.81959
+  dps: 37661.99208
+  tps: 24649.99231
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-VialofShadows-77979"
  value: {
-  dps: 36790.42379
-  tps: 23842.38573
+  dps: 37377.5039
+  tps: 24429.46584
  }
 }
 dps_results: {
  key: "TestEnhancement-AllItems-VialofShadows-77999"
  value: {
-  dps: 37304.6959
-  tps: 24237.32266
+  dps: 38043.96489
+  tps: 24976.59164
  }
 }
 dps_results: {

--- a/sim/warlock/affliction/TestAffliction.results
+++ b/sim/warlock/affliction/TestAffliction.results
@@ -1749,22 +1749,22 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-VialofShadows-77207"
  value: {
-  dps: 35859.22723
-  tps: 25172.00508
+  dps: 35867.53324
+  tps: 25180.31109
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VialofShadows-77979"
  value: {
-  dps: 35843.68153
-  tps: 25157.086
+  dps: 35850.88434
+  tps: 25164.2888
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VialofShadows-77999"
  value: {
-  dps: 35860.68298
-  tps: 25175.31593
+  dps: 35869.11407
+  tps: 25183.74702
  }
 }
 dps_results: {

--- a/sim/warlock/demonology/TestDemonology.results
+++ b/sim/warlock/demonology/TestDemonology.results
@@ -1749,22 +1749,22 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-VialofShadows-77207"
  value: {
-  dps: 36917.66775
-  tps: 18952.44568
+  dps: 36926.79038
+  tps: 18961.56831
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VialofShadows-77979"
  value: {
-  dps: 36889.74838
-  tps: 18924.66608
+  dps: 36897.7234
+  tps: 18932.6411
  }
 }
 dps_results: {
  key: "TestDemonology-AllItems-VialofShadows-77999"
  value: {
-  dps: 36921.75687
-  tps: 18955.75029
+  dps: 36931.03401
+  tps: 18965.02743
  }
 }
 dps_results: {

--- a/sim/warlock/destruction/TestDestruction.results
+++ b/sim/warlock/destruction/TestDestruction.results
@@ -1749,22 +1749,22 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-VialofShadows-77207"
  value: {
-  dps: 38182.89937
-  tps: 22687.90215
+  dps: 38191.14383
+  tps: 22696.14661
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VialofShadows-77979"
  value: {
-  dps: 38153.11514
-  tps: 22655.96503
+  dps: 38160.21293
+  tps: 22663.06281
  }
 }
 dps_results: {
  key: "TestDestruction-AllItems-VialofShadows-77999"
  value: {
-  dps: 38184.99149
-  tps: 22688.63259
+  dps: 38193.49007
+  tps: 22697.13117
  }
 }
 dps_results: {

--- a/sim/warrior/arms/TestArms.results
+++ b/sim/warrior/arms/TestArms.results
@@ -1864,22 +1864,22 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-VialofShadows-77207"
  value: {
-  dps: 32427.71714
-  tps: 21857.88699
+  dps: 33211.30463
+  tps: 22641.47448
  }
 }
 dps_results: {
  key: "TestArms-AllItems-VialofShadows-77979"
  value: {
-  dps: 32329.84131
-  tps: 21856.63418
+  dps: 33019.3612
+  tps: 22546.15406
  }
 }
 dps_results: {
  key: "TestArms-AllItems-VialofShadows-77999"
  value: {
-  dps: 32689.9783
-  tps: 22185.78454
+  dps: 33577.04254
+  tps: 23072.84878
  }
 }
 dps_results: {

--- a/sim/warrior/fury/TestFury.results
+++ b/sim/warrior/fury/TestFury.results
@@ -1903,22 +1903,22 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-VialofShadows-77207"
  value: {
-  dps: 46831.61376
-  tps: 37469.81026
+  dps: 47948.23123
+  tps: 38586.42773
  }
 }
 dps_results: {
  key: "TestFury-AllItems-VialofShadows-77979"
  value: {
-  dps: 46729.57491
-  tps: 37448.81125
+  dps: 47681.21206
+  tps: 38400.4484
  }
 }
 dps_results: {
  key: "TestFury-AllItems-VialofShadows-77999"
  value: {
-  dps: 47085.42804
-  tps: 37947.9396
+  dps: 48304.0572
+  tps: 39166.56877
  }
 }
 dps_results: {

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -1872,22 +1872,22 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-VialofShadows-77207"
  value: {
-  dps: 5043.36544
-  tps: 30425.14957
+  dps: 5299.58652
+  tps: 31706.25495
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-VialofShadows-77979"
  value: {
-  dps: 4972.51353
-  tps: 30064.64423
+  dps: 5206.42257
+  tps: 31234.18944
  }
 }
 dps_results: {
  key: "TestProtectionWarrior-AllItems-VialofShadows-77999"
  value: {
-  dps: 5104.76902
-  tps: 30757.55427
+  dps: 5392.2653
+  tps: 32195.03563
  }
 }
 dps_results: {


### PR DESCRIPTION
 On branch feral
 Changes to be committed:
	modified:   sim/common/cata/other_effects.go
	modified:   sim/death_knight/blood/TestBlood.results
	modified:   sim/death_knight/frost/TestFrost.results
	modified:   sim/death_knight/unholy/TestUnholy.results
	modified:   sim/druid/feral/TestFeral.results
	modified:   sim/druid/guardian/TestGuardian.results
	modified:   sim/hunter/beast_mastery/TestBM.results
	modified:   sim/hunter/marksmanship/TestMM.results
	modified:   sim/hunter/survival/TestSV.results
	modified:   sim/paladin/protection/TestProtection.results
	modified:   sim/paladin/retribution/TestRetribution.results
	modified:   sim/rogue/assassination/TestAssassination.results
	modified:   sim/rogue/combat/TestCombat.results
	modified:   sim/rogue/subtlety/TestSubtlety.results
	modified:   sim/shaman/enhancement/TestEnhancement.results
	modified:   sim/warlock/affliction/TestAffliction.results
	modified:   sim/warlock/demonology/TestDemonology.results
	modified:   sim/warlock/destruction/TestDestruction.results
	modified:   sim/warrior/arms/TestArms.results
	modified:   sim/warrior/fury/TestFury.results
	modified:   sim/warrior/protection/TestProtectionWarrior.results