### PR TITLE
[Combat] Panic increase spell hit EP after recent sim adjustments

### DIFF
--- a/ui/rogue/combat/presets.ts
+++ b/ui/rogue/combat/presets.ts
@@ -107,7 +107,7 @@ export const CBAT_NOKALED_EP_PRESET = PresetUtils.makePresetEpWeights(
 		{
 			[PseudoStat.PseudoStatMainHandDps]: 4.31,
 			[PseudoStat.PseudoStatOffHandDps]: 1.32,
-			[PseudoStat.PseudoStatSpellHitPercent]: 52,
+			[PseudoStat.PseudoStatSpellHitPercent]: 100, // Yeah this is a big number, idk Combat is weird this makes dps big
 			[PseudoStat.PseudoStatPhysicalHitPercent]: 250,
 		},
 	),


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e9c7f862-1fcf-4b60-9dc1-7a8187ef11a6)

no test or armor set adjustments. This is a EP set for No'Kaled which isn't bis, but is _very_ good on the way to oranges.