### PR TITLE
Fully remove bulk sim tab for the time being

### DIFF
--- a/ui/core/individual_sim_ui.tsx
+++ b/ui/core/individual_sim_ui.tsx
@@ -340,7 +340,9 @@ export abstract class IndividualSimUI<SpecType extends Spec> extends SimUI {
 			this.addDetailedResultsTab();
 		}
 
-		this.bt = this.addBulkTab();
+		// TODO: Fix intermittent memory leak in the Calculate Combos
+		// request so that this can be re-enabled.
+		//this.bt = this.addBulkTab();
 
 		this.addTopbarComponents();
 	}


### PR DESCRIPTION
Fully remove bulk sim tab for the time being, until the intermittent memory leak with the Calculate Combos request is resolved.

 On branch batch
 Changes to be committed:
	modified:   ui/core/individual_sim_ui.tsx