### PR TITLE
[Rogue] Fix HaT Register Aura error

### DIFF
--- a/sim/rogue/subtlety/honor_among_thieves.go
+++ b/sim/rogue/subtlety/honor_among_thieves.go
@@ -31,7 +31,7 @@ func (subRogue *SubtletyRogue) registerHonorAmongThieves() {
 	}
 
 	subRogue.HonorAmongThieves = core.MakePermanent(subRogue.RegisterAura(core.Aura{
-		Label:    "Honor Among Thieves",
+		Label:    "Honor Among Thieves Combo Point Aura",
 		ActionID: honorAmongThievesID,
 		Icd:      &icd,
 		OnGain: func(_ *core.Aura, sim *core.Simulation) {


### PR DESCRIPTION
Addresses #1383 and others related - when selecting the HaT 5% Crit buff + simming as Subtlety, it would error out.