### PR TITLE
[Guardian] Dynamically adjust post-cap EP for Expertise Rating

### DIFF
--- a/ui/druid/guardian/sim.ts
+++ b/ui/druid/guardian/sim.ts
@@ -78,7 +78,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecGuardianDruid, {
 			const expertiseSoftCapConfig = StatCap.fromStat(Stat.StatExpertiseRating, {
 				breakpoints: [6.5 * 4 * Mechanics.EXPERTISE_PER_QUARTER_PERCENT_REDUCTION, 14 * 4 * Mechanics.EXPERTISE_PER_QUARTER_PERCENT_REDUCTION],
 				capType: StatCapType.TypeSoftCap,
-				postCapEPs: [0.535, 0],
+				postCapEPs: [0.185, 0],
 			});
 
 			const hitSoftCapConfig = StatCap.fromPseudoStat(PseudoStat.PseudoStatPhysicalHitPercent, {
@@ -281,7 +281,12 @@ export class GuardianDruidSimUI extends IndividualSimUI<Spec.SpecGuardianDruid> 
 		super(parentElem, player, SPEC_CONFIG);
 
 		player.sim.waitForInit().then(() => {
-			new ReforgeOptimizer(this);
+			new ReforgeOptimizer(this, {
+				updateSoftCaps: softCaps => {
+					softCaps[0].postCapEPs[0] = player.getEpWeights().getStat(Stat.StatExpertiseRating) / 2;
+					return softCaps;
+				},
+			});
 		});
 	}
 }


### PR DESCRIPTION
Dynamically adjust post-cap EP for Expertise Rating based on pre-cap value.

 On branch guardian
 Changes to be committed:
	modified:   ui/druid/guardian/sim.ts