### PR TITLE
[APL] Strict multidotting

### DIFF
--- a/proto/apl.proto
+++ b/proto/apl.proto
@@ -41,7 +41,7 @@ message APLListItem {
     APLAction action = 3; // The action to be performed.
 }
 
-// NextIndex: 26
+// NextIndex: 27
 message APLAction {
     APLValue condition = 1; // If set, action will only execute if value is true or != 0.
 
@@ -51,6 +51,7 @@ message APLAction {
 		APLActionCastFriendlySpell cast_friendly_spell = 20;
         APLActionChannelSpell channel_spell = 16;
         APLActionMultidot multidot = 8;
+        APLActionStrictMultidot strict_multidot = 26;
         APLActionMultishield multishield = 12;
         APLActionCastAllStatBuffCooldowns cast_all_stat_buff_cooldowns = 23;
         APLActionAutocastOtherCooldowns autocast_other_cooldowns = 7;
@@ -233,6 +234,12 @@ message APLActionChannelSpell {
 }
 
 message APLActionMultidot {
+    ActionID spell_id = 1;
+    int32 max_dots = 2;
+    APLValue max_overlap = 3;
+}
+
+message APLActionStrictMultidot {
     ActionID spell_id = 1;
     int32 max_dots = 2;
     APLValue max_overlap = 3;

--- a/sim/core/apl_action.go
+++ b/sim/core/apl_action.go
@@ -59,6 +59,8 @@ func (action *APLAction) GetAllSpells() []*Spell {
 			spells = append(spells, impl.spell)
 		} else if impl, ok := a.impl.(*APLActionMultidot); ok {
 			spells = append(spells, impl.spell)
+		} else if impl, ok := a.impl.(*APLActionStrictMultidot); ok {
+			spells = append(spells, impl.spell)
 		} else if impl, ok := a.impl.(*APLActionMultishield); ok {
 			spells = append(spells, impl.spell)
 		}
@@ -149,6 +151,8 @@ func (rot *APLRotation) newAPLActionImpl(config *proto.APLAction) APLActionImpl 
 		return rot.newActionChannelSpell(config.GetChannelSpell())
 	case *proto.APLAction_Multidot:
 		return rot.newActionMultidot(config.GetMultidot())
+	case *proto.APLAction_StrictMultidot:
+		return rot.newActionStrictMultidot(config.GetStrictMultidot())
 	case *proto.APLAction_Multishield:
 		return rot.newActionMultishield(config.GetMultishield())
 	case *proto.APLAction_CastAllStatBuffCooldowns:

--- a/sim/core/apl_actions_casting.go
+++ b/sim/core/apl_actions_casting.go
@@ -291,9 +291,9 @@ func (action *APLActionStrictMultidot) IsReady(sim *Simulation) bool {
 			action.readyActions = append(action.readyActions, action.actions[i])
 			previousTarget = target
 		} else if previousTarget != nil {
-			// If the Current Dot - Cast Time is less than the Previous Dot's Remaining Duration, add it to the renew queue
 			previousDot := action.spell.Dot(previousTarget)
-			if (!previousDot.IsActive() || dot.RemainingDuration(sim)-action.spell.EffectiveCastTime() < previousDot.RemainingDuration(sim)) && action.spell.CanCastOrQueue(sim, target) {
+			// Take the previous Dot + Cast Time into account for the overlap check
+			if (!previousDot.IsActive() || dot.RemainingDuration(sim)-action.spell.EffectiveCastTime() <= previousDot.RemainingDuration(sim)) && action.spell.CanCastOrQueue(sim, target) {
 				action.readyActions = append(action.readyActions, action.actions[i])
 				previousTarget = target
 			}

--- a/ui/core/components/individual_sim_ui/apl_actions.ts
+++ b/ui/core/components/individual_sim_ui/apl_actions.ts
@@ -385,7 +385,7 @@ const actionKindFactories: { [f in NonNullable<APLActionKind>]: ActionKindConfig
 	['strictMultidot']: inputBuilder({
 		label: 'Strict Multi Dot',
 		submenu: ['Casting'],
-		shortDescription: 'Like a regular <b>Multi Dot</b>, except all Dots are applied immediately after each other. Keeps a DoT active on multiple targets by casting the specified spell.',
+		shortDescription: 'Like a regular <b>Multi Dot</b>, except all Dots are applied immediately after each other. Keeps a DoT active on multiple targets by casting the specified spell. Will take Cast Time/GCD into account when refreshing subsequent DoTs.',
 		includeIf: (player: Player<any>, isPrepull: boolean) => !isPrepull,
 		newValue: () =>
 			APLActionStrictMultidot.create({

--- a/ui/core/components/individual_sim_ui/apl_actions.ts
+++ b/ui/core/components/individual_sim_ui/apl_actions.ts
@@ -23,6 +23,7 @@ import {
 	APLActionResetSequence,
 	APLActionSchedule,
 	APLActionSequence,
+	APLActionStrictMultidot,
 	APLActionStrictSequence,
 	APLActionTriggerICD,
 	APLActionWait,
@@ -359,6 +360,35 @@ const actionKindFactories: { [f in NonNullable<APLActionKind>]: ActionKindConfig
 		includeIf: (player: Player<any>, isPrepull: boolean) => !isPrepull,
 		newValue: () =>
 			APLActionMultidot.create({
+				maxDots: 3,
+				maxOverlap: {
+					value: {
+						oneofKind: 'const',
+						const: {
+							val: '0ms',
+						},
+					},
+				},
+			}),
+		fields: [
+			AplHelpers.actionIdFieldConfig('spellId', 'castable_dot_spells', ''),
+			AplHelpers.numberFieldConfig('maxDots', false, {
+				label: 'Max Dots',
+				labelTooltip: 'Maximum number of DoTs to simultaneously apply.',
+			}),
+			AplValues.valueFieldConfig('maxOverlap', {
+				label: 'Overlap',
+				labelTooltip: 'Maximum amount of time before a DoT expires when it may be refreshed.',
+			}),
+		],
+	}),
+	['strictMultidot']: inputBuilder({
+		label: 'Strict Multi Dot',
+		submenu: ['Casting'],
+		shortDescription: 'Like a regular <b>Multi Dot</b>, except all Dots are applied immediately after each other. Keeps a DoT active on multiple targets by casting the specified spell.',
+		includeIf: (player: Player<any>, isPrepull: boolean) => !isPrepull,
+		newValue: () =>
+			APLActionStrictMultidot.create({
 				maxDots: 3,
 				maxOverlap: {
 					value: {


### PR DESCRIPTION
- Will cast all Dots to given targets in a strict sequence, not interrupting casting. (e.g. Useful for Boomkin when you don't want to desync application of Dots)
- Will check for previous Dots and offset a potential GCD/Cast time difference to account for re-casting.