### PR TITLE
Fix Armor Spec check and tiktok staff proc condition

### DIFF
--- a/sim/common/cata/other_effects.go
+++ b/sim/common/cata/other_effects.go
@@ -1419,6 +1419,53 @@ func init() {
 
 			character.ItemSwap.RegisterProc(vishankaItemID, triggerAura)
 		})
+
+		// Ti'tahk, the Steps of Time
+		// Equip: Your spells have a chance to grant you 1708/1928/2176 haste rating for 10 sec and 342/386/435 haste rating to up to 3 allies within 20 yards.
+		// (Proc chance: 15%, 50s cooldown)
+		// The buff has two effects, one for the caster and one shared.
+		// * The first effect is 1366/1542/1741 haste rating on the caster.
+		// * The second effect is 342/386/435 haste rating on the caster and up to 3 allies within 20 yards.
+		// E.g. for the LFR version it's 1366 + 342 = 1708 haste rating for the caster with a shared ID so we just combine them.
+		// TODO: Add the shared buff as an optional misc raid buff?
+		//       Could be annoying with 3 different versions, uptime etc.
+		titahkItemID := []int32{78486, 77190, 78477}[version]
+		titahkAuraID := []int32{109842, 107804, 109844}[version]
+		titahkBonus := []float64{1366 + 342, 1542 + 386, 1741 + 435}[version]
+		titahkLabel := fmt.Sprintf("Ti'tahk, the Steps of Time %s", labelSuffix)
+		core.NewItemEffect(titahkItemID, func(agent core.Agent) {
+			character := agent.GetCharacter()
+			procAura := character.NewTemporaryStatsAura(titahkLabel, core.ActionID{SpellID: titahkAuraID}, stats.Stats{stats.HasteRating: titahkBonus}, time.Second*10)
+
+			handler := func(triggerAura *core.Aura, sim *core.Simulation, spell *core.Spell, _ *core.SpellResult) {
+				if spell.ProcMask.Matches(core.ProcMaskMeleeOrMeleeProc | core.ProcMaskRangedOrRangedProc) {
+					return
+				}
+				if triggerAura.Icd.IsReady(sim) && sim.Proc(0.15, fmt.Sprintf("%s Trigger", titahkLabel)) {
+					procAura.Activate(sim)
+					triggerAura.Icd.Use(sim)
+				}
+			}
+
+			triggerAura := character.RegisterAura(core.Aura{
+				Label:    fmt.Sprintf("%s Trigger", titahkLabel),
+				ActionID: core.ActionID{ItemID: titahkItemID},
+				Duration: core.NeverExpires,
+				Icd: &core.Cooldown{
+					Timer:    character.NewTimer(),
+					Duration: time.Second * 50,
+				},
+				OnSpellHitDealt:       handler,
+				OnPeriodicDamageDealt: handler,
+				OnHealDealt:           handler,
+				OnPeriodicHealDealt:   handler,
+				OnCastComplete: func(aura *core.Aura, sim *core.Simulation, spell *core.Spell) {
+					handler(aura, sim, spell, nil)
+				},
+			})
+
+			character.ItemSwap.RegisterProc(titahkItemID, triggerAura)
+		})
 	}
 }
 

--- a/sim/common/cata/stat_bonus_procs.go
+++ b/sim/common/cata/stat_bonus_procs.go
@@ -1182,28 +1182,6 @@ func init() {
 			ProcChance: 0.15,
 			ICD:        time.Second * 115,
 		})
-
-		// Ti'tahk, the Steps of Time
-		// Equip: Your spells have a chance to grant you 1708/1928/2176 haste rating for 10 sec and 342/386/435 haste rating to up to 3 allies within 20 yards.
-		// (Proc chance: 15%, 50s cooldown)
-		// The buff has two effects, one for the caster and one shared.
-		// * The first effect is 1366/1542/1741 haste rating on the caster.
-		// * The second effect is 342/386/435 haste rating on the caster and up to 3 allies within 20 yards.
-		// E.g. for the LFR version it's 1366 + 342 = 1708 haste rating for the caster with a shared ID so we just combine them.
-		// TODO: Add the shared buff as an optional misc raid buff?
-		//       Could be annoying with 3 different versions, uptime etc.
-		shared.NewProcStatBonusEffect(shared.ProcStatBonusEffect{
-			Name:       "Ti'tahk, the Steps of Time" + labelSuffix,
-			ItemID:     []int32{78486, 77190, 78477}[version],
-			AuraID:     []int32{109842, 107804, 109844}[version],
-			Bonus:      stats.Stats{stats.HasteRating: []float64{1366 + 342, 1542 + 386, 1741 + 435}[version]},
-			Duration:   time.Second * 10,
-			Callback:   core.CallbackOnSpellHitDealt | core.CallbackOnHealDealt,
-			ProcMask:   core.ProcMaskSpellDamage | core.ProcMaskSpellHealing | core.ProcMaskSpellProc,
-			Outcome:    core.OutcomeLanded,
-			ProcChance: 0.15,
-			ICD:        time.Second * 50,
-		})
 	}
 
 	shared.NewProcStatBonusEffect(shared.ProcStatBonusEffect{

--- a/sim/core/character.go
+++ b/sim/core/character.go
@@ -803,15 +803,14 @@ func FillTalentsProto(data protoreflect.Message, talentsStr string, treeSizes [3
 }
 
 func (character *Character) MeetsArmorSpecializationRequirement(armorType proto.ArmorType) bool {
-	if character.Head().ArmorType != armorType ||
-		character.Shoulder().ArmorType != armorType ||
-		character.Chest().ArmorType != armorType ||
-		character.Wrist().ArmorType != armorType ||
-		character.Hands().ArmorType != armorType ||
-		character.Waist().ArmorType != armorType ||
-		character.Legs().ArmorType != armorType ||
-		character.Feet().ArmorType != armorType {
-		return false
+	for _, itemSlot := range ArmorSpecializationSlots() {
+		item := character.Equipment[itemSlot]
+		if item.ArmorType == proto.ArmorType_ArmorTypeUnknown {
+			continue
+		}
+		if item.ArmorType != armorType {
+			return false
+		}
 	}
 
 	return true
@@ -834,16 +833,7 @@ func (character *Character) ApplyArmorSpecializationEffect(primaryStat stats.Sta
 		aura = MakePermanent(aura)
 	}
 
-	character.RegisterItemSwapCallback([]proto.ItemSlot{
-		proto.ItemSlot_ItemSlotHead,
-		proto.ItemSlot_ItemSlotShoulder,
-		proto.ItemSlot_ItemSlotChest,
-		proto.ItemSlot_ItemSlotWrist,
-		proto.ItemSlot_ItemSlotHands,
-		proto.ItemSlot_ItemSlotWaist,
-		proto.ItemSlot_ItemSlotLegs,
-		proto.ItemSlot_ItemSlotFeet,
-	},
+	character.RegisterItemSwapCallback(ArmorSpecializationSlots(),
 		func(sim *Simulation, _ proto.ItemSlot) {
 			if character.MeetsArmorSpecializationRequirement(armorType) {
 				if !aura.IsActive() {

--- a/sim/core/constants.go
+++ b/sim/core/constants.go
@@ -52,3 +52,16 @@ func MeleeWeaponSlots() []proto.ItemSlot {
 func AllWeaponSlots() []proto.ItemSlot {
 	return []proto.ItemSlot{proto.ItemSlot_ItemSlotMainHand, proto.ItemSlot_ItemSlotOffHand, proto.ItemSlot_ItemSlotRanged}
 }
+
+func ArmorSpecializationSlots() []proto.ItemSlot {
+	return []proto.ItemSlot{
+		proto.ItemSlot_ItemSlotHead,
+		proto.ItemSlot_ItemSlotShoulder,
+		proto.ItemSlot_ItemSlotChest,
+		proto.ItemSlot_ItemSlotWrist,
+		proto.ItemSlot_ItemSlotHands,
+		proto.ItemSlot_ItemSlotWaist,
+		proto.ItemSlot_ItemSlotLegs,
+		proto.ItemSlot_ItemSlotFeet,
+	}
+}

--- a/sim/druid/balance/TestBalance.results
+++ b/sim/druid/balance/TestBalance.results
@@ -1966,22 +1966,22 @@ dps_results: {
 dps_results: {
  key: "TestBalance-AllItems-Ti'tahk,theStepsofTime-77190"
  value: {
-  dps: 63023.09429
-  tps: 58377.00183
+  dps: 61433.53594
+  tps: 57159.19043
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Ti'tahk,theStepsofTime-78477"
  value: {
-  dps: 64601.32564
-  tps: 60080.22655
+  dps: 63071.2215
+  tps: 58675.14044
  }
 }
 dps_results: {
  key: "TestBalance-AllItems-Ti'tahk,theStepsofTime-78486"
  value: {
-  dps: 60952.87817
-  tps: 56732.70414
+  dps: 60022.69255
+  tps: 55855.01714
  }
 }
 dps_results: {

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -2246,24 +2246,24 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-77190"
  value: {
-  dps: 53369.22253
-  tps: 73873.87242
+  dps: 53313.72086
+  tps: 74427.52523
   hps: 43.3126
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-78477"
  value: {
-  dps: 53360.95036
-  tps: 74201.43677
+  dps: 53313.72086
+  tps: 74427.45425
   hps: 45.44545
  }
 }
 dps_results: {
  key: "TestFeral-AllItems-Ti'tahk,theStepsofTime-78486"
  value: {
-  dps: 53338.53024
-  tps: 74163.75415
+  dps: 53313.72086
+  tps: 74427.58795
   hps: 41.41459
  }
 }

--- a/sim/druid/guardian/TestGuardian.results
+++ b/sim/druid/guardian/TestGuardian.results
@@ -2238,25 +2238,25 @@ dps_results: {
 dps_results: {
  key: "TestGuardian-AllItems-Ti'tahk,theStepsofTime-77190"
  value: {
-  dps: 10677.21579
-  tps: 53453.55041
+  dps: 10598.35875
+  tps: 53058.25835
   hps: 356.7355
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Ti'tahk,theStepsofTime-78477"
  value: {
-  dps: 10787.91778
-  tps: 54006.94684
+  dps: 10630.07293
+  tps: 53216.85592
   hps: 356.7355
  }
 }
 dps_results: {
  key: "TestGuardian-AllItems-Ti'tahk,theStepsofTime-78486"
  value: {
-  dps: 10696.7603
-  tps: 53550.87274
-  hps: 358.34242
+  dps: 10598.35875
+  tps: 53058.25835
+  hps: 356.7355
  }
 }
 dps_results: {

--- a/sim/hunter/beast_mastery/TestBM.results
+++ b/sim/hunter/beast_mastery/TestBM.results
@@ -2043,22 +2043,22 @@ dps_results: {
 dps_results: {
  key: "TestBM-AllItems-Ti'tahk,theStepsofTime-77190"
  value: {
-  dps: 25502.59248
-  tps: 16071.43446
+  dps: 25512.49225
+  tps: 16084.64157
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Ti'tahk,theStepsofTime-78477"
  value: {
-  dps: 25517.62574
-  tps: 16069.85136
+  dps: 25512.49225
+  tps: 16084.64157
  }
 }
 dps_results: {
  key: "TestBM-AllItems-Ti'tahk,theStepsofTime-78486"
  value: {
-  dps: 25519.17075
-  tps: 16102.40321
+  dps: 25512.49225
+  tps: 16084.64157
  }
 }
 dps_results: {

--- a/sim/hunter/marksmanship/TestMM.results
+++ b/sim/hunter/marksmanship/TestMM.results
@@ -2043,22 +2043,22 @@ dps_results: {
 dps_results: {
  key: "TestMM-AllItems-Ti'tahk,theStepsofTime-77190"
  value: {
-  dps: 25326.54551
-  tps: 22876.48777
+  dps: 25467.15531
+  tps: 23019.74352
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Ti'tahk,theStepsofTime-78477"
  value: {
-  dps: 25597.95174
-  tps: 23136.67039
+  dps: 25642.88424
+  tps: 23195.47246
  }
 }
 dps_results: {
  key: "TestMM-AllItems-Ti'tahk,theStepsofTime-78486"
  value: {
-  dps: 25258.99128
-  tps: 22814.20848
+  dps: 25310.43663
+  tps: 22863.02484
  }
 }
 dps_results: {

--- a/sim/hunter/survival/TestSV.results
+++ b/sim/hunter/survival/TestSV.results
@@ -2045,22 +2045,22 @@ dps_results: {
 dps_results: {
  key: "TestSV-AllItems-Ti'tahk,theStepsofTime-77190"
  value: {
-  dps: 50920.41691
-  tps: 46436.69808
+  dps: 50752.18438
+  tps: 46298.17692
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Ti'tahk,theStepsofTime-78477"
  value: {
-  dps: 50816.18087
-  tps: 46363.14828
+  dps: 50752.18438
+  tps: 46298.17692
  }
 }
 dps_results: {
  key: "TestSV-AllItems-Ti'tahk,theStepsofTime-78486"
  value: {
-  dps: 50823.49777
-  tps: 46379.60624
+  dps: 50752.18438
+  tps: 46298.17692
  }
 }
 dps_results: {

--- a/sim/mage/arcane/TestArcane.results
+++ b/sim/mage/arcane/TestArcane.results
@@ -1945,22 +1945,22 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-Ti'tahk,theStepsofTime-77190"
  value: {
-  dps: 50623.7816
-  tps: 46337.52317
+  dps: 49394.38656
+  tps: 45337.94936
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Ti'tahk,theStepsofTime-78477"
  value: {
-  dps: 51748.63694
-  tps: 47520.08566
+  dps: 50837.63421
+  tps: 46615.19828
  }
 }
 dps_results: {
  key: "TestArcane-AllItems-Ti'tahk,theStepsofTime-78486"
  value: {
-  dps: 48927.71015
-  tps: 44843.52848
+  dps: 48056.63878
+  tps: 44080.35126
  }
 }
 dps_results: {

--- a/sim/mage/fire/TestFire.results
+++ b/sim/mage/fire/TestFire.results
@@ -1945,22 +1945,22 @@ dps_results: {
 dps_results: {
  key: "TestFire-AllItems-Ti'tahk,theStepsofTime-77190"
  value: {
-  dps: 64253.34728
-  tps: 58067.15118
+  dps: 62959.69606
+  tps: 56844.06095
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Ti'tahk,theStepsofTime-78477"
  value: {
-  dps: 67360.05529
-  tps: 60821.76036
+  dps: 64993.91086
+  tps: 58658.08166
  }
 }
 dps_results: {
  key: "TestFire-AllItems-Ti'tahk,theStepsofTime-78486"
  value: {
-  dps: 63304.92454
-  tps: 57156.82237
+  dps: 61390.53647
+  tps: 55469.3337
  }
 }
 dps_results: {

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -1945,22 +1945,22 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-Ti'tahk,theStepsofTime-77190"
  value: {
-  dps: 63799.34717
-  tps: 56147.83155
+  dps: 62643.22978
+  tps: 54964.95879
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Ti'tahk,theStepsofTime-78477"
  value: {
-  dps: 65431.25634
-  tps: 57450.22036
+  dps: 64218.00601
+  tps: 56349.2234
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Ti'tahk,theStepsofTime-78486"
  value: {
-  dps: 62100.19868
-  tps: 54625.1307
+  dps: 61147.75411
+  tps: 53704.39749
  }
 }
 dps_results: {

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -1987,22 +1987,22 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-Ti'tahk,theStepsofTime-77190"
  value: {
-  dps: 64717.1156
-  tps: 1995.29753
+  dps: 63335.17291
+  tps: 1950.16321
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Ti'tahk,theStepsofTime-78477"
  value: {
-  dps: 66204.42425
-  tps: 2007.50707
+  dps: 64971.81257
+  tps: 1974.34643
  }
 }
 dps_results: {
  key: "TestElemental-AllItems-Ti'tahk,theStepsofTime-78486"
  value: {
-  dps: 62843.28797
-  tps: 1960.54792
+  dps: 61879.8141
+  tps: 1929.35959
  }
 }
 dps_results: {
@@ -2414,85 +2414,85 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Orc-p4.default-DefaultTalents-Standard-aoe-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 141044.50656
-  tps: 66741.04219
+  dps: 141057.10272
+  tps: 66739.77553
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4.default-DefaultTalents-Standard-aoe-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 52788.75069
-  tps: 1767.42383
+  dps: 52960.45068
+  tps: 1759.92941
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4.default-DefaultTalents-Standard-aoe-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 67403.32305
-  tps: 2023.3117
+  dps: 68024.87904
+  tps: 2002.84786
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4.default-DefaultTalents-Standard-aoe-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 112890.25694
-  tps: 62745.25349
+  dps: 112900.76271
+  tps: 62748.39713
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4.default-DefaultTalents-Standard-aoe-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 41449.49719
-  tps: 1595.22775
+  dps: 41506.87779
+  tps: 1587.6848
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4.default-DefaultTalents-Standard-aoe-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 50542.69602
-  tps: 1806.11972
+  dps: 50970.28849
+  tps: 1792.07852
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4.default-DefaultTalents-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 87451.12089
-  tps: 33898.96829
+  dps: 87483.66246
+  tps: 33914.89429
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4.default-DefaultTalents-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 52781.7171
-  tps: 1776.99247
+  dps: 52686.16227
+  tps: 1773.15916
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4.default-DefaultTalents-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 67752.13176
-  tps: 2056.32013
+  dps: 68063.20921
+  tps: 2049.05983
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4.default-DefaultTalents-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 69208.1562
-  tps: 30206.63364
+  dps: 69187.13116
+  tps: 30198.47626
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4.default-DefaultTalents-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 41310.31105
-  tps: 1586.15372
+  dps: 41331.70344
+  tps: 1580.15958
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4.default-DefaultTalents-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 51017.63127
-  tps: 1770.48573
+  dps: 51281.36415
+  tps: 1777.97469
  }
 }
 dps_results: {
@@ -2540,85 +2540,85 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Orc-p4.default-TalentsAoE-Standard-aoe-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 204957.59098
-  tps: 108294.69651
+  dps: 205115.60837
+  tps: 108267.84472
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4.default-TalentsAoE-Standard-aoe-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 52043.14059
-  tps: 1760.88872
+  dps: 52179.49192
+  tps: 1758.51187
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4.default-TalentsAoE-Standard-aoe-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 67823.07249
-  tps: 2029.64632
+  dps: 68461.8253
+  tps: 2010.7168
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4.default-TalentsAoE-Standard-aoe-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 169359.74918
-  tps: 97903.73769
+  dps: 169503.69525
+  tps: 97910.92327
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4.default-TalentsAoE-Standard-aoe-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 40796.6297
-  tps: 1592.76596
+  dps: 40935.03168
+  tps: 1588.70068
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4.default-TalentsAoE-Standard-aoe-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 50856.03797
-  tps: 1806.76514
+  dps: 51298.07536
+  tps: 1792.72393
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4.default-TalentsAoE-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 79541.17652
-  tps: 33970.21884
+  dps: 79420.43361
+  tps: 33985.14842
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4.default-TalentsAoE-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 51675.23432
-  tps: 1758.85641
+  dps: 51583.28353
+  tps: 1753.3834
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4.default-TalentsAoE-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 68155.56239
-  tps: 2063.4083
+  dps: 68460.94064
+  tps: 2056.37916
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4.default-TalentsAoE-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 62925.22573
-  tps: 30267.42378
+  dps: 62917.6582
+  tps: 30269.19832
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4.default-TalentsAoE-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 40687.80628
-  tps: 1582.09412
+  dps: 40719.71308
+  tps: 1583.19165
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4.default-TalentsAoE-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 51311.18788
-  tps: 1770.88708
+  dps: 51569.29224
+  tps: 1779.02146
  }
 }
 dps_results: {
@@ -2666,85 +2666,85 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Orc-p4.default-TalentsImprovedShields-Standard-aoe-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 178272.78308
-  tps: 108986.62581
+  dps: 178105.38353
+  tps: 109060.67201
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4.default-TalentsImprovedShields-Standard-aoe-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 49764.79333
-  tps: 1776.16533
+  dps: 49730.39083
+  tps: 1773.59456
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4.default-TalentsImprovedShields-Standard-aoe-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 65622.77527
-  tps: 2115.65311
+  dps: 65830.24155
+  tps: 2097.65826
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4.default-TalentsImprovedShields-Standard-aoe-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 147895.79695
-  tps: 99236.01244
+  dps: 147817.59958
+  tps: 99238.90385
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4.default-TalentsImprovedShields-Standard-aoe-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 39074.85721
-  tps: 1590.33648
+  dps: 39106.78581
+  tps: 1586.99509
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4.default-TalentsImprovedShields-Standard-aoe-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 48954.40707
-  tps: 1795.88709
+  dps: 49221.29524
+  tps: 1769.74781
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4.default-TalentsImprovedShields-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 79541.17652
-  tps: 33970.21884
+  dps: 79420.43361
+  tps: 33985.14842
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4.default-TalentsImprovedShields-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 49833.43886
-  tps: 1775.73093
+  dps: 49797.75659
+  tps: 1784.45183
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4.default-TalentsImprovedShields-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 65750.53344
-  tps: 2040.61133
+  dps: 66060.28713
+  tps: 2059.56762
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4.default-TalentsImprovedShields-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 62925.22573
-  tps: 30267.42378
+  dps: 62917.6582
+  tps: 30269.19832
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4.default-TalentsImprovedShields-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 39031.24936
-  tps: 1584.90234
+  dps: 38993.92536
+  tps: 1588.66724
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Orc-p4.default-TalentsImprovedShields-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 49166.43084
-  tps: 1747.76769
+  dps: 49291.34579
+  tps: 1765.08271
  }
 }
 dps_results: {
@@ -2799,78 +2799,78 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Troll-p4.default-DefaultTalents-Standard-aoe-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 52701.30751
-  tps: 1779.7456
+  dps: 52531.81836
+  tps: 1791.57403
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p4.default-DefaultTalents-Standard-aoe-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 67565.44621
-  tps: 2077.28102
+  dps: 67072.76302
+  tps: 2077.93757
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p4.default-DefaultTalents-Standard-aoe-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 110989.38028
-  tps: 62867.25639
+  dps: 110988.00055
+  tps: 62868.79064
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p4.default-DefaultTalents-Standard-aoe-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 41189.84848
-  tps: 1585.04487
+  dps: 41091.65242
+  tps: 1591.01211
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p4.default-DefaultTalents-Standard-aoe-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 49681.98958
-  tps: 1747.93569
+  dps: 49516.17304
+  tps: 1745.82774
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p4.default-DefaultTalents-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 85316.40691
-  tps: 33980.66595
+  dps: 85350.75125
+  tps: 33980.46637
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p4.default-DefaultTalents-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 52480.68444
-  tps: 1762.14131
+  dps: 52296.03038
+  tps: 1771.90796
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p4.default-DefaultTalents-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 68004.00138
-  tps: 2055.73363
+  dps: 67468.74273
+  tps: 2097.96307
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p4.default-DefaultTalents-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 67359.1081
-  tps: 30260.00441
+  dps: 67325.95365
+  tps: 30252.61716
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p4.default-DefaultTalents-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 41492.56549
-  tps: 1600.80752
+  dps: 41392.05502
+  tps: 1599.46787
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p4.default-DefaultTalents-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 50924.98713
-  tps: 1721.39798
+  dps: 50347.60425
+  tps: 1717.70295
  }
 }
 dps_results: {
@@ -2918,85 +2918,85 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Troll-p4.default-TalentsAoE-Standard-aoe-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 202607.33316
-  tps: 108089.46564
+  dps: 202445.21237
+  tps: 108178.82618
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p4.default-TalentsAoE-Standard-aoe-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 51927.40916
-  tps: 1769.96254
+  dps: 51731.25318
+  tps: 1776.13746
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p4.default-TalentsAoE-Standard-aoe-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 67987.83781
-  tps: 2086.36765
+  dps: 67473.63949
+  tps: 2086.31717
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p4.default-TalentsAoE-Standard-aoe-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 167852.50274
-  tps: 97523.6326
+  dps: 167827.1983
+  tps: 97577.98114
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p4.default-TalentsAoE-Standard-aoe-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 40365.08759
-  tps: 1603.45341
+  dps: 40454.8658
+  tps: 1605.39784
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p4.default-TalentsAoE-Standard-aoe-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 49941.75162
-  tps: 1747.93569
+  dps: 49772.21794
+  tps: 1745.82774
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p4.default-TalentsAoE-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 77917.73279
-  tps: 33901.94701
+  dps: 77905.11234
+  tps: 33915.22953
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p4.default-TalentsAoE-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 51832.93358
-  tps: 1771.00532
+  dps: 51748.1901
+  tps: 1777.31789
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p4.default-TalentsAoE-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 68421.92538
-  tps: 2062.88239
+  dps: 67877.55673
+  tps: 2103.64148
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p4.default-TalentsAoE-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 61806.04311
-  tps: 30249.33141
+  dps: 61784.98119
+  tps: 30247.18786
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p4.default-TalentsAoE-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 40901.13599
-  tps: 1581.84781
+  dps: 40799.31805
+  tps: 1596.26429
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p4.default-TalentsAoE-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 51237.86659
-  tps: 1722.0434
+  dps: 50646.74549
+  tps: 1718.34836
  }
 }
 dps_results: {
@@ -3044,85 +3044,85 @@ dps_results: {
 dps_results: {
  key: "TestElemental-Settings-Troll-p4.default-TalentsImprovedShields-Standard-aoe-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 175940.1186
-  tps: 108741.94214
+  dps: 175936.9241
+  tps: 108765.11203
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p4.default-TalentsImprovedShields-Standard-aoe-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 49324.15099
-  tps: 1783.51587
+  dps: 49384.38972
+  tps: 1779.37798
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p4.default-TalentsImprovedShields-Standard-aoe-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 64152.82475
-  tps: 2080.44711
+  dps: 64405.83331
+  tps: 2071.58262
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p4.default-TalentsImprovedShields-Standard-aoe-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 146069.72451
-  tps: 99049.71532
+  dps: 146090.59073
+  tps: 99196.19222
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p4.default-TalentsImprovedShields-Standard-aoe-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 38877.52357
-  tps: 1588.25729
+  dps: 38692.62681
+  tps: 1585.38864
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p4.default-TalentsImprovedShields-Standard-aoe-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 47899.77109
-  tps: 1735.33382
+  dps: 47972.1755
+  tps: 1728.22782
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p4.default-TalentsImprovedShields-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 77917.73279
-  tps: 33901.94701
+  dps: 77905.11234
+  tps: 33915.22953
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p4.default-TalentsImprovedShields-Standard-default-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 49711.97223
-  tps: 1758.53616
+  dps: 49532.10282
+  tps: 1763.82701
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p4.default-TalentsImprovedShields-Standard-default-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 65375.65524
-  tps: 2060.29675
+  dps: 64932.07704
+  tps: 2035.0021
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p4.default-TalentsImprovedShields-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 61806.04311
-  tps: 30249.33141
+  dps: 61784.98119
+  tps: 30247.18786
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p4.default-TalentsImprovedShields-Standard-default-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 38879.40497
-  tps: 1598.11588
+  dps: 38688.21634
+  tps: 1590.13405
  }
 }
 dps_results: {
  key: "TestElemental-Settings-Troll-p4.default-TalentsImprovedShields-Standard-default-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 49121.49948
-  tps: 1792.86938
+  dps: 48589.75723
+  tps: 1793.72297
  }
 }
 dps_results: {


### PR DESCRIPTION
- Fixes TikTok staff pro conditions
- Fixes issue where Armor Spec was not being applied when having empty slots (Useful to have fixed for scaling testing when not having full item sets equipped)