### PR TITLE
Fix Drain Soul not counting spell hit

### DIFF
--- a/sim/warlock/affliction/TestAffliction.results
+++ b/sim/warlock/affliction/TestAffliction.results
@@ -38,2404 +38,2404 @@ character_stats_results: {
 dps_results: {
  key: "TestAffliction-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 45594.57445
-  tps: 31933.41933
+  dps: 46213.12608
+  tps: 32381.54992
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 43030.32375
-  tps: 29472.91336
+  dps: 43635.24961
+  tps: 29913.65968
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 42634.12011
-  tps: 29538.16269
+  dps: 43277.23226
+  tps: 30005.3407
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 42890.52088
-  tps: 29384.08376
+  dps: 43502.38925
+  tps: 29812.07438
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 43077.89859
-  tps: 29520.82789
+  dps: 43705.15885
+  tps: 29972.20074
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ArrowofTime-72897"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 45034.22621
-  tps: 31431.54271
+  dps: 45658.73249
+  tps: 31887.19051
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Balespider'sBurningVestments"
  value: {
-  dps: 38273.7045
-  tps: 27312.11852
+  dps: 38882.02448
+  tps: 27746.17246
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 42095.35073
-  tps: 29002.79857
+  dps: 42677.84651
+  tps: 29429.7849
   hps: 102.46304
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 44129.7291
-  tps: 30103.64107
+  dps: 44745.96772
+  tps: 30557.65738
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 44417.80924
-  tps: 30351.49065
+  dps: 45036.59305
+  tps: 30811.05778
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BindingPromise-67037"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 42471.61439
-  tps: 29313.89777
+  dps: 43053.99906
+  tps: 29748.58024
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 42622.50155
-  tps: 29362.20212
+  dps: 43243.62384
+  tps: 29814.36595
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 42671.10106
-  tps: 29406.25723
+  dps: 43293.28257
+  tps: 29859.37197
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 41804.70415
-  tps: 28746.54105
+  dps: 42362.15847
+  tps: 29159.14327
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 43025.53158
-  tps: 29460.02953
+  dps: 43605.4352
+  tps: 29878.34299
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 41893.74325
-  tps: 28741.56351
+  dps: 42472.3837
+  tps: 29159.31994
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 42715.84819
-  tps: 29319.73858
+  dps: 43312.28264
+  tps: 29749.88768
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 42200.99612
-  tps: 28995.88894
+  dps: 42793.73739
+  tps: 29416.90356
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 42233.4797
-  tps: 29000.11353
+  dps: 42841.25339
+  tps: 29436.2109
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 43258.52051
-  tps: 29660.60787
+  dps: 43854.11581
+  tps: 30097.81631
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BottledLightning-66879"
  value: {
-  dps: 42956.66825
-  tps: 29413.65024
+  dps: 43551.188
+  tps: 29840.80532
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BottledWishes-77114"
  value: {
-  dps: 44826.02271
-  tps: 30863.02604
+  dps: 45521.20216
+  tps: 31375.47789
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 45316.99977
-  tps: 30973.4526
+  dps: 45935.49715
+  tps: 31418.89607
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 45862.94987
-  tps: 32083.20202
+  dps: 46492.24998
+  tps: 32547.41587
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CataclysmicGladiator'sBadgeofConquest-73648"
  value: {
-  dps: 41893.74325
-  tps: 28741.56351
+  dps: 42472.3837
+  tps: 29159.31994
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CataclysmicGladiator'sBadgeofDominance-73498"
  value: {
-  dps: 43694.92481
-  tps: 29884.96437
+  dps: 44275.57552
+  tps: 30303.60728
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CataclysmicGladiator'sBadgeofVictory-73496"
  value: {
-  dps: 41893.74325
-  tps: 28741.56351
+  dps: 42472.3837
+  tps: 29159.31994
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CataclysmicGladiator'sInsigniaofConquest-73643"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CataclysmicGladiator'sInsigniaofDominance-73497"
  value: {
-  dps: 43942.78311
-  tps: 30112.04353
+  dps: 44555.40301
+  tps: 30554.71622
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CataclysmicGladiator'sInsigniaofVictory-73491"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 45721.1547
-  tps: 32009.80514
+  dps: 46333.99744
+  tps: 32453.26909
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 42748.02806
-  tps: 29347.26845
+  dps: 43359.61558
+  tps: 29795.99172
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 43243.80805
-  tps: 29659.05882
+  dps: 43885.46573
+  tps: 30117.01013
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CrushingWeight-59506"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CrushingWeight-65118"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 45350.58561
-  tps: 31786.18938
+  dps: 45973.96755
+  tps: 32232.8629
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 44880.15337
-  tps: 31306.9605
+  dps: 45474.67182
+  tps: 31746.02815
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 42233.4797
-  tps: 29000.15682
+  dps: 42841.25339
+  tps: 29436.25419
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 43451.69503
-  tps: 29827.4893
+  dps: 44023.59364
+  tps: 30242.01504
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 44642.87647
-  tps: 30654.78895
+  dps: 45245.9116
+  tps: 31093.93711
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkwalkerIdolofRage-92118"
  value: {
-  dps: 42724.11871
-  tps: 29454.31736
+  dps: 43347.45574
+  tps: 29908.46944
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkwalkerStoneofRage-92117"
  value: {
-  dps: 43206.54567
-  tps: 29910.16017
+  dps: 43901.15793
+  tps: 30421.98525
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 42520.3183
-  tps: 29193.72929
+  dps: 43120.98021
+  tps: 29637.99232
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DelivererIdolofDestruction-92113"
  value: {
-  dps: 43104.97024
-  tps: 29697.7032
+  dps: 43725.61928
+  tps: 30138.47879
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DelivererStoneofDestruction-92151"
  value: {
-  dps: 44305.31721
-  tps: 30670.63915
+  dps: 44936.26652
+  tps: 31135.26946
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DelivererStoneofWisdom-92115"
  value: {
-  dps: 43515.67413
-  tps: 29915.91861
+  dps: 44073.06282
+  tps: 30316.62107
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 45171.97009
-  tps: 31524.3866
+  dps: 45774.90242
+  tps: 31959.06369
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 43173.54894
-  tps: 29724.10798
+  dps: 43742.49936
+  tps: 30142.23696
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 42814.4211
-  tps: 29359.66945
+  dps: 43475.70082
+  tps: 29845.65193
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 45034.22621
-  tps: 31431.54271
+  dps: 45658.73249
+  tps: 31887.19051
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 42403.08911
-  tps: 29111.00388
+  dps: 42987.55715
+  tps: 29533.01562
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 45186.36148
-  tps: 31509.34605
+  dps: 45768.01601
+  tps: 31928.03108
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 45171.97009
-  tps: 31524.3866
+  dps: 45774.90242
+  tps: 31959.06369
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnlightenedIdolofDestruction-92144"
  value: {
-  dps: 43105.96412
-  tps: 29716.22835
+  dps: 43778.61262
+  tps: 30194.10533
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnlightenedStoneofDestruction-92143"
  value: {
-  dps: 44267.78269
-  tps: 30611.5669
+  dps: 44922.3309
+  tps: 31100.58817
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 42634.12011
-  tps: 29538.16269
+  dps: 43277.23226
+  tps: 30005.3407
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 45034.22621
-  tps: 31431.54271
+  dps: 45658.73249
+  tps: 31887.19051
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FallofMortality-59500"
  value: {
-  dps: 43451.69503
-  tps: 29827.4893
+  dps: 44023.59364
+  tps: 30242.01504
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FallofMortality-65124"
  value: {
-  dps: 43561.3594
-  tps: 29905.56439
+  dps: 44155.77129
+  tps: 30342.95341
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 43544.82081
-  tps: 29862.69768
+  dps: 44126.26254
+  tps: 30280.52978
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 41893.74325
-  tps: 28741.56351
+  dps: 42472.3837
+  tps: 29159.31994
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 43126.97765
-  tps: 29644.7574
+  dps: 43785.40146
+  tps: 30111.14719
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 42403.96378
-  tps: 29148.4232
+  dps: 42981.07404
+  tps: 29569.5798
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 44189.8301
-  tps: 30323.5258
+  dps: 44854.88043
+  tps: 30794.16838
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 42308.06485
-  tps: 29117.19796
+  dps: 42895.24361
+  tps: 29542.74929
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 42924.2422
-  tps: 29637.61025
+  dps: 43560.09359
+  tps: 30100.44765
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 45130.81058
-  tps: 31526.0738
+  dps: 45740.80776
+  tps: 31966.67114
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FluidDeath-58181"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForestwalkerIdolofRage-92142"
  value: {
-  dps: 42724.11871
-  tps: 29454.31736
+  dps: 43347.45574
+  tps: 29908.46944
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForestwalkerStoneofRage-92141"
  value: {
-  dps: 43008.84372
-  tps: 29726.0016
+  dps: 43679.81829
+  tps: 30219.22151
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 45316.99977
-  tps: 31599.32155
+  dps: 45935.49715
+  tps: 32053.85571
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 44290.18099
-  tps: 30592.3179
+  dps: 44905.18423
+  tps: 31045.57234
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 42785.69692
-  tps: 29370.65026
+  dps: 43406.68292
+  tps: 29828.44777
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GaleofShadows-56138"
  value: {
-  dps: 43459.63752
-  tps: 29971.3718
+  dps: 44056.95553
+  tps: 30396.20725
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GaleofShadows-56462"
  value: {
-  dps: 43646.50036
-  tps: 30086.94066
+  dps: 44303.91964
+  tps: 30554.08999
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GearDetector-61462"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 31914.11596
-  tps: 23217.32739
+  dps: 32047.40066
+  tps: 23306.30391
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 42940.97966
-  tps: 29443.4786
+  dps: 43537.04833
+  tps: 29873.11825
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HarmlightToken-63839"
  value: {
-  dps: 43587.73842
-  tps: 29853.92493
+  dps: 44127.72273
+  tps: 30280.6688
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 42126.92503
-  tps: 29041.75946
+  dps: 42733.64564
+  tps: 29491.45781
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 43629.50416
-  tps: 30162.4709
+  dps: 44271.36678
+  tps: 30644.034
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 44221.39665
-  tps: 30496.61197
+  dps: 44789.86326
+  tps: 30930.84156
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofRage-59224"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofRage-65072"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofSolace-55868"
  value: {
-  dps: 42639.55548
-  tps: 29388.73458
+  dps: 43235.40224
+  tps: 29812.77505
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofSolace-56393"
  value: {
-  dps: 42714.53381
-  tps: 29425.46815
+  dps: 43369.10714
+  tps: 29890.69316
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofThunder-55845"
  value: {
-  dps: 42263.46336
-  tps: 29039.85289
+  dps: 42872.39417
+  tps: 29476.34996
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofThunder-56370"
  value: {
-  dps: 42258.32113
-  tps: 29034.90599
+  dps: 42872.39417
+  tps: 29476.57676
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 45171.97009
-  tps: 31524.3866
+  dps: 45774.90242
+  tps: 31959.06369
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 42360.40021
-  tps: 29164.64652
+  dps: 42948.65749
+  tps: 29591.18247
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 42360.40021
-  tps: 29164.64652
+  dps: 42948.65749
+  tps: 29591.18247
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 42574.63661
-  tps: 29340.22818
+  dps: 43196.22946
+  tps: 29786.11736
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 42623.12201
-  tps: 29384.23986
+  dps: 43245.77937
+  tps: 29831.07947
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-IndomitablePride-77211"
  value: {
-  dps: 42318.36599
-  tps: 29120.46265
+  dps: 42911.3338
+  tps: 29563.10933
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-IndomitablePride-77983"
  value: {
-  dps: 42326.9937
-  tps: 29153.54145
+  dps: 42926.58621
+  tps: 29594.54576
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-IndomitablePride-78003"
  value: {
-  dps: 42259.76544
-  tps: 29063.55156
+  dps: 42830.04202
+  tps: 29488.31008
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 42263.46336
-  tps: 29039.78494
+  dps: 42872.39417
+  tps: 29476.28201
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 45457.43154
-  tps: 31308.7344
+  dps: 45964.22916
+  tps: 31665.77695
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 45424.74865
-  tps: 31213.05021
+  dps: 45872.75151
+  tps: 31543.16114
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 46289.77223
-  tps: 31832.93983
+  dps: 46725.88403
+  tps: 32152.47701
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 43139.30102
-  tps: 29726.90541
+  dps: 43721.29781
+  tps: 30161.7578
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 42233.7241
-  tps: 28999.1318
+  dps: 42796.39779
+  tps: 29408.99662
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 42278.25437
-  tps: 28953.91056
+  dps: 42860.26235
+  tps: 29369.89403
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 43524.22793
-  tps: 29932.47298
+  dps: 44160.86705
+  tps: 30387.83698
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 43715.27137
-  tps: 30159.46417
+  dps: 44296.02656
+  tps: 30582.42706
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 42471.61439
-  tps: 29313.89777
+  dps: 43053.99906
+  tps: 29748.58024
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 43107.60746
-  tps: 29781.44147
+  dps: 43788.41296
+  tps: 30283.0772
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 42319.12459
-  tps: 29273.61637
+  dps: 42921.09051
+  tps: 29705.76331
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 42319.12459
-  tps: 29273.61637
+  dps: 42921.09051
+  tps: 29705.76331
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 42627.84225
-  tps: 29274.13033
+  dps: 43225.55518
+  tps: 29718.3449
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LeadenDespair-55816"
  value: {
-  dps: 42370.16395
-  tps: 29140.24727
+  dps: 42951.89816
+  tps: 29568.99302
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LeadenDespair-56347"
  value: {
-  dps: 42403.96378
-  tps: 29148.4232
+  dps: 42981.07404
+  tps: 29569.5798
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 42148.86385
-  tps: 29021.54465
+  dps: 42724.66178
+  tps: 29450.061
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 42148.86385
-  tps: 29021.54465
+  dps: 42724.66178
+  tps: 29450.061
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 42125.11678
-  tps: 28997.42685
+  dps: 42734.22455
+  tps: 29448.88458
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 42125.11678
-  tps: 28997.42685
+  dps: 42734.22455
+  tps: 29448.88458
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 42564.35088
-  tps: 29402.87206
+  dps: 43152.72615
+  tps: 29843.92593
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 42618.7599
-  tps: 29452.80779
+  dps: 43208.7822
+  tps: 29895.50348
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MartialDefenderIdol-92127"
  value: {
-  dps: 42386.90436
-  tps: 29143.2673
+  dps: 42966.26012
+  tps: 29569.55407
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MartialDefenderStone-92126"
  value: {
-  dps: 43194.08573
-  tps: 29854.08148
+  dps: 43803.1715
+  tps: 30298.76157
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MartialIdolofBattle-92128"
  value: {
-  dps: 42785.69692
-  tps: 29370.65026
+  dps: 43406.68292
+  tps: 29828.44777
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MartialStoneofBattle-92129"
  value: {
-  dps: 43230.08934
-  tps: 29887.04038
+  dps: 43807.75996
+  tps: 30314.4972
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 42148.86385
-  tps: 29021.54465
+  dps: 42724.66178
+  tps: 29450.061
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 42148.86385
-  tps: 29021.54465
+  dps: 42724.66178
+  tps: 29450.061
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 42676.01517
-  tps: 29432.25261
+  dps: 43299.83381
+  tps: 29880.12905
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 42676.01517
-  tps: 29432.25261
+  dps: 43299.83381
+  tps: 29880.12905
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 44202.5377
-  tps: 30136.04744
+  dps: 44781.65244
+  tps: 30558.32649
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 43916.94389
-  tps: 30270.6793
+  dps: 44584.29185
+  tps: 30746.27827
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 42384.36654
-  tps: 29141.33233
+  dps: 42961.643
+  tps: 29567.20404
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-NaturalistIdolofDestruction-92137"
  value: {
-  dps: 43005.70364
-  tps: 29635.61817
+  dps: 43694.48048
+  tps: 30128.98188
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-NaturalistIdolofRage-92133"
  value: {
-  dps: 42724.11871
-  tps: 29454.31736
+  dps: 43347.45574
+  tps: 29908.46944
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-NaturalistStoneofDestruction-92136"
  value: {
-  dps: 44517.33054
-  tps: 30712.86474
+  dps: 45151.13888
+  tps: 31165.29389
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-NaturalistStoneofRage-92138"
  value: {
-  dps: 43473.71948
-  tps: 30054.69639
+  dps: 44139.6611
+  tps: 30547.83881
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-NaturalistStoneofWisdom-92139"
  value: {
-  dps: 43515.67413
-  tps: 29915.91861
+  dps: 44073.06282
+  tps: 30316.62107
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 44087.10636
-  tps: 30449.4904
+  dps: 44698.9794
+  tps: 30902.80879
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 44279.76522
-  tps: 30638.19084
+  dps: 44882.32722
+  tps: 31079.25334
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 42248.94414
-  tps: 28940.64783
+  dps: 42838.78123
+  tps: 29365.60128
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PartisanDefenderIdol-92147"
  value: {
-  dps: 42386.90436
-  tps: 29143.2673
+  dps: 42966.26012
+  tps: 29569.55407
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PartisanDefenderStone-92114"
  value: {
-  dps: 43351.67086
-  tps: 29971.58552
+  dps: 44016.66903
+  tps: 30466.76723
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PartisanIdolofBattle-92148"
  value: {
-  dps: 42785.69692
-  tps: 29370.65026
+  dps: 43406.68292
+  tps: 29828.44777
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PartisanStoneofBattle-92149"
  value: {
-  dps: 43083.24841
-  tps: 29861.0559
+  dps: 43751.82895
+  tps: 30354.87573
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PartisanStoneofWisdom-92145"
  value: {
-  dps: 43515.67413
-  tps: 29915.91861
+  dps: 44073.06282
+  tps: 30316.62107
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 43328.14689
-  tps: 29740.04815
+  dps: 43928.55612
+  tps: 30177.3314
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 43370.00655
-  tps: 29723.46722
+  dps: 43955.54459
+  tps: 30160.38826
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 42126.92503
-  tps: 29041.75946
+  dps: 42733.64564
+  tps: 29491.45781
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 42126.92503
-  tps: 29041.75946
+  dps: 42733.64564
+  tps: 29491.45781
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 45034.22621
-  tps: 31431.54271
+  dps: 45658.73249
+  tps: 31887.19051
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Rainsong-55854"
  value: {
-  dps: 42199.53928
-  tps: 29055.96525
+  dps: 42807.447
+  tps: 29492.95175
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Rainsong-56377"
  value: {
-  dps: 42199.53928
-  tps: 29055.96525
+  dps: 42807.447
+  tps: 29492.95175
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 43815.98709
-  tps: 30074.27361
+  dps: 44451.12683
+  tps: 30558.96729
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 45594.57445
-  tps: 31933.41933
+  dps: 46213.12608
+  tps: 32381.54992
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 45594.57445
-  tps: 31933.41933
+  dps: 46213.12608
+  tps: 32381.54992
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 42595.44396
-  tps: 29168.2211
+  dps: 43177.16627
+  tps: 29593.77189
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RosaryofLight-72901"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RottingSkull-77116"
  value: {
-  dps: 42908.07227
-  tps: 29490.80825
+  dps: 43500.96212
+  tps: 29925.38808
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuneofZeth-68998"
  value: {
-  dps: 43966.58275
-  tps: 30147.72083
+  dps: 44543.94758
+  tps: 30576.81619
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuthlessGladiator'sBadgeofConquest-70399"
  value: {
-  dps: 41893.74325
-  tps: 28741.56351
+  dps: 42472.3837
+  tps: 29159.31994
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuthlessGladiator'sBadgeofConquest-72304"
  value: {
-  dps: 41893.74325
-  tps: 28741.56351
+  dps: 42472.3837
+  tps: 29159.31994
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuthlessGladiator'sBadgeofDominance-70401"
  value: {
-  dps: 43404.53175
-  tps: 29700.62112
+  dps: 43984.85836
+  tps: 30119.1211
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuthlessGladiator'sBadgeofDominance-72448"
  value: {
-  dps: 43490.16047
-  tps: 29754.97874
+  dps: 44070.58265
+  tps: 30173.52087
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuthlessGladiator'sBadgeofVictory-70400"
  value: {
-  dps: 41893.74325
-  tps: 28741.56351
+  dps: 42472.3837
+  tps: 29159.31994
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuthlessGladiator'sBadgeofVictory-72450"
  value: {
-  dps: 41893.74325
-  tps: 28741.56351
+  dps: 42472.3837
+  tps: 29159.31994
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuthlessGladiator'sInsigniaofConquest-70404"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuthlessGladiator'sInsigniaofConquest-72309"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuthlessGladiator'sInsigniaofDominance-70402"
  value: {
-  dps: 43680.46514
-  tps: 29869.76917
+  dps: 44300.05904
+  tps: 30319.06598
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuthlessGladiator'sInsigniaofDominance-72449"
  value: {
-  dps: 43765.82736
-  tps: 29925.5112
+  dps: 44381.56424
+  tps: 30371.66804
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuthlessGladiator'sInsigniaofVictory-70403"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuthlessGladiator'sInsigniaofVictory-72455"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ScalesofLife-68915"
  value: {
-  dps: 42216.90666
-  tps: 29121.27764
+  dps: 42778.88641
+  tps: 29527.69866
   hps: 360.05275
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ScalesofLife-69109"
  value: {
-  dps: 42238.18304
-  tps: 29110.85595
+  dps: 42816.61489
+  tps: 29539.55501
   hps: 406.13614
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 42126.92503
-  tps: 29041.75946
+  dps: 42733.64564
+  tps: 29491.45781
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ScourgeheartDefenderIdol-92135"
  value: {
-  dps: 42386.90436
-  tps: 29143.2673
+  dps: 42966.26012
+  tps: 29569.55407
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ScourgeheartDefenderStone-92134"
  value: {
-  dps: 43203.28011
-  tps: 29920.52719
+  dps: 43865.79883
+  tps: 30416.96782
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ScourgeheartIdolofBattle-92167"
  value: {
-  dps: 42785.69692
-  tps: 29370.65026
+  dps: 43406.68292
+  tps: 29828.44777
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ScourgeheartStoneofBattle-92168"
  value: {
-  dps: 43116.08726
-  tps: 29880.76385
+  dps: 43775.07751
+  tps: 30378.73687
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SeaStar-55256"
  value: {
-  dps: 42466.35525
-  tps: 29091.88965
+  dps: 43038.79265
+  tps: 29505.04878
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SeaStar-56290"
  value: {
-  dps: 42961.84078
-  tps: 29406.36388
+  dps: 43535.02511
+  tps: 29819.96332
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SealoftheSevenSigns-77204"
  value: {
-  dps: 43867.46591
-  tps: 30190.30681
+  dps: 44467.0522
+  tps: 30626.1927
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SealoftheSevenSigns-77969"
  value: {
-  dps: 43489.23881
-  tps: 29973.60776
+  dps: 44084.41932
+  tps: 30402.45098
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SealoftheSevenSigns-77989"
  value: {
-  dps: 44099.92721
-  tps: 30351.6323
+  dps: 44725.96134
+  tps: 30797.82293
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ShadowflameRegalia"
  value: {
-  dps: 35193.02002
-  tps: 25676.66934
+  dps: 35692.18749
+  tps: 26055.84224
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ShardofWoe-60233"
  value: {
-  dps: 42998.13388
-  tps: 29605.50602
+  dps: 43541.11744
+  tps: 29999.7165
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 42286.45336
-  tps: 29081.32822
+  dps: 42878.98945
+  tps: 29514.25303
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 42327.43229
-  tps: 29135.41345
+  dps: 42913.896
+  tps: 29560.50593
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 42384.2249
-  tps: 29186.98903
+  dps: 42971.71309
+  tps: 29613.0422
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Sorrowsong-55879"
  value: {
-  dps: 43406.87184
-  tps: 29929.52841
+  dps: 44027.29829
+  tps: 30379.51479
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Sorrowsong-56400"
  value: {
-  dps: 43559.50639
-  tps: 30049.07684
+  dps: 44180.89654
+  tps: 30499.72367
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 42148.86385
-  tps: 29021.54465
+  dps: 42724.66178
+  tps: 29450.061
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SoulCasket-58183"
  value: {
-  dps: 43809.71869
-  tps: 30088.86081
+  dps: 44399.59024
+  tps: 30516.11627
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SoulseizerIdolofDestruction-92125"
  value: {
-  dps: 43059.52107
-  tps: 29628.16487
+  dps: 43721.52867
+  tps: 30084.10686
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SoulseizerStoneofDestruction-92124"
  value: {
-  dps: 44397.00835
-  tps: 30738.65219
+  dps: 44989.23577
+  tps: 31181.06261
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 42944.6981
-  tps: 29694.61259
+  dps: 43687.37852
+  tps: 30266.80447
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 42978.11111
-  tps: 29693.17331
+  dps: 43604.88747
+  tps: 30163.84189
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 43052.58396
-  tps: 29674.20509
+  dps: 43689.75486
+  tps: 30158.48422
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 42815.42688
-  tps: 29537.08757
+  dps: 43440.75396
+  tps: 29993.02621
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 42889.06251
-  tps: 29603.83774
+  dps: 43515.99447
+  tps: 30061.21715
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 43362.72455
-  tps: 29826.96845
+  dps: 44104.30294
+  tps: 30387.94552
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 43157.20643
-  tps: 29726.16468
+  dps: 44025.19187
+  tps: 30345.29902
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 43276.28597
-  tps: 29683.21634
+  dps: 44014.23496
+  tps: 30237.54728
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StayofExecution-68996"
  value: {
-  dps: 41893.74325
-  tps: 28741.56351
+  dps: 42472.3837
+  tps: 29159.31994
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 43359.72502
-  tps: 29664.10574
+  dps: 43968.11652
+  tps: 30106.10746
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StumpofTime-62465"
  value: {
-  dps: 43488.31893
-  tps: 29830.87193
+  dps: 44106.53521
+  tps: 30272.88008
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StumpofTime-62470"
  value: {
-  dps: 43471.97558
-  tps: 29844.24326
+  dps: 44047.93362
+  tps: 30263.24107
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 42386.90436
-  tps: 29143.2673
+  dps: 42966.26012
+  tps: 29569.55407
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 42376.58065
-  tps: 29144.40197
+  dps: 42952.78969
+  tps: 29570.03929
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 43325.25139
-  tps: 29729.16612
+  dps: 43903.77754
+  tps: 30150.75282
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TearofBlood-55819"
  value: {
-  dps: 42953.40989
-  tps: 29426.7181
+  dps: 43535.78537
+  tps: 29849.93396
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TearofBlood-56351"
  value: {
-  dps: 43242.01669
-  tps: 29704.63193
+  dps: 43838.93626
+  tps: 30136.93523
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 43094.2076
-  tps: 29668.67378
+  dps: 43720.60592
+  tps: 30129.21418
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 43554.38686
-  tps: 29946.79328
+  dps: 44219.5622
+  tps: 30428.1387
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TheHungerer-68927"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TheHungerer-69112"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 43944.54782
-  tps: 30317.13342
+  dps: 44613.20171
+  tps: 30806.77099
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 44230.90418
-  tps: 30576.30399
+  dps: 44829.16363
+  tps: 31007.6901
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ThundercallerIdolofDestruction-92120"
  value: {
-  dps: 42957.51913
-  tps: 29701.44422
+  dps: 43595.99979
+  tps: 30174.0365
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ThundercallerIdolofRage-92116"
  value: {
-  dps: 42724.11871
-  tps: 29454.31736
+  dps: 43347.45574
+  tps: 29908.46944
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ThundercallerStoneofDestruction-92119"
  value: {
-  dps: 44339.56679
-  tps: 30698.33857
+  dps: 45011.97544
+  tps: 31211.81129
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ThundercallerStoneofRage-92121"
  value: {
-  dps: 43222.53147
-  tps: 29838.01351
+  dps: 43867.91725
+  tps: 30298.847
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ThundercallerStoneofWisdom-92122"
  value: {
-  dps: 43515.67413
-  tps: 29915.91861
+  dps: 44073.06282
+  tps: 30316.62107
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 42622.50155
-  tps: 29362.20212
+  dps: 43243.62384
+  tps: 29814.36595
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 42671.10106
-  tps: 29406.25723
+  dps: 43293.28257
+  tps: 29859.37197
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 42938.99576
-  tps: 29585.65343
+  dps: 43549.19874
+  tps: 30025.83317
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnheededWarning-59520"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 41875.53164
-  tps: 28730.30522
+  dps: 42446.01899
+  tps: 29141.80213
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 42360.40021
-  tps: 29164.64652
+  dps: 42948.65749
+  tps: 29591.18247
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 42360.40021
-  tps: 29164.64652
+  dps: 42948.65749
+  tps: 29591.18247
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 42360.40021
-  tps: 29164.64652
+  dps: 42948.65749
+  tps: 29591.18247
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 44574.52386
-  tps: 31040.72946
+  dps: 45178.56016
+  tps: 31479.10402
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 45064.62804
-  tps: 31420.6492
+  dps: 45662.49765
+  tps: 31859.39556
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 42126.92503
-  tps: 29041.75946
+  dps: 42733.64564
+  tps: 29491.45781
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VeilofLies-72900"
  value: {
-  dps: 42303.58585
-  tps: 29146.51274
+  dps: 42880.05919
+  tps: 29570.51941
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VestmentsoftheFacelessShroud"
  value: {
-  dps: 37704.50966
-  tps: 26350.05835
+  dps: 38210.99432
+  tps: 26722.79771
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VialofShadows-77207"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VialofShadows-77979"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VialofShadows-77999"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 42386.90436
-  tps: 29143.2673
+  dps: 42966.26012
+  tps: 29569.55407
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 42376.58065
-  tps: 29144.40197
+  dps: 42952.78969
+  tps: 29570.03929
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 41893.74325
-  tps: 28741.56351
+  dps: 42472.3837
+  tps: 29159.31994
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sBadgeofConquest-70517"
  value: {
-  dps: 41893.74325
-  tps: 28741.56351
+  dps: 42472.3837
+  tps: 29159.31994
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 43088.82237
-  tps: 29500.20691
+  dps: 43668.79663
+  tps: 29918.55151
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sBadgeofDominance-70518"
  value: {
-  dps: 43229.55131
-  tps: 29589.54249
+  dps: 43809.68264
+  tps: 30007.95635
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 41893.74325
-  tps: 28741.56351
+  dps: 42472.3837
+  tps: 29159.31994
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sBadgeofVictory-70519"
  value: {
-  dps: 41893.74325
-  tps: 28741.56351
+  dps: 42472.3837
+  tps: 29159.31994
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 42233.7333
-  tps: 29000.31969
+  dps: 42841.507
+  tps: 29436.41705
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 42765.94931
-  tps: 29567.32491
+  dps: 43426.3131
+  tps: 30052.62774
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 42785.61625
-  tps: 29359.52442
+  dps: 43392.7467
+  tps: 29808.43479
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 42233.7333
-  tps: 29000.31969
+  dps: 42841.507
+  tps: 29436.41705
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 42733.9162
-  tps: 29453.99354
+  dps: 43352.5424
+  tps: 29899.88791
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 42233.7333
-  tps: 29000.31969
+  dps: 42841.507
+  tps: 29436.41705
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sInsigniaofConquest-70577"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 43357.71854
-  tps: 29714.81118
+  dps: 43976.12005
+  tps: 30164.31347
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sInsigniaofDominance-70578"
  value: {
-  dps: 43475.66398
-  tps: 29799.53971
+  dps: 44078.52084
+  tps: 30237.84468
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sInsigniaofVictory-70579"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WaterdancerDefenderIdol-92399"
  value: {
-  dps: 42386.90436
-  tps: 29143.2673
+  dps: 42966.26012
+  tps: 29569.55407
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WaterdancerDefenderStone-92398"
  value: {
-  dps: 43361.54824
-  tps: 30027.94738
+  dps: 43987.78824
+  tps: 30489.69939
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WaterdancerIdolofRage-92401"
  value: {
-  dps: 42724.11871
-  tps: 29454.31736
+  dps: 43347.45574
+  tps: 29908.46944
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WaterdancerStoneofRage-92400"
  value: {
-  dps: 43232.96812
-  tps: 29883.97894
+  dps: 43914.61101
+  tps: 30393.25078
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WaterdancerStoneofWisdom-92402"
  value: {
-  dps: 43515.67413
-  tps: 29915.91861
+  dps: 44073.06282
+  tps: 30316.62107
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 44885.62763
-  tps: 30900.60084
+  dps: 46023.00058
+  tps: 31716.0285
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 44570.80346
-  tps: 30662.72516
+  dps: 45638.83719
+  tps: 31432.08083
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 43403.76378
-  tps: 29792.69149
+  dps: 43997.88985
+  tps: 30202.39068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 43928.78075
-  tps: 30215.51425
+  dps: 44532.35972
+  tps: 30652.41545
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 42212.11669
-  tps: 29030.20893
+  dps: 42797.31816
+  tps: 29453.95512
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 42251.378
-  tps: 29025.78125
+  dps: 42864.4117
+  tps: 29470.68361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 42344.03177
-  tps: 29249.92369
+  dps: 42929.74388
+  tps: 29685.97069
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 42344.03177
-  tps: 29249.92369
+  dps: 42929.74388
+  tps: 29685.97069
  }
 }
 dps_results: {
  key: "TestAffliction-Average-Default"
  value: {
-  dps: 46451.33708
-  tps: 32502.51141
+  dps: 47047.81355
+  tps: 32943.57285
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p4-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 78921.71452
-  tps: 71526.38496
+  dps: 79789.22663
+  tps: 72251.86188
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p4-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 45432.60321
-  tps: 32198.31515
+  dps: 46011.08042
+  tps: 32641.536
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p4-Affliction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 55641.09999
-  tps: 36256.24665
+  dps: 55662.60133
+  tps: 36260.57036
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p4-Affliction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 55198.13298
-  tps: 53414.21531
+  dps: 55794.3358
+  tps: 53905.40864
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p4-Affliction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 30508.84093
-  tps: 21349.75463
+  dps: 30888.58126
+  tps: 21636.93054
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p4-Affliction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 33799.10363
-  tps: 20697.58171
+  dps: 33811.0668
+  tps: 20698.47708
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p4-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 78653.90878
-  tps: 71376.64829
+  dps: 79579.09385
+  tps: 72137.49273
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p4-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 45055.56451
-  tps: 31866.64589
+  dps: 45678.73468
+  tps: 32330.51267
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p4-Affliction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 54031.92858
-  tps: 35033.10576
+  dps: 54081.11894
+  tps: 35050.62163
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p4-Affliction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 54790.71247
-  tps: 53132.78733
+  dps: 55410.86814
+  tps: 53645.76326
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p4-Affliction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 30216.0356
-  tps: 21019.8553
+  dps: 30609.56906
+  tps: 21314.25246
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p4-Affliction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 32919.09265
-  tps: 19877.14952
+  dps: 32922.41946
+  tps: 19876.19912
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p4-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 79562.02832
-  tps: 71707.2126
+  dps: 80493.55003
+  tps: 72468.78701
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p4-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 45862.94987
-  tps: 32083.20202
+  dps: 46492.24998
+  tps: 32547.41587
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p4-Affliction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 55111.43125
-  tps: 35630.78208
+  dps: 55156.30177
+  tps: 35641.47408
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p4-Affliction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 55444.44634
-  tps: 53374.64931
+  dps: 56068.85627
+  tps: 53892.2388
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p4-Affliction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 30797.84464
-  tps: 21168.51761
+  dps: 31198.64721
+  tps: 21466.38636
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p4-Affliction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 33481.36041
+  dps: 33489.15909
   tps: 20162.22984
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p4-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 79155.82404
-  tps: 71804.00884
+  dps: 80021.49952
+  tps: 72518.97216
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p4-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 45526.3431
-  tps: 32360.69752
+  dps: 46097.06448
+  tps: 32778.58601
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p4-Affliction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 56177.81398
-  tps: 36532.89474
+  dps: 56217.30797
+  tps: 36538.00335
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p4-Affliction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 55221.27209
-  tps: 53439.45274
+  dps: 55813.47956
+  tps: 53924.49645
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p4-Affliction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 30605.49158
-  tps: 21356.00225
+  dps: 30990.77489
+  tps: 21631.54521
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p4-Affliction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 33859.77477
-  tps: 20865.33105
+  dps: 33872.09558
+  tps: 20865.63778
  }
 }
 dps_results: {
  key: "TestAffliction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 45704.94631
-  tps: 32083.20202
+  dps: 46333.61462
+  tps: 32547.41587
  }
 }

--- a/sim/warlock/drain_life.go
+++ b/sim/warlock/drain_life.go
@@ -44,6 +44,7 @@ func (warlock *Warlock) registerDrainLife() {
 			warlock.SoulBurnAura.Deactivate(sim)
 			if result.Landed() {
 				spell.Dot(target).Apply(sim)
+				spell.DealOutcome(sim, result)
 			}
 		},
 	})

--- a/sim/warlock/drain_soul.go
+++ b/sim/warlock/drain_soul.go
@@ -68,6 +68,7 @@ func (warlock *Warlock) registerDrainSoul() {
 				dot := spell.Dot(target)
 				dot.Apply(sim)
 				dot.UpdateExpires(dot.ExpiresAt())
+				spell.DealOutcome(sim, result)
 			}
 		},
 		ExpectedTickDamage: func(sim *core.Simulation, target *core.Unit, spell *core.Spell, useSnapshot bool) *core.SpellResult {


### PR DESCRIPTION
- Added `DealOutcome` to DS and DL so they can proc items that rely on "Spell Hit"