### PR TITLE
Feral 4pT13 Rotation Adjustments

### DIFF
--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -2421,8 +2421,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p4-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 35261.44071
-  tps: 48139.52482
+  dps: 35265.82887
+  tps: 48025.33865
  }
 }
 dps_results: {
@@ -2435,8 +2435,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p4-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 38000.4717
-  tps: 40259.84808
+  dps: 38080.05499
+  tps: 40718.5172
  }
 }
 dps_results: {
@@ -2477,8 +2477,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p4-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 37481.38534
-  tps: 26612.35159
+  dps: 37477.51215
+  tps: 26609.60163
  }
 }
 dps_results: {
@@ -2533,8 +2533,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p4-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 50218.85482
-  tps: 68472.02458
+  dps: 50198.60937
+  tps: 68661.29533
  }
 }
 dps_results: {
@@ -2547,8 +2547,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p4-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 33475.7945
-  tps: 45648.63316
+  dps: 33480.65836
+  tps: 45652.08651
  }
 }
 dps_results: {
@@ -3156,8 +3156,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p4-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 53145.79407
-  tps: 71993.29196
+  dps: 53133.33697
+  tps: 71692.78211
  }
 }
 dps_results: {
@@ -3198,15 +3198,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p4-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 51969.97692
-  tps: 36900.94425
+  dps: 51989.90666
+  tps: 36915.09437
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p4-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 51529.57548
-  tps: 36585.99859
+  dps: 51506.17398
+  tps: 36569.38353
  }
 }
 dps_results: {
@@ -3282,8 +3282,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p4-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 50660.11327
-  tps: 66883.17099
+  dps: 50664.6997
+  tps: 66742.68041
  }
 }
 dps_results: {
@@ -3324,8 +3324,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p4-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 49345.10585
-  tps: 35037.2858
+  dps: 49351.97876
+  tps: 35042.16556
  }
 }
 dps_results: {
@@ -3345,15 +3345,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p4-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 32240.43812
-  tps: 22893.07394
+  dps: 32241.89393
+  tps: 22894.10757
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p4-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 32384.3234
-  tps: 22993.07977
+  dps: 32393.56274
+  tps: 22999.6397
  }
 }
 dps_results: {

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -38,8 +38,8 @@ character_stats_results: {
 dps_results: {
  key: "TestFeral-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 33037.13669
-  tps: 47945.00008
+  dps: 33025.57366
+  tps: 47872.1001
  }
 }
 dps_results: {
@@ -94,8 +94,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 32208.02108
-  tps: 46699.65888
+  dps: 32197.12559
+  tps: 46628.49088
  }
 }
 dps_results: {
@@ -256,8 +256,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 32208.02108
-  tps: 45765.90386
+  dps: 32197.12559
+  tps: 45696.15592
  }
 }
 dps_results: {
@@ -270,8 +270,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 32813.42816
-  tps: 47546.19421
+  dps: 32801.95499
+  tps: 47473.72499
  }
 }
 dps_results: {
@@ -319,8 +319,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 32870.62089
-  tps: 47521.8523
+  dps: 32859.77994
+  tps: 47449.83233
  }
 }
 dps_results: {
@@ -445,8 +445,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-DeepEarthBattlegarb"
  value: {
-  dps: 30572.2003
-  tps: 41569.421
+  dps: 30929.95453
+  tps: 42710.14499
  }
 }
 dps_results: {
@@ -459,8 +459,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 32261.27224
-  tps: 46674.8635
+  dps: 32250.97318
+  tps: 46604.11896
  }
 }
 dps_results: {
@@ -487,8 +487,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 32208.02108
-  tps: 46699.65888
+  dps: 32197.12559
+  tps: 46628.49088
  }
 }
 dps_results: {
@@ -501,15 +501,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 32208.02108
-  tps: 46699.59752
+  dps: 32197.12559
+  tps: 46628.42897
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 32261.27224
-  tps: 46674.8635
+  dps: 32250.97318
+  tps: 46604.11896
  }
 }
 dps_results: {
@@ -529,8 +529,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 32208.02108
-  tps: 46699.65888
+  dps: 32197.12559
+  tps: 46628.49088
  }
 }
 dps_results: {
@@ -620,8 +620,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 32279.68616
-  tps: 46818.71158
+  dps: 32268.76671
+  tps: 46747.36274
  }
 }
 dps_results: {
@@ -634,8 +634,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 32208.02108
-  tps: 46699.61842
+  dps: 32197.12559
+  tps: 46628.45005
  }
 }
 dps_results: {
@@ -788,8 +788,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 32261.27224
-  tps: 46674.8635
+  dps: 32250.97318
+  tps: 46604.11896
  }
 }
 dps_results: {
@@ -928,22 +928,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-77194"
  value: {
-  dps: 36508.45196
-  tps: 51941.0746
+  dps: 36514.8819
+  tps: 51920.1239
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-78473"
  value: {
-  dps: 37160.81292
-  tps: 52904.76717
+  dps: 37162.03636
+  tps: 52885.16521
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Kiril,FuryofBeasts-78482"
  value: {
-  dps: 36244.39421
-  tps: 51615.16586
+  dps: 36249.20203
+  tps: 51593.55841
  }
 }
 dps_results: {
@@ -977,8 +977,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-LastWord-50708"
  value: {
-  dps: 33222.17483
-  tps: 48212.57064
+  dps: 33210.51849
+  tps: 48139.22254
  }
 }
 dps_results: {
@@ -1194,8 +1194,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 32208.02108
-  tps: 46699.65888
+  dps: 32197.12559
+  tps: 46628.49088
  }
 }
 dps_results: {
@@ -1271,15 +1271,15 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 32900.85746
-  tps: 47672.00417
+  dps: 32889.34047
+  tps: 47599.3249
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 32813.42816
-  tps: 47546.23466
+  dps: 32801.95499
+  tps: 47473.76582
  }
 }
 dps_results: {
@@ -1728,22 +1728,22 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-77190"
  value: {
-  dps: 33087.05509
-  tps: 47977.52561
+  dps: 33075.49206
+  tps: 47904.62218
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-78477"
  value: {
-  dps: 33037.97339
-  tps: 47924.43877
+  dps: 33026.41036
+  tps: 47851.53488
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-78486"
  value: {
-  dps: 33065.5922
-  tps: 48039.88649
+  dps: 33054.02917
+  tps: 47966.98345
  }
 }
 dps_results: {
@@ -2099,8 +2099,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Average-Default"
  value: {
-  dps: 33383.92631
-  tps: 48149.21494
+  dps: 33384.27947
+  tps: 48150.41229
  }
 }
 dps_results: {
@@ -2400,85 +2400,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p4-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 52708.15354
-  tps: 66500.82463
+  dps: 53046.75974
+  tps: 71099.29165
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p4-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 52494.6605
-  tps: 71262.50895
+  dps: 53196.10765
+  tps: 72015.12143
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p4-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 63878.37561
-  tps: 63532.48492
+  dps: 63797.57011
+  tps: 65376.97615
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p4-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 34540.81702
-  tps: 46436.03134
+  dps: 35261.44071
+  tps: 48139.52482
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p4-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 35242.41891
-  tps: 49325.0399
+  dps: 35462.3824
+  tps: 49482.27292
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p4-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 37681.65634
-  tps: 40639.15558
+  dps: 38000.4717
+  tps: 40259.84808
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p4-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 51463.20449
-  tps: 36541.13583
+  dps: 51814.39482
+  tps: 36790.48096
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p4-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 51208.59715
-  tps: 36358.10398
+  dps: 51552.79504
+  tps: 36602.48448
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p4-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 62608.51781
-  tps: 44452.04765
+  dps: 62493.18786
+  tps: 44370.16338
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p4-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 33615.76593
-  tps: 23869.55669
+  dps: 34157.78776
+  tps: 24254.39219
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p4-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 33860.35865
-  tps: 24041.0648
+  dps: 34258.36584
+  tps: 24323.6499
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p4-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 37065.83317
-  tps: 26317.30955
+  dps: 37481.38534
+  tps: 26612.35159
  }
 }
 dps_results: {
@@ -2526,85 +2526,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p4-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 50539.0743
-  tps: 66929.97943
+  dps: 50754.62923
+  tps: 67818.796
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p4-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 49881.61203
-  tps: 66910.80545
+  dps: 50218.85482
+  tps: 68472.02458
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p4-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 60829.52554
-  tps: 59779.35738
+  dps: 60531.0303
+  tps: 59070.21518
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p4-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 33079.31708
-  tps: 44042.34749
+  dps: 33475.7945
+  tps: 45648.63316
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p4-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 33323.69567
-  tps: 45719.79033
+  dps: 33690.73945
+  tps: 46575.07111
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p4-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 35448.24466
-  tps: 35921.25105
+  dps: 35990.26475
+  tps: 36464.70467
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p4-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 49314.58672
-  tps: 35015.61721
+  dps: 49211.64077
+  tps: 34942.52559
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p4-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 48742.90254
-  tps: 34607.4608
+  dps: 48945.40634
+  tps: 34751.2385
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p4-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 59714.89125
-  tps: 42397.57279
+  dps: 59634.83013
+  tps: 42340.72939
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p4-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 32087.00228
-  tps: 22784.1345
+  dps: 32156.10779
+  tps: 22833.19941
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p4-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 32292.44648
-  tps: 22927.84716
+  dps: 32390.89654
+  tps: 22997.74671
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p4-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 34989.57504
-  tps: 24843.16628
+  dps: 35367.83482
+  tps: 25111.73072
  }
 }
 dps_results: {
@@ -3156,85 +3156,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p4-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 52636.56318
-  tps: 68192.65788
+  dps: 53145.79407
+  tps: 71993.29196
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p4-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 52707.90636
-  tps: 71920.67318
+  dps: 53239.90722
+  tps: 74308.96576
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p4-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 62531.59532
-  tps: 63485.34063
+  dps: 63426.86674
+  tps: 65455.17227
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p4-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 34618.28196
-  tps: 46400.21296
+  dps: 35123.02195
+  tps: 47738.95678
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p4-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 34994.87293
-  tps: 48029.1255
+  dps: 35426.95849
+  tps: 49234.6424
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p4-DefaultTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 37211.72126
-  tps: 39857.76315
+  dps: 37330.49982
+  tps: 39745.93351
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p4-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 51703.71306
-  tps: 36711.89692
+  dps: 51969.97692
+  tps: 36900.94425
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p4-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 51211.02339
-  tps: 36359.82661
+  dps: 51529.57548
+  tps: 36585.99859
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p4-DefaultTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 61342.92323
-  tps: 43553.47549
+  dps: 62153.06652
+  tps: 44128.67723
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p4-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 33537.86192
-  tps: 23814.24484
+  dps: 33952.6352
+  tps: 24108.73387
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p4-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 33785.28351
-  tps: 23987.76145
+  dps: 34255.74944
+  tps: 24321.79227
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p4-DefaultTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 36290.34039
-  tps: 25766.70968
+  dps: 36990.92502
+  tps: 26264.12476
  }
 }
 dps_results: {
@@ -3282,85 +3282,85 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p4-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 50217.18694
-  tps: 66386.01585
+  dps: 50660.11327
+  tps: 66883.17099
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p4-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 49893.95074
-  tps: 66726.67733
+  dps: 50242.58377
+  tps: 68382.13344
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p4-HybridTalents-ExternalBleed-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 59596.0328
-  tps: 58069.13407
+  dps: 60163.68959
+  tps: 59505.62049
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p4-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 33183.60494
-  tps: 43374.7111
+  dps: 33416.86214
+  tps: 45183.46758
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p4-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 33282.98591
-  tps: 46226.91397
+  dps: 33478.54194
+  tps: 46426.38942
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p4-HybridTalents-ExternalBleed-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 34725.46449
-  tps: 36555.59414
+  dps: 35439.74
+  tps: 37532.04343
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p4-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 49096.21232
-  tps: 34860.57139
+  dps: 49345.10585
+  tps: 35037.2858
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p4-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 48607.08492
-  tps: 34511.03029
+  dps: 48836.28661
+  tps: 34673.76349
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p4-HybridTalents-ExternalBleed-monocat-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 58767.7694
-  tps: 41725.11628
+  dps: 59148.61671
+  tps: 41995.51786
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p4-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 32045.88044
-  tps: 22754.93799
+  dps: 32240.43812
+  tps: 22893.07394
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p4-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 32089.80336
-  tps: 22783.97054
+  dps: 32384.3234
+  tps: 22993.07977
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p4-HybridTalents-ExternalBleed-monocat-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 34179.07709
-  tps: 24267.71274
+  dps: 35060.81442
+  tps: 24893.74624
  }
 }
 dps_results: {
@@ -3415,8 +3415,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-preraid-DefaultTalents-ExternalBleed-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 33037.13669
-  tps: 47945.00008
+  dps: 33025.57366
+  tps: 47872.1001
  }
 }
 dps_results: {

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -247,9 +247,8 @@ func (cat *FeralDruid) TryBerserk(sim *core.Simulation) {
 	simTimeRemain := sim.GetRemainingDuration()
 	tfCdRemain := cat.TigersFury.TimeToReady(sim)
 	waitForTf := cat.Talents.Berserk && (tfCdRemain <= cat.BerserkAura.Duration) && (tfCdRemain+cat.ReactionTime < simTimeRemain-cat.BerserkAura.Duration)
-	waitForRavage := cat.StampedeCatAura.IsActive() && (cat.Rotation.RotationType == proto.FeralDruid_Rotation_SingleTarget)
 	isClearcast := cat.ClearcastingAura.IsActive()
-	berserkNow := cat.Rotation.UseBerserk && cat.Berserk.IsReady(sim) && !waitForTf && !waitForRavage && !isClearcast
+	berserkNow := cat.Rotation.UseBerserk && cat.Berserk.IsReady(sim) && !waitForTf && !isClearcast
 
 	if berserkNow {
 		cat.Berserk.Cast(sim, nil)

--- a/sim/druid/feral/rotation.go
+++ b/sim/druid/feral/rotation.go
@@ -229,7 +229,7 @@ func (cat *FeralDruid) TryTigersFury(sim *core.Simulation) {
 	gcdTimeToRdy := cat.GCD.TimeToReady(sim)
 	leewayTime := max(gcdTimeToRdy, cat.ReactionTime)
 	tfEnergyThresh := cat.calcTfEnergyThresh(leewayTime)
-	tfNow := (cat.CurrentEnergy() < tfEnergyThresh) && !cat.BerserkAura.IsActive()
+	tfNow := (cat.CurrentEnergy() < tfEnergyThresh) && !cat.BerserkAura.IsActive() && (!cat.T13Feral4pBonus.IsActive() || !cat.StampedeCatAura.IsActive() || (cat.Rotation.RotationType == proto.FeralDruid_Rotation_Aoe))
 
 	if tfNow {
 		cat.TigersFury.Cast(sim, nil)


### PR DESCRIPTION
- Remove rotational blocker on Berserk when a Stampede proc is active. This sims as a wash for pre-P4 setups but has a substantial impact on 4pT13 setups.
- Delay TF usage in 4pT13 setups if a Stampede proc is already active. Minor impact but included for thoroughness.

Net DPS impacts of this PR under default conditions:
```
Pre-Raid, Mono-Cat: +1.3 DPS
P3, Mono-Cat: -0.1 DPS
P4, Mono-Cat: +585 DPS
P4, Hybrid: +473 DPS
P3, Hybrid: -1.6 DPS
Pre-Raid, Hybrid: +0.5 DPS
```