### PR TITLE
Implement findings

### DIFF
--- a/sim/core/spell_mod.go
+++ b/sim/core/spell_mod.go
@@ -106,7 +106,7 @@ func shouldApply(spell *Spell, mod *SpellMod) bool {
 		return false
 	}
 
-	if mod.ClassMask > 0 && mod.ClassMask&spell.ClassSpellMask == 0 {
+	if mod.ClassMask > 0 && !spell.Matches(mod.ClassMask) {
 		return false
 	}
 

--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -2190,85 +2190,85 @@ dps_results: {
 dps_results: {
  key: "TestBalance-Settings-NightElf-t12-Default-t11-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 52181.26075
-  tps: 51033.19446
+  dps: 45551.51219
+  tps: 51149.16224
  }
 }
 dps_results: {
  key: "TestBalance-Settings-NightElf-t12-Default-t11-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 38717.95719
-  tps: 35555.02941
+  dps: 38729.9806
+  tps: 35569.55287
  }
 }
 dps_results: {
  key: "TestBalance-Settings-NightElf-t12-Default-t11-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 47516.99677
-  tps: 43021.03992
+  dps: 47434.82872
+  tps: 43018.48243
  }
 }
 dps_results: {
  key: "TestBalance-Settings-NightElf-t12-Default-t11-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 35359.12735
-  tps: 37829.62199
+  dps: 30797.09191
+  tps: 37892.33607
  }
 }
 dps_results: {
  key: "TestBalance-Settings-NightElf-t12-Default-t11-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26369.14892
-  tps: 24224.67306
+  dps: 26365.33721
+  tps: 24222.09948
  }
 }
 dps_results: {
  key: "TestBalance-Settings-NightElf-t12-Default-t11-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 26907.01027
-  tps: 24401.80438
+  dps: 26904.25216
+  tps: 24474.65831
  }
 }
 dps_results: {
  key: "TestBalance-Settings-NightElf-t12-Default-t12-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 52227.49194
-  tps: 51792.52582
+  dps: 46030.71094
+  tps: 51654.41948
  }
 }
 dps_results: {
  key: "TestBalance-Settings-NightElf-t12-Default-t12-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 38942.33954
-  tps: 35920.26343
+  dps: 38940.40413
+  tps: 35908.54176
  }
 }
 dps_results: {
  key: "TestBalance-Settings-NightElf-t12-Default-t12-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 47551.12626
-  tps: 43409.18225
+  dps: 47665.84826
+  tps: 43499.62818
  }
 }
 dps_results: {
  key: "TestBalance-Settings-NightElf-t12-Default-t12-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 35755.9855
-  tps: 38254.07027
+  dps: 31230.63442
+  tps: 38124.95544
  }
 }
 dps_results: {
  key: "TestBalance-Settings-NightElf-t12-Default-t12-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26377.24821
-  tps: 24329.19982
+  dps: 26389.1128
+  tps: 24348.1352
  }
 }
 dps_results: {
  key: "TestBalance-Settings-NightElf-t12-Default-t12-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 26967.81306
-  tps: 24642.24696
+  dps: 26944.33474
+  tps: 24654.50409
  }
 }
 dps_results: {

--- a/sim/druid/balance/dragonwrath.go
+++ b/sim/druid/balance/dragonwrath.go
@@ -9,5 +9,5 @@ func init() {
 	// https://docs.google.com/spreadsheets/d/e/2PACX-1vTaCACFb7dqXpF2qwAZIAgXX-p2VTuJWqmyWXqaJ3c49FNWm61E9-unEdN3cn7YHevoGWWPmqkqJv6h/pubhtml
 	cata.CreateDTRClassConfig(proto.Spec_SpecBalanceDruid, 0.08).
 		AddSpell(42231, cata.NewDragonwrathSpellConfig().IsAoESpell()).
-		AddSpell(88751, cata.NewDragonwrathSpellConfig().IsAoESpell())
+		AddSpell(78777, cata.NewDragonwrathSpellConfig().IsAoESpell())
 }

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -2260,8 +2260,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Orc-p3.default-TalentsAoE-Standard-aoe-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 171751.61422
-  tps: 84748.02965
+  dps: 167764.22156
+  tps: 85128.84383
  }
 }
 dps_results: {
@@ -2281,8 +2281,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Orc-p3.default-TalentsAoE-Standard-aoe-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 140023.56612
-  tps: 77514.03779
+  dps: 136513.71807
+  tps: 77806.85617
  }
 }
 dps_results: {
@@ -2386,8 +2386,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Orc-p3.default-TalentsImprovedShields-Standard-aoe-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 155019.82869
-  tps: 82602.35218
+  dps: 151342.06768
+  tps: 82276.89204
  }
 }
 dps_results: {
@@ -2407,8 +2407,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Orc-p3.default-TalentsImprovedShields-Standard-aoe-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 126582.14764
-  tps: 75863.64339
+  dps: 123088.6998
+  tps: 75831.66985
  }
 }
 dps_results: {
@@ -2638,8 +2638,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Troll-p3.default-TalentsAoE-Standard-aoe-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 168901.02962
-  tps: 85256.49814
+  dps: 164993.38719
+  tps: 85381.35524
  }
 }
 dps_results: {
@@ -2659,8 +2659,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Troll-p3.default-TalentsAoE-Standard-aoe-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 137707.64268
-  tps: 77652.25862
+  dps: 134272.7445
+  tps: 77963.95592
  }
 }
 dps_results: {
@@ -2764,8 +2764,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Troll-p3.default-TalentsImprovedShields-Standard-aoe-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 151609.3246
-  tps: 82956.22643
+  dps: 147994.80436
+  tps: 82799.16222
  }
 }
 dps_results: {
@@ -2785,8 +2785,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Troll-p3.default-TalentsImprovedShields-Standard-aoe-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 123617.38029
-  tps: 76033.358
+  dps: 120529.66822
+  tps: 75823.33698
  }
 }
 dps_results: {

--- a/sim/shaman/elemental/dragonwrath.go
+++ b/sim/shaman/elemental/dragonwrath.go
@@ -14,13 +14,14 @@ func init() {
 	//so DPS on a specific target might not be accurate.
 	cata.CreateDTRClassConfig(proto.Spec_SpecElementalShaman, 0.108).
 		AddSpell(88767, cata.NewDragonwrathSpellConfig().WithSpellHandler(customFulminationHandler)).       // Fullmination
-		AddSpell(403, cata.NewDragonwrathSpellConfig().WithCustomSpell(overloadCopyHandler)).               // Lightning Bold
+		AddSpell(403, cata.NewDragonwrathSpellConfig().WithCustomSpell(overloadCopyHandler)).               // Lightning Bolt
 		AddSpell(421, cata.NewDragonwrathSpellConfig().WithCustomSpell(overloadCopyHandler).ProcPerCast()). // Chain Lightning
 		AddSpell(51505, cata.NewDragonwrathSpellConfig().WithCustomSpell(overloadCopyHandler)).             // Lava Burst
 		AddSpell(3599, cata.NewDragonwrathSpellConfig().SupressSpell()).                                    // Searing Totem
 		AddSpell(8190, cata.NewDragonwrathSpellConfig().SupressSpell()).                                    // Magma Totem
 		AddSpell(51490, cata.NewDragonwrathSpellConfig().ProcPerCast()).                                    // Thunderstorm
-		AddSpell(77478, cata.NewDragonwrathSpellConfig().IsAoESpell())                                      // Earthquake
+		AddSpell(77478, cata.NewDragonwrathSpellConfig().IsAoESpell()).                                     // Earthquake
+		AddSpell(1535, cata.NewDragonwrathSpellConfig().IsAoESpell())                                       // Fire Nova
 }
 
 func overloadCopyHandler(unit *core.Unit, spell *core.Spell) {


### PR DESCRIPTION
Discussed this with InDebt, Exesian and Polynomix:
- Mushrooms can only proc once, but the proc "roll" is done for each target until it either didn't proc, or found 1 proc.
  - Currently each duplicated shroom can in theory dupe for each target (3x3x3), which is not how it should be.
- Applied same logic to Fire Nova (seems to be AOE flagged as the proc rate is much lower)