### PR TITLE
[Fix] Round spell mod after iteration

### DIFF
--- a/sim/core/spell_mod.go
+++ b/sim/core/spell_mod.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"math"
 	"slices"
 	"strconv"
 	"time"
@@ -97,6 +98,16 @@ func buildMod(unit *Unit, config SpellModConfig) *SpellMod {
 			if mod.IsActive {
 				mod.Apply(mod, spell)
 			}
+		}
+	})
+
+	unit.RegisterResetEffect(func(s *Simulation) {
+		for _, spell := range unit.Spellbook {
+			spell.DamageMultiplierAdditive = math.Round(spell.DamageMultiplierAdditive*10000) / 10000
+
+			// Possibly add other spell mod variables here to safely round them
+			// Spell values are not reset on Iteration Reset so small floating point errors by multiplying / adding to a field
+			// Will carry over through iterations
 		}
 	})
 

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -38,2314 +38,2311 @@ character_stats_results: {
 dps_results: {
  key: "TestShadow-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 49634.37523
-  tps: 43845.61163
+  dps: 51532.22689
+  tps: 46684.45669
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 46505.17224
-  tps: 40862.61407
+  dps: 48377.15646
+  tps: 43646.35526
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 46521.92217
-  tps: 40999.47425
+  dps: 48964.10249
+  tps: 44226.37919
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 46289.64272
-  tps: 40658.62906
+  dps: 48643.56488
+  tps: 43834.65394
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 46368.46795
-  tps: 40740.91744
+  dps: 48696.1341
+  tps: 43877.27433
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ArrowofTime-72897"
  value: {
-  dps: 46097.00224
-  tps: 40521.80544
+  dps: 48150.64213
+  tps: 43493.88976
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 48728.06058
-  tps: 43016.31582
+  dps: 50492.28247
+  tps: 45710.57046
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 45382.80593
-  tps: 39899.9754
-  hps: 126.26596
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 48015.67846
-  tps: 42066.96782
+  dps: 49951.47301
+  tps: 44977.29143
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 48282.79953
-  tps: 42288.71254
+  dps: 50253.92398
+  tps: 45250.17391
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BindingPromise-67037"
  value: {
-  dps: 45441.15293
-  tps: 39912.02671
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 46372.83562
-  tps: 40798.04047
+  dps: 48452.40698
+  tps: 43729.5656
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 46136.94421
-  tps: 40604.25041
+  dps: 48555.3701
+  tps: 43829.53419
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 46220.12369
-  tps: 40683.38234
+  dps: 48658.33322
+  tps: 43929.50278
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 45749.54053
-  tps: 40297.31377
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 46754.89424
-  tps: 41161.47623
+  dps: 48772.24431
+  tps: 44011.47948
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 45621.21656
-  tps: 40205.23483
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 46602.64005
-  tps: 40881.75991
+  dps: 48393.33063
+  tps: 43614.02378
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 45432.63901
-  tps: 39912.02671
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 45432.63901
-  tps: 39912.02671
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 45491.80726
-  tps: 39999.97022
+  dps: 47763.7884
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 46640.69013
-  tps: 40959.8481
+  dps: 48902.53549
+  tps: 44071.04567
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 45490.6453
-  tps: 39999.97022
+  dps: 47764.62271
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 45563.96471
-  tps: 40062.10846
+  dps: 47830.26133
+  tps: 43127.16521
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 45549.71152
-  tps: 40047.99866
+  dps: 47818.2741
+  tps: 43115.27615
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 45571.41188
-  tps: 40069.58001
+  dps: 47835.23605
+  tps: 43132.27734
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BottledLightning-66879"
  value: {
-  dps: 46832.94449
-  tps: 41171.57575
+  dps: 48377.15646
+  tps: 43646.35526
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BottledWishes-77114"
  value: {
-  dps: 48584.47136
-  tps: 42642.27348
+  dps: 51054.8231
+  tps: 46012.37321
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 48963.81856
-  tps: 42348.82028
+  dps: 50825.14004
+  tps: 45075.24715
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 45441.15293
-  tps: 39912.02671
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 49875.68324
-  tps: 44032.20132
+  dps: 51876.13602
+  tps: 46963.05536
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CataclysmicGladiator'sBadgeofConquest-73648"
  value: {
-  dps: 45621.21656
-  tps: 40205.23483
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CataclysmicGladiator'sBadgeofDominance-73498"
  value: {
-  dps: 47425.40491
-  tps: 41727.04269
+  dps: 49427.81764
+  tps: 44573.40842
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CataclysmicGladiator'sBadgeofVictory-73496"
  value: {
-  dps: 45621.21656
-  tps: 40205.23483
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CataclysmicGladiator'sInsigniaofConquest-73643"
  value: {
-  dps: 45494.03283
-  tps: 39999.97022
+  dps: 47764.11689
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CataclysmicGladiator'sInsigniaofDominance-73497"
  value: {
-  dps: 47485.66328
-  tps: 41681.00024
+  dps: 49708.32984
+  tps: 44769.19397
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CataclysmicGladiator'sInsigniaofVictory-73491"
  value: {
-  dps: 45492.63657
-  tps: 39999.97022
+  dps: 47763.55951
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 49694.5819
-  tps: 43856.41696
+  dps: 51657.47237
+  tps: 46819.97901
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 46626.41011
-  tps: 40881.99182
+  dps: 48407.86267
+  tps: 43626.14793
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 47083.87811
-  tps: 41502.88043
+  dps: 49067.66006
+  tps: 44262.75383
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 46154.15954
-  tps: 40500.24645
+  dps: 48288.94146
+  tps: 43486.74867
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 46224.43809
-  tps: 40599.25831
+  dps: 48210.793
+  tps: 43590.78383
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 46244.03556
-  tps: 40540.04486
+  dps: 48035.16565
+  tps: 43335.31833
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CrimsonAcolyte'sRaiment"
  value: {
-  dps: 32383.97421
-  tps: 28575.86917
+  dps: 30094.6086
+  tps: 26750.52476
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CrimsonAcolyte'sRegalia"
  value: {
-  dps: 34956.97162
-  tps: 30837.69921
+  dps: 32069.50003
+  tps: 28548.89512
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CrushingWeight-59506"
  value: {
-  dps: 45837.86152
-  tps: 40365.3883
+  dps: 47886.04798
+  tps: 43220.27277
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CrushingWeight-65118"
  value: {
-  dps: 45940.99684
-  tps: 40424.51517
+  dps: 48072.14859
+  tps: 43350.94442
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 49395.23322
-  tps: 43628.70038
+  dps: 51194.68919
+  tps: 46373.01554
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 48967.68786
-  tps: 43184.54411
+  dps: 50924.49927
+  tps: 46064.14811
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 45432.63901
-  tps: 39912.02671
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 47052.38283
-  tps: 41337.42081
+  dps: 49067.66006
+  tps: 44262.75383
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 48794.12863
-  tps: 42933.53557
+  dps: 51321.77454
+  tps: 46463.59004
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkwalkerIdolofRage-92118"
  value: {
-  dps: 46302.09862
-  tps: 40769.70808
+  dps: 48765.47888
+  tps: 44038.55942
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DarkwalkerStoneofRage-92117"
  value: {
-  dps: 46522.37053
-  tps: 40975.05071
+  dps: 49244.47327
+  tps: 44500.10716
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 46100.77264
-  tps: 40516.07618
+  dps: 48047.34182
+  tps: 43313.89467
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DelivererIdolofDestruction-92113"
  value: {
-  dps: 47108.80313
-  tps: 41526.02182
+  dps: 49215.52205
+  tps: 44507.36506
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DelivererStoneofDestruction-92151"
  value: {
-  dps: 48019.22422
-  tps: 42261.93314
+  dps: 50418.27643
+  tps: 45577.3604
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DelivererStoneofWisdom-92115"
  value: {
-  dps: 47052.38283
-  tps: 41337.42081
+  dps: 49067.66006
+  tps: 44262.75383
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 48784.50134
-  tps: 43024.37688
+  dps: 50608.73349
+  tps: 45835.46444
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 46827.47779
-  tps: 41251.34659
+  dps: 48871.43827
+  tps: 44007.11171
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 46405.16123
-  tps: 40669.34927
+  dps: 48524.08171
+  tps: 43726.76129
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 48728.06058
-  tps: 43016.31582
+  dps: 50492.28247
+  tps: 45710.57046
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 46284.62852
-  tps: 40767.18616
+  dps: 48215.7211
+  tps: 43552.59706
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 48963.81856
-  tps: 43202.93635
+  dps: 50825.14004
+  tps: 45984.1983
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 48784.50134
-  tps: 43024.37688
+  dps: 50608.73349
+  tps: 45835.46444
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EnlightenedIdolofDestruction-92144"
  value: {
-  dps: 47319.8284
-  tps: 41557.81314
+  dps: 48998.65796
+  tps: 44236.52836
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EnlightenedStoneofDestruction-92143"
  value: {
-  dps: 47997.66815
-  tps: 42242.83031
+  dps: 50460.8948
+  tps: 45616.81085
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 46521.92217
-  tps: 40999.47425
+  dps: 48964.10249
+  tps: 44226.37919
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 48728.06058
-  tps: 43016.31582
+  dps: 50492.28247
+  tps: 45710.57046
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FallofMortality-59500"
  value: {
-  dps: 47052.38283
-  tps: 41337.42081
+  dps: 49067.66006
+  tps: 44262.75383
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FallofMortality-65124"
  value: {
-  dps: 47270.84567
-  tps: 41529.98859
+  dps: 49248.20165
+  tps: 44425.97477
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 47232.47559
-  tps: 41538.94048
+  dps: 49339.71766
+  tps: 44516.20897
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 45621.21656
-  tps: 40205.23483
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 46878.87669
-  tps: 41322.71498
+  dps: 48888.78903
+  tps: 44103.10915
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 45441.15293
-  tps: 39912.02671
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 47932.51825
-  tps: 42214.2026
+  dps: 50012.51949
+  tps: 45078.96673
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 46345.11243
-  tps: 40895.15185
+  dps: 48658.33322
+  tps: 43929.50278
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 46562.29686
-  tps: 41140.49477
+  dps: 49198.10958
+  tps: 44453.58052
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 48869.49622
-  tps: 43151.02834
+  dps: 50664.66029
+  tps: 45877.85699
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FluidDeath-58181"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForestwalkerIdolofRage-92142"
  value: {
-  dps: 46301.65476
-  tps: 40769.70808
+  dps: 48764.64312
+  tps: 44038.55942
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForestwalkerStoneofRage-92141"
  value: {
-  dps: 46458.07414
-  tps: 40913.19637
+  dps: 49060.31359
+  tps: 44314.82102
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 48963.81856
-  tps: 43197.97657
+  dps: 50825.14004
+  tps: 45979.5888
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 48572.01983
-  tps: 42772.12437
+  dps: 50891.85193
+  tps: 46018.34348
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 46613.22879
-  tps: 40887.56243
+  dps: 48428.93892
+  tps: 43641.84434
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GaleofShadows-56138"
  value: {
-  dps: 47517.51432
-  tps: 41877.0793
+  dps: 49018.33489
+  tps: 44270.5846
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GaleofShadows-56462"
  value: {
-  dps: 47618.73743
-  tps: 41907.36908
+  dps: 49265.745
+  tps: 44593.09505
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GearDetector-61462"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Gladiator'sInvestiture"
  value: {
-  dps: 34238.52525
-  tps: 30185.72006
+  dps: 31695.37364
+  tps: 28090.01815
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Gladiator'sRaiment"
  value: {
-  dps: 38386.73623
-  tps: 33649.94107
+  dps: 35547.52971
+  tps: 31472.07398
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 46435.8438
-  tps: 40767.68806
+  dps: 48439.05714
+  tps: 43700.40342
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-HarmlightToken-63839"
  value: {
-  dps: 46598.19531
-  tps: 41102.32471
+  dps: 49017.56478
+  tps: 44177.3052
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 47766.3775
-  tps: 42045.85683
+  dps: 49047.30833
+  tps: 44210.702
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 48104.17431
-  tps: 42272.64798
+  dps: 49215.27287
+  tps: 44359.34672
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-HeartofRage-59224"
  value: {
-  dps: 45500.51702
-  tps: 39999.97022
+  dps: 47769.07759
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-HeartofRage-65072"
  value: {
-  dps: 45499.00164
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-HeartofSolace-55868"
  value: {
-  dps: 46600.395
-  tps: 41043.50603
+  dps: 48068.18412
+  tps: 43419.40888
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-HeartofSolace-56393"
  value: {
-  dps: 46573.64716
-  tps: 40964.76795
+  dps: 48184.15749
+  tps: 43623.0516
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-HeartofThunder-55845"
  value: {
-  dps: 45487.49687
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-HeartofThunder-56370"
  value: {
-  dps: 45487.49687
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Heartpierce-50641"
  value: {
-  dps: 49875.68324
-  tps: 44032.20132
+  dps: 51876.13602
+  tps: 46963.05536
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 48784.50134
-  tps: 43024.37688
+  dps: 50608.73349
+  tps: 45835.46444
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 46436.55191
-  tps: 40982.29926
+  dps: 48770.65663
+  tps: 44038.55942
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 46436.55191
-  tps: 40982.29926
+  dps: 48770.65663
+  tps: 44038.55942
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 46122.95192
-  tps: 40604.25041
+  dps: 48555.3701
+  tps: 43829.53419
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 46206.13139
-  tps: 40683.38234
+  dps: 48658.33322
+  tps: 43929.50278
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-IndomitablePride-77211"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-IndomitablePride-77983"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-IndomitablePride-78003"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 45487.49687
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 49555.99731
-  tps: 43495.8974
+  dps: 50860.34796
+  tps: 45934.77291
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 48985.92628
-  tps: 43026.18042
+  dps: 50401.36407
+  tps: 45493.39814
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 49848.99589
-  tps: 43863.47918
+  dps: 51314.56883
+  tps: 46329.83149
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 47076.56524
-  tps: 41381.38964
+  dps: 49089.5186
+  tps: 44331.42558
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 45450.00614
-  tps: 39915.24571
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 45450.00614
-  tps: 39915.6006
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 47353.34769
-  tps: 41714.38327
+  dps: 49338.48812
+  tps: 44507.71758
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 47548.47075
-  tps: 41824.45167
+  dps: 49538.29484
+  tps: 44691.27366
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 46372.83562
-  tps: 40798.04047
+  dps: 48452.40698
+  tps: 43729.5656
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 46771.67826
-  tps: 41106.90158
+  dps: 49176.76783
+  tps: 44342.62076
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 46131.45086
-  tps: 40650.09002
+  dps: 48052.58258
+  tps: 43252.6232
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 46131.45086
-  tps: 40650.09002
+  dps: 48052.58258
+  tps: 43252.6232
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 46161.34469
-  tps: 40611.81888
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-LastWord-50708"
  value: {
-  dps: 49868.53336
-  tps: 44032.20132
+  dps: 51873.19985
+  tps: 46963.05536
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-LeadenDespair-55816"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-LeadenDespair-56347"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 45486.97005
-  tps: 39999.97022
+  dps: 47764.17884
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 45813.44282
-  tps: 40264.7849
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 45813.44282
-  tps: 40264.7849
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 46547.89198
-  tps: 40964.89541
+  dps: 49300.58526
+  tps: 44701.92024
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 46644.06985
-  tps: 41056.57655
+  dps: 49542.26047
+  tps: 44940.82172
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MartialDefenderIdol-92127"
  value: {
-  dps: 45493.53078
-  tps: 39999.97022
+  dps: 47763.48508
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MartialDefenderStone-92126"
  value: {
-  dps: 46501.09044
-  tps: 40953.62557
+  dps: 49109.44232
+  tps: 44363.78721
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MartialIdolofBattle-92128"
  value: {
-  dps: 46605.02131
-  tps: 40887.56243
+  dps: 48423.78508
+  tps: 43641.84434
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MartialStoneofBattle-92129"
  value: {
-  dps: 46507.65921
-  tps: 40958.52419
+  dps: 49212.79694
+  tps: 44470.94347
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MercurialRegalia"
  value: {
-  dps: 38565.1368
-  tps: 33495.81194
+  dps: 35502.95536
+  tps: 31246.30997
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 45813.44282
-  tps: 40264.7849
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 45813.44282
-  tps: 40264.7849
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 46296.87264
-  tps: 40769.70808
+  dps: 48770.65663
+  tps: 44038.55942
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 46296.87264
-  tps: 40769.70808
+  dps: 48770.65663
+  tps: 44038.55942
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 47998.0314
-  tps: 42069.37533
+  dps: 49844.58323
+  tps: 44895.5137
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 48187.23406
-  tps: 42544.01085
+  dps: 50719.4397
+  tps: 45881.52036
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 45441.15293
-  tps: 39912.02671
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-NaturalistIdolofDestruction-92137"
  value: {
-  dps: 47457.45516
-  tps: 41730.18531
+  dps: 48949.89906
+  tps: 44199.86008
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-NaturalistIdolofRage-92133"
  value: {
-  dps: 46303.6612
-  tps: 40769.70808
+  dps: 48765.1373
+  tps: 44038.55942
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-NaturalistStoneofDestruction-92136"
  value: {
-  dps: 47998.79155
-  tps: 42246.19352
+  dps: 50305.25404
+  tps: 45458.86835
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-NaturalistStoneofRage-92138"
  value: {
-  dps: 46403.00484
-  tps: 40865.71906
+  dps: 49073.06854
+  tps: 44329.6049
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-NaturalistStoneofWisdom-92139"
  value: {
-  dps: 47052.38283
-  tps: 41337.42081
+  dps: 49067.66006
+  tps: 44262.75383
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 48283.81167
-  tps: 42529.63269
+  dps: 50510.17304
+  tps: 45648.74154
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 48646.39461
-  tps: 42851.66561
+  dps: 50867.54003
+  tps: 45984.907
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 46192.29046
-  tps: 40681.47759
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PartisanDefenderIdol-92147"
  value: {
-  dps: 45493.59146
-  tps: 39999.97022
+  dps: 47762.64329
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PartisanDefenderStone-92114"
  value: {
-  dps: 46451.53367
-  tps: 40906.26619
+  dps: 49120.00338
+  tps: 44376.67242
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PartisanIdolofBattle-92148"
  value: {
-  dps: 46601.97495
-  tps: 40887.56243
+  dps: 48423.11231
+  tps: 43641.84434
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PartisanStoneofBattle-92149"
  value: {
-  dps: 46505.68029
-  tps: 40959.56991
+  dps: 49230.98098
+  tps: 44487.94259
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PartisanStoneofWisdom-92145"
  value: {
-  dps: 47052.38283
-  tps: 41337.42081
+  dps: 49067.66006
+  tps: 44262.75383
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 47072.8483
-  tps: 41331.79165
+  dps: 48995.86873
+  tps: 44200.23728
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 46945.95538
-  tps: 41236.3245
+  dps: 48910.8384
+  tps: 44113.47378
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 48728.06058
-  tps: 43016.31582
+  dps: 50492.28247
+  tps: 45710.57046
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Rainsong-55854"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Rainsong-56377"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Rathrak,thePoisonousMind-77195"
  value: {
-  dps: 44186.12405
-  tps: 41665.1696
+  dps: 45755.16492
+  tps: 43837.14978
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Rathrak,thePoisonousMind-78475"
  value: {
-  dps: 45735.30839
-  tps: 43141.64415
+  dps: 47236.42052
+  tps: 45221.83398
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Rathrak,thePoisonousMind-78484"
  value: {
-  dps: 43031.27511
-  tps: 40555.46651
+  dps: 44565.99886
+  tps: 42718.18947
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 47606.78316
-  tps: 41767.81696
+  dps: 49855.45517
+  tps: 44894.35174
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RegaliaofDyingLight"
  value: {
-  dps: 40552.84592
-  tps: 35966.65037
+  dps: 41823.74819
+  tps: 37851.03672
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RegaliaoftheCleansingFlame"
  value: {
-  dps: 41637.38217
-  tps: 35568.99522
+  dps: 37666.04039
+  tps: 33215.60881
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 49634.37523
-  tps: 43845.61163
+  dps: 51532.22689
+  tps: 46684.45669
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 49634.37523
-  tps: 43845.61163
+  dps: 51532.22689
+  tps: 46684.45669
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 46542.1439
-  tps: 40807.80586
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RosaryofLight-72901"
  value: {
-  dps: 46012.25793
-  tps: 40356.11577
+  dps: 47937.66001
+  tps: 43276.84207
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RottingSkull-77116"
  value: {
-  dps: 46865.90563
-  tps: 41104.49922
+  dps: 48672.52028
+  tps: 43889.73688
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RuneofZeth-68998"
  value: {
-  dps: 48259.21171
-  tps: 42312.71875
+  dps: 50103.5982
+  tps: 45249.20251
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RuthlessGladiator'sBadgeofConquest-70399"
  value: {
-  dps: 45621.21656
-  tps: 40205.23483
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RuthlessGladiator'sBadgeofConquest-72304"
  value: {
-  dps: 45621.21656
-  tps: 40205.23483
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RuthlessGladiator'sBadgeofDominance-70401"
  value: {
-  dps: 47134.52709
-  tps: 41481.69128
+  dps: 49143.41987
+  tps: 44329.63502
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RuthlessGladiator'sBadgeofDominance-72448"
  value: {
-  dps: 47220.29876
-  tps: 41554.03849
+  dps: 49227.28075
+  tps: 44401.51692
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RuthlessGladiator'sBadgeofVictory-70400"
  value: {
-  dps: 45621.21656
-  tps: 40205.23483
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RuthlessGladiator'sBadgeofVictory-72450"
  value: {
-  dps: 45621.21656
-  tps: 40205.23483
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RuthlessGladiator'sInsigniaofConquest-70404"
  value: {
-  dps: 45494.45112
-  tps: 39999.97022
+  dps: 47764.60358
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RuthlessGladiator'sInsigniaofConquest-72309"
  value: {
-  dps: 45494.60164
-  tps: 39999.97022
+  dps: 47763.93934
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RuthlessGladiator'sInsigniaofDominance-70402"
  value: {
-  dps: 47147.20747
-  tps: 41395.18704
+  dps: 49368.68617
+  tps: 44477.06264
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RuthlessGladiator'sInsigniaofDominance-72449"
  value: {
-  dps: 47183.75599
-  tps: 41430.87827
+  dps: 49469.19363
+  tps: 44561.51802
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RuthlessGladiator'sInsigniaofVictory-70403"
  value: {
-  dps: 45494.44551
-  tps: 39999.97022
+  dps: 47762.75285
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-RuthlessGladiator'sInsigniaofVictory-72455"
  value: {
-  dps: 45492.3083
-  tps: 39999.97022
+  dps: 47764.1936
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ScalesofLife-68915"
  value: {
-  dps: 45433.98923
-  tps: 39986.75146
-  hps: 392.74201
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ScalesofLife-69109"
  value: {
-  dps: 45433.98923
-  tps: 39986.75146
-  hps: 443.00931
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ScourgeheartDefenderIdol-92135"
  value: {
-  dps: 45492.19416
-  tps: 39999.97022
+  dps: 47763.9462
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ScourgeheartDefenderStone-92134"
  value: {
-  dps: 46539.23954
-  tps: 40992.97309
+  dps: 49268.43756
+  tps: 44519.43545
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ScourgeheartIdolofBattle-92167"
  value: {
-  dps: 46602.23067
-  tps: 40887.56243
+  dps: 48422.96117
+  tps: 43641.84434
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ScourgeheartStoneofBattle-92168"
  value: {
-  dps: 46487.82246
-  tps: 40943.39073
+  dps: 49203.57978
+  tps: 44463.72967
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SeaStar-55256"
  value: {
-  dps: 46191.7846
-  tps: 40686.50106
+  dps: 48221.67939
+  tps: 43539.55918
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SeaStar-56290"
  value: {
-  dps: 46684.03938
-  tps: 41101.71115
+  dps: 48702.96793
+  tps: 43952.09878
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SealoftheSevenSigns-77204"
  value: {
-  dps: 47691.02789
-  tps: 41891.68871
+  dps: 49645.71806
+  tps: 44786.82043
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SealoftheSevenSigns-77969"
  value: {
-  dps: 47474.00909
-  tps: 41695.4565
+  dps: 49434.32984
+  tps: 44593.73343
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SealoftheSevenSigns-77989"
  value: {
-  dps: 47985.41599
-  tps: 42137.88641
+  dps: 49976.29203
+  tps: 45026.58512
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ShardofWoe-60233"
  value: {
-  dps: 46660.62908
-  tps: 41000.66131
+  dps: 47769.10628
+  tps: 43017.01563
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 45487.76319
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 46363.67989
-  tps: 40914.5319
+  dps: 48749.23473
+  tps: 44132.58885
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 46460.90723
-  tps: 41007.41604
+  dps: 48891.37209
+  tps: 44272.86511
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Sorrowsong-55879"
  value: {
-  dps: 47056.53311
-  tps: 41408.30325
+  dps: 49544.18395
+  tps: 44695.60402
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Sorrowsong-56400"
  value: {
-  dps: 47262.64513
-  tps: 41594.40888
+  dps: 49779.4815
+  tps: 44911.06209
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 45813.44282
-  tps: 40264.7849
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SoulCasket-58183"
  value: {
-  dps: 47898.23962
-  tps: 42217.97024
+  dps: 50105.85819
+  tps: 45273.09829
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SoulseizerIdolofDestruction-92125"
  value: {
-  dps: 47359.56551
-  tps: 41719.97459
+  dps: 48885.54519
+  tps: 44109.30526
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SoulseizerStoneofDestruction-92124"
  value: {
-  dps: 48019.96111
-  tps: 42265.55837
+  dps: 50515.72896
+  tps: 45668.67686
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 47084.70888
-  tps: 41509.60263
+  dps: 49897.33831
+  tps: 45140.27653
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 46867.77482
-  tps: 41307.05351
+  dps: 49624.0665
+  tps: 44875.35655
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 47222.00034
-  tps: 41640.00611
+  dps: 50059.50678
+  tps: 45290.26372
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 46467.14153
-  tps: 40918.38019
+  dps: 48964.10249
+  tps: 44226.37919
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 46593.17104
-  tps: 41038.27705
+  dps: 49120.10722
+  tps: 44377.84674
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 47341.67332
-  tps: 41693.46243
+  dps: 48791.14405
+  tps: 44026.84718
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 47166.05535
-  tps: 41524.38557
+  dps: 48745.8124
+  tps: 44055.50058
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 47433.75845
-  tps: 41711.10586
+  dps: 48655.9737
+  tps: 43980.20687
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-StayofExecution-68996"
  value: {
-  dps: 45628.83194
-  tps: 40205.23483
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 47211.66904
-  tps: 41438.7449
+  dps: 49042.48336
+  tps: 44187.79262
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-StumpofTime-62465"
  value: {
-  dps: 46841.13149
-  tps: 41140.63707
+  dps: 49071.76662
+  tps: 44224.32605
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-StumpofTime-62470"
  value: {
-  dps: 46855.36442
-  tps: 41136.5184
+  dps: 49078.91395
+  tps: 44226.58898
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 47248.75786
-  tps: 41559.17793
+  dps: 49393.27889
+  tps: 44614.92482
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TearofBlood-55819"
  value: {
-  dps: 46639.13653
-  tps: 40979.55561
+  dps: 48571.44769
+  tps: 43822.64035
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TearofBlood-56351"
  value: {
-  dps: 46962.69144
-  tps: 41236.13675
+  dps: 48888.78903
+  tps: 44103.10915
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 46803.03388
-  tps: 41167.90874
+  dps: 49364.81224
+  tps: 44530.92206
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 47309.20348
-  tps: 41621.97652
+  dps: 49886.09123
+  tps: 44995.3036
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TheHungerer-68927"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TheHungerer-69112"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 48031.54935
-  tps: 42274.3316
+  dps: 50299.29508
+  tps: 45451.91419
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 48398.90588
-  tps: 42605.65701
+  dps: 50699.90739
+  tps: 45832.61086
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ThundercallerIdolofDestruction-92120"
  value: {
-  dps: 47237.20507
-  tps: 41586.315
+  dps: 49114.74333
+  tps: 44321.57317
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ThundercallerIdolofRage-92116"
  value: {
-  dps: 46304.40382
-  tps: 40769.70808
+  dps: 48765.94852
+  tps: 44038.55942
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ThundercallerStoneofDestruction-92119"
  value: {
-  dps: 48032.67396
-  tps: 42276.46858
+  dps: 50487.07647
+  tps: 45643.43453
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ThundercallerStoneofRage-92121"
  value: {
-  dps: 46439.97397
-  tps: 40897.44439
+  dps: 49084.17251
+  tps: 44345.59713
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ThundercallerStoneofWisdom-92122"
  value: {
-  dps: 47052.38283
-  tps: 41337.42081
+  dps: 49067.66006
+  tps: 44262.75383
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Ti'tahk,theStepsofTime-77190"
  value: {
-  dps: 62643.22978
-  tps: 54964.95879
+  dps: 64807.7233
+  tps: 58400.79724
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Ti'tahk,theStepsofTime-78477"
  value: {
-  dps: 64218.00601
-  tps: 56349.2234
+  dps: 66489.14958
+  tps: 59893.45563
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Ti'tahk,theStepsofTime-78486"
  value: {
-  dps: 61147.75411
-  tps: 53704.39749
+  dps: 63250.01207
+  tps: 57059.84901
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 46136.94421
-  tps: 40604.25041
+  dps: 48555.3701
+  tps: 43829.53419
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 46220.12369
-  tps: 40683.38234
+  dps: 48658.33322
+  tps: 43929.50278
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 46870.96547
-  tps: 41224.49628
+  dps: 49067.66006
+  tps: 44262.75383
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-UnheededWarning-59520"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 45621.21656
-  tps: 40205.23483
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 46436.55191
-  tps: 40982.29926
+  dps: 48770.65663
+  tps: 44038.55942
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 46436.55191
-  tps: 40982.29926
+  dps: 48770.65663
+  tps: 44038.55942
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 46436.55191
-  tps: 40982.29926
+  dps: 48770.65663
+  tps: 44038.55942
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Val'anyr,HammerofAncientKings-46017"
  value: {
-  dps: 36306.2001
-  tps: 34292.93129
+  dps: 37706.34236
+  tps: 36258.25595
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 48683.04448
-  tps: 42941.38785
+  dps: 50580.3181
+  tps: 45767.23312
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 49259.57604
-  tps: 43463.03131
+  dps: 51086.62791
+  tps: 46239.936
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 45803.46148
-  tps: 40291.50653
+  dps: 48100.20502
+  tps: 43387.23209
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-VeilofLies-72900"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 45522.48694
-  tps: 40005.49022
+  dps: 47800.68745
+  tps: 43122.60334
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 45527.03455
-  tps: 40010.03783
+  dps: 47802.56791
+  tps: 43124.48379
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-VialofShadows-77207"
  value: {
-  dps: 45598.33468
-  tps: 40096.51653
+  dps: 47860.70689
+  tps: 43157.74065
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-VialofShadows-77979"
  value: {
-  dps: 45587.59608
-  tps: 40085.75061
+  dps: 47854.98503
+  tps: 43151.9155
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-VialofShadows-77999"
  value: {
-  dps: 45604.70648
-  tps: 40102.90035
+  dps: 47869.21992
+  tps: 43166.09283
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 45441.15293
-  tps: 39912.02671
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 45441.15293
-  tps: 39912.02671
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 45621.21656
-  tps: 40205.23483
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sBadgeofConquest-70517"
  value: {
-  dps: 45621.21656
-  tps: 40205.23483
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 46818.29069
-  tps: 41214.95026
+  dps: 48834.22844
+  tps: 44064.60958
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sBadgeofDominance-70518"
  value: {
-  dps: 46959.25455
-  tps: 41333.85133
+  dps: 48972.05198
+  tps: 44182.74592
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 45621.21656
-  tps: 40205.23483
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sBadgeofVictory-70519"
  value: {
-  dps: 45621.21656
-  tps: 40205.23483
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 45432.63901
-  tps: 39912.02671
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 46444.36175
-  tps: 40874.69252
+  dps: 48501.05495
+  tps: 43779.71197
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 46681.83988
-  tps: 40954.39743
+  dps: 48462.83487
+  tps: 43674.73014
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 45432.63901
-  tps: 39912.02671
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 46287.87095
-  tps: 40725.67539
+  dps: 48829.93842
+  tps: 44096.11709
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 45432.63901
-  tps: 39912.02671
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 45492.69686
-  tps: 39999.97022
+  dps: 47763.77156
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sInsigniaofConquest-70577"
  value: {
-  dps: 45493.36817
-  tps: 39999.97022
+  dps: 47764.40919
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 46794.91525
-  tps: 41102.33413
+  dps: 49015.57453
+  tps: 44168.09674
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sInsigniaofDominance-70578"
  value: {
-  dps: 46942.24573
-  tps: 41225.42597
+  dps: 49182.55079
+  tps: 44311.82812
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 45492.53033
-  tps: 39999.97022
+  dps: 47763.04059
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-ViciousGladiator'sInsigniaofVictory-70579"
  value: {
-  dps: 45493.79707
-  tps: 39999.97022
+  dps: 47764.27219
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-WaterdancerDefenderIdol-92399"
  value: {
-  dps: 45493.01412
-  tps: 39999.97022
+  dps: 47763.63331
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-WaterdancerDefenderStone-92398"
  value: {
-  dps: 46525.66944
-  tps: 40976.03614
+  dps: 49171.29917
+  tps: 44432.35366
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-WaterdancerIdolofRage-92401"
  value: {
-  dps: 46302.5479
-  tps: 40769.70808
+  dps: 48765.03855
+  tps: 44038.55942
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-WaterdancerStoneofRage-92400"
  value: {
-  dps: 46481.30869
-  tps: 40938.9445
+  dps: 49117.01982
+  tps: 44373.0632
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-WaterdancerStoneofWisdom-92402"
  value: {
-  dps: 47052.38283
-  tps: 41337.42081
+  dps: 49067.66006
+  tps: 44262.75383
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 49573.5677
-  tps: 43566.36957
+  dps: 51336.12413
+  tps: 46311.93499
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 49027.75395
-  tps: 43089.18065
+  dps: 50941.04705
+  tps: 45950.70671
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 47231.13996
-  tps: 41577.34788
+  dps: 48959.87413
+  tps: 44130.41162
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 48149.58455
-  tps: 42307.81773
+  dps: 49795.89603
+  tps: 45020.23393
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 46185.08877
-  tps: 40735.38159
+  dps: 48452.40698
+  tps: 43729.5656
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 45501.75548
-  tps: 39999.97022
+  dps: 47769.10628
+  tps: 43066.1377
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 46451.71412
-  tps: 40873.21427
+  dps: 49058.91005
+  tps: 44463.01876
  }
 }
 dps_results: {
  key: "TestShadow-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 46451.71412
-  tps: 40873.21427
+  dps: 49058.91005
+  tps: 44463.01876
  }
 }
 dps_results: {
  key: "TestShadow-Average-Default"
  value: {
-  dps: 50066.85782
-  tps: 44218.76631
+  dps: 51979.52723
+  tps: 47064.03574
  }
 }
 dps_results: {
@@ -2391,6 +2388,48 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestShadow-Settings-Draenei-p3-Basic-p4-FullBuffs-0.0yards-LongMultiTarget"
+ value: {
+  dps: 35383.50919
+  tps: 48264.63868
+ }
+}
+dps_results: {
+ key: "TestShadow-Settings-Draenei-p3-Basic-p4-FullBuffs-0.0yards-LongSingleTarget"
+ value: {
+  dps: 35383.50919
+  tps: 31196.80893
+ }
+}
+dps_results: {
+ key: "TestShadow-Settings-Draenei-p3-Basic-p4-FullBuffs-0.0yards-ShortSingleTarget"
+ value: {
+  dps: 41014.19906
+  tps: 35744.90328
+ }
+}
+dps_results: {
+ key: "TestShadow-Settings-Draenei-p3-Basic-p4-NoBuffs-0.0yards-LongMultiTarget"
+ value: {
+  dps: 22393.89499
+  tps: 33654.92362
+ }
+}
+dps_results: {
+ key: "TestShadow-Settings-Draenei-p3-Basic-p4-NoBuffs-0.0yards-LongSingleTarget"
+ value: {
+  dps: 22393.89499
+  tps: 19936.51195
+ }
+}
+dps_results: {
+ key: "TestShadow-Settings-Draenei-p3-Basic-p4-NoBuffs-0.0yards-ShortSingleTarget"
+ value: {
+  dps: 21377.13538
+  tps: 18663.4779
+ }
+}
+dps_results: {
  key: "TestShadow-Settings-Draenei-p4-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 81874.14329
@@ -2430,6 +2469,48 @@ dps_results: {
  value: {
   dps: 30516.23955
   tps: 27450.96401
+ }
+}
+dps_results: {
+ key: "TestShadow-Settings-Draenei-p4-Basic-p4-FullBuffs-0.0yards-LongMultiTarget"
+ value: {
+  dps: 82598.18438
+  tps: 92205.1824
+ }
+}
+dps_results: {
+ key: "TestShadow-Settings-Draenei-p4-Basic-p4-FullBuffs-0.0yards-LongSingleTarget"
+ value: {
+  dps: 50918.54419
+  tps: 46201.50984
+ }
+}
+dps_results: {
+ key: "TestShadow-Settings-Draenei-p4-Basic-p4-FullBuffs-0.0yards-ShortSingleTarget"
+ value: {
+  dps: 59589.06921
+  tps: 54199.27439
+ }
+}
+dps_results: {
+ key: "TestShadow-Settings-Draenei-p4-Basic-p4-NoBuffs-0.0yards-LongMultiTarget"
+ value: {
+  dps: 55828.80348
+  tps: 65411.36656
+ }
+}
+dps_results: {
+ key: "TestShadow-Settings-Draenei-p4-Basic-p4-NoBuffs-0.0yards-LongSingleTarget"
+ value: {
+  dps: 31008.52036
+  tps: 28408.40724
+ }
+}
+dps_results: {
+ key: "TestShadow-Settings-Draenei-p4-Basic-p4-NoBuffs-0.0yards-ShortSingleTarget"
+ value: {
+  dps: 32463.09452
+  tps: 29879.50721
  }
 }
 dps_results: {
@@ -2475,6 +2556,48 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestShadow-Settings-NightElf-p3-Basic-p4-FullBuffs-0.0yards-LongMultiTarget"
+ value: {
+  dps: 35319.83354
+  tps: 48192.30148
+ }
+}
+dps_results: {
+ key: "TestShadow-Settings-NightElf-p3-Basic-p4-FullBuffs-0.0yards-LongSingleTarget"
+ value: {
+  dps: 35319.83354
+  tps: 31122.32804
+ }
+}
+dps_results: {
+ key: "TestShadow-Settings-NightElf-p3-Basic-p4-FullBuffs-0.0yards-ShortSingleTarget"
+ value: {
+  dps: 40906.91099
+  tps: 35654.33769
+ }
+}
+dps_results: {
+ key: "TestShadow-Settings-NightElf-p3-Basic-p4-NoBuffs-0.0yards-LongMultiTarget"
+ value: {
+  dps: 22382.00512
+  tps: 33724.88945
+ }
+}
+dps_results: {
+ key: "TestShadow-Settings-NightElf-p3-Basic-p4-NoBuffs-0.0yards-LongSingleTarget"
+ value: {
+  dps: 22382.00512
+  tps: 19922.63654
+ }
+}
+dps_results: {
+ key: "TestShadow-Settings-NightElf-p3-Basic-p4-NoBuffs-0.0yards-ShortSingleTarget"
+ value: {
+  dps: 21267.97838
+  tps: 18568.33447
+ }
+}
+dps_results: {
  key: "TestShadow-Settings-NightElf-p4-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 81874.14329
@@ -2514,6 +2637,48 @@ dps_results: {
  value: {
   dps: 30516.23955
   tps: 27450.96401
+ }
+}
+dps_results: {
+ key: "TestShadow-Settings-NightElf-p4-Basic-p4-FullBuffs-0.0yards-LongMultiTarget"
+ value: {
+  dps: 82598.18438
+  tps: 92205.1824
+ }
+}
+dps_results: {
+ key: "TestShadow-Settings-NightElf-p4-Basic-p4-FullBuffs-0.0yards-LongSingleTarget"
+ value: {
+  dps: 50918.54419
+  tps: 46201.50984
+ }
+}
+dps_results: {
+ key: "TestShadow-Settings-NightElf-p4-Basic-p4-FullBuffs-0.0yards-ShortSingleTarget"
+ value: {
+  dps: 59589.06921
+  tps: 54199.27439
+ }
+}
+dps_results: {
+ key: "TestShadow-Settings-NightElf-p4-Basic-p4-NoBuffs-0.0yards-LongMultiTarget"
+ value: {
+  dps: 55828.80348
+  tps: 65411.36656
+ }
+}
+dps_results: {
+ key: "TestShadow-Settings-NightElf-p4-Basic-p4-NoBuffs-0.0yards-LongSingleTarget"
+ value: {
+  dps: 31008.52036
+  tps: 28408.40724
+ }
+}
+dps_results: {
+ key: "TestShadow-Settings-NightElf-p4-Basic-p4-NoBuffs-0.0yards-ShortSingleTarget"
+ value: {
+  dps: 32463.09452
+  tps: 29879.50721
  }
 }
 dps_results: {
@@ -2559,6 +2724,48 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestShadow-Settings-Troll-p3-Basic-p4-FullBuffs-0.0yards-LongMultiTarget"
+ value: {
+  dps: 36218.33614
+  tps: 48891.72486
+ }
+}
+dps_results: {
+ key: "TestShadow-Settings-Troll-p3-Basic-p4-FullBuffs-0.0yards-LongSingleTarget"
+ value: {
+  dps: 36218.33614
+  tps: 31805.76394
+ }
+}
+dps_results: {
+ key: "TestShadow-Settings-Troll-p3-Basic-p4-FullBuffs-0.0yards-ShortSingleTarget"
+ value: {
+  dps: 42452.62516
+  tps: 36916.39923
+ }
+}
+dps_results: {
+ key: "TestShadow-Settings-Troll-p3-Basic-p4-NoBuffs-0.0yards-LongMultiTarget"
+ value: {
+  dps: 22746.74947
+  tps: 34107.2446
+ }
+}
+dps_results: {
+ key: "TestShadow-Settings-Troll-p3-Basic-p4-NoBuffs-0.0yards-LongSingleTarget"
+ value: {
+  dps: 22746.74947
+  tps: 20216.88808
+ }
+}
+dps_results: {
+ key: "TestShadow-Settings-Troll-p3-Basic-p4-NoBuffs-0.0yards-ShortSingleTarget"
+ value: {
+  dps: 22293.89403
+  tps: 19777.80469
+ }
+}
+dps_results: {
  key: "TestShadow-Settings-Troll-p4-Basic-default-FullBuffs-0.0yards-LongMultiTarget"
  value: {
   dps: 82710.91357
@@ -2601,9 +2808,51 @@ dps_results: {
  }
 }
 dps_results: {
+ key: "TestShadow-Settings-Troll-p4-Basic-p4-FullBuffs-0.0yards-LongMultiTarget"
+ value: {
+  dps: 84094.14505
+  tps: 93711.95698
+ }
+}
+dps_results: {
+ key: "TestShadow-Settings-Troll-p4-Basic-p4-FullBuffs-0.0yards-LongSingleTarget"
+ value: {
+  dps: 51876.13602
+  tps: 46963.05536
+ }
+}
+dps_results: {
+ key: "TestShadow-Settings-Troll-p4-Basic-p4-FullBuffs-0.0yards-ShortSingleTarget"
+ value: {
+  dps: 62215.51723
+  tps: 56539.72508
+ }
+}
+dps_results: {
+ key: "TestShadow-Settings-Troll-p4-Basic-p4-NoBuffs-0.0yards-LongMultiTarget"
+ value: {
+  dps: 56308.33827
+  tps: 66069.00403
+ }
+}
+dps_results: {
+ key: "TestShadow-Settings-Troll-p4-Basic-p4-NoBuffs-0.0yards-LongSingleTarget"
+ value: {
+  dps: 31442.10736
+  tps: 28890.85534
+ }
+}
+dps_results: {
+ key: "TestShadow-Settings-Troll-p4-Basic-p4-NoBuffs-0.0yards-ShortSingleTarget"
+ value: {
+  dps: 34129.58095
+  tps: 31250.15904
+ }
+}
+dps_results: {
  key: "TestShadow-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 49832.4065
-  tps: 44032.20132
+  dps: 51846.81363
+  tps: 46963.05536
  }
 }

--- a/sim/priest/shadow/shadow_test.go
+++ b/sim/priest/shadow/shadow_test.go
@@ -28,7 +28,7 @@ func TestShadow(t *testing.T) {
 
 		SpecOptions: core.SpecOptionsCombo{Label: "Basic", SpecOptions: PlayerOptionsBasic},
 
-		Rotation: core.GetAplRotation("../../../ui/priest/shadow/apls", "default"),
+		Rotation: core.GetAplRotation("../../../ui/priest/shadow/apls", "p4"),
 		OtherRotations: []core.RotationCombo{
 			core.GetAplRotation("../../../ui/priest/shadow/apls", "default"),
 		},

--- a/sim/rogue/assassination/TestAssassination.results
+++ b/sim/rogue/assassination/TestAssassination.results
@@ -67,3350 +67,3350 @@ stat_weights_results: {
   weights: 0
   weights: 0
   weights: 0
-  weights: 39.71959
-  weights: 14.87987
+  weights: 39.71969
+  weights: 14.87981
   weights: 0
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 29510.57762
-  tps: 20952.51011
+  dps: 29510.45638
+  tps: 20952.42403
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 29252.14126
-  tps: 20769.0203
+  dps: 29252.17085
+  tps: 20769.04131
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 27963.96615
-  tps: 19854.41597
+  dps: 27963.75778
+  tps: 19854.26802
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 27998.82983
-  tps: 19879.16918
+  dps: 27998.62083
+  tps: 19879.02079
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 28323.4581
-  tps: 20109.65525
+  dps: 28323.25146
+  tps: 20109.50854
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 28534.12037
-  tps: 20259.22546
+  dps: 28533.91224
+  tps: 20259.07769
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ArrowofTime-72897"
  value: {
-  dps: 29667.51675
-  tps: 21063.93689
+  dps: 29667.29787
+  tps: 21063.78149
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 28951.42588
-  tps: 20555.51238
+  dps: 28951.30631
+  tps: 20555.42748
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
   hps: 83.99244
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 27757.60132
-  tps: 19707.89694
+  dps: 27757.39712
+  tps: 19707.75195
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 27830.48456
-  tps: 19759.64403
+  dps: 27830.27995
+  tps: 19759.49876
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BindingPromise-67037"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BlackfangBattleweave"
  value: {
-  dps: 28304.82074
-  tps: 20096.42273
+  dps: 28305.09962
+  tps: 20096.62073
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 28515.71449
-  tps: 20246.15729
+  dps: 28515.88335
+  tps: 20246.27718
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 27694.67724
-  tps: 19663.22084
+  dps: 27694.50147
+  tps: 19663.09605
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 27746.25084
-  tps: 19699.8381
+  dps: 27746.5359
+  tps: 19700.04049
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 28927.43032
-  tps: 20538.47553
+  dps: 28927.21695
+  tps: 20538.32403
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 27842.89781
-  tps: 19768.45744
+  dps: 27842.69203
+  tps: 19768.31134
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 27741.31175
-  tps: 19696.33134
+  dps: 27741.10765
+  tps: 19696.18643
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 28598.19064
-  tps: 20304.71535
+  dps: 28597.97975
+  tps: 20304.56562
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 27796.66678
-  tps: 19735.63341
+  dps: 27796.46124
+  tps: 19735.48748
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 29101.8385
-  tps: 20662.30533
+  dps: 29101.62986
+  tps: 20662.1572
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 28895.12192
-  tps: 20515.53656
+  dps: 28894.91382
+  tps: 20515.38881
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 29335.59593
-  tps: 20828.27311
+  dps: 29335.38637
+  tps: 20828.12432
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BottledLightning-66879"
  value: {
-  dps: 27490.84227
-  tps: 19518.49801
+  dps: 27490.63969
+  tps: 19518.35418
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BottledWishes-77114"
  value: {
-  dps: 28008.39324
-  tps: 19885.9592
+  dps: 28008.18665
+  tps: 19885.81252
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 28951.42588
-  tps: 20144.40213
+  dps: 28951.30631
+  tps: 20144.31893
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 29293.48569
-  tps: 20798.37484
+  dps: 29293.36533
+  tps: 20798.28939
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CataclysmicGladiator'sBadgeofConquest-73648"
  value: {
-  dps: 29576.90038
-  tps: 20999.59927
+  dps: 29576.68263
+  tps: 20999.44467
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CataclysmicGladiator'sBadgeofDominance-73498"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CataclysmicGladiator'sBadgeofVictory-73496"
  value: {
-  dps: 28163.49502
-  tps: 19996.08146
+  dps: 28163.28674
+  tps: 19995.93359
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CataclysmicGladiator'sInsigniaofConquest-73643"
  value: {
-  dps: 29417.35499
-  tps: 20886.32204
+  dps: 29417.13788
+  tps: 20886.16789
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CataclysmicGladiator'sInsigniaofDominance-73497"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CataclysmicGladiator'sInsigniaofVictory-73491"
  value: {
-  dps: 28105.84553
-  tps: 19955.15032
+  dps: 28105.63755
+  tps: 19955.00266
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 29384.26789
-  tps: 20862.8302
+  dps: 29384.14725
+  tps: 20862.74455
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 28673.41537
-  tps: 20358.12491
+  dps: 28673.20381
+  tps: 20357.97471
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 28956.20394
-  tps: 20558.9048
+  dps: 28955.99012
+  tps: 20558.75299
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 28747.00677
-  tps: 20410.37481
+  dps: 28746.79482
+  tps: 20410.22432
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 29103.12953
-  tps: 20663.22197
+  dps: 29102.91517
+  tps: 20663.06977
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CrushingWeight-59506"
  value: {
-  dps: 28498.7925
-  tps: 20234.14267
+  dps: 28498.58172
+  tps: 20233.99302
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CrushingWeight-65118"
  value: {
-  dps: 28621.14451
-  tps: 20321.0126
+  dps: 28620.93318
+  tps: 20320.86256
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 27586.37219
-  tps: 19586.32426
+  dps: 27586.17055
+  tps: 19586.18109
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 27538.58122
-  tps: 19552.39266
+  dps: 27538.37966
+  tps: 19552.24956
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-CunningoftheCruel-78000"
  value: {
-  dps: 27625.21699
-  tps: 19613.90406
+  dps: 27625.01525
+  tps: 19613.76083
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 28281.03251
-  tps: 20079.53308
+  dps: 28280.82677
+  tps: 20079.38701
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 29097.42056
-  tps: 20659.16859
+  dps: 29097.20934
+  tps: 20659.01863
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 27833.46462
-  tps: 19761.75988
+  dps: 27833.52466
+  tps: 19761.80251
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkwalkerIdolofRage-92118"
  value: {
-  dps: 29213.14622
-  tps: 20741.33381
+  dps: 29213.20918
+  tps: 20741.37852
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DarkwalkerStoneofRage-92117"
  value: {
-  dps: 29313.15776
-  tps: 20812.34201
+  dps: 29312.94685
+  tps: 20812.19226
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 28262.1971
-  tps: 20066.15994
+  dps: 28261.98887
+  tps: 20066.0121
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DelivererIdolofDestruction-92113"
  value: {
-  dps: 28186.53965
-  tps: 20012.44315
+  dps: 28186.60048
+  tps: 20012.48634
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DelivererStoneofDestruction-92151"
  value: {
-  dps: 28016.70791
-  tps: 19891.86261
+  dps: 28016.50633
+  tps: 19891.7195
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DelivererStoneofWisdom-92115"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 29037.81395
-  tps: 20616.8479
+  dps: 29037.6941
+  tps: 20616.76281
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 27535.02434
-  tps: 19549.86728
+  dps: 27534.82108
+  tps: 19549.72297
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 28372.38086
-  tps: 20144.39041
+  dps: 28372.17163
+  tps: 20144.24185
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 28951.42588
-  tps: 20555.51238
+  dps: 28951.30631
+  tps: 20555.42748
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 28951.42588
-  tps: 20555.51238
+  dps: 28951.30631
+  tps: 20555.42748
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 29037.81395
-  tps: 20616.8479
+  dps: 29037.6941
+  tps: 20616.76281
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnlightenedIdolofDestruction-92144"
  value: {
-  dps: 28225.88135
-  tps: 20040.37576
+  dps: 28225.94241
+  tps: 20040.41911
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EnlightenedStoneofDestruction-92143"
  value: {
-  dps: 28012.83295
-  tps: 19889.1114
+  dps: 28012.63138
+  tps: 19888.96828
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 29038.41869
-  tps: 20617.27727
+  dps: 29038.20454
+  tps: 20617.12522
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 29368.10239
-  tps: 20851.3527
+  dps: 29367.88586
+  tps: 20851.19896
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 28396.32352
-  tps: 20161.3897
+  dps: 28396.35231
+  tps: 20161.41014
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 28951.42588
-  tps: 20555.51238
+  dps: 28951.30631
+  tps: 20555.42748
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 28605.41156
-  tps: 20309.8422
+  dps: 28605.19949
+  tps: 20309.69164
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 28457.16507
-  tps: 20204.5872
+  dps: 28456.9542
+  tps: 20204.43748
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 28768.48269
-  tps: 20425.62271
+  dps: 28768.26932
+  tps: 20425.47122
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FallofMortality-59500"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FallofMortality-65124"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FangsoftheFather"
  value: {
-  dps: 34602.25242
-  tps: 24567.59922
+  dps: 34601.91707
+  tps: 24567.36112
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Fear-77945"
  value: {
-  dps: 29695.78221
-  tps: 21084.00537
+  dps: 29695.44676
+  tps: 21083.7672
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 29281.39116
-  tps: 20789.78772
+  dps: 29281.17314
+  tps: 20789.63293
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 28263.14368
-  tps: 20066.83201
+  dps: 28263.43432
+  tps: 20067.03836
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 28016.62154
-  tps: 19891.80129
+  dps: 28016.31439
+  tps: 19891.58322
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 29041.34651
-  tps: 20619.35602
+  dps: 29041.72024
+  tps: 20619.62137
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForestwalkerIdolofRage-92142"
  value: {
-  dps: 29239.04645
-  tps: 20759.72298
+  dps: 29239.10946
+  tps: 20759.76771
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForestwalkerStoneofRage-92141"
  value: {
-  dps: 29312.23189
-  tps: 20811.68464
+  dps: 29312.02097
+  tps: 20811.53489
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 28951.42588
-  tps: 20555.51238
+  dps: 28951.30631
+  tps: 20555.42748
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 27906.1738
-  tps: 19813.3834
+  dps: 27905.97222
+  tps: 19813.24028
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 28402.47179
-  tps: 20165.75497
+  dps: 28402.26232
+  tps: 20165.60625
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GaleofShadows-56138"
  value: {
-  dps: 27813.90716
-  tps: 19747.87408
+  dps: 27813.70199
+  tps: 19747.72842
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GaleofShadows-56462"
  value: {
-  dps: 27750.68296
-  tps: 19702.9849
+  dps: 27750.47783
+  tps: 19702.83926
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GearDetector-61462"
  value: {
-  dps: 28380.4189
-  tps: 20150.09742
+  dps: 28380.20938
+  tps: 20149.94866
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Gladiator'sVestments"
  value: {
-  dps: 23487.76024
-  tps: 16676.30977
+  dps: 23487.51451
+  tps: 16676.13531
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Golad,TwilightofAspects-77949"
  value: {
-  dps: 30581.55168
-  tps: 21712.90169
+  dps: 30581.21216
+  tps: 21712.66063
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 28285.7033
-  tps: 20082.84934
+  dps: 28285.49429
+  tps: 20082.70094
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 28701.0378
-  tps: 20377.73684
+  dps: 28700.82614
+  tps: 20377.58656
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HarmlightToken-63839"
  value: {
-  dps: 27420.77048
-  tps: 19468.74704
+  dps: 27420.56878
+  tps: 19468.60383
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 27985.83064
-  tps: 19869.93976
+  dps: 27985.62628
+  tps: 19869.79466
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 27976.70233
-  tps: 19863.45865
+  dps: 27976.49578
+  tps: 19863.312
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 27996.80268
-  tps: 19877.7299
+  dps: 27996.59574
+  tps: 19877.58298
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofRage-59224"
  value: {
-  dps: 28405.57138
-  tps: 20167.95568
+  dps: 28405.3613
+  tps: 20167.80652
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofRage-65072"
  value: {
-  dps: 28589.85955
-  tps: 20298.80028
+  dps: 28589.64805
+  tps: 20298.65011
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofSolace-55868"
  value: {
-  dps: 28326.97484
-  tps: 20112.15214
+  dps: 28326.76567
+  tps: 20112.00362
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofSolace-56393"
  value: {
-  dps: 28322.206
-  tps: 20108.76626
+  dps: 28321.99639
+  tps: 20108.61744
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofThunder-55845"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartofThunder-56370"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 28406.10565
-  tps: 20168.33501
+  dps: 28405.89584
+  tps: 20168.18604
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Heartpierce-50641"
  value: {
-  dps: 29510.57762
-  tps: 20952.51011
+  dps: 29510.45638
+  tps: 20952.42403
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 29037.81395
-  tps: 20616.8479
+  dps: 29037.6941
+  tps: 20616.76281
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 28385.93755
-  tps: 20154.01566
+  dps: 28385.99889
+  tps: 20154.05921
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 28385.93755
-  tps: 20154.01566
+  dps: 28385.99889
+  tps: 20154.05921
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 27694.67724
-  tps: 19663.22084
+  dps: 27694.50147
+  tps: 19663.09605
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 27746.25084
-  tps: 19699.8381
+  dps: 27746.5359
+  tps: 19700.04049
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IndomitablePride-77211"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IndomitablePride-77983"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-IndomitablePride-78003"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 28406.45186
-  tps: 20168.58082
+  dps: 28406.24313
+  tps: 20168.43263
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 28291.28651
-  tps: 20086.81342
+  dps: 28291.07756
+  tps: 20086.66507
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 28519.80042
-  tps: 20249.0583
+  dps: 28519.59051
+  tps: 20248.90927
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 27604.03273
-  tps: 19598.86324
+  dps: 27604.04162
+  tps: 19598.86955
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-JawsofRetribution"
  value: {
-  dps: 30066.49519
-  tps: 21347.21158
+  dps: 30066.81807
+  tps: 21347.44083
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 28515.71449
-  tps: 20246.15729
+  dps: 28515.88335
+  tps: 20246.27718
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 28928.27925
-  tps: 20539.07826
+  dps: 28928.06433
+  tps: 20538.92567
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 29414.44597
-  tps: 20884.25664
+  dps: 29414.22665
+  tps: 20884.10092
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 29860.57313
-  tps: 21201.00692
+  dps: 29860.35352
+  tps: 21200.851
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 27729.56227
-  tps: 19687.98921
+  dps: 27729.3574
+  tps: 19687.84376
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 27729.56227
-  tps: 19687.98921
+  dps: 27729.3574
+  tps: 19687.84376
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 27512.19145
-  tps: 19533.65593
+  dps: 27511.98854
+  tps: 19533.51186
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-LeadenDespair-55816"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-LeadenDespair-56347"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 28918.7241
-  tps: 20532.29411
+  dps: 28918.51038
+  tps: 20532.14237
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 29147.47608
-  tps: 20694.70802
+  dps: 29147.2606
+  tps: 20694.55502
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 28577.13062
-  tps: 20289.76274
+  dps: 28576.91712
+  tps: 20289.61115
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 27896.76035
-  tps: 19806.69985
+  dps: 27896.55478
+  tps: 19806.55389
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 28187.47084
-  tps: 20013.10429
+  dps: 28187.26264
+  tps: 20012.95647
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 28084.96168
-  tps: 19940.32279
+  dps: 28084.7571
+  tps: 19940.17754
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 28188.50719
-  tps: 20013.84011
+  dps: 28188.30222
+  tps: 20013.69458
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MartialDefenderIdol-92127"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MartialDefenderStone-92126"
  value: {
-  dps: 28014.26099
-  tps: 19890.1253
+  dps: 28014.05942
+  tps: 19889.98219
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MartialIdolofBattle-92128"
  value: {
-  dps: 28165.34808
-  tps: 19997.39714
+  dps: 28165.14062
+  tps: 19997.24984
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MartialStoneofBattle-92129"
  value: {
-  dps: 28502.35907
-  tps: 20236.67494
+  dps: 28502.15367
+  tps: 20236.52911
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 29833.46039
-  tps: 21181.75688
+  dps: 29833.24633
+  tps: 21181.6049
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 30138.19746
-  tps: 21398.1202
+  dps: 30137.98205
+  tps: 21397.96726
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MawofOblivion"
  value: {
-  dps: 31161.96594
-  tps: 22124.99582
+  dps: 31161.83796
+  tps: 22124.90495
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 28108.57601
-  tps: 19957.08897
+  dps: 28108.36648
+  tps: 19956.9402
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 28442.26542
-  tps: 20194.00844
+  dps: 28442.0529
+  tps: 20193.85756
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 27802.51295
-  tps: 19739.7842
+  dps: 27802.57297
+  tps: 19739.82681
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 27802.51295
-  tps: 19739.7842
+  dps: 27802.57297
+  tps: 19739.82681
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 27742.56649
-  tps: 19697.22221
+  dps: 27742.36238
+  tps: 19697.07729
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 27944.18067
-  tps: 19840.36827
+  dps: 27943.97909
+  tps: 19840.22515
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-NaturalistIdolofDestruction-92137"
  value: {
-  dps: 28005.46648
-  tps: 19883.8812
+  dps: 28005.52676
+  tps: 19883.924
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-NaturalistIdolofRage-92133"
  value: {
-  dps: 29306.34293
-  tps: 20807.50348
+  dps: 29306.40607
+  tps: 20807.54831
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-NaturalistStoneofDestruction-92136"
  value: {
-  dps: 28012.95224
-  tps: 19889.19609
+  dps: 28012.75067
+  tps: 19889.05298
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-NaturalistStoneofRage-92138"
  value: {
-  dps: 29323.01265
-  tps: 20819.33898
+  dps: 29322.80174
+  tps: 20819.18923
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-NaturalistStoneofWisdom-92139"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 27992.65871
-  tps: 19874.78769
+  dps: 27992.45232
+  tps: 19874.64115
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PartisanDefenderIdol-92147"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PartisanDefenderStone-92114"
  value: {
-  dps: 28005.99923
-  tps: 19884.25945
+  dps: 28005.79765
+  tps: 19884.11633
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PartisanIdolofBattle-92148"
  value: {
-  dps: 28164.28162
-  tps: 19996.63995
+  dps: 28164.07416
+  tps: 19996.49265
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PartisanStoneofBattle-92149"
  value: {
-  dps: 28499.71925
-  tps: 20234.80067
+  dps: 28499.51385
+  tps: 20234.65483
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PartisanStoneofWisdom-92145"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 27578.13661
-  tps: 19580.47699
+  dps: 27577.93334
+  tps: 19580.33267
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 27638.08653
-  tps: 19623.04143
+  dps: 27637.88495
+  tps: 19622.89832
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 27928.49495
-  tps: 19829.23141
+  dps: 27928.29337
+  tps: 19829.08829
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 28951.42588
-  tps: 20555.51238
+  dps: 28951.30631
+  tps: 20555.42748
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 29351.79884
-  tps: 20839.77718
+  dps: 29351.58254
+  tps: 20839.62361
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Rainsong-55854"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Rainsong-56377"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Rathrak,thePoisonousMind-77195"
  value: {
-  dps: 29184.65269
-  tps: 20721.10341
+  dps: 29184.31952
+  tps: 20720.86686
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Rathrak,thePoisonousMind-78475"
  value: {
-  dps: 29569.16927
-  tps: 20994.11018
+  dps: 29568.83609
+  tps: 20993.87362
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Rathrak,thePoisonousMind-78484"
  value: {
-  dps: 28888.4829
-  tps: 20510.82286
+  dps: 28888.14932
+  tps: 20510.58602
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 29376.75387
-  tps: 20857.49525
+  dps: 29376.63314
+  tps: 20857.40953
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 29293.48569
-  tps: 20798.37484
+  dps: 29293.36533
+  tps: 20798.28939
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 29274.91895
-  tps: 20785.19246
+  dps: 29274.70316
+  tps: 20785.03925
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 28431.1739
-  tps: 20186.13347
+  dps: 28430.96183
+  tps: 20185.9829
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 28526.17562
-  tps: 20253.58469
+  dps: 28525.96238
+  tps: 20253.43329
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RosaryofLight-72901"
  value: {
-  dps: 28529.33543
-  tps: 20255.82816
+  dps: 28529.1251
+  tps: 20255.67882
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RottingSkull-77116"
  value: {
-  dps: 28658.15111
-  tps: 20347.28729
+  dps: 28657.94039
+  tps: 20347.13768
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RuneofZeth-68998"
  value: {
-  dps: 27880.43768
-  tps: 19795.11075
+  dps: 27880.2329
+  tps: 19794.96536
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RuthlessGladiator'sBadgeofConquest-70399"
  value: {
-  dps: 29223.52289
-  tps: 20748.70125
+  dps: 29223.30767
+  tps: 20748.54845
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RuthlessGladiator'sBadgeofConquest-72304"
  value: {
-  dps: 29330.12468
-  tps: 20824.38852
+  dps: 29329.9087
+  tps: 20824.23517
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RuthlessGladiator'sBadgeofDominance-70401"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RuthlessGladiator'sBadgeofDominance-72448"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RuthlessGladiator'sBadgeofVictory-70400"
  value: {
-  dps: 28024.41503
-  tps: 19897.33467
+  dps: 28024.20783
+  tps: 19897.18756
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RuthlessGladiator'sBadgeofVictory-72450"
  value: {
-  dps: 28065.42579
-  tps: 19926.45231
+  dps: 28065.21828
+  tps: 19926.30498
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RuthlessGladiator'sInsigniaofConquest-70404"
  value: {
-  dps: 29088.88608
-  tps: 20653.10912
+  dps: 29088.67167
+  tps: 20652.95689
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RuthlessGladiator'sInsigniaofConquest-72309"
  value: {
-  dps: 29225.0301
-  tps: 20749.77137
+  dps: 29224.81433
+  tps: 20749.61818
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RuthlessGladiator'sInsigniaofDominance-70402"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RuthlessGladiator'sInsigniaofDominance-72449"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RuthlessGladiator'sInsigniaofVictory-70403"
  value: {
-  dps: 27968.47138
-  tps: 19857.61468
+  dps: 27968.26448
+  tps: 19857.46778
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-RuthlessGladiator'sInsigniaofVictory-72455"
  value: {
-  dps: 28020.07258
-  tps: 19894.25153
+  dps: 28019.86531
+  tps: 19894.10437
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ScalesofLife-68915"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
   hps: 291.12785
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ScalesofLife-69109"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
   hps: 328.38949
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 28545.86157
-  tps: 20267.56172
+  dps: 28545.6535
+  tps: 20267.41399
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ScourgeheartDefenderIdol-92135"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ScourgeheartDefenderStone-92134"
  value: {
-  dps: 28007.96507
-  tps: 19885.6552
+  dps: 28007.76349
+  tps: 19885.51208
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ScourgeheartIdolofBattle-92167"
  value: {
-  dps: 28164.95
-  tps: 19997.1145
+  dps: 28164.74256
+  tps: 19996.96721
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ScourgeheartStoneofBattle-92168"
  value: {
-  dps: 28497.67159
-  tps: 20233.34683
+  dps: 28497.46618
+  tps: 20233.20099
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SeaStar-55256"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SeaStar-56290"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SealoftheSevenSigns-77204"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SealoftheSevenSigns-77969"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SealoftheSevenSigns-77989"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ShardofWoe-60233"
  value: {
-  dps: 27867.9154
-  tps: 19786.21994
+  dps: 27867.70953
+  tps: 19786.07376
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 27971.28079
-  tps: 19859.60936
+  dps: 27971.07382
+  tps: 19859.46241
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 28763.92616
-  tps: 20422.38757
+  dps: 28763.71762
+  tps: 20422.23951
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 28984.45173
-  tps: 20578.96073
+  dps: 28984.24198
+  tps: 20578.81181
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Slayer'sArmor"
  value: {
-  dps: 15806.41844
-  tps: 11222.55709
+  dps: 15806.51359
+  tps: 11222.62465
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Sorrowsong-55879"
  value: {
-  dps: 27694.67724
-  tps: 19663.22084
+  dps: 27694.50147
+  tps: 19663.09605
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Sorrowsong-56400"
  value: {
-  dps: 27746.25084
-  tps: 19699.8381
+  dps: 27746.5359
+  tps: 19700.04049
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 28202.61739
-  tps: 20023.85835
+  dps: 28202.40713
+  tps: 20023.70906
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SoulCasket-58183"
  value: {
-  dps: 27802.51295
-  tps: 19739.7842
+  dps: 27802.57297
+  tps: 19739.82681
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SoulseizerIdolofDestruction-92125"
  value: {
-  dps: 28040.81218
-  tps: 19908.97665
+  dps: 28040.87266
+  tps: 19909.01959
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SoulseizerStoneofDestruction-92124"
  value: {
-  dps: 28007.58517
-  tps: 19885.38547
+  dps: 28007.38359
+  tps: 19885.24235
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 28393.57689
-  tps: 20159.43959
+  dps: 28393.37532
+  tps: 20159.29648
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 28252.66763
-  tps: 20059.39401
+  dps: 28252.46605
+  tps: 20059.2509
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 28549.61565
-  tps: 20270.22711
+  dps: 28549.41407
+  tps: 20270.08399
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 27899.40881
-  tps: 19808.58026
+  dps: 27899.43706
+  tps: 19808.60031
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 27977.55063
-  tps: 19864.06095
+  dps: 27977.88897
+  tps: 19864.30117
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 30206.6931
-  tps: 21446.7521
+  dps: 30206.47037
+  tps: 21446.59396
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 29873.68633
-  tps: 21210.31729
+  dps: 29873.46607
+  tps: 21210.16091
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 30533.44188
-  tps: 21678.74373
+  dps: 30533.21669
+  tps: 21678.58385
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-StayofExecution-68996"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 27492.97024
-  tps: 19520.00887
+  dps: 27492.76762
+  tps: 19519.86501
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-StumpofTime-62465"
  value: {
-  dps: 27999.05182
-  tps: 19879.32679
+  dps: 27998.84301
+  tps: 19879.17853
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-StumpofTime-62470"
  value: {
-  dps: 27999.05182
-  tps: 19879.32679
+  dps: 27998.84301
+  tps: 19879.17853
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 27578.38986
-  tps: 19580.6568
+  dps: 27578.18828
+  tps: 19580.51368
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 28187.86441
-  tps: 20013.38373
+  dps: 28187.65603
+  tps: 20013.23578
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TearofBlood-55819"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TearofBlood-56351"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 27636.85229
-  tps: 19622.16513
+  dps: 27636.86334
+  tps: 19622.17297
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 27746.25084
-  tps: 19699.8381
+  dps: 27746.5359
+  tps: 19700.04049
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TheHungerer-68927"
  value: {
-  dps: 29491.30268
-  tps: 20938.8249
+  dps: 29491.08544
+  tps: 20938.67066
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TheHungerer-69112"
  value: {
-  dps: 29811.39116
-  tps: 21166.08773
+  dps: 29811.1709
+  tps: 21165.93134
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TheSleeper-77947"
  value: {
-  dps: 30115.11962
-  tps: 21381.73493
+  dps: 30114.7814
+  tps: 21381.49479
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 27849.01328
-  tps: 19772.79943
+  dps: 27848.8117
+  tps: 19772.65631
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 27924.70373
-  tps: 19826.53965
+  dps: 27924.50215
+  tps: 19826.39653
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ThundercallerIdolofDestruction-92120"
  value: {
-  dps: 28169.15105
-  tps: 20000.09724
+  dps: 28169.21178
+  tps: 20000.14037
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ThundercallerIdolofRage-92116"
  value: {
-  dps: 29261.77125
-  tps: 20775.85759
+  dps: 29261.8343
+  tps: 20775.90235
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ThundercallerStoneofDestruction-92119"
  value: {
-  dps: 28011.94918
-  tps: 19888.48392
+  dps: 28011.74761
+  tps: 19888.3408
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ThundercallerStoneofRage-92121"
  value: {
-  dps: 29310.00731
-  tps: 20810.10519
+  dps: 29309.7964
+  tps: 20809.95544
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ThundercallerStoneofWisdom-92122"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 28893.342
-  tps: 20514.27282
+  dps: 28893.15873
+  tps: 20514.1427
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 29110.00711
-  tps: 20668.10505
+  dps: 29110.30593
+  tps: 20668.31721
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 28598.62831
-  tps: 20305.0261
+  dps: 28598.41553
+  tps: 20304.87502
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 27363.74816
-  tps: 19428.26119
+  dps: 27363.54519
+  tps: 19428.11709
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-UnheededWarning-59520"
  value: {
-  dps: 29127.26663
-  tps: 20680.35931
+  dps: 29127.05136
+  tps: 20680.20647
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 29408.80157
-  tps: 20880.24911
+  dps: 29408.86489
+  tps: 20880.29407
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 29408.80157
-  tps: 20880.24911
+  dps: 29408.86489
+  tps: 20880.29407
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 29408.80157
-  tps: 20880.24911
+  dps: 29408.86489
+  tps: 20880.29407
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 27469.26215
-  tps: 19503.17612
+  dps: 27469.0597
+  tps: 19503.03239
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 27427.84102
-  tps: 19473.76712
+  dps: 27427.63943
+  tps: 19473.624
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 28635.78776
-  tps: 20331.40931
+  dps: 28635.58162
+  tps: 20331.26295
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VeilofLies-72900"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 28516.77392
-  tps: 20246.90948
+  dps: 28516.56393
+  tps: 20246.76039
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 28645.37274
-  tps: 20338.21464
+  dps: 28645.16194
+  tps: 20338.06498
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VestmentsoftheDarkPhoenix"
  value: {
-  dps: 28735.74999
-  tps: 20402.38249
+  dps: 28735.70458
+  tps: 20402.35025
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VialofShadows-77207"
  value: {
-  dps: 30440.66809
-  tps: 21612.87434
+  dps: 30440.45307
+  tps: 21612.72168
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VialofShadows-77979"
  value: {
-  dps: 30175.42085
-  tps: 21424.5488
+  dps: 30175.20613
+  tps: 21424.39636
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VialofShadows-77999"
  value: {
-  dps: 30839.04018
-  tps: 21895.71853
+  dps: 30838.82344
+  tps: 21895.56464
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 28879.5518
-  tps: 20504.48178
+  dps: 28879.33914
+  tps: 20504.33079
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sBadgeofConquest-70517"
  value: {
-  dps: 29005.85074
-  tps: 20594.15403
+  dps: 29005.63705
+  tps: 20594.00231
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sBadgeofDominance-70518"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 27873.21011
-  tps: 19789.97918
+  dps: 27873.0041
+  tps: 19789.83291
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sBadgeofVictory-70519"
  value: {
-  dps: 27940.61042
-  tps: 19837.8334
+  dps: 27940.40388
+  tps: 19837.68675
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 28053.03202
-  tps: 19917.65274
+  dps: 28052.82275
+  tps: 19917.50415
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 27824.0475
-  tps: 19755.07372
+  dps: 27823.84227
+  tps: 19754.92801
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 27782.50539
-  tps: 19725.57883
+  dps: 27782.30097
+  tps: 19725.43369
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 27803.23909
-  tps: 19740.29976
+  dps: 27803.03403
+  tps: 19740.15416
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 27832.20684
-  tps: 19760.86686
+  dps: 27832.19257
+  tps: 19760.85673
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 28710.13425
-  tps: 20384.19532
+  dps: 28709.92263
+  tps: 20384.04507
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sInsigniaofConquest-70577"
  value: {
-  dps: 28842.0606
-  tps: 20477.86303
+  dps: 28841.84799
+  tps: 20477.71207
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sInsigniaofDominance-70578"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 27829.3652
-  tps: 19758.84929
+  dps: 27829.15939
+  tps: 19758.70317
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-ViciousGladiator'sInsigniaofVictory-70579"
  value: {
-  dps: 27895.3093
-  tps: 19805.66961
+  dps: 27895.103
+  tps: 19805.52313
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Vishanka,JawsoftheEarth-78359"
  value: {
-  dps: 29402.93919
-  tps: 20876.08683
+  dps: 29403.2263
+  tps: 20876.29067
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Vishanka,JawsoftheEarth-78471"
  value: {
-  dps: 29483.4123
-  tps: 20933.22273
+  dps: 29483.70005
+  tps: 20933.42703
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Vishanka,JawsoftheEarth-78480"
  value: {
-  dps: 29302.48505
-  tps: 20804.76439
+  dps: 29302.77105
+  tps: 20804.96745
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WaterdancerDefenderIdol-92399"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WaterdancerDefenderStone-92398"
  value: {
-  dps: 28019.33493
-  tps: 19893.7278
+  dps: 28019.13335
+  tps: 19893.58468
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WaterdancerIdolofRage-92401"
  value: {
-  dps: 29272.94356
-  tps: 20783.78993
+  dps: 29273.00663
+  tps: 20783.8347
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WaterdancerStoneofRage-92400"
  value: {
-  dps: 29311.37247
-  tps: 20811.07445
+  dps: 29311.16155
+  tps: 20810.9247
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WaterdancerStoneofWisdom-92402"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WillofUnbinding-77995"
  value: {
-  dps: 27300.84246
-  tps: 19383.59815
+  dps: 27300.64089
+  tps: 19383.45503
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WindDancer'sRegalia"
  value: {
-  dps: 26389.36006
-  tps: 18736.44564
+  dps: 26389.0582
+  tps: 18736.23132
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 27567.79182
-  tps: 19573.13219
+  dps: 27567.58862
+  tps: 19572.98792
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 27718.76162
-  tps: 19680.32075
+  dps: 27718.55718
+  tps: 19680.1756
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 27643.10364
-  tps: 19626.60358
+  dps: 27643.26758
+  tps: 19626.71998
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 30661.7882
-  tps: 21769.86962
+  dps: 30661.56266
+  tps: 21769.70949
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 30270.16979
-  tps: 21491.82055
+  dps: 30269.94704
+  tps: 21491.6624
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 31098.89775
-  tps: 22080.2174
+  dps: 31098.66896
+  tps: 22080.05496
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 27650.78674
-  tps: 19632.05858
+  dps: 27650.58516
+  tps: 19631.91547
  }
 }
 dps_results: {
  key: "TestAssassination-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 27650.78674
-  tps: 19632.05858
+  dps: 27650.58516
+  tps: 19631.91547
  }
 }
 dps_results: {
  key: "TestAssassination-Average-Default"
  value: {
-  dps: 29729.81258
-  tps: 21108.16693
+  dps: 29729.69041
+  tps: 21108.08019
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-Assassination-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 29510.57762
-  tps: 20952.51011
+  dps: 29510.45638
+  tps: 20952.42403
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-Assassination-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 29510.57762
-  tps: 20952.51011
+  dps: 29510.45638
+  tps: 20952.42403
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-Assassination-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 38788.56136
-  tps: 27539.87856
+  dps: 38788.40399
+  tps: 27539.76683
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-Assassination-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17453.86135
-  tps: 12392.24156
+  dps: 17453.78749
+  tps: 12392.18912
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-Assassination-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 17453.86135
-  tps: 12392.24156
+  dps: 17453.78749
+  tps: 12392.18912
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-Assassination-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 19406.6864
-  tps: 13778.74734
+  dps: 19406.60472
+  tps: 13778.68935
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 22288.6205
-  tps: 15824.92055
+  dps: 22288.54972
+  tps: 15824.8703
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 22288.6205
-  tps: 15824.92055
+  dps: 22288.54972
+  tps: 15824.8703
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 29380.35211
-  tps: 20860.05
+  dps: 29380.26048
+  tps: 20859.98494
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 13285.25548
-  tps: 9432.53139
+  dps: 13285.21067
+  tps: 9432.49958
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 13285.25548
-  tps: 9432.53139
+  dps: 13285.21067
+  tps: 9432.49958
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 15062.06366
-  tps: 10694.0652
+  dps: 15062.01221
+  tps: 10694.02867
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 30186.56134
-  tps: 21432.45855
+  dps: 30186.43542
+  tps: 21432.36915
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 30186.56134
-  tps: 21432.45855
+  dps: 30186.43542
+  tps: 21432.36915
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 39545.82787
-  tps: 28077.53779
+  dps: 39545.66533
+  tps: 28077.42239
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17821.41253
-  tps: 12653.20289
+  dps: 17821.33602
+  tps: 12653.14858
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 17821.41253
-  tps: 12653.20289
+  dps: 17821.33602
+  tps: 12653.14858
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 19865.40626
-  tps: 14104.43845
+  dps: 19865.3214
+  tps: 14104.37819
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17716.33668
-  tps: 12578.59904
+  dps: 17716.28113
+  tps: 12578.5596
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 17716.33668
-  tps: 12578.59904
+  dps: 17716.28113
+  tps: 12578.5596
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 22312.6162
-  tps: 15841.9575
+  dps: 22312.54603
+  tps: 15841.90768
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 10126.43093
-  tps: 7189.76596
+  dps: 10126.39962
+  tps: 7189.74373
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 10126.43093
-  tps: 7189.76596
+  dps: 10126.39962
+  tps: 7189.74373
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p1_assassination-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 11166.33289
-  tps: 7928.09635
+  dps: 11166.29715
+  tps: 7928.07098
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-Assassination-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 37077.4492
-  tps: 26324.98893
+  dps: 37077.39132
+  tps: 26324.94784
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-Assassination-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 37077.4492
-  tps: 26324.98893
+  dps: 37077.39132
+  tps: 26324.94784
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-Assassination-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 49048.72551
-  tps: 34824.59511
+  dps: 49048.64861
+  tps: 34824.54051
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-Assassination-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 21894.41808
-  tps: 15545.03684
+  dps: 21894.38286
+  tps: 15545.01183
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-Assassination-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 21894.41808
-  tps: 15545.03684
+  dps: 21894.38286
+  tps: 15545.01183
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-Assassination-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 24553.35936
-  tps: 17432.88515
+  dps: 24553.31916
+  tps: 17432.8566
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 27828.73068
-  tps: 19758.39878
+  dps: 27828.69733
+  tps: 19758.37511
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 27828.73068
-  tps: 19758.39878
+  dps: 27828.69733
+  tps: 19758.37511
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 36961.2578
-  tps: 26242.49304
+  dps: 36961.21395
+  tps: 26242.46191
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 16522.41648
-  tps: 11730.9157
+  dps: 16522.39556
+  tps: 11730.90085
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 16522.41648
-  tps: 11730.9157
+  dps: 16522.39556
+  tps: 11730.90085
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 18879.19572
-  tps: 13404.22896
+  dps: 18879.17107
+  tps: 13404.21146
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 37832.54536
-  tps: 26861.10721
+  dps: 37832.48547
+  tps: 26861.06468
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 37832.54536
-  tps: 26861.10721
+  dps: 37832.48547
+  tps: 26861.06468
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 50107.18626
-  tps: 35576.10225
+  dps: 50107.10642
+  tps: 35576.04556
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 22332.46518
-  tps: 15856.05028
+  dps: 22332.42892
+  tps: 15856.02454
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 22332.46518
-  tps: 15856.05028
+  dps: 22332.42892
+  tps: 15856.02454
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 25010.17228
-  tps: 17757.22232
+  dps: 25010.13084
+  tps: 17757.1929
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 21944.81808
-  tps: 15580.82084
+  dps: 21944.79193
+  tps: 15580.80227
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 21944.81808
-  tps: 15580.82084
+  dps: 21944.79193
+  tps: 15580.80227
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 27772.84263
-  tps: 19718.71827
+  dps: 27772.80908
+  tps: 19718.69444
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 12707.33394
-  tps: 9022.2071
+  dps: 12707.31899
+  tps: 9022.19648
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 12707.33394
-  tps: 9022.2071
+  dps: 12707.31899
+  tps: 9022.19648
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 14116.03795
-  tps: 10022.38695
+  dps: 14116.02051
+  tps: 10022.37456
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-Assassination-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 55505.68608
-  tps: 39409.03712
+  dps: 55506.41385
+  tps: 39409.55383
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-Assassination-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 55505.68608
-  tps: 39409.03712
+  dps: 55506.41385
+  tps: 39409.55383
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-Assassination-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 69500.59923
-  tps: 49345.42545
+  dps: 69501.4983
+  tps: 49346.0638
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-Assassination-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 34068.428
-  tps: 24188.58388
+  dps: 34068.88066
+  tps: 24188.90527
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-Assassination-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 34068.428
-  tps: 24188.58388
+  dps: 34068.88066
+  tps: 24188.90527
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-Assassination-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 36187.4387
-  tps: 25693.08148
+  dps: 36187.91833
+  tps: 25693.42201
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 43279.69225
-  tps: 30728.5815
+  dps: 43280.14421
+  tps: 30728.90239
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 43279.69225
-  tps: 30728.5815
+  dps: 43280.14421
+  tps: 30728.90239
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 54168.88365
-  tps: 38459.90739
+  dps: 54169.43691
+  tps: 38460.30021
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 26625.01606
-  tps: 18903.7614
+  dps: 26625.30075
+  tps: 18903.96353
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26625.01606
-  tps: 18903.7614
+  dps: 26625.30075
+  tps: 18903.96353
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 28594.55583
-  tps: 20302.13464
+  dps: 28594.86368
+  tps: 20302.35321
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 56925.04096
-  tps: 40416.77908
+  dps: 56925.80088
+  tps: 40417.31862
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 56925.04096
-  tps: 40416.77908
+  dps: 56925.80088
+  tps: 40417.31862
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 71097.78112
-  tps: 50479.4246
+  dps: 71098.71569
+  tps: 50480.08814
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 34914.46497
-  tps: 24789.27013
+  dps: 34914.93698
+  tps: 24789.60526
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 34914.46497
-  tps: 24789.27013
+  dps: 34914.93698
+  tps: 24789.60526
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 36929.00867
-  tps: 26219.59616
+  dps: 36929.5048
+  tps: 26219.94841
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 30142.10446
-  tps: 21400.89416
+  dps: 30142.38131
+  tps: 21401.09073
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 30142.10446
-  tps: 21400.89416
+  dps: 30142.38131
+  tps: 21401.09073
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 37328.68525
-  tps: 26503.36653
+  dps: 37329.03246
+  tps: 26503.61305
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17940.34384
-  tps: 12737.64413
+  dps: 17940.50503
+  tps: 12737.75857
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 17940.34384
-  tps: 12737.64413
+  dps: 17940.50503
+  tps: 12737.75857
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p4_assassination-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 20044.02382
-  tps: 14231.25691
+  dps: 20044.20899
+  tps: 14231.38838
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-Assassination-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 29797.11228
-  tps: 21155.94972
+  dps: 29796.9898
+  tps: 21155.86276
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-Assassination-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 29797.11228
-  tps: 21155.94972
+  dps: 29796.9898
+  tps: 21155.86276
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-Assassination-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 39384.76368
-  tps: 27963.18222
+  dps: 39384.60383
+  tps: 27963.06872
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-Assassination-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17629.65351
-  tps: 12517.05399
+  dps: 17629.57884
+  tps: 12517.00098
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-Assassination-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 17629.65351
-  tps: 12517.05399
+  dps: 17629.57884
+  tps: 12517.00098
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-Assassination-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 19742.62244
-  tps: 14017.26193
+  dps: 19742.53927
+  tps: 14017.20288
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 22505.79792
-  tps: 15979.11653
+  dps: 22505.72639
+  tps: 15979.06574
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 22505.79792
-  tps: 15979.11653
+  dps: 22505.72639
+  tps: 15979.06574
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 29840.60378
-  tps: 21186.82869
+  dps: 29840.51061
+  tps: 21186.76253
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 13419.74898
-  tps: 9528.02178
+  dps: 13419.70367
+  tps: 9527.9896
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 13419.74898
-  tps: 9528.02178
+  dps: 13419.70367
+  tps: 9527.9896
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 15327.45394
-  tps: 10882.4923
+  dps: 15327.4015
+  tps: 10882.45506
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 30480.22947
-  tps: 21640.96292
+  dps: 30480.10227
+  tps: 21640.87261
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 30480.22947
-  tps: 21640.96292
+  dps: 30480.10227
+  tps: 21640.87261
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 40156.80016
-  tps: 28511.32811
+  dps: 40156.63504
+  tps: 28511.21088
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 18002.82755
-  tps: 12782.00756
+  dps: 18002.75021
+  tps: 12781.95265
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 18002.82755
-  tps: 12782.00756
+  dps: 18002.75021
+  tps: 12781.95265
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 20205.7996
-  tps: 14346.11771
+  dps: 20205.71322
+  tps: 14346.05639
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17883.52741
-  tps: 12697.30446
+  dps: 17883.4713
+  tps: 12697.26462
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 17883.52741
-  tps: 12697.30446
+  dps: 17883.4713
+  tps: 12697.26462
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 22687.21622
-  tps: 16107.92352
+  dps: 22687.1449
+  tps: 16107.87288
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 10230.58025
-  tps: 7263.71198
+  dps: 10230.54859
+  tps: 7263.6895
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 10230.58025
-  tps: 7263.71198
+  dps: 10230.54859
+  tps: 7263.6895
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p1_assassination-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 11380.58127
-  tps: 8080.2127
+  dps: 11380.54484
+  tps: 8080.18684
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-Assassination-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 37406.97797
-  tps: 26558.95436
+  dps: 37406.91951
+  tps: 26558.91285
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-Assassination-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 37406.97797
-  tps: 26558.95436
+  dps: 37406.91951
+  tps: 26558.91285
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-Assassination-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 49753.78476
-  tps: 35325.18718
+  dps: 49753.70671
+  tps: 35325.13176
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-Assassination-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 22103.48112
-  tps: 15693.4716
+  dps: 22103.44555
+  tps: 15693.44634
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-Assassination-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 22103.48112
-  tps: 15693.4716
+  dps: 22103.44555
+  tps: 15693.44634
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-Assassination-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 24933.13431
-  tps: 17702.52536
+  dps: 24933.09343
+  tps: 17702.49634
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 28070.65617
-  tps: 19930.16588
+  dps: 28070.62246
+  tps: 19930.14195
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 28070.65617
-  tps: 19930.16588
+  dps: 28070.62246
+  tps: 19930.14195
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 37496.24583
-  tps: 26622.33454
+  dps: 37496.20129
+  tps: 26622.30292
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 16677.13444
-  tps: 11840.76545
+  dps: 16677.1133
+  tps: 11840.75045
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 16677.13444
-  tps: 11840.76545
+  dps: 16677.1133
+  tps: 11840.75045
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 19174.84404
-  tps: 13614.13927
+  dps: 19174.81894
+  tps: 13614.12145
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 38146.94836
-  tps: 27084.33334
+  dps: 38146.88795
+  tps: 27084.29045
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 38146.94836
-  tps: 27084.33334
+  dps: 38146.88795
+  tps: 27084.29045
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 50827.78557
-  tps: 36087.72776
+  dps: 50827.70453
+  tps: 36087.67021
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 22546.45978
-  tps: 16007.98644
+  dps: 22546.42316
+  tps: 16007.96044
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 22546.45978
-  tps: 16007.98644
+  dps: 22546.42316
+  tps: 16007.96044
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 25397.22829
-  tps: 18032.03208
+  dps: 25397.18616
+  tps: 18032.00217
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 22144.75341
-  tps: 15722.77492
+  dps: 22144.72704
+  tps: 15722.7562
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 22144.75341
-  tps: 15722.77492
+  dps: 22144.72704
+  tps: 15722.7562
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 28190.47207
-  tps: 20015.23517
+  dps: 28190.43801
+  tps: 20015.21098
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 12829.21848
-  tps: 9108.74512
+  dps: 12829.20338
+  tps: 9108.7344
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 12829.21848
-  tps: 9108.74512
+  dps: 12829.20338
+  tps: 9108.7344
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 14352.52915
-  tps: 10190.2957
+  dps: 14352.5114
+  tps: 10190.28309
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-Assassination-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 55859.3965
-  tps: 39660.17152
+  dps: 55860.12904
+  tps: 39660.69162
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-Assassination-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 55859.3965
-  tps: 39660.17152
+  dps: 55860.12904
+  tps: 39660.69162
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-Assassination-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 70186.73321
-  tps: 49832.58058
+  dps: 70187.64129
+  tps: 49833.22532
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-Assassination-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 34312.49675
-  tps: 24361.87269
+  dps: 34312.95307
+  tps: 24362.19668
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-Assassination-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 34312.49675
-  tps: 24361.87269
+  dps: 34312.95307
+  tps: 24362.19668
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-Assassination-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 36602.46455
-  tps: 25987.74983
+  dps: 36602.95008
+  tps: 25988.09456
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 43551.86834
-  tps: 30921.82652
+  dps: 43552.32325
+  tps: 30922.14951
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 43551.86834
-  tps: 30921.82652
+  dps: 43552.32325
+  tps: 30922.14951
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 54704.52345
-  tps: 38840.21165
+  dps: 54705.08237
+  tps: 38840.60848
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 26812.45026
-  tps: 19036.83969
+  dps: 26812.73732
+  tps: 19037.0435
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 26812.45026
-  tps: 19036.83969
+  dps: 26812.73732
+  tps: 19037.0435
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 28920.52329
-  tps: 20533.57153
+  dps: 28920.83502
+  tps: 20533.79287
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 57287.80985
-  tps: 40674.345
+  dps: 57288.57477
+  tps: 40674.88809
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 57287.80985
-  tps: 40674.345
+  dps: 57288.57477
+  tps: 40674.88809
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 71795.86715
-  tps: 50975.06568
+  dps: 71796.81105
+  tps: 50975.73585
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 35159.67636
-  tps: 24963.37022
+  dps: 35160.15205
+  tps: 24963.70796
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 35159.67636
-  tps: 24963.37022
+  dps: 35160.15205
+  tps: 24963.70796
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 37351.10186
-  tps: 26519.28232
+  dps: 37351.604
+  tps: 26519.63884
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 30325.55745
-  tps: 21531.14579
+  dps: 30325.83623
+  tps: 21531.34372
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 30325.55745
-  tps: 21531.14579
+  dps: 30325.83623
+  tps: 21531.34372
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 37746.39017
-  tps: 26799.93702
+  dps: 37746.74132
+  tps: 26800.18634
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 18060.61608
-  tps: 12823.03742
+  dps: 18060.77852
+  tps: 12823.15275
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 18060.61608
-  tps: 12823.03742
+  dps: 18060.77852
+  tps: 12823.15275
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p4_assassination-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 20289.04338
-  tps: 14405.2208
+  dps: 20289.231
+  tps: 14405.35401
  }
 }
 dps_results: {
  key: "TestAssassination-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 24285.38983
-  tps: 17242.62678
+  dps: 24285.28592
+  tps: 17242.553
  }
 }

--- a/sim/warlock/affliction/TestAffliction.results
+++ b/sim/warlock/affliction/TestAffliction.results
@@ -38,2404 +38,2404 @@ character_stats_results: {
 dps_results: {
  key: "TestAffliction-AllItems-AgileShadowspiritDiamond"
  value: {
-  dps: 46633.44053
-  tps: 32570.59716
+  dps: 46633.27959
+  tps: 32570.45138
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Althor'sAbacus-50366"
  value: {
-  dps: 43846.36301
-  tps: 30146.92007
+  dps: 43846.20578
+  tps: 30146.77748
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AncientPetrifiedSeed-69001"
  value: {
-  dps: 43685.67733
-  tps: 30309.13467
+  dps: 43685.26668
+  tps: 30308.76297
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Anhuur'sHymnal-55889"
  value: {
-  dps: 43870.58178
-  tps: 30135.23038
+  dps: 43870.42529
+  tps: 30135.08827
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Anhuur'sHymnal-56407"
  value: {
-  dps: 44070.86795
-  tps: 30229.58631
+  dps: 44070.71015
+  tps: 30229.44337
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ApparatusofKhaz'goroth-68972"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ApparatusofKhaz'goroth-69113"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ArrowofTime-72897"
  value: {
-  dps: 41450.88017
-  tps: 29709.77817
+  dps: 41450.7255
+  tps: 29709.63853
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-AustereShadowspiritDiamond"
  value: {
-  dps: 46070.01618
-  tps: 32050.88498
+  dps: 46069.85799
+  tps: 32050.74167
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Balespider'sBurningVestments"
  value: {
-  dps: 39366.79471
-  tps: 27691.59545
+  dps: 39367.44267
+  tps: 27692.18539
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BaubleofTrueBlood-50726"
  value: {
-  dps: 43185.5287
-  tps: 29755.93526
+  dps: 43185.37406
+  tps: 29755.7948
   hps: 102.5886
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BedrockTalisman-58182"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BellofEnragingResonance-59326"
  value: {
-  dps: 45197.63651
-  tps: 30930.02078
+  dps: 45197.47617
+  tps: 30929.8753
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BellofEnragingResonance-65053"
  value: {
-  dps: 45478.47113
-  tps: 31113.81233
+  dps: 45478.30983
+  tps: 31113.66596
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BindingPromise-67037"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Blood-SoakedAleMug-63843"
  value: {
-  dps: 43502.08603
-  tps: 30138.50894
+  dps: 43502.76605
+  tps: 30139.12372
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodofIsiset-55995"
  value: {
-  dps: 43617.28903
-  tps: 30078.7568
+  dps: 43618.11199
+  tps: 30079.50336
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodofIsiset-56414"
  value: {
-  dps: 43667.16299
-  tps: 30124.00081
+  dps: 43666.46645
+  tps: 30123.36893
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sBadgeofConquest-64687"
  value: {
-  dps: 42918.61193
-  tps: 29504.70659
+  dps: 42918.4577
+  tps: 29504.56785
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sBadgeofDominance-64688"
  value: {
-  dps: 44122.35369
-  tps: 30246.41916
+  dps: 44122.19487
+  tps: 30246.27656
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sBadgeofVictory-64689"
  value: {
-  dps: 42807.71202
-  tps: 29367.45135
+  dps: 42807.55828
+  tps: 29367.31335
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sEmblemofCruelty-64740"
  value: {
-  dps: 43825.99805
-  tps: 30077.75146
+  dps: 43825.84107
+  tps: 30077.6095
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sEmblemofMeditation-64741"
  value: {
-  dps: 43305.02024
-  tps: 29774.08287
+  dps: 43304.86472
+  tps: 29773.94232
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sEmblemofTenacity-64742"
  value: {
-  dps: 43261.5492
-  tps: 29706.21366
+  dps: 43261.39413
+  tps: 29706.07341
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sInsigniaofConquest-64761"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sInsigniaofDominance-64762"
  value: {
-  dps: 44344.32881
-  tps: 30486.41514
+  dps: 44344.16992
+  tps: 30486.27099
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BloodthirstyGladiator'sInsigniaofVictory-64763"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Bone-LinkFetish-77210"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Bone-LinkFetish-77982"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Bone-LinkFetish-78002"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BottledLightning-66879"
  value: {
-  dps: 43957.16789
-  tps: 30239.85222
+  dps: 43957.00949
+  tps: 30239.70905
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BottledWishes-77114"
  value: {
-  dps: 45707.43949
-  tps: 31672.61707
+  dps: 45707.27497
+  tps: 31672.467
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BracingShadowspiritDiamond"
  value: {
-  dps: 46209.21653
-  tps: 31642.5875
+  dps: 46209.05793
+  tps: 31642.4461
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Brawler'sTrophy-232015"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-BurningShadowspiritDiamond"
  value: {
-  dps: 46773.62887
-  tps: 32782.72709
+  dps: 46773.46759
+  tps: 32782.58034
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CataclysmicGladiator'sBadgeofConquest-73648"
  value: {
-  dps: 42807.71202
-  tps: 29367.45135
+  dps: 42807.55828
+  tps: 29367.31335
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CataclysmicGladiator'sBadgeofDominance-73498"
  value: {
-  dps: 44899.89504
-  tps: 30766.28236
+  dps: 44899.73323
+  tps: 30766.13703
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CataclysmicGladiator'sBadgeofVictory-73496"
  value: {
-  dps: 42807.71202
-  tps: 29367.45135
+  dps: 42807.55828
+  tps: 29367.31335
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CataclysmicGladiator'sInsigniaofConquest-73643"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CataclysmicGladiator'sInsigniaofDominance-73497"
  value: {
-  dps: 45095.44229
-  tps: 30954.30352
+  dps: 45095.2807
+  tps: 30954.15693
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CataclysmicGladiator'sInsigniaofVictory-73491"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ChaoticShadowspiritDiamond"
  value: {
-  dps: 46755.51155
-  tps: 32647.08749
+  dps: 46755.35034
+  tps: 32646.94145
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Coren'sChilledChromiumCoaster-232012"
  value: {
-  dps: 43811.27665
-  tps: 30107.62733
+  dps: 43811.12002
+  tps: 30107.48522
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CoreofRipeness-58184"
  value: {
-  dps: 44254.36888
-  tps: 30412.36345
+  dps: 44254.20958
+  tps: 30412.2199
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CorpseTongueCoin-50349"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CrecheoftheFinalDragon-77205"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CrecheoftheFinalDragon-77972"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CrecheoftheFinalDragon-77992"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CrushingWeight-59506"
  value: {
-  dps: 41450.88017
-  tps: 29709.77817
+  dps: 41450.7255
+  tps: 29709.63853
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CrushingWeight-65118"
  value: {
-  dps: 41450.88017
-  tps: 29709.77817
+  dps: 41450.7255
+  tps: 29709.63853
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CunningoftheCruel-77208"
  value: {
-  dps: 46411.40769
-  tps: 32462.13545
+  dps: 46411.24681
+  tps: 32461.98972
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-CunningoftheCruel-77980"
  value: {
-  dps: 45887.96415
-  tps: 32094.5398
+  dps: 45887.80427
+  tps: 32094.39486
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Earthquake-62048"
  value: {
-  dps: 43261.5492
-  tps: 29706.24363
+  dps: 43261.39413
+  tps: 29706.10338
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Hurricane-62049"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Hurricane-62051"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Tsunami-62050"
  value: {
-  dps: 44346.7981
-  tps: 30503.46449
+  dps: 44346.63945
+  tps: 30503.32035
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkmoonCard:Volcano-62047"
  value: {
-  dps: 45683.45704
-  tps: 31563.14442
+  dps: 45683.37286
+  tps: 31563.06816
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkwalkerIdolofRage-92118"
  value: {
-  dps: 43721.57094
-  tps: 30173.35791
+  dps: 43721.49048
+  tps: 30173.28492
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DarkwalkerStoneofRage-92117"
  value: {
-  dps: 43461.39144
-  tps: 30335.56322
+  dps: 43461.236
+  tps: 30335.42299
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Deathbringer'sWill-50363"
  value: {
-  dps: 43529.24112
-  tps: 29931.30565
+  dps: 43529.08537
+  tps: 29931.16432
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DelivererIdolofDestruction-92113"
  value: {
-  dps: 43839.1366
-  tps: 30354.33546
+  dps: 43839.05543
+  tps: 30354.26198
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DelivererStoneofDestruction-92151"
  value: {
-  dps: 44188.30092
-  tps: 31064.11683
+  dps: 44188.14196
+  tps: 31063.97299
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DelivererStoneofWisdom-92115"
  value: {
-  dps: 42805.35737
-  tps: 30618.95225
+  dps: 42805.19799
+  tps: 30618.80861
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DestructiveShadowspiritDiamond"
  value: {
-  dps: 46192.58663
-  tps: 32149.52875
+  dps: 46192.42811
+  tps: 32149.38517
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-DislodgedForeignObject-50348"
  value: {
-  dps: 44177.78382
-  tps: 30348.75034
+  dps: 44177.62535
+  tps: 30348.6067
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Dwyer'sCaber-70141"
  value: {
-  dps: 43921.05513
-  tps: 30175.23551
+  dps: 43920.89788
+  tps: 30175.09291
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EffulgentShadowspiritDiamond"
  value: {
-  dps: 46070.01618
-  tps: 32050.88498
+  dps: 46069.85799
+  tps: 32050.74167
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ElectrosparkHeartstarter-67118"
  value: {
-  dps: 43552.81386
-  tps: 29873.08366
+  dps: 43552.65734
+  tps: 29872.94312
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EmberShadowspiritDiamond"
  value: {
-  dps: 46375.33829
-  tps: 32360.23132
+  dps: 46375.179
+  tps: 32360.08696
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnigmaticShadowspiritDiamond"
  value: {
-  dps: 46192.58663
-  tps: 32149.52875
+  dps: 46192.42811
+  tps: 32149.38517
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnlightenedIdolofDestruction-92144"
  value: {
-  dps: 43902.48006
-  tps: 30383.79113
+  dps: 43902.39892
+  tps: 30383.7176
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EnlightenedStoneofDestruction-92143"
  value: {
-  dps: 44491.77783
-  tps: 31045.48901
+  dps: 44491.61998
+  tps: 31045.34542
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EssenceoftheCyclone-59473"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EssenceoftheCyclone-65140"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EssenceoftheEternalFlame-69002"
  value: {
-  dps: 43685.67733
-  tps: 30309.13467
+  dps: 43685.26668
+  tps: 30308.76297
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EternalShadowspiritDiamond"
  value: {
-  dps: 46070.01618
-  tps: 32050.88498
+  dps: 46069.85799
+  tps: 32050.74167
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EyeofUnmaking-77200"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EyeofUnmaking-77977"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-EyeofUnmaking-77997"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FallofMortality-59500"
  value: {
-  dps: 44346.7981
-  tps: 30503.46449
+  dps: 44346.63945
+  tps: 30503.32035
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FallofMortality-65124"
  value: {
-  dps: 44417.41001
-  tps: 30561.8853
+  dps: 44417.25142
+  tps: 30561.74124
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FieryQuintessence-69000"
  value: {
-  dps: 44216.78508
-  tps: 30354.73032
+  dps: 44216.62738
+  tps: 30354.58762
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-DemonPanther-52199"
  value: {
-  dps: 42807.71202
-  tps: 29367.45135
+  dps: 42807.55828
+  tps: 29367.31335
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-DreamOwl-52354"
  value: {
-  dps: 44183.51331
-  tps: 30352.54095
+  dps: 44183.35436
+  tps: 30352.39752
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-EarthenGuardian-52352"
  value: {
-  dps: 43086.63787
-  tps: 29765.82788
+  dps: 43086.48313
+  tps: 29765.68743
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-JeweledSerpent-52353"
  value: {
-  dps: 45454.54204
-  tps: 31200.73216
+  dps: 45454.37809
+  tps: 31200.58425
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Figurine-KingofBoars-52351"
  value: {
-  dps: 43235.52248
-  tps: 29751.4617
+  dps: 43234.83066
+  tps: 29750.84071
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 43912.2599
-  tps: 30352.75293
+  dps: 43911.88416
+  tps: 30352.412
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FleetShadowspiritDiamond"
  value: {
-  dps: 46158.9317
-  tps: 32152.96084
+  dps: 46158.86588
+  tps: 32152.90123
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FluidDeath-58181"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForestwalkerIdolofRage-92142"
  value: {
-  dps: 43721.57094
-  tps: 30173.35791
+  dps: 43721.49048
+  tps: 30173.28492
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForestwalkerStoneofRage-92141"
  value: {
-  dps: 43222.81657
-  tps: 30410.26138
+  dps: 43222.66124
+  tps: 30410.12045
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ForlornShadowspiritDiamond"
  value: {
-  dps: 46209.21653
-  tps: 32282.11226
+  dps: 46209.05793
+  tps: 32281.96798
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FoulGiftoftheDemonLord-72898"
  value: {
-  dps: 45311.37926
-  tps: 31336.16641
+  dps: 45311.22002
+  tps: 31336.02176
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-FuryofAngerforge-59461"
  value: {
-  dps: 43836.56796
-  tps: 30120.41129
+  dps: 43836.4113
+  tps: 30120.26915
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GaleofShadows-56138"
  value: {
-  dps: 44375.71774
-  tps: 30686.99887
+  dps: 44375.5587
+  tps: 30686.85438
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GaleofShadows-56462"
  value: {
-  dps: 44579.64013
-  tps: 30776.02285
+  dps: 44579.47974
+  tps: 30775.8777
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GearDetector-61462"
  value: {
-  dps: 41450.88017
-  tps: 29709.77817
+  dps: 41450.7255
+  tps: 29709.63853
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Gladiator'sFelshroud"
  value: {
-  dps: 33037.66035
-  tps: 23397.93186
+  dps: 33038.1128
+  tps: 23398.34377
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GlowingTwilightScale-54589"
  value: {
-  dps: 43943.60347
-  tps: 30212.68855
+  dps: 43943.44598
+  tps: 30212.54558
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GraceoftheHerald-55266"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-GraceoftheHerald-56295"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HarmlightToken-63839"
  value: {
-  dps: 44034.26523
-  tps: 30302.8685
+  dps: 44034.10869
+  tps: 30302.72596
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Harrison'sInsigniaofPanache-65803"
  value: {
-  dps: 41413.53481
-  tps: 29800.65935
+  dps: 41413.38048
+  tps: 29800.51958
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofIgnacious-59514"
  value: {
-  dps: 44701.11921
-  tps: 30866.5286
+  dps: 44700.95813
+  tps: 30866.38303
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofIgnacious-65110"
  value: {
-  dps: 44970.35063
-  tps: 30999.70733
+  dps: 44970.18924
+  tps: 30999.56108
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofRage-59224"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofRage-65072"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofSolace-55868"
  value: {
-  dps: 43548.62233
-  tps: 30103.64343
+  dps: 43548.46636
+  tps: 30103.50173
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofSolace-56393"
  value: {
-  dps: 43639.98596
-  tps: 30114.49094
+  dps: 43639.82907
+  tps: 30114.34895
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofThunder-55845"
  value: {
-  dps: 43236.43333
-  tps: 29733.81435
+  dps: 43236.27854
+  tps: 29733.67393
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartofThunder-56370"
  value: {
-  dps: 43236.43333
-  tps: 29733.99579
+  dps: 43236.27854
+  tps: 29733.85537
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-HeartoftheVile-66969"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpassiveShadowspiritDiamond"
  value: {
-  dps: 46192.58663
-  tps: 32149.52875
+  dps: 46192.42811
+  tps: 32149.38517
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpatienceofYouth-62464"
  value: {
-  dps: 43289.56169
-  tps: 29799.96827
+  dps: 43289.48178
+  tps: 29799.89653
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpatienceofYouth-62469"
  value: {
-  dps: 43289.56169
-  tps: 29799.96827
+  dps: 43289.48178
+  tps: 29799.89653
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpetuousQuery-55881"
  value: {
-  dps: 43617.28903
-  tps: 30078.7568
+  dps: 43618.11199
+  tps: 30079.50336
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ImpetuousQuery-56406"
  value: {
-  dps: 43667.16299
-  tps: 30124.00081
+  dps: 43666.46645
+  tps: 30123.36893
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-IndomitablePride-77211"
  value: {
-  dps: 43110.9789
-  tps: 29728.07198
+  dps: 43110.82418
+  tps: 29727.93178
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-IndomitablePride-77983"
  value: {
-  dps: 43175.6828
-  tps: 29754.53913
+  dps: 43175.52763
+  tps: 29754.39852
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-IndomitablePride-78003"
  value: {
-  dps: 43121.42875
-  tps: 29695.42627
+  dps: 43121.27424
+  tps: 29695.2863
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InsigniaofDiplomacy-61433"
  value: {
-  dps: 43236.43333
-  tps: 29733.75999
+  dps: 43236.27854
+  tps: 29733.61957
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InsigniaoftheCorruptedMind-77203"
  value: {
-  dps: 46230.88704
-  tps: 31759.17075
+  dps: 46230.72181
+  tps: 31759.02068
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InsigniaoftheCorruptedMind-77971"
  value: {
-  dps: 45992.30347
-  tps: 31519.57256
+  dps: 45992.13904
+  tps: 31519.42368
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InsigniaoftheCorruptedMind-77991"
  value: {
-  dps: 46870.54116
-  tps: 32298.28426
+  dps: 46870.37258
+  tps: 32298.13129
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-InsigniaoftheEarthenLord-61429"
  value: {
-  dps: 44203.59681
-  tps: 30577.66304
+  dps: 44203.70778
+  tps: 30577.76335
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JarofAncientRemedies-59354"
  value: {
-  dps: 43190.12718
-  tps: 29764.45696
+  dps: 43189.97233
+  tps: 29764.3164
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JarofAncientRemedies-65029"
  value: {
-  dps: 43227.84223
-  tps: 29741.97864
+  dps: 43227.68754
+  tps: 29741.83831
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JawsofDefeat-68926"
  value: {
-  dps: 44534.08614
-  tps: 30551.4466
+  dps: 44533.92583
+  tps: 30551.30209
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JawsofDefeat-69111"
  value: {
-  dps: 44714.71841
-  tps: 30703.91142
+  dps: 44714.55746
+  tps: 30703.76635
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-JujuofNimbleness-63840"
  value: {
-  dps: 43502.08603
-  tps: 30138.50894
+  dps: 43502.76605
+  tps: 30139.12372
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KeytotheEndlessChamber-55795"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KeytotheEndlessChamber-56328"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KiroptyricSigil-77113"
  value: {
-  dps: 43970.31398
-  tps: 30551.08683
+  dps: 43970.15579
+  tps: 30550.94265
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KvaldirBattleStandard-59685"
  value: {
-  dps: 43261.94968
-  tps: 29856.39421
+  dps: 43261.79431
+  tps: 29856.25393
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-KvaldirBattleStandard-59689"
  value: {
-  dps: 43261.94968
-  tps: 29856.39421
+  dps: 43261.79431
+  tps: 29856.25393
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LadyLa-La'sSingingShell-67152"
  value: {
-  dps: 43384.38503
-  tps: 29864.92548
+  dps: 43384.22868
+  tps: 29864.78451
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LeadenDespair-55816"
  value: {
-  dps: 43232.37819
-  tps: 29844.32366
+  dps: 43232.22265
+  tps: 29844.18274
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LeadenDespair-56347"
  value: {
-  dps: 43086.63787
-  tps: 29765.82788
+  dps: 43086.48313
+  tps: 29765.68743
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LeftEyeofRajh-56102"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LeftEyeofRajh-56427"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-LicensetoSlay-58180"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MagnetiteMirror-55814"
  value: {
-  dps: 43168.67922
-  tps: 29837.08872
+  dps: 43168.5233
+  tps: 29836.94775
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MagnetiteMirror-56345"
  value: {
-  dps: 43168.67922
-  tps: 29837.08872
+  dps: 43168.5233
+  tps: 29836.94775
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MandalaofStirringPatterns-62467"
  value: {
-  dps: 41358.91249
-  tps: 29741.26755
+  dps: 41358.75891
+  tps: 29741.12813
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MandalaofStirringPatterns-62472"
  value: {
-  dps: 41358.91249
-  tps: 29741.26755
+  dps: 41358.75891
+  tps: 29741.12813
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MarkofKhardros-56132"
  value: {
-  dps: 43650.95682
-  tps: 30271.07993
+  dps: 43650.8009
+  tps: 30270.93896
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MarkofKhardros-56458"
  value: {
-  dps: 43714.11222
-  tps: 30327.91211
+  dps: 43713.9563
+  tps: 30327.77115
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MartialDefenderIdol-92127"
  value: {
-  dps: 43098.17499
-  tps: 29771.02893
+  dps: 43098.02024
+  tps: 29770.88845
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MartialDefenderStone-92126"
  value: {
-  dps: 43106.46025
-  tps: 30335.69802
+  dps: 43106.30626
+  tps: 30335.55806
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MartialIdolofBattle-92128"
  value: {
-  dps: 43836.56796
-  tps: 30120.41129
+  dps: 43836.4113
+  tps: 30120.26915
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MartialStoneofBattle-92129"
  value: {
-  dps: 43326.76612
-  tps: 30236.38995
+  dps: 43326.61235
+  tps: 30236.25038
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MatrixRestabilizer-68994"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MatrixRestabilizer-69150"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MightoftheOcean-55251"
  value: {
-  dps: 43168.67922
-  tps: 29837.08872
+  dps: 43168.5233
+  tps: 29836.94775
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MightoftheOcean-56285"
  value: {
-  dps: 43168.67922
-  tps: 29837.08872
+  dps: 43168.5233
+  tps: 29836.94775
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MirrorofBrokenImages-62466"
  value: {
-  dps: 43721.57094
-  tps: 30173.35791
+  dps: 43721.49048
+  tps: 30173.28492
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MirrorofBrokenImages-62471"
  value: {
-  dps: 43721.57094
-  tps: 30173.35791
+  dps: 43721.49048
+  tps: 30173.28492
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MithrilStopwatch-232013"
  value: {
-  dps: 45116.56313
-  tps: 30957.55745
+  dps: 45116.40216
+  tps: 30957.41134
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MoonwellChalice-70142"
  value: {
-  dps: 45169.1541
-  tps: 31227.9538
+  dps: 45168.99467
+  tps: 31227.8101
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-MoonwellPhial-70143"
  value: {
-  dps: 43096.96775
-  tps: 29757.48192
+  dps: 43096.81297
+  tps: 29757.34144
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-NaturalistIdolofDestruction-92137"
  value: {
-  dps: 44006.07991
-  tps: 30531.47594
+  dps: 44005.9977
+  tps: 30531.40186
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-NaturalistIdolofRage-92133"
  value: {
-  dps: 43721.57094
-  tps: 30173.35791
+  dps: 43721.49048
+  tps: 30173.28492
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-NaturalistStoneofDestruction-92136"
  value: {
-  dps: 44187.93288
-  tps: 31099.13419
+  dps: 44187.77374
+  tps: 31098.99051
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-NaturalistStoneofRage-92138"
  value: {
-  dps: 43115.74555
-  tps: 30254.18423
+  dps: 43115.59207
+  tps: 30254.04442
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-NaturalistStoneofWisdom-92139"
  value: {
-  dps: 42805.35737
-  tps: 30618.95225
+  dps: 42805.19799
+  tps: 30618.80861
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-NecromanticFocus-68982"
  value: {
-  dps: 45161.19391
-  tps: 31197.99788
+  dps: 45161.03466
+  tps: 31197.85322
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-NecromanticFocus-69139"
  value: {
-  dps: 45426.16911
-  tps: 31339.15838
+  dps: 45426.00903
+  tps: 31339.01336
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Oremantle'sFavor-61448"
  value: {
-  dps: 43248.61515
-  tps: 29665.20472
+  dps: 43248.45966
+  tps: 29665.06511
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PartisanDefenderIdol-92147"
  value: {
-  dps: 43098.17499
-  tps: 29771.02893
+  dps: 43098.02024
+  tps: 29770.88845
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PartisanDefenderStone-92114"
  value: {
-  dps: 43029.97537
-  tps: 30162.16948
+  dps: 43029.82201
+  tps: 30162.03048
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PartisanIdolofBattle-92148"
  value: {
-  dps: 43836.56796
-  tps: 30120.41129
+  dps: 43836.4113
+  tps: 30120.26915
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PartisanStoneofBattle-92149"
  value: {
-  dps: 43343.23865
-  tps: 30323.74819
+  dps: 43343.0841
+  tps: 30323.60808
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PartisanStoneofWisdom-92145"
  value: {
-  dps: 42805.35737
-  tps: 30618.95225
+  dps: 42805.19799
+  tps: 30618.80861
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PetrifiedPickledEgg-232014"
  value: {
-  dps: 42551.41972
-  tps: 30484.26518
+  dps: 42551.26101
+  tps: 30484.12184
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PetrifiedTwilightScale-54591"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PhylacteryoftheNamelessLich-50365"
  value: {
-  dps: 44408.18769
-  tps: 30460.81266
+  dps: 44408.02954
+  tps: 30460.66915
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PorcelainCrab-55237"
  value: {
-  dps: 41413.53481
-  tps: 29800.65935
+  dps: 41413.38048
+  tps: 29800.51958
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PorcelainCrab-56280"
  value: {
-  dps: 41413.53481
-  tps: 29800.65935
+  dps: 41413.38048
+  tps: 29800.51958
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-PowerfulShadowspiritDiamond"
  value: {
-  dps: 46070.01618
-  tps: 32050.88498
+  dps: 46069.85799
+  tps: 32050.74167
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Prestor'sTalismanofMachination-59441"
  value: {
-  dps: 41450.88017
-  tps: 29709.77817
+  dps: 41450.7255
+  tps: 29709.63853
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Prestor'sTalismanofMachination-65026"
  value: {
-  dps: 41450.88017
-  tps: 29709.77817
+  dps: 41450.7255
+  tps: 29709.63853
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Rainsong-55854"
  value: {
-  dps: 41471.59951
-  tps: 29724.73024
+  dps: 41471.44476
+  tps: 29724.59044
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Rainsong-56377"
  value: {
-  dps: 41471.61556
-  tps: 29724.74629
+  dps: 41471.46081
+  tps: 29724.60649
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ReflectionoftheLight-77115"
  value: {
-  dps: 44916.43837
-  tps: 30927.43337
+  dps: 44916.27674
+  tps: 30927.28678
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ResolveofUndying-77201"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ResolveofUndying-77978"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ResolveofUndying-77998"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ReverberatingShadowspiritDiamond"
  value: {
-  dps: 46633.44053
-  tps: 32570.59716
+  dps: 46633.27959
+  tps: 32570.45138
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RevitalizingShadowspiritDiamond"
  value: {
-  dps: 46627.64545
-  tps: 32583.20542
+  dps: 46627.48445
+  tps: 32583.05961
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Ricket'sMagneticFireball-70144"
  value: {
-  dps: 43620.27748
-  tps: 29932.98504
+  dps: 43620.12057
+  tps: 29932.84418
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RightEyeofRajh-56100"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RightEyeofRajh-56431"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RosaryofLight-72901"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RottingSkull-77116"
  value: {
-  dps: 43926.56561
-  tps: 30355.97252
+  dps: 43926.40726
+  tps: 30355.82934
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuneofZeth-68998"
  value: {
-  dps: 45024.43623
-  tps: 30975.44911
+  dps: 45024.27472
+  tps: 30975.30286
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuthlessGladiator'sBadgeofConquest-70399"
  value: {
-  dps: 42807.71202
-  tps: 29367.45135
+  dps: 42807.55828
+  tps: 29367.31335
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuthlessGladiator'sBadgeofConquest-72304"
  value: {
-  dps: 42807.71202
-  tps: 29367.45135
+  dps: 42807.55828
+  tps: 29367.31335
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuthlessGladiator'sBadgeofDominance-70401"
  value: {
-  dps: 44562.58567
-  tps: 30540.75772
+  dps: 44562.42515
+  tps: 30540.61358
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuthlessGladiator'sBadgeofDominance-72448"
  value: {
-  dps: 44662.04869
-  tps: 30607.25858
+  dps: 44661.88779
+  tps: 30607.11408
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuthlessGladiator'sBadgeofVictory-70400"
  value: {
-  dps: 42807.71202
-  tps: 29367.45135
+  dps: 42807.55828
+  tps: 29367.31335
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuthlessGladiator'sBadgeofVictory-72450"
  value: {
-  dps: 42807.71202
-  tps: 29367.45135
+  dps: 42807.55828
+  tps: 29367.31335
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuthlessGladiator'sInsigniaofConquest-70404"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuthlessGladiator'sInsigniaofConquest-72309"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuthlessGladiator'sInsigniaofDominance-70402"
  value: {
-  dps: 44796.47426
-  tps: 30769.65233
+  dps: 44796.31375
+  tps: 30769.5067
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuthlessGladiator'sInsigniaofDominance-72449"
  value: {
-  dps: 44874.01069
-  tps: 30819.17919
+  dps: 44873.84995
+  tps: 30819.03335
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuthlessGladiator'sInsigniaofVictory-70403"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-RuthlessGladiator'sInsigniaofVictory-72455"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ScalesofLife-68915"
  value: {
-  dps: 43128.22496
-  tps: 29722.05806
+  dps: 43128.07007
+  tps: 29721.91767
   hps: 363.0582
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ScalesofLife-69109"
  value: {
-  dps: 43130.90834
-  tps: 29727.4483
+  dps: 43130.75338
+  tps: 29727.3079
   hps: 409.52625
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Schnottz'sMedallionofCommand-65805"
  value: {
-  dps: 41413.53481
-  tps: 29800.65935
+  dps: 41413.38048
+  tps: 29800.51958
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ScourgeheartDefenderIdol-92135"
  value: {
-  dps: 43098.17499
-  tps: 29771.02893
+  dps: 43098.02024
+  tps: 29770.88845
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ScourgeheartDefenderStone-92134"
  value: {
-  dps: 43594.59048
-  tps: 30407.17684
+  dps: 43594.4357
+  tps: 30407.03634
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ScourgeheartIdolofBattle-92167"
  value: {
-  dps: 43836.56796
-  tps: 30120.41129
+  dps: 43836.4113
+  tps: 30120.26915
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ScourgeheartStoneofBattle-92168"
  value: {
-  dps: 43704.90337
-  tps: 30289.88177
+  dps: 43704.74867
+  tps: 30289.7415
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SeaStar-55256"
  value: {
-  dps: 43473.66452
-  tps: 29819.10062
+  dps: 43473.50826
+  tps: 29818.96032
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SeaStar-56290"
  value: {
-  dps: 44044.2688
-  tps: 30201.09141
+  dps: 44044.11036
+  tps: 30200.94911
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SealoftheSevenSigns-77204"
  value: {
-  dps: 43341.00011
-  tps: 30954.08627
+  dps: 43340.83812
+  tps: 30953.94036
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SealoftheSevenSigns-77969"
  value: {
-  dps: 43050.03272
-  tps: 30797.88362
+  dps: 43049.87175
+  tps: 30797.73865
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SealoftheSevenSigns-77989"
  value: {
-  dps: 43318.79196
-  tps: 31032.00623
+  dps: 43318.63102
+  tps: 31031.86042
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ShadowflameRegalia"
  value: {
-  dps: 36532.37839
-  tps: 25887.17276
+  dps: 36532.63279
+  tps: 25887.40245
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ShardofWoe-60233"
  value: {
-  dps: 43731.13399
-  tps: 30117.46724
+  dps: 43730.97722
+  tps: 30117.32494
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Shrine-CleansingPurifier-63838"
  value: {
-  dps: 41450.88017
-  tps: 29709.77817
+  dps: 41450.7255
+  tps: 29709.63853
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Sindragosa'sFlawlessFang-50364"
  value: {
-  dps: 43297.58952
-  tps: 29877.07991
+  dps: 43297.43358
+  tps: 29876.93892
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Skardyn'sGrace-56115"
  value: {
-  dps: 43405.90313
-  tps: 29909.6182
+  dps: 43405.74939
+  tps: 29909.4802
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Skardyn'sGrace-56440"
  value: {
-  dps: 43484.23768
-  tps: 29980.61624
+  dps: 43484.08394
+  tps: 29980.47824
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Sorrowsong-55879"
  value: {
-  dps: 44520.18464
-  tps: 30759.1731
+  dps: 44521.03157
+  tps: 30759.94152
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Sorrowsong-56400"
  value: {
-  dps: 44689.93771
-  tps: 30895.01728
+  dps: 44689.21822
+  tps: 30894.36448
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Soul'sAnguish-66994"
  value: {
-  dps: 43168.67922
-  tps: 29837.08872
+  dps: 43168.5233
+  tps: 29836.94775
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SoulCasket-58183"
  value: {
-  dps: 44975.49609
-  tps: 30931.98637
+  dps: 44975.41283
+  tps: 30931.91161
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SoulseizerIdolofDestruction-92125"
  value: {
-  dps: 43644.28529
-  tps: 30431.18195
+  dps: 43644.20478
+  tps: 30431.10822
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SoulseizerStoneofDestruction-92124"
  value: {
-  dps: 44722.25883
-  tps: 31178.31013
+  dps: 44722.10008
+  tps: 31178.16601
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SoulshifterVortex-77206"
  value: {
-  dps: 43926.05954
-  tps: 30740.54733
+  dps: 43925.90508
+  tps: 30740.40726
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SoulshifterVortex-77970"
  value: {
-  dps: 44032.38465
-  tps: 30571.3352
+  dps: 44032.22885
+  tps: 30571.19457
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SoulshifterVortex-77990"
  value: {
-  dps: 43692.00237
-  tps: 30658.79756
+  dps: 43691.84964
+  tps: 30658.65858
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SpidersilkSpindle-68981"
  value: {
-  dps: 43815.27354
-  tps: 30258.36182
+  dps: 43814.8646
+  tps: 30257.99084
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SpidersilkSpindle-69138"
  value: {
-  dps: 43890.84014
-  tps: 30326.91335
+  dps: 43891.56477
+  tps: 30327.5707
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StarcatcherCompass-77202"
  value: {
-  dps: 43877.02976
-  tps: 30402.97244
+  dps: 43876.87149
+  tps: 30402.82884
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StarcatcherCompass-77973"
  value: {
-  dps: 43734.76512
-  tps: 30390.40418
+  dps: 43734.60751
+  tps: 30390.26114
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StarcatcherCompass-77993"
  value: {
-  dps: 44272.54764
-  tps: 30591.19625
+  dps: 44272.38876
+  tps: 30591.05189
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StayofExecution-68996"
  value: {
-  dps: 42807.71202
-  tps: 29367.45135
+  dps: 42807.55828
+  tps: 29367.31335
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Stonemother'sKiss-61411"
  value: {
-  dps: 44483.06911
-  tps: 30587.60877
+  dps: 44482.90961
+  tps: 30587.46388
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StumpofTime-62465"
  value: {
-  dps: 44667.5634
-  tps: 30705.57876
+  dps: 44667.40305
+  tps: 30705.43375
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-StumpofTime-62470"
  value: {
-  dps: 44731.3341
-  tps: 30707.45361
+  dps: 44731.17396
+  tps: 30707.30842
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SymbioticWorm-59332"
  value: {
-  dps: 43098.17499
-  tps: 29771.02893
+  dps: 43098.02024
+  tps: 29770.88845
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-SymbioticWorm-65048"
  value: {
-  dps: 43195.00604
-  tps: 29756.76354
+  dps: 43194.85097
+  tps: 29756.62294
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TalismanofSinisterOrder-65804"
  value: {
-  dps: 44411.15902
-  tps: 30681.71441
+  dps: 44411.00081
+  tps: 30681.57045
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Tank-CommanderInsignia-63841"
  value: {
-  dps: 41450.88017
-  tps: 29709.77817
+  dps: 41450.7255
+  tps: 29709.63853
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TearofBlood-55819"
  value: {
-  dps: 44121.78165
-  tps: 30334.27848
+  dps: 44121.62351
+  tps: 30334.13476
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TearofBlood-56351"
  value: {
-  dps: 44241.34927
-  tps: 30414.99674
+  dps: 44241.19112
+  tps: 30414.85298
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TendrilsofBurrowingDark-55810"
  value: {
-  dps: 44136.9879
-  tps: 30399.6185
+  dps: 44137.03922
+  tps: 30399.66503
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TendrilsofBurrowingDark-56339"
  value: {
-  dps: 44618.96275
-  tps: 30752.30198
+  dps: 44618.25086
+  tps: 30751.65603
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TheHungerer-68927"
  value: {
-  dps: 41450.88017
-  tps: 29709.77817
+  dps: 41450.7255
+  tps: 29709.63853
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TheHungerer-69112"
  value: {
-  dps: 41450.88017
-  tps: 29709.77817
+  dps: 41450.7255
+  tps: 29709.63853
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Theralion'sMirror-59519"
  value: {
-  dps: 44072.94076
-  tps: 31132.72079
+  dps: 44072.78069
+  tps: 31132.57677
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Theralion'sMirror-65105"
  value: {
-  dps: 44327.13028
-  tps: 31258.94638
+  dps: 44326.97199
+  tps: 31258.80224
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Throngus'sFinger-56121"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Throngus'sFinger-56449"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ThundercallerIdolofDestruction-92120"
  value: {
-  dps: 43680.97873
-  tps: 30363.24293
+  dps: 43680.89835
+  tps: 30363.16971
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ThundercallerIdolofRage-92116"
  value: {
-  dps: 43721.57094
-  tps: 30173.35791
+  dps: 43721.49048
+  tps: 30173.28492
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ThundercallerStoneofDestruction-92119"
  value: {
-  dps: 44446.58264
-  tps: 31110.29026
+  dps: 44446.42311
+  tps: 31110.14617
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ThundercallerStoneofRage-92121"
  value: {
-  dps: 43204.3134
-  tps: 30211.19446
+  dps: 43204.15946
+  tps: 30211.05506
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ThundercallerStoneofWisdom-92122"
  value: {
-  dps: 42805.35737
-  tps: 30618.95225
+  dps: 42805.19799
+  tps: 30618.80861
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Tia'sGrace-55874"
  value: {
-  dps: 43617.28903
-  tps: 30078.7568
+  dps: 43618.11199
+  tps: 30079.50336
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Tia'sGrace-56394"
  value: {
-  dps: 43667.16299
-  tps: 30124.00081
+  dps: 43666.46645
+  tps: 30123.36893
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-TinyAbominationinaJar-50706"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Tyrande'sFavoriteDoll-64645"
  value: {
-  dps: 44126.27611
-  tps: 30499.05198
+  dps: 44126.11802
+  tps: 30498.90841
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnheededWarning-59520"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnquenchableFlame-67101"
  value: {
-  dps: 42812.25646
-  tps: 29376.81944
+  dps: 42812.10276
+  tps: 29376.68146
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnsolvableRiddle-62463"
  value: {
-  dps: 43289.56169
-  tps: 29799.96827
+  dps: 43289.48178
+  tps: 29799.89653
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnsolvableRiddle-62468"
  value: {
-  dps: 43289.56169
-  tps: 29799.96827
+  dps: 43289.48178
+  tps: 29799.89653
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-UnsolvableRiddle-68709"
  value: {
-  dps: 43289.56169
-  tps: 29799.96827
+  dps: 43289.48178
+  tps: 29799.89653
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VariablePulseLightningCapacitor-68925"
  value: {
-  dps: 45683.22676
-  tps: 31853.39302
+  dps: 45683.06689
+  tps: 31853.24808
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VariablePulseLightningCapacitor-69110"
  value: {
-  dps: 46003.27158
-  tps: 32065.17874
+  dps: 46003.1107
+  tps: 32065.03302
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Varo'then'sBrooch-72899"
  value: {
-  dps: 41413.53481
-  tps: 29800.65935
+  dps: 41413.38048
+  tps: 29800.51958
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VeilofLies-72900"
  value: {
-  dps: 43142.18063
-  tps: 29721.71226
+  dps: 43142.02568
+  tps: 29721.57183
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VesselofAcceleration-68995"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VesselofAcceleration-69167"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VestmentsoftheFacelessShroud"
  value: {
-  dps: 38623.61159
-  tps: 26930.76337
+  dps: 38623.42425
+  tps: 26930.59371
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VialofShadows-77207"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VialofShadows-77979"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VialofShadows-77999"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VialofStolenMemories-59515"
  value: {
-  dps: 43098.17499
-  tps: 29771.02893
+  dps: 43098.02024
+  tps: 29770.88845
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-VialofStolenMemories-65109"
  value: {
-  dps: 43195.00604
-  tps: 29756.76354
+  dps: 43194.85097
+  tps: 29756.62294
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sBadgeofConquest-61033"
  value: {
-  dps: 42807.71202
-  tps: 29367.45135
+  dps: 42807.55828
+  tps: 29367.31335
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sBadgeofConquest-70517"
  value: {
-  dps: 42807.71202
-  tps: 29367.45135
+  dps: 42807.55828
+  tps: 29367.31335
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sBadgeofDominance-61035"
  value: {
-  dps: 44195.86983
-  tps: 30295.57197
+  dps: 44195.71073
+  tps: 30295.42911
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sBadgeofDominance-70518"
  value: {
-  dps: 44359.33515
-  tps: 30404.86467
+  dps: 44359.17542
+  tps: 30404.72124
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sBadgeofVictory-61034"
  value: {
-  dps: 42807.71202
-  tps: 29367.45135
+  dps: 42807.55828
+  tps: 29367.31335
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sBadgeofVictory-70519"
  value: {
-  dps: 42807.71202
-  tps: 29367.45135
+  dps: 42807.55828
+  tps: 29367.31335
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofAccuracy-61027"
  value: {
-  dps: 43261.5492
-  tps: 29706.35638
+  dps: 43261.39413
+  tps: 29706.21613
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofAlacrity-61028"
  value: {
-  dps: 43917.36302
-  tps: 30411.20806
+  dps: 43917.20496
+  tps: 30411.06467
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 43899.36994
-  tps: 30134.8946
+  dps: 43899.21271
+  tps: 30134.75241
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofProficiency-61030"
  value: {
-  dps: 43261.5492
-  tps: 29706.35638
+  dps: 43261.39413
+  tps: 29706.21613
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofProwess-61029"
  value: {
-  dps: 43776.31878
-  tps: 30171.92997
+  dps: 43775.86791
+  tps: 30171.5222
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 43261.5492
-  tps: 29706.35638
+  dps: 43261.39413
+  tps: 29706.21613
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sInsigniaofConquest-61047"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sInsigniaofConquest-70577"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sInsigniaofDominance-61045"
  value: {
-  dps: 44459.03228
-  tps: 30544.69677
+  dps: 44458.87303
+  tps: 30544.55228
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sInsigniaofDominance-70578"
  value: {
-  dps: 44603.40917
-  tps: 30638.9123
+  dps: 44603.24939
+  tps: 30638.76733
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sInsigniaofVictory-61046"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sInsigniaofVictory-70579"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WaterdancerDefenderIdol-92399"
  value: {
-  dps: 43098.17499
-  tps: 29771.02893
+  dps: 43098.02024
+  tps: 29770.88845
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WaterdancerDefenderStone-92398"
  value: {
-  dps: 43554.80218
-  tps: 30314.74431
+  dps: 43554.64831
+  tps: 30314.60432
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WaterdancerIdolofRage-92401"
  value: {
-  dps: 43721.57094
-  tps: 30173.35791
+  dps: 43721.49048
+  tps: 30173.28492
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WaterdancerStoneofRage-92400"
  value: {
-  dps: 43319.34096
-  tps: 30309.95846
+  dps: 43319.1863
+  tps: 30309.81826
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WaterdancerStoneofWisdom-92402"
  value: {
-  dps: 42805.35737
-  tps: 30618.95225
+  dps: 42805.19799
+  tps: 30618.80861
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WillofUnbinding-77198"
  value: {
-  dps: 46441.35013
-  tps: 31942.90068
+  dps: 46441.18375
+  tps: 31942.74985
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WillofUnbinding-77975"
  value: {
-  dps: 46070.18638
-  tps: 31736.71262
+  dps: 46070.02143
+  tps: 31736.56267
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WitchingHourglass-55787"
  value: {
-  dps: 43810.0045
-  tps: 30430.79519
+  dps: 43809.84502
+  tps: 30430.65121
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WitchingHourglass-56320"
  value: {
-  dps: 44611.36787
-  tps: 30940.91941
+  dps: 44611.20642
+  tps: 30940.77361
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-World-QuellerFocus-63842"
  value: {
-  dps: 43136.45058
-  tps: 29662.53299
+  dps: 43137.12108
+  tps: 29663.13484
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WrathofUnchaining-77197"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WrathofUnchaining-77974"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-WrathofUnchaining-77994"
  value: {
-  dps: 43236.43333
-  tps: 29733.25707
+  dps: 43236.27854
+  tps: 29733.11665
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Za'brox'sLuckyTooth-63742"
  value: {
-  dps: 43327.63208
-  tps: 30050.69441
+  dps: 43327.478
+  tps: 30050.55443
  }
 }
 dps_results: {
  key: "TestAffliction-AllItems-Za'brox'sLuckyTooth-63745"
  value: {
-  dps: 43327.63208
-  tps: 30050.69441
+  dps: 43327.478
+  tps: 30050.55443
  }
 }
 dps_results: {
  key: "TestAffliction-Average-Default"
  value: {
-  dps: 47301.22321
-  tps: 33150.22103
+  dps: 47301.05985
+  tps: 33150.07322
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p4-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 80402.25813
-  tps: 72690.0066
+  dps: 80402.09504
+  tps: 72689.85867
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p4-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 46438.92097
-  tps: 32882.60933
+  dps: 46438.75788
+  tps: 32882.4614
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p4-Affliction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 50901.91393
-  tps: 37092.48601
+  dps: 50901.73581
+  tps: 37092.32596
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p4-Affliction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 55888.31807
-  tps: 54005.64763
+  dps: 55888.21314
+  tps: 54005.55264
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p4-Affliction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 30966.17777
-  tps: 21690.47879
+  dps: 30966.07285
+  tps: 21690.3838
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Goblin-p4-Affliction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 29891.54522
-  tps: 21113.94585
+  dps: 29891.44404
+  tps: 21113.85396
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p4-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 79697.39492
-  tps: 72247.32616
+  dps: 79697.23553
+  tps: 72247.18132
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p4-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 45872.27234
-  tps: 32458.10567
+  dps: 45872.11296
+  tps: 32457.96083
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p4-Affliction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 49695.77741
-  tps: 36152.4921
+  dps: 49695.60547
+  tps: 36152.3349
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p4-Affliction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 55585.96111
-  tps: 53684.94593
+  dps: 55585.85602
+  tps: 53684.85031
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p4-Affliction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 30887.37543
-  tps: 21598.66695
+  dps: 30887.27034
+  tps: 21598.57133
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Human-p4-Affliction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 29574.34298
-  tps: 20902.82009
+  dps: 29574.24091
+  tps: 20902.72744
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p4-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 80728.42589
-  tps: 72741.8443
+  dps: 80728.26461
+  tps: 72741.69755
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p4-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 46773.62887
-  tps: 32782.72709
+  dps: 46773.46759
+  tps: 32782.58034
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p4-Affliction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 50615.36648
-  tps: 36524.29401
+  dps: 50615.19212
+  tps: 36524.13454
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p4-Affliction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 56399.09761
-  tps: 54015.01118
+  dps: 56398.99138
+  tps: 54014.9146
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p4-Affliction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 31521.07765
-  tps: 21806.89322
+  dps: 31520.97141
+  tps: 21806.79664
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Orc-p4-Affliction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 30244.57476
-  tps: 21179.71041
+  dps: 30244.47084
+  tps: 21179.61609
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p4-Affliction Warlock-default-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 80207.16862
-  tps: 72672.24723
+  dps: 80207.00624
+  tps: 72672.09967
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p4-Affliction Warlock-default-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 46589.11267
-  tps: 33035.87056
+  dps: 46588.95029
+  tps: 33035.723
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p4-Affliction Warlock-default-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 51479.11396
-  tps: 37586.71138
+  dps: 51478.9338
+  tps: 37586.54777
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p4-Affliction Warlock-default-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 55855.13399
-  tps: 53988.1102
+  dps: 55855.02768
+  tps: 53988.01342
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p4-Affliction Warlock-default-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 31091.77869
-  tps: 21943.33349
+  dps: 31091.67237
+  tps: 21943.23671
  }
 }
 dps_results: {
  key: "TestAffliction-Settings-Troll-p4-Affliction Warlock-default-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 30735.44831
-  tps: 22002.24635
+  dps: 30735.34099
+  tps: 22002.15001
  }
 }
 dps_results: {
  key: "TestAffliction-SwitchInFrontOfTarget-Default"
  value: {
-  dps: 46615.58145
-  tps: 32782.72709
+  dps: 46615.42016
+  tps: 32782.58034
  }
 }

--- a/sim/warrior/fury/TestFury.results
+++ b/sim/warrior/fury/TestFury.results
@@ -11,7 +11,7 @@ character_stats_results: {
   final_stats: 412
   final_stats: 692
   final_stats: 0
-  final_stats: 2731.66358
+  final_stats: 2731.66357
   final_stats: 1315
   final_stats: 25247.454
   final_stats: 209


### PR DESCRIPTION
This should help mitigate errors inf loating point computation that might accumulate over iterations.
When a serial simulation of N iterations is performed spell mods are going to add add subtract to the respective field for every iteration. That field is never reset between iterations but relies on the assumption that `1 + 1 - 1 = 1`.

This however is not true for all combinations of floating point numbers and orders of execution. Small errors might leave the field in a state where it is now 0.9999999998 after an iteration. This error accumulates over thousands of iterations.

When a parallalel simulation is run, only a fraction of iterations is performed per instance of the simulation and the error will not manifest it self as pronounced, causing slight differences in the amounts calculated for higher iterations.

For now we noticed this issue only for addative damage mods but we can easily add more here if we wish for it. 