### PR TITLE
[Rogue] Fix for Bandit's Guile/Vendetta Class Mask Damage Multiplier, + cosmetic updates

### DIFF
--- a/sim/rogue/assassination/TestAssassination.results
+++ b/sim/rogue/assassination/TestAssassination.results
@@ -265,22 +265,22 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 29125.77074
-  tps: 20679.29722
+  dps: 29068.15538
+  tps: 20638.39032
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 29087.04263
-  tps: 20651.80027
+  dps: 29038.33328
+  tps: 20617.21663
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 29399.00471
-  tps: 20873.29334
+  dps: 29341.75155
+  tps: 20832.6436
  }
 }
 dps_results: {
@@ -426,22 +426,22 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 27742.72291
-  tps: 19697.33327
+  dps: 27724.55569
+  tps: 19684.43454
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 27685.91344
-  tps: 19656.99854
+  dps: 27670.8451
+  tps: 19646.30002
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CunningoftheCruel-78000"
  value: {
-  dps: 27759.04501
-  tps: 19708.92195
+  dps: 27739.76835
+  tps: 19695.23553
  }
 }
 dps_results: {
@@ -475,8 +475,8 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 27970.73757
-  tps: 19859.22368
+  dps: 27969.35605
+  tps: 19858.24279
  }
 }
 dps_results: {
@@ -748,8 +748,8 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-HarmlightToken-63839"
  value: {
-  dps: 27562.59766
-  tps: 19569.44434
+  dps: 27551.5736
+  tps: 19561.61726
  }
 }
 dps_results: {
@@ -1238,22 +1238,22 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-Rathrak,thePoisonousMind-77195"
  value: {
-  dps: 29194.96807
-  tps: 20728.42733
+  dps: 29178.35078
+  tps: 20716.62905
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Rathrak,thePoisonousMind-78475"
  value: {
-  dps: 29571.51409
-  tps: 20995.775
+  dps: 29554.34376
+  tps: 20983.58407
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Rathrak,thePoisonousMind-78484"
  value: {
-  dps: 28882.66324
-  tps: 20506.6909
+  dps: 28866.10853
+  tps: 20494.93706
  }
 }
 dps_results: {
@@ -1758,8 +1758,8 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 28557.53812
-  tps: 20275.85207
+  dps: 28540.56848
+  tps: 20263.80362
  }
 }
 dps_results: {
@@ -1807,15 +1807,15 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 27501.99925
-  tps: 19526.41946
+  dps: 27496.65116
+  tps: 19522.62232
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 27536.8947
-  tps: 19551.19524
+  dps: 27529.58706
+  tps: 19546.00681
  }
 }
 dps_results: {
@@ -1856,22 +1856,22 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-VialofShadows-77207"
  value: {
-  dps: 30519.00783
-  tps: 21668.49556
+  dps: 30438.89298
+  tps: 21611.61401
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VialofShadows-77979"
  value: {
-  dps: 30216.19153
-  tps: 21453.49598
+  dps: 30147.8095
+  tps: 21404.94475
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VialofShadows-77999"
  value: {
-  dps: 30953.38639
-  tps: 21976.90433
+  dps: 30869.53566
+  tps: 21917.37032
  }
 }
 dps_results: {
@@ -2465,169 +2465,169 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-Assassination-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 55647.50074
-  tps: 39509.72552
+  dps: 55489.19394
+  tps: 39397.3277
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-Assassination-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 55647.50074
-  tps: 39509.72552
+  dps: 55489.19394
+  tps: 39397.3277
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-Assassination-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 69726.25683
-  tps: 49505.64235
+  dps: 69450.04399
+  tps: 49309.53123
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-Assassination-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 34196.36296
-  tps: 24279.4177
+  dps: 34089.72232
+  tps: 24203.70285
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-Assassination-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 34196.36296
-  tps: 24279.4177
+  dps: 34089.72232
+  tps: 24203.70285
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-Assassination-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 36349.50942
-  tps: 25808.15169
+  dps: 36186.15743
+  tps: 25692.17178
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 43438.44067
-  tps: 30841.29288
+  dps: 43279.58018
+  tps: 30728.50193
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 43438.44067
-  tps: 30841.29288
+  dps: 43279.58018
+  tps: 30728.50193
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 54444.98219
-  tps: 38655.93736
+  dps: 54168.76703
+  tps: 38459.82459
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 26732.38458
-  tps: 18979.99305
+  dps: 26624.90728
+  tps: 18903.68417
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26732.38458
-  tps: 18979.99305
+  dps: 26624.90728
+  tps: 18903.68417
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 28757.79476
-  tps: 20418.03428
+  dps: 28594.44276
+  tps: 20302.05436
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 57152.8302
-  tps: 40578.50944
+  dps: 56995.95543
+  tps: 40467.12836
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 57152.8302
-  tps: 40578.50944
+  dps: 56995.95543
+  tps: 40467.12836
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 71481.58413
-  tps: 50751.92473
+  dps: 71207.61948
+  tps: 50557.40983
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 34926.81024
-  tps: 24798.03527
+  dps: 34819.03156
+  tps: 24721.5124
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 34926.81024
-  tps: 24798.03527
+  dps: 34819.03156
+  tps: 24721.5124
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 37127.49971
-  tps: 26360.52479
+  dps: 36964.14772
+  tps: 26244.54488
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 30181.78922
-  tps: 21429.07035
+  dps: 30030.67213
+  tps: 21321.77721
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 30181.78922
-  tps: 21429.07035
+  dps: 30030.67213
+  tps: 21321.77721
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 37533.69298
-  tps: 26648.92201
+  dps: 37270.50328
+  tps: 26462.05733
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 18065.28288
-  tps: 12826.35085
+  dps: 17960.76042
+  tps: 12752.1399
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 18065.28288
-  tps: 12826.35085
+  dps: 17960.76042
+  tps: 12752.1399
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 20164.94378
-  tps: 14317.11009
+  dps: 20001.6174
+  tps: 14201.14835
  }
 }
 dps_results: {
@@ -2969,169 +2969,169 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-Assassination-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 56006.02465
-  tps: 39764.2775
+  dps: 55846.47559
+  tps: 39650.99767
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-Assassination-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 56006.02465
-  tps: 39764.2775
+  dps: 55846.47559
+  tps: 39650.99767
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-Assassination-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 70414.69362
-  tps: 49994.43247
+  dps: 70136.4395
+  tps: 49796.87204
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-Assassination-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 34439.22579
-  tps: 24451.85031
+  dps: 34331.81126
+  tps: 24375.586
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-Assassination-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 34439.22579
-  tps: 24451.85031
+  dps: 34331.81126
+  tps: 24375.586
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-Assassination-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 36765.582
-  tps: 26103.56322
+  dps: 36600.87089
+  tps: 25986.61833
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 43711.82995
-  tps: 31035.39926
+  dps: 43551.75626
+  tps: 30921.74694
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 43711.82995
-  tps: 31035.39926
+  dps: 43551.75626
+  tps: 30921.74694
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 54982.66328
-  tps: 39037.69093
+  dps: 54704.40683
+  tps: 38840.12885
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 26920.61498
-  tps: 19113.63663
+  dps: 26812.34148
+  tps: 19036.76245
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26920.61498
-  tps: 19113.63663
+  dps: 26812.34148
+  tps: 19036.76245
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 29085.12133
-  tps: 20650.43614
+  dps: 28920.41022
+  tps: 20533.49126
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 57518.35962
-  tps: 40838.03533
+  dps: 57360.28687
+  tps: 40725.80368
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 57518.35962
-  tps: 40838.03533
+  dps: 57360.28687
+  tps: 40725.80368
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 72185.19384
-  tps: 51251.48763
+  dps: 71909.18768
+  tps: 51055.52325
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 35173.85058
-  tps: 24973.43392
+  dps: 35065.2981
+  tps: 24896.36165
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 35173.85058
-  tps: 24973.43392
+  dps: 35065.2981
+  tps: 24896.36165
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 37549.41196
-  tps: 26660.08249
+  dps: 37384.70085
+  tps: 26543.13761
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 30365.35266
-  tps: 21559.40039
+  dps: 30213.1268
+  tps: 21451.32003
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 30365.35266
-  tps: 21559.40039
+  dps: 30213.1268
+  tps: 21451.32003
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 37951.02012
-  tps: 26945.22429
+  dps: 37685.55731
+  tps: 26756.74569
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 18187.29816
-  tps: 12912.98169
+  dps: 18081.92494
+  tps: 12838.16671
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 18187.29816
-  tps: 12912.98169
+  dps: 18081.92494
+  tps: 12838.16671
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 20412.4368
-  tps: 14492.83013
+  dps: 20247.52104
+  tps: 14375.73994
  }
 }
 dps_results: {

--- a/sim/rogue/assassination/assassination.go
+++ b/sim/rogue/assassination/assassination.go
@@ -7,6 +7,13 @@ import (
 	"github.com/wowsims/cata/sim/rogue"
 )
 
+// Damage Done By Caster setup
+const (
+	DDBC_Vendetta = iota
+
+	DDBC_Total
+)
+
 func RegisterAssassinationRogue() {
 	core.RegisterAgentFactory(
 		proto.Player_AssassinationRogue{},

--- a/sim/rogue/assassination/vendetta.go
+++ b/sim/rogue/assassination/vendetta.go
@@ -23,10 +23,15 @@ func (sinRogue *AssassinationRogue) registerVendetta() {
 			ActionID: actionID,
 			Duration: duration,
 			OnGain: func(aura *core.Aura, sim *core.Simulation) {
-				sinRogue.AttackTables[aura.Unit.UnitIndex].DamageTakenMultiplier *= 1.2
+				core.EnableDamageDoneByCaster(DDBC_Vendetta, DDBC_Total, sinRogue.AttackTables[aura.Unit.UnitIndex], func(sim *core.Simulation, spell *core.Spell, attackTable *core.AttackTable) float64 {
+					if spell.Matches(rogue.RogueSpellsAll) || spell.ProcMask.Matches(core.ProcMaskMeleeWhiteHit) {
+						return 1.2
+					}
+					return 1.0
+				})
 			},
 			OnExpire: func(aura *core.Aura, sim *core.Simulation) {
-				sinRogue.AttackTables[aura.Unit.UnitIndex].DamageTakenMultiplier /= 1.2
+				core.DisableDamageDoneByCaster(0, sinRogue.AttackTables[aura.Unit.UnitIndex])
 			},
 		})
 	})

--- a/sim/rogue/combat/TestCombat.results
+++ b/sim/rogue/combat/TestCombat.results
@@ -242,22 +242,22 @@ dps_results: {
 dps_results: {
  key: "TestCombat-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 29694.07857
-  tps: 21082.79579
+  dps: 29519.78649
+  tps: 20959.0484
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 29622.03443
-  tps: 21031.64445
+  dps: 29477.9233
+  tps: 20929.32555
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 30147.29405
-  tps: 21404.57878
+  dps: 29955.10039
+  tps: 21268.12128
  }
 }
 dps_results: {
@@ -1784,8 +1784,8 @@ dps_results: {
 dps_results: {
  key: "TestCombat-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 29336.39972
-  tps: 20828.8438
+  dps: 29239.32752
+  tps: 20759.92254
  }
 }
 dps_results: {
@@ -1889,22 +1889,22 @@ dps_results: {
 dps_results: {
  key: "TestCombat-AllItems-VialofShadows-77207"
  value: {
-  dps: 31441.81284
-  tps: 22323.68712
+  dps: 31200.07255
+  tps: 22152.05151
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-VialofShadows-77979"
  value: {
-  dps: 31053.71162
-  tps: 22048.13525
+  dps: 30847.96673
+  tps: 21902.05638
  }
 }
 dps_results: {
  key: "TestCombat-AllItems-VialofShadows-77999"
  value: {
-  dps: 31865.65487
-  tps: 22624.61496
+  dps: 31603.68389
+  tps: 22438.61556
  }
 }
 dps_results: {
@@ -2498,169 +2498,169 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-p4_combat-Combat-combat-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 53738.65002
-  tps: 38154.44152
+  dps: 53344.90578
+  tps: 37874.8831
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p4_combat-Combat-combat-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 54193.73684
-  tps: 38477.55316
+  dps: 53789.88806
+  tps: 38190.82052
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p4_combat-Combat-combat-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 61209.39307
-  tps: 43458.66908
+  dps: 60766.03605
+  tps: 43143.88559
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p4_combat-Combat-combat-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 32325.23304
-  tps: 22950.91546
+  dps: 32065.70329
+  tps: 22766.64933
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p4_combat-Combat-combat-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 32575.51161
-  tps: 23128.61324
+  dps: 32309.29125
+  tps: 22939.59679
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p4_combat-Combat-combat-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 31850.82203
-  tps: 22614.08364
+  dps: 31568.6262
+  tps: 22413.7246
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p4_combat-MH Deadly OH Deadly-combat-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 48212.81075
-  tps: 34231.09563
+  dps: 47819.79837
+  tps: 33952.05684
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p4_combat-MH Deadly OH Deadly-combat-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 48030.62293
-  tps: 34101.74228
+  dps: 47627.50601
+  tps: 33815.52927
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p4_combat-MH Deadly OH Deadly-combat-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 54163.99127
-  tps: 38456.4338
+  dps: 53720.63424
+  tps: 38141.65031
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p4_combat-MH Deadly OH Deadly-combat-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 29337.77114
-  tps: 20829.81751
+  dps: 29078.14173
+  tps: 20645.48063
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p4_combat-MH Deadly OH Deadly-combat-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 29187.10463
-  tps: 20722.84429
+  dps: 28920.78462
+  tps: 20533.75708
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p4_combat-MH Deadly OH Deadly-combat-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 28611.24242
-  tps: 20313.98212
+  dps: 28329.04658
+  tps: 20113.62307
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p4_combat-MH Deadly OH Instant-combat-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 53593.56736
-  tps: 38051.43282
+  dps: 53200.55498
+  tps: 37772.39403
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p4_combat-MH Deadly OH Instant-combat-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 53926.91029
-  tps: 38288.10631
+  dps: 53523.79337
+  tps: 38001.89329
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p4_combat-MH Deadly OH Instant-combat-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 60940.05367
-  tps: 43267.4381
+  dps: 60496.69664
+  tps: 42952.65461
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p4_combat-MH Deadly OH Instant-combat-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 32354.78692
-  tps: 22971.89871
+  dps: 32095.15751
+  tps: 22787.56183
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p4_combat-MH Deadly OH Instant-combat-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 32531.00336
-  tps: 23097.01238
+  dps: 32264.68334
+  tps: 22907.92517
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p4_combat-MH Deadly OH Instant-combat-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 31734.53277
-  tps: 22531.51827
+  dps: 31452.33693
+  tps: 22331.15922
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p4_combat-MH Instant OH Instant-combat-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 49791.19141
-  tps: 35351.7459
+  dps: 49398.17903
+  tps: 35072.70711
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p4_combat-MH Instant OH Instant-combat-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 50236.70841
-  tps: 35668.06297
+  dps: 49833.59149
+  tps: 35381.84996
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p4_combat-MH Instant OH Instant-combat-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 57361.40629
-  tps: 40726.59847
+  dps: 56918.04927
+  tps: 40411.81498
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p4_combat-MH Instant OH Instant-combat-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 28915.72823
-  tps: 20530.16704
+  dps: 28666.08456
+  tps: 20352.92004
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p4_combat-MH Instant OH Instant-combat-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 29128.61663
-  tps: 20681.31781
+  dps: 28872.5397
+  tps: 20499.50318
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p4_combat-MH Instant OH Instant-combat-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 28655.54671
-  tps: 20345.43816
+  dps: 28384.20456
+  tps: 20152.78524
  }
 }
 dps_results: {
@@ -3002,169 +3002,169 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-p4_combat-Combat-combat-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 54046.54107
-  tps: 38373.04416
+  dps: 53651.13014
+  tps: 38092.3024
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p4_combat-Combat-combat-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 54503.594
-  tps: 38697.55174
+  dps: 54098.04899
+  tps: 38409.61478
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p4_combat-Combat-combat-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 61805.9102
-  tps: 43882.19624
+  dps: 61361.32629
+  tps: 43566.54167
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p4_combat-Combat-combat-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 32540.08905
-  tps: 23103.46322
+  dps: 32279.25494
+  tps: 22918.27101
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p4_combat-Combat-combat-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 32791.53672
-  tps: 23281.99107
+  dps: 32523.96555
+  tps: 23092.01554
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p4_combat-Combat-combat-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 32204.46524
-  tps: 22865.17032
+  dps: 31921.29063
+  tps: 22664.11635
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p4_combat-MH Deadly OH Deadly-combat-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 48489.37515
-  tps: 34427.45636
+  dps: 48094.69601
+  tps: 34147.23417
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p4_combat-MH Deadly OH Deadly-combat-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 48302.47592
-  tps: 34294.75791
+  dps: 47897.6627
+  tps: 34007.34052
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p4_combat-MH Deadly OH Deadly-combat-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 54692.62006
-  tps: 38831.76024
+  dps: 54248.03615
+  tps: 38516.10567
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p4_combat-MH Deadly OH Deadly-combat-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 29532.30714
-  tps: 20967.93807
+  dps: 29271.37338
+  tps: 20782.6751
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p4_combat-MH Deadly OH Deadly-combat-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 29378.69827
-  tps: 20858.87577
+  dps: 29111.02745
+  tps: 20668.82949
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p4_combat-MH Deadly OH Deadly-combat-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 28931.56878
-  tps: 20541.41383
+  dps: 28648.39417
+  tps: 20340.35986
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p4_combat-MH Deadly OH Instant-combat-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 53903.12018
-  tps: 38271.21533
+  dps: 53508.44104
+  tps: 37990.99314
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p4_combat-MH Deadly OH Instant-combat-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 54236.90982
-  tps: 38508.20597
+  dps: 53832.0966
+  tps: 38220.78858
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p4_combat-MH Deadly OH Instant-combat-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 61538.56324
-  tps: 43692.3799
+  dps: 61093.97933
+  tps: 43376.72533
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p4_combat-MH Deadly OH Instant-combat-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 32570.5323
-  tps: 23125.07793
+  dps: 32309.59854
+  tps: 22939.81497
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p4_combat-MH Deadly OH Instant-combat-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 32746.78206
-  tps: 23250.21526
+  dps: 32479.11124
+  tps: 23060.16898
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p4_combat-MH Deadly OH Instant-combat-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 32093.64019
-  tps: 22786.48454
+  dps: 31810.46558
+  tps: 22585.43056
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p4_combat-MH Instant OH Instant-combat-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 50078.02632
-  tps: 35555.39868
+  dps: 49683.34717
+  tps: 35275.17649
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p4_combat-MH Instant OH Instant-combat-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 50525.43652
-  tps: 35873.05993
+  dps: 50120.6233
+  tps: 35585.64254
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p4_combat-MH Instant OH Instant-combat-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 57935.61722
-  tps: 41134.28823
+  dps: 57491.03331
+  tps: 40818.63365
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p4_combat-MH Instant OH Instant-combat-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 29109.01248
-  tps: 20667.39886
+  dps: 28858.11464
+  tps: 20489.2614
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p4_combat-MH Instant OH Instant-combat-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 29322.59558
-  tps: 20819.04287
+  dps: 29065.21979
+  tps: 20636.30605
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p4_combat-MH Instant OH Instant-combat-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 28984.33844
-  tps: 20578.88029
+  dps: 28712.05516
+  tps: 20385.55916
  }
 }
 dps_results: {

--- a/sim/rogue/combat/combat.go
+++ b/sim/rogue/combat/combat.go
@@ -7,6 +7,13 @@ import (
 	"github.com/wowsims/cata/sim/rogue"
 )
 
+// Damage Done By Caster setup
+const (
+	DDBC_BanditsGuile int = iota
+
+	DDBC_Total
+)
+
 func RegisterCombatRogue() {
 	core.RegisterAgentFactory(
 		proto.Player_CombatRogue{},

--- a/sim/rogue/combat/killing_spree.go
+++ b/sim/rogue/combat/killing_spree.go
@@ -15,10 +15,11 @@ func (comRogue *CombatRogue) registerKillingSpreeCD() {
 	}
 
 	mhWeaponSwing := comRogue.GetOrRegisterSpell(core.SpellConfig{
-		ActionID:    core.ActionID{SpellID: 51690, Tag: 1}, // actual spellID is 57841
-		SpellSchool: core.SpellSchoolPhysical,
-		ProcMask:    core.ProcMaskMeleeMHSpecial,
-		Flags:       core.SpellFlagMeleeMetrics | core.SpellFlagIncludeTargetBonusDamage,
+		ActionID:       core.ActionID{SpellID: 51690, Tag: 1}, // actual spellID is 57841
+		SpellSchool:    core.SpellSchoolPhysical,
+		ProcMask:       core.ProcMaskMeleeMHSpecial,
+		Flags:          core.SpellFlagMeleeMetrics | core.SpellFlagIncludeTargetBonusDamage,
+		ClassSpellMask: rogue.RogueSpellKillingSpreeHit,
 
 		DamageMultiplier: 1,
 		CritMultiplier:   comRogue.MeleeCritMultiplier(false),
@@ -34,10 +35,11 @@ func (comRogue *CombatRogue) registerKillingSpreeCD() {
 		},
 	})
 	ohWeaponSwing := comRogue.GetOrRegisterSpell(core.SpellConfig{
-		ActionID:    core.ActionID{SpellID: 51690, Tag: 2}, // actual spellID is 57842
-		SpellSchool: core.SpellSchoolPhysical,
-		ProcMask:    core.ProcMaskMeleeOHSpecial,
-		Flags:       core.SpellFlagMeleeMetrics | core.SpellFlagIncludeTargetBonusDamage,
+		ActionID:       core.ActionID{SpellID: 51690, Tag: 2}, // actual spellID is 57842
+		SpellSchool:    core.SpellSchoolPhysical,
+		ProcMask:       core.ProcMaskMeleeOHSpecial,
+		Flags:          core.SpellFlagMeleeMetrics | core.SpellFlagIncludeTargetBonusDamage,
+		ClassSpellMask: rogue.RogueSpellKillingSpreeHit,
 
 		DamageMultiplier: 1 * comRogue.DWSMultiplier(),
 		CritMultiplier:   comRogue.MeleeCritMultiplier(false),

--- a/sim/rogue/rogue.go
+++ b/sim/rogue/rogue.go
@@ -381,6 +381,7 @@ const (
 	RogueSpellAdrenalineRush
 	RogueSpellBladeFlurry
 	RogueSpellKillingSpree
+	RogueSpellKillingSpreeHit
 	RogueSpellMainGauche
 	RogueSpellRevealingStrike
 	RogueSpellColdBlood

--- a/ui/core/launched_sims.ts
+++ b/ui/core/launched_sims.ts
@@ -113,15 +113,15 @@ export const simLaunchStatuses: Record<Spec, SimStatus> = {
 	// Rogue
 	[Spec.SpecAssassinationRogue]: {
 		phase: Phase.Phase4,
-		status: LaunchStatus.Beta,
+		status: LaunchStatus.Launched,
 	},
 	[Spec.SpecCombatRogue]: {
 		phase: Phase.Phase4,
-		status: LaunchStatus.Beta,
+		status: LaunchStatus.Launched,
 	},
 	[Spec.SpecSubtletyRogue]: {
 		phase: Phase.Phase4,
-		status: LaunchStatus.Beta,
+		status: LaunchStatus.Launched,
 	},
 	// Shaman
 	[Spec.SpecElementalShaman]: {

--- a/ui/rogue/assassination/sim.ts
+++ b/ui/rogue/assassination/sim.ts
@@ -53,7 +53,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecAssassinationRogue, {
 
 	defaults: {
 		// Default equipped gear.
-		gear: Presets.P3_PRESET_ASSASSINATION.gear,
+		gear: Presets.P4_PRESET_ASSASSINATION.gear,
 		// Default EP weights for sorting gear in the gear picker.
 		epWeights: Presets.P1_EP_PRESET.epWeights,
 		// Stat caps for reforge optimizer

--- a/ui/rogue/combat/sim.ts
+++ b/ui/rogue/combat/sim.ts
@@ -53,7 +53,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecCombatRogue, {
 
 	defaults: {
 		// Default equipped gear.
-		gear: Presets.P3_PRESET_COMBAT.gear,
+		gear: Presets.P4_PRESET_COMBAT.gear,
 		// Default EP weights for sorting gear in the gear picker.
 		epWeights: Presets.CBAT_STANDARD_EP_PRESET.epWeights,
 		// Stat caps for reforge optimizer

--- a/ui/rogue/subtlety/sim.ts
+++ b/ui/rogue/subtlety/sim.ts
@@ -53,7 +53,7 @@ const SPEC_CONFIG = registerSpecConfig(Spec.SpecSubtletyRogue, {
 
 	defaults: {
 		// Default equipped gear.
-		gear: Presets.P3_PRESET_SUB.gear,
+		gear: Presets.P4_PRESET_SUB.gear,
 		// Default EP weights for sorting gear in the gear picker.
 		epWeights: Presets.P1_EP_PRESET.epWeights,
 		// Stat caps for reforge optimizer


### PR DESCRIPTION
Previously these effects multiplied all damage, including procs like No'Kaled and Vial of Shadows. This has been found to be inaccurate. I suspect there may be other damage multipliers like this lurking in other specs, might need a focused sweep of all modifiers like these.