### PR TITLE
Change FS spread to be copied

### DIFF
--- a/sim/core/dot.go
+++ b/sim/core/dot.go
@@ -171,7 +171,7 @@ func (dot *Dot) BaseDuration() time.Duration {
 }
 
 // Copy's the original DoT's period and duration to the current DoT.
-// This is only currently used for Mage's Impact DoT spreading.
+// This is only currently used for Mage's Impact DoT spreading and Enhancement's ImprovedLava Lash.
 func (dot *Dot) CopyDotAndApply(sim *Simulation, originaldot *Dot) {
 	dot.TakeSnapshot(sim, false)
 	dot.SnapshotBaseDamage = originaldot.SnapshotBaseDamage

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -2414,8 +2414,8 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Dwarf-p4.orc-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 60320.95498
-  tps: 38413.84669
+  dps: 57191.02177
+  tps: 38417.84511
  }
 }
 dps_results: {
@@ -2435,8 +2435,8 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Dwarf-p4.orc-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 46139.50566
-  tps: 31270.73126
+  dps: 43938.04076
+  tps: 31267.98111
  }
 }
 dps_results: {
@@ -2456,8 +2456,8 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p4.orc-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 60856.22896
-  tps: 38552.11714
+  dps: 57805.92485
+  tps: 38549.00186
  }
 }
 dps_results: {
@@ -2477,8 +2477,8 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Orc-p4.orc-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 46699.70054
-  tps: 31550.10811
+  dps: 44418.76538
+  tps: 31558.22228
  }
 }
 dps_results: {
@@ -2498,8 +2498,8 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p4.orc-Standard-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 60503.03834
-  tps: 38610.56427
+  dps: 57499.81237
+  tps: 38611.0571
  }
 }
 dps_results: {
@@ -2519,8 +2519,8 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-Settings-Troll-p4.orc-Standard-default-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 46542.05375
-  tps: 31538.84348
+  dps: 44385.89273
+  tps: 31537.71757
  }
 }
 dps_results: {

--- a/sim/shaman/enhancement/lavalash.go
+++ b/sim/shaman/enhancement/lavalash.go
@@ -72,7 +72,7 @@ func (enh *EnhancementShaman) registerLavaLashSpell() {
 
 					for _, otherTarget := range validTargets {
 						if otherTarget != target {
-							enh.FlameShock.RelatedDotSpell.Dot(otherTarget).Apply(sim)
+							enh.FlameShock.RelatedDotSpell.Dot(otherTarget).CopyDotAndApply(sim, flameShockDot)
 							numberSpread++
 						}
 


### PR DESCRIPTION
- Flame Shock Dot is copied with the original Dot's properties, not applied as a new one.