### PR TITLE
Fix incorrect proc data for The Hungerer (H) and Idol of Battle trinkets

### DIFF
--- a/sim/common/cata/stat_bonus_procs.go
+++ b/sim/common/cata/stat_bonus_procs.go
@@ -1113,7 +1113,7 @@ func init() {
 		ProcMask:   core.ProcMaskMeleeOrRanged,
 		Outcome:    core.OutcomeLanded,
 		ProcChance: 1, //TODO: verify proc chance, seems wrong?
-		ICD:        time.Second * 60,
+		ICD:        time.Second * 59,
 	})
 
 	for _, version := range []ItemVersion{ItemVersionLFR, ItemVersionNormal, ItemVersionHeroic} {
@@ -1282,7 +1282,7 @@ func init() {
 			ItemID:     id,
 			AuraID:     126582,
 			Bonus:      stats.Stats{stats.Strength: 963},
-			Duration:   time.Second * 15,
+			Duration:   time.Second * 20,
 			Callback:   core.CallbackOnSpellHitDealt,
 			ProcMask:   core.ProcMaskDirect | core.ProcMaskProc,
 			Outcome:    core.OutcomeLanded,

--- a/sim/death_knight/blood/TestBlood.results
+++ b/sim/death_knight/blood/TestBlood.results
@@ -1286,8 +1286,8 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-MartialIdolofBattle-92128"
  value: {
-  dps: 22795.11453
-  tps: 114864.8467
+  dps: 22940.20205
+  tps: 115664.82163
   hps: 5309.79177
  }
 }
@@ -1462,8 +1462,8 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-PartisanIdolofBattle-92148"
  value: {
-  dps: 22814.33494
-  tps: 114965.10941
+  dps: 22959.3479
+  tps: 115786.09258
   hps: 5309.79177
  }
 }
@@ -1790,8 +1790,8 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-ScourgeheartIdolofBattle-92167"
  value: {
-  dps: 22797.70512
-  tps: 114898.06162
+  dps: 22933.44098
+  tps: 115639.70807
   hps: 5309.79177
  }
 }
@@ -2110,9 +2110,9 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-TheHungerer-69112"
  value: {
-  dps: 22348.52869
-  tps: 112489.47041
-  hps: 5464.34341
+  dps: 22510.74329
+  tps: 113800.73606
+  hps: 5457.94224
  }
 }
 dps_results: {

--- a/sim/death_knight/frost/TestFrost.results
+++ b/sim/death_knight/frost/TestFrost.results
@@ -1286,9 +1286,9 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-MartialIdolofBattle-92128"
  value: {
-  dps: 50131.92941
-  tps: 47354.89914
-  hps: 1672.0269
+  dps: 50487.73284
+  tps: 47713.92484
+  hps: 1668.53011
  }
 }
 dps_results: {
@@ -1486,9 +1486,9 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-PartisanIdolofBattle-92148"
  value: {
-  dps: 50066.7854
-  tps: 47344.63
-  hps: 1679.55131
+  dps: 50630.55665
+  tps: 47837.92006
+  hps: 1675.56119
  }
 }
 dps_results: {
@@ -1822,9 +1822,9 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-ScourgeheartIdolofBattle-92167"
  value: {
-  dps: 50163.76246
-  tps: 47406.68133
-  hps: 1680.19759
+  dps: 50550.3764
+  tps: 47769.2239
+  hps: 1672.48275
  }
 }
 dps_results: {
@@ -2158,9 +2158,9 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-TheHungerer-69112"
  value: {
-  dps: 49698.72718
-  tps: 46920.42315
-  hps: 1698.4778
+  dps: 49631.90383
+  tps: 46872.54756
+  hps: 1694.75308
  }
 }
 dps_results: {

--- a/sim/death_knight/unholy/TestUnholy.results
+++ b/sim/death_knight/unholy/TestUnholy.results
@@ -1270,9 +1270,9 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-MartialIdolofBattle-92128"
  value: {
-  dps: 51545.88136
-  tps: 36322.23006
-  hps: 703.46131
+  dps: 51822.58144
+  tps: 36565.99452
+  hps: 702.57646
  }
 }
 dps_results: {
@@ -1446,9 +1446,9 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-PartisanIdolofBattle-92148"
  value: {
-  dps: 51461.84085
-  tps: 36212.81482
-  hps: 702.57646
+  dps: 51928.74142
+  tps: 36563.62009
+  hps: 703.46131
  }
 }
 dps_results: {
@@ -1782,8 +1782,8 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-ScourgeheartIdolofBattle-92167"
  value: {
-  dps: 51629.94262
-  tps: 36323.02988
+  dps: 51978.00915
+  tps: 36622.76538
   hps: 705.23103
  }
 }
@@ -2102,9 +2102,9 @@ dps_results: {
 dps_results: {
  key: "TestUnholy-AllItems-TheHungerer-69112"
  value: {
-  dps: 51287.73703
-  tps: 36009.22827
-  hps: 702.57646
+  dps: 51180.12918
+  tps: 35936.19839
+  hps: 700.80674
  }
 }
 dps_results: {

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -1294,8 +1294,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-MartialIdolofBattle-92128"
  value: {
-  dps: 49327.63092
-  tps: 66813.54962
+  dps: 49543.54553
+  tps: 66683.18813
   hps: 26.77086
  }
 }
@@ -1478,8 +1478,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-PartisanIdolofBattle-92148"
  value: {
-  dps: 49211.28924
-  tps: 66910.29282
+  dps: 49532.128
+  tps: 66841.66801
   hps: 26.77086
  }
 }
@@ -1838,8 +1838,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-ScourgeheartIdolofBattle-92167"
  value: {
-  dps: 49373.53138
-  tps: 67746.68415
+  dps: 49427.89941
+  tps: 67153.74917
   hps: 26.77086
  }
 }
@@ -2166,8 +2166,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-TheHungerer-69112"
  value: {
-  dps: 50903.89644
-  tps: 68427.22394
+  dps: 51044.55762
+  tps: 68020.84012
   hps: 26.77086
  }
 }
@@ -2702,16 +2702,16 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-aoe-no_item_swap-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 86290.77807
-  tps: 118629.37019
+  dps: 86009.38479
+  tps: 118712.4046
   hps: 26.77086
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-aoe-no_item_swap-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20970.62858
-  tps: 37299.4493
+  dps: 20870.74014
+  tps: 35989.98723
   hps: 26.77086
  }
 }
@@ -2726,16 +2726,16 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-aoe-no_item_swap-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 58958.4646
-  tps: 82508.3812
+  dps: 58999.26705
+  tps: 82669.15195
   hps: 26.68987
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-aoe-no_item_swap-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 12878.9638
-  tps: 23118.62256
+  dps: 12921.04548
+  tps: 23252.34532
   hps: 26.68987
  }
 }
@@ -2750,64 +2750,64 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-aoe-p4_item_swap-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 86223.73433
-  tps: 117462.37574
+  dps: 86154.79555
+  tps: 118535.48701
   hps: 31.07137
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-aoe-p4_item_swap-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 21036.40711
-  tps: 35935.06116
+  dps: 21005.33309
+  tps: 36405.78747
   hps: 31.07137
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-aoe-p4_item_swap-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 24880.99537
-  tps: 31985.52541
+  dps: 24904.69004
+  tps: 32002.34862
   hps: 155.35685
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-aoe-p4_item_swap-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 58821.09339
-  tps: 83014.69932
+  dps: 58871.90935
+  tps: 83244.62933
   hps: 30.59943
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-aoe-p4_item_swap-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 12988.93237
-  tps: 23306.13903
+  dps: 13004.03618
+  tps: 22991.41951
   hps: 30.59943
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-aoe-p4_item_swap-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 13535.74208
-  tps: 23308.09967
+  dps: 13565.39505
+  tps: 23329.15327
   hps: 152.99714
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-no_item_swap-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 39436.62459
-  tps: 51317.03845
+  dps: 39432.04564
+  tps: 50908.22477
   hps: 26.77086
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-no_item_swap-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39053.9055
-  tps: 51768.34257
+  dps: 39135.03746
+  tps: 51277.18736
   hps: 26.77086
  }
 }
@@ -2822,16 +2822,16 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-no_item_swap-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 25074.68829
-  tps: 33452.75636
+  dps: 25014.17633
+  tps: 33121.35526
   hps: 26.68987
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-no_item_swap-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25313.95933
-  tps: 36106.06921
+  dps: 25283.98666
+  tps: 34991.62764
   hps: 26.68987
  }
 }
@@ -2846,88 +2846,88 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-p4_item_swap-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 39486.95734
-  tps: 51245.46747
+  dps: 39454.12936
+  tps: 52309.32074
   hps: 31.07137
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-p4_item_swap-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39297.31351
-  tps: 51759.79062
+  dps: 39286.75207
+  tps: 50761.52546
   hps: 31.07137
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-p4_item_swap-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 50781.27656
-  tps: 44043.33671
+  dps: 50881.56143
+  tps: 44114.53897
   hps: 155.35685
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-p4_item_swap-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 25073.88187
-  tps: 32803.13385
+  dps: 25140.06791
+  tps: 33308.12029
   hps: 30.59943
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-p4_item_swap-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25396.17432
-  tps: 35139.99518
+  dps: 25432.16195
+  tps: 34411.49133
   hps: 30.59943
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-default-p4_item_swap-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 28619.61085
-  tps: 26533.2915
+  dps: 28638.6567
+  tps: 26546.81406
   hps: 152.99714
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-no_item_swap-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38384.117
-  tps: 27361.30686
+  dps: 38468.93926
+  tps: 27421.53066
   hps: 26.77086
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-no_item_swap-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38128.94726
-  tps: 27077.19371
+  dps: 38146.42159
+  tps: 27089.60048
   hps: 26.77086
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-no_item_swap-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 49740.79453
-  tps: 35344.1699
+  dps: 49743.51967
+  tps: 35346.10475
   hps: 133.8543
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-no_item_swap-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24039.73843
-  tps: 17201.24409
+  dps: 24022.00291
+  tps: 17188.65188
   hps: 26.68987
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-no_item_swap-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24177.88706
-  tps: 17173.02316
+  dps: 24247.57708
+  tps: 17222.50308
   hps: 26.68987
  }
 }
@@ -2942,88 +2942,88 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-p4_item_swap-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38336.82078
-  tps: 27223.95471
+  dps: 38406.18388
+  tps: 27273.20251
   hps: 31.07137
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-p4_item_swap-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38168.5031
-  tps: 27099.75059
+  dps: 38174.95735
+  tps: 27104.33311
   hps: 31.07137
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-p4_item_swap-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 50407.64332
-  tps: 35789.99372
+  dps: 50453.80578
+  tps: 35822.76906
   hps: 155.35685
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-p4_item_swap-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24112.34791
-  tps: 17126.85695
+  dps: 24094.80798
+  tps: 17114.4036
   hps: 30.59943
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-p4_item_swap-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24317.89013
-  tps: 17266.1485
+  dps: 24371.87414
+  tps: 17304.47715
   hps: 30.59943
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-DefaultTalents-ExternalBleed-monocat-p4_item_swap-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 28159.85472
-  tps: 19995.24661
+  dps: 28168.66562
+  tps: 20001.50236
   hps: 152.99714
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-aoe-no_item_swap-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 85955.7798
-  tps: 118560.78359
+  dps: 86077.16316
+  tps: 120752.00774
   hps: 26.77086
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-aoe-no_item_swap-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20812.98732
-  tps: 36336.65141
+  dps: 20774.00713
+  tps: 35774.85781
   hps: 26.77086
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-aoe-no_item_swap-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 24524.35176
-  tps: 32573.1597
+  dps: 24532.15549
+  tps: 32578.70035
   hps: 133.8543
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-aoe-no_item_swap-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 58487.44628
-  tps: 81905.0593
+  dps: 58395.74656
+  tps: 81329.29411
   hps: 26.68987
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-aoe-no_item_swap-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 12812.00991
-  tps: 22873.26708
+  dps: 12810.72822
+  tps: 22930.09913
   hps: 26.68987
  }
 }
@@ -3038,64 +3038,64 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-aoe-p4_item_swap-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 85922.31107
-  tps: 119383.61731
+  dps: 86259.05192
+  tps: 120047.15244
   hps: 31.07137
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-aoe-p4_item_swap-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20790.03599
-  tps: 35724.59989
+  dps: 20863.23833
+  tps: 35981.94007
   hps: 31.07137
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-aoe-p4_item_swap-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 24731.74912
-  tps: 32590.45921
+  dps: 24770.25951
+  tps: 32617.80159
   hps: 155.35685
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-aoe-p4_item_swap-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 58318.56643
-  tps: 81731.42756
+  dps: 58450.91214
+  tps: 82328.12031
   hps: 30.59943
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-aoe-p4_item_swap-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 12842.14347
-  tps: 22293.99944
+  dps: 12835.66385
+  tps: 22548.01045
   hps: 30.59943
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-aoe-p4_item_swap-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 13267.60281
-  tps: 22158.1308
+  dps: 13288.61105
+  tps: 22173.04665
   hps: 152.99714
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-no_item_swap-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38477.64034
-  tps: 49381.67121
+  dps: 38717.57506
+  tps: 49762.39421
   hps: 26.77086
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-no_item_swap-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38144.38129
-  tps: 48733.22832
+  dps: 38240.98479
+  tps: 48659.02795
   hps: 26.77086
  }
 }
@@ -3110,16 +3110,16 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-no_item_swap-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24529.97483
-  tps: 32372.08451
+  dps: 24453.77329
+  tps: 32316.65132
   hps: 26.68987
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-no_item_swap-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24680.53841
-  tps: 32452.54341
+  dps: 24598.38415
+  tps: 32309.2135
   hps: 26.68987
  }
 }
@@ -3134,64 +3134,64 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-p4_item_swap-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38505.68561
-  tps: 47569.18739
+  dps: 38634.53908
+  tps: 49436.37858
   hps: 31.07137
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-p4_item_swap-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38293.62645
-  tps: 48858.09162
+  dps: 38314.01056
+  tps: 48770.65209
   hps: 31.07137
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-p4_item_swap-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 49315.68667
-  tps: 39844.83136
+  dps: 49393.54126
+  tps: 39900.10812
   hps: 155.35685
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-p4_item_swap-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24447.80617
-  tps: 31872.52006
+  dps: 24568.88656
+  tps: 32880.83105
   hps: 30.59943
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-p4_item_swap-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24614.28589
-  tps: 32682.38175
+  dps: 24649.50003
+  tps: 32721.46711
   hps: 30.59943
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-default-p4_item_swap-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27391.73309
-  tps: 25856.89077
+  dps: 27402.64987
+  tps: 25864.64168
   hps: 152.99714
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-no_item_swap-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 37659.38195
-  tps: 26845.81641
+  dps: 37631.33284
+  tps: 26825.90154
   hps: 26.77086
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-no_item_swap-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37274.13497
-  tps: 26470.27699
+  dps: 37325.022
+  tps: 26506.40678
   hps: 26.77086
  }
 }
@@ -3206,16 +3206,16 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-no_item_swap-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 23603.43675
-  tps: 16891.06677
+  dps: 23546.68066
+  tps: 16850.76995
   hps: 26.68987
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-no_item_swap-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 23677.18868
-  tps: 16817.50715
+  dps: 23710.85274
+  tps: 16841.40864
   hps: 26.68987
  }
 }
@@ -3230,48 +3230,48 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-p4_item_swap-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 37539.17971
-  tps: 26657.62955
+  dps: 37549.75197
+  tps: 26665.13585
   hps: 31.07137
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-p4_item_swap-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37364.38773
-  tps: 26528.82868
+  dps: 37421.45903
+  tps: 26569.3493
   hps: 31.07137
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-p4_item_swap-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 48952.23059
-  tps: 34756.65068
+  dps: 49047.3312
+  tps: 34824.17211
   hps: 155.35685
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-p4_item_swap-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 23643.23986
-  tps: 16793.79023
+  dps: 23672.46438
+  tps: 16814.53964
   hps: 30.59943
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-p4_item_swap-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 23692.10311
-  tps: 16821.83972
+  dps: 23756.41127
+  tps: 16867.49851
   hps: 30.59943
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Troll-p3-HybridTalents-ExternalBleed-monocat-p4_item_swap-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27054.98969
-  tps: 19210.79244
+  dps: 27070.54594
+  tps: 19221.83738
   hps: 152.99714
  }
 }
@@ -3854,40 +3854,40 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-aoe-no_item_swap-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 86031.34884
-  tps: 118609.55442
+  dps: 85799.94349
+  tps: 118372.26843
   hps: 26.77086
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-aoe-no_item_swap-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20892.24558
-  tps: 36865.49525
+  dps: 20968.16195
+  tps: 37033.67608
   hps: 26.77086
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-aoe-no_item_swap-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 24511.1196
-  tps: 34768.21064
+  dps: 24514.86199
+  tps: 34770.86774
   hps: 133.8543
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-aoe-no_item_swap-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 58924.20578
-  tps: 84601.85915
+  dps: 59134.74441
+  tps: 84946.80413
   hps: 26.68987
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-aoe-no_item_swap-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 12934.89786
-  tps: 23871.06927
+  dps: 12932.14888
+  tps: 23452.52045
   hps: 26.68987
  }
 }
@@ -3902,64 +3902,64 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-aoe-p4_item_swap-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 85798.01445
-  tps: 119714.30997
+  dps: 85806.90641
+  tps: 119875.86986
   hps: 31.07137
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-aoe-p4_item_swap-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20947.39362
-  tps: 37225.17648
+  dps: 20897.71165
+  tps: 36479.29709
   hps: 31.07137
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-aoe-p4_item_swap-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 24428.52841
-  tps: 34263.11534
+  dps: 24432.94625
+  tps: 34266.17415
   hps: 155.35685
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-aoe-p4_item_swap-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 58721.16925
-  tps: 83817.64098
+  dps: 59002.92773
+  tps: 84344.19554
   hps: 30.59943
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-aoe-p4_item_swap-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 12961.38623
-  tps: 23160.04472
+  dps: 12946.04145
+  tps: 23468.52747
   hps: 30.59943
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-aoe-p4_item_swap-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 13050.01039
-  tps: 22838.13519
+  dps: 13093.13781
+  tps: 22868.75566
   hps: 152.99714
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-no_item_swap-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 39476.39771
-  tps: 52894.80602
+  dps: 39596.13854
+  tps: 52970.18873
   hps: 26.77086
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-no_item_swap-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39131.80009
-  tps: 51935.85792
+  dps: 39174.17776
+  tps: 52697.35846
   hps: 26.77086
  }
 }
@@ -3974,112 +3974,112 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-no_item_swap-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24975.05701
-  tps: 33679.38569
+  dps: 25044.05372
+  tps: 33619.56718
   hps: 26.68987
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-no_item_swap-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25394.61198
-  tps: 35820.43324
+  dps: 25336.93308
+  tps: 35366.34736
   hps: 26.68987
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-no_item_swap-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27846.34598
-  tps: 27554.5672
+  dps: 27851.09279
+  tps: 27557.93743
   hps: 133.44937
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-p4_item_swap-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 39450.90044
-  tps: 51102.8556
+  dps: 39312.48075
+  tps: 51030.53663
   hps: 31.07137
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-p4_item_swap-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 39255.79452
-  tps: 51627.94652
+  dps: 39197.45435
+  tps: 49173.99374
   hps: 31.07137
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-p4_item_swap-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 50401.09836
-  tps: 40789.04332
+  dps: 50457.60258
+  tps: 40829.16131
   hps: 155.35685
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-p4_item_swap-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 25081.31552
-  tps: 32938.83269
+  dps: 24986.10111
+  tps: 32973.1156
   hps: 30.59943
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-p4_item_swap-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 25228.82339
-  tps: 34377.61873
+  dps: 25361.60428
+  tps: 34867.88055
   hps: 30.59943
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-default-p4_item_swap-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 28123.29874
-  tps: 27013.22069
+  dps: 28133.93112
+  tps: 27020.76968
   hps: 152.99714
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-no_item_swap-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38308.29815
-  tps: 27306.559
+  dps: 38370.93487
+  tps: 27351.03107
   hps: 26.77086
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-no_item_swap-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37936.80841
-  tps: 26940.68287
+  dps: 38100.99858
+  tps: 27057.25789
   hps: 26.77086
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-no_item_swap-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 49260.74102
-  tps: 35002.87064
+  dps: 49275.13681
+  tps: 35013.09165
   hps: 133.8543
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-no_item_swap-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24126.90828
-  tps: 17263.53781
+  dps: 24149.03236
+  tps: 17279.24591
   hps: 26.68987
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-no_item_swap-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24265.77474
-  tps: 17235.4436
+  dps: 24270.15818
+  tps: 17238.55585
   hps: 26.68987
  }
 }
@@ -4094,64 +4094,64 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-p4_item_swap-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38466.97592
-  tps: 27316.36745
+  dps: 38424.02945
+  tps: 27285.87546
   hps: 31.07137
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-p4_item_swap-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38148.40853
-  tps: 27085.48356
+  dps: 38134.84916
+  tps: 27075.85641
   hps: 31.07137
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-p4_item_swap-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 49948.40965
-  tps: 35463.93838
+  dps: 49973.17459
+  tps: 35481.52149
   hps: 155.35685
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-p4_item_swap-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24173.32082
-  tps: 17170.74119
+  dps: 24179.76388
+  tps: 17175.31576
   hps: 30.59943
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-p4_item_swap-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24216.78146
-  tps: 17194.39102
+  dps: 24240.74706
+  tps: 17211.4066
   hps: 30.59943
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-DefaultTalents-ExternalBleed-monocat-p4_item_swap-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 27614.92036
-  tps: 19608.49159
+  dps: 27674.8131
+  tps: 19651.01544
   hps: 152.99714
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-aoe-no_item_swap-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 85568.31855
-  tps: 120010.35496
+  dps: 85351.04692
+  tps: 119254.34113
   hps: 26.77086
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-aoe-no_item_swap-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20818.57341
-  tps: 36070.56025
+  dps: 20833.34743
+  tps: 36780.5024
   hps: 26.77086
  }
 }
@@ -4166,16 +4166,16 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-aoe-no_item_swap-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 58825.18782
-  tps: 85043.30731
+  dps: 58878.68804
+  tps: 84683.46566
   hps: 26.68987
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-aoe-no_item_swap-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 12894.97603
-  tps: 23130.76462
+  dps: 12855.40843
+  tps: 22961.19762
   hps: 26.68987
  }
 }
@@ -4190,64 +4190,64 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-aoe-p4_item_swap-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 85720.07608
-  tps: 120662.69032
+  dps: 85666.89334
+  tps: 119712.73661
   hps: 31.07137
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-aoe-p4_item_swap-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 20786.96643
-  tps: 36403.6869
+  dps: 20697.44102
+  tps: 36445.37759
   hps: 31.07137
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-aoe-p4_item_swap-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 24240.01768
-  tps: 33622.58413
+  dps: 24254.93764
+  tps: 33633.17729
   hps: 155.35685
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-aoe-p4_item_swap-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 58902.27541
-  tps: 84026.49818
+  dps: 58499.02289
+  tps: 82795.07564
   hps: 30.59943
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-aoe-p4_item_swap-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 12860.3044
-  tps: 22770.26857
+  dps: 12900.88344
+  tps: 22734.73338
   hps: 30.59943
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-aoe-p4_item_swap-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 13161.37936
-  tps: 22651.71016
+  dps: 13163.37475
+  tps: 22653.12689
   hps: 152.99714
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-no_item_swap-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38531.77901
-  tps: 50184.90233
+  dps: 38598.83779
+  tps: 49912.32977
   hps: 26.77086
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-no_item_swap-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38148.80757
-  tps: 50202.5939
+  dps: 38195.90924
+  tps: 49726.29848
   hps: 26.77086
  }
 }
@@ -4262,112 +4262,112 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-no_item_swap-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24315.06425
-  tps: 32340.7167
+  dps: 24314.02222
+  tps: 32742.5286
   hps: 26.68987
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-no_item_swap-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24506.07496
-  tps: 33898.46142
+  dps: 24586.44442
+  tps: 33587.71293
   hps: 26.68987
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-no_item_swap-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 26725.06359
-  tps: 25329.70178
+  dps: 26730.38285
+  tps: 25333.47845
   hps: 133.44937
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-p4_item_swap-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 38720.18474
-  tps: 50038.05837
+  dps: 38723.09589
+  tps: 50174.2284
   hps: 31.07137
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-p4_item_swap-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 38282.26386
-  tps: 50181.55913
+  dps: 38256.99245
+  tps: 49953.86431
   hps: 31.07137
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-p4_item_swap-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 48932.16678
-  tps: 40217.51504
+  dps: 48950.96014
+  tps: 40230.85833
   hps: 155.35685
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-p4_item_swap-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 24373.35769
-  tps: 32900.1336
+  dps: 24438.26738
+  tps: 32847.62768
   hps: 30.59943
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-p4_item_swap-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 24677.33646
-  tps: 33960.82493
+  dps: 24514.40069
+  tps: 32922.7383
   hps: 30.59943
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-default-p4_item_swap-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 26904.36716
-  tps: 25071.45431
+  dps: 26923.24906
+  tps: 25084.86047
   hps: 152.99714
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-no_item_swap-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 37565.3674
-  tps: 26778.14959
+  dps: 37677.70875
+  tps: 26857.91196
   hps: 26.77086
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-no_item_swap-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37058.34666
-  tps: 26316.97503
+  dps: 37141.16812
+  tps: 26375.77827
   hps: 26.77086
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-no_item_swap-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 47845.80387
-  tps: 33998.26526
+  dps: 47845.94321
+  tps: 33998.3642
   hps: 133.8543
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-no_item_swap-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 23496.76745
-  tps: 16815.7353
+  dps: 23418.34963
+  tps: 16760.05865
   hps: 26.68987
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-no_item_swap-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 23586.41283
-  tps: 16753.07652
+  dps: 23557.09448
+  tps: 16732.26049
   hps: 26.68987
  }
 }
@@ -4382,48 +4382,48 @@ dps_results: {
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-p4_item_swap-FullBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 37635.94859
-  tps: 26726.33805
+  dps: 37626.04443
+  tps: 26719.3061
   hps: 31.07137
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-p4_item_swap-FullBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 37241.26695
-  tps: 26441.41304
+  dps: 37222.12255
+  tps: 26427.82052
   hps: 31.07137
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-p4_item_swap-FullBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 48487.93926
-  tps: 34427.00441
+  dps: 48516.43758
+  tps: 34447.23822
   hps: 155.35685
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-p4_item_swap-NoBuffs-25.0yards-LongMultiTarget"
  value: {
-  dps: 23614.55243
-  tps: 16774.01563
+  dps: 23627.76102
+  tps: 16783.39373
   hps: 30.59943
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-p4_item_swap-NoBuffs-25.0yards-LongSingleTarget"
  value: {
-  dps: 23686.13707
-  tps: 16817.6335
+  dps: 23650.84926
+  tps: 16792.57916
   hps: 30.59943
  }
 }
 dps_results: {
  key: "TestFeral-Settings-Worgen-p3-HybridTalents-ExternalBleed-monocat-p4_item_swap-NoBuffs-25.0yards-ShortSingleTarget"
  value: {
-  dps: 26626.62543
-  tps: 18906.80219
+  dps: 26652.74642
+  tps: 18925.34809
   hps: 152.99714
  }
 }

--- a/sim/druid/guardian/TestGuardian.results
+++ b/sim/druid/guardian/TestGuardian.results
@@ -1294,8 +1294,8 @@ dps_results: {
 dps_results: {
  key: "TestGuardian-AllItems-MartialIdolofBattle-92128"
  value: {
-  dps: 10961.8548
-  tps: 54876.93275
+  dps: 10998.72318
+  tps: 55061.27465
   hps: 361.55625
  }
 }
@@ -1478,8 +1478,8 @@ dps_results: {
 dps_results: {
  key: "TestGuardian-AllItems-PartisanIdolofBattle-92148"
  value: {
-  dps: 10961.76723
-  tps: 54876.49492
+  dps: 11000.33797
+  tps: 55069.34858
   hps: 361.55625
  }
 }
@@ -1830,8 +1830,8 @@ dps_results: {
 dps_results: {
  key: "TestGuardian-AllItems-ScourgeheartIdolofBattle-92167"
  value: {
-  dps: 10963.47382
-  tps: 54885.02783
+  dps: 10999.41883
+  tps: 55064.75292
   hps: 361.55625
  }
 }
@@ -2158,9 +2158,9 @@ dps_results: {
 dps_results: {
  key: "TestGuardian-AllItems-TheHungerer-69112"
  value: {
-  dps: 11302.88179
-  tps: 56583.05164
-  hps: 355.12858
+  dps: 11367.0621
+  tps: 56904.41427
+  hps: 356.7355
  }
 }
 dps_results: {

--- a/sim/hunter/beast_mastery/TestBM.results
+++ b/sim/hunter/beast_mastery/TestBM.results
@@ -1973,8 +1973,8 @@ dps_results: {
 dps_results: {
  key: "TestBM-AllItems-TheHungerer-69112"
  value: {
-  dps: 26168.85379
-  tps: 16322.80135
+  dps: 26058.32714
+  tps: 16282.16937
  }
 }
 dps_results: {

--- a/sim/hunter/marksmanship/TestMM.results
+++ b/sim/hunter/marksmanship/TestMM.results
@@ -1973,8 +1973,8 @@ dps_results: {
 dps_results: {
  key: "TestMM-AllItems-TheHungerer-69112"
  value: {
-  dps: 24473.36196
-  tps: 22002.44641
+  dps: 24285.07535
+  tps: 21824.14695
  }
 }
 dps_results: {

--- a/sim/hunter/survival/TestSV.results
+++ b/sim/hunter/survival/TestSV.results
@@ -1975,8 +1975,8 @@ dps_results: {
 dps_results: {
  key: "TestSV-AllItems-TheHungerer-69112"
  value: {
-  dps: 48835.23851
-  tps: 44286.09316
+  dps: 48973.64085
+  tps: 44444.51677
  }
 }
 dps_results: {

--- a/sim/mage/arcane/TestArcane.results
+++ b/sim/mage/arcane/TestArcane.results
@@ -1124,8 +1124,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-MartialIdolofBattle-92128"
  value: {
-  dps: 34204.4112
-  tps: 31514.42796
+  dps: 34204.23249
+  tps: 31514.24925
  }
 }
 dps_results: {
@@ -1271,8 +1271,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-PartisanIdolofBattle-92148"
  value: {
-  dps: 34204.4112
-  tps: 31514.42796
+  dps: 34204.23249
+  tps: 31514.24925
  }
 }
 dps_results: {
@@ -1588,8 +1588,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-ScourgeheartIdolofBattle-92167"
  value: {
-  dps: 34204.4112
-  tps: 31514.42796
+  dps: 34204.23249
+  tps: 31514.24925
  }
 }
 dps_results: {

--- a/sim/paladin/protection/TestProtection.results
+++ b/sim/paladin/protection/TestProtection.results
@@ -1123,8 +1123,8 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-MartialIdolofBattle-92128"
  value: {
-  dps: 11297.59391
-  tps: 56790.79115
+  dps: 11434.93343
+  tps: 57477.48877
  }
 }
 dps_results: {
@@ -1291,8 +1291,8 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-PartisanIdolofBattle-92148"
  value: {
-  dps: 11300.48113
-  tps: 56805.22728
+  dps: 11431.17888
+  tps: 57458.716
  }
 }
 dps_results: {
@@ -1592,8 +1592,8 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-ScourgeheartIdolofBattle-92167"
  value: {
-  dps: 11305.89079
-  tps: 56832.27554
+  dps: 11440.76284
+  tps: 57506.63583
  }
 }
 dps_results: {
@@ -1879,8 +1879,8 @@ dps_results: {
 dps_results: {
  key: "TestProtection-AllItems-TheHungerer-69112"
  value: {
-  dps: 10993.42449
-  tps: 55278.51501
+  dps: 11003.08022
+  tps: 55327.70687
  }
 }
 dps_results: {

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -1145,8 +1145,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-MartialIdolofBattle-92128"
  value: {
-  dps: 48051.92451
-  tps: 45502.81743
+  dps: 48401.91112
+  tps: 45852.80404
  }
 }
 dps_results: {
@@ -1292,8 +1292,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-PartisanIdolofBattle-92148"
  value: {
-  dps: 48030.86568
-  tps: 45481.7586
+  dps: 48376.73367
+  tps: 45827.6266
  }
 }
 dps_results: {
@@ -1602,8 +1602,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-ScourgeheartIdolofBattle-92167"
  value: {
-  dps: 48040.57209
-  tps: 45491.46501
+  dps: 48381.5508
+  tps: 45832.44372
  }
 }
 dps_results: {
@@ -1882,8 +1882,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-TheHungerer-69112"
  value: {
-  dps: 48238.3945
-  tps: 45617.19734
+  dps: 48220.61227
+  tps: 45597.48318
  }
 }
 dps_results: {

--- a/sim/priest/shadow/TestShadow.results
+++ b/sim/priest/shadow/TestShadow.results
@@ -1116,7 +1116,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-MartialIdolofBattle-92128"
  value: {
-  dps: 48423.78508
+  dps: 48423.32187
   tps: 43641.84434
  }
 }
@@ -1270,7 +1270,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-PartisanIdolofBattle-92148"
  value: {
-  dps: 48423.11231
+  dps: 48423.54973
   tps: 43641.84434
  }
 }
@@ -1599,7 +1599,7 @@ dps_results: {
 dps_results: {
  key: "TestShadow-AllItems-ScourgeheartIdolofBattle-92167"
  value: {
-  dps: 48422.96117
+  dps: 48423.15659
   tps: 43641.84434
  }
 }

--- a/sim/rogue/assassination/TestAssassination.results
+++ b/sim/rogue/assassination/TestAssassination.results
@@ -1161,8 +1161,8 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-MartialIdolofBattle-92128"
  value: {
-  dps: 28165.14062
-  tps: 19997.24984
+  dps: 28298.16449
+  tps: 20091.69679
  }
 }
 dps_results: {
@@ -1315,8 +1315,8 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-PartisanIdolofBattle-92148"
  value: {
-  dps: 28164.07416
-  tps: 19996.49265
+  dps: 28299.10507
+  tps: 20092.3646
  }
 }
 dps_results: {
@@ -1625,8 +1625,8 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-ScourgeheartIdolofBattle-92167"
  value: {
-  dps: 28164.74256
-  tps: 19996.96721
+  dps: 28299.21868
+  tps: 20092.44526
  }
 }
 dps_results: {
@@ -1905,8 +1905,8 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-AllItems-TheHungerer-69112"
  value: {
-  dps: 29811.1709
-  tps: 21165.93134
+  dps: 29742.37137
+  tps: 21117.08367
  }
 }
 dps_results: {
@@ -2570,141 +2570,141 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-Assassination-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 37077.39132
-  tps: 26324.94784
+  dps: 36982.20295
+  tps: 26257.36409
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-Assassination-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 37077.39132
-  tps: 26324.94784
+  dps: 36982.20295
+  tps: 26257.36409
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-Assassination-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 49048.64861
-  tps: 34824.54051
+  dps: 49050.82278
+  tps: 34826.08417
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-Assassination-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 21894.38286
-  tps: 15545.01183
+  dps: 21942.12547
+  tps: 15578.90908
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-Assassination-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 21894.38286
-  tps: 15545.01183
+  dps: 21942.12547
+  tps: 15578.90908
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-Assassination-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 24553.31916
-  tps: 17432.8566
+  dps: 24562.95448
+  tps: 17439.69768
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 27828.69733
-  tps: 19758.37511
+  dps: 27799.87376
+  tps: 19737.91037
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 27828.69733
-  tps: 19758.37511
+  dps: 27799.87376
+  tps: 19737.91037
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 36961.21395
-  tps: 26242.46191
+  dps: 36965.53492
+  tps: 26245.5298
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 16522.39556
-  tps: 11730.90085
+  dps: 16558.99027
+  tps: 11756.88309
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 16522.39556
-  tps: 11730.90085
+  dps: 16558.99027
+  tps: 11756.88309
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 18879.17107
-  tps: 13404.21146
+  dps: 18882.81939
+  tps: 13406.80177
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 37832.48547
-  tps: 26861.06468
+  dps: 37768.74743
+  tps: 26815.81068
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 37832.48547
-  tps: 26861.06468
+  dps: 37768.74743
+  tps: 26815.81068
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 50107.10642
-  tps: 35576.04556
+  dps: 50109.28058
+  tps: 35577.58921
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 22332.42892
-  tps: 15856.02454
+  dps: 22341.29212
+  tps: 15862.3174
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 22332.42892
-  tps: 15856.02454
+  dps: 22341.29212
+  tps: 15862.3174
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 25010.13084
-  tps: 17757.1929
+  dps: 25022.64566
+  tps: 17766.07842
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 21944.79193
-  tps: 15580.80227
+  dps: 21932.89635
+  tps: 15572.35641
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 21944.79193
-  tps: 15580.80227
+  dps: 21932.89635
+  tps: 15572.35641
  }
 }
 dps_results: {
@@ -2717,22 +2717,22 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 12707.31899
-  tps: 9022.19648
+  dps: 12729.05576
+  tps: 9037.62959
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 12707.31899
-  tps: 9022.19648
+  dps: 12729.05576
+  tps: 9037.62959
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Human-p3_assassination-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 14116.02051
-  tps: 10022.37456
+  dps: 14122.53047
+  tps: 10026.99663
  }
 }
 dps_results: {
@@ -3074,141 +3074,141 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-Assassination-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 37406.91951
-  tps: 26558.91285
+  dps: 37321.63991
+  tps: 26498.36434
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-Assassination-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 37406.91951
-  tps: 26558.91285
+  dps: 37321.63991
+  tps: 26498.36434
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-Assassination-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 49753.70671
-  tps: 35325.13176
+  dps: 49755.88057
+  tps: 35326.6752
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-Assassination-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 22103.44555
-  tps: 15693.44634
+  dps: 22147.62168
+  tps: 15724.81139
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-Assassination-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 22103.44555
-  tps: 15693.44634
+  dps: 22147.62168
+  tps: 15724.81139
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-Assassination-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 24933.09343
-  tps: 17702.49634
+  dps: 24942.72712
+  tps: 17709.33625
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 28070.62246
-  tps: 19930.14195
+  dps: 28043.53296
+  tps: 19910.9084
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 28070.62246
-  tps: 19930.14195
+  dps: 28043.53296
+  tps: 19910.9084
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-MH Deadly OH Deadly-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 37496.20129
-  tps: 26622.30292
+  dps: 37500.52165
+  tps: 26625.37037
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 16677.1133
-  tps: 11840.75045
+  dps: 16712.06093
+  tps: 11865.56326
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 16677.1133
-  tps: 11840.75045
+  dps: 16712.06093
+  tps: 11865.56326
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-MH Deadly OH Deadly-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 19174.81894
-  tps: 13614.12145
+  dps: 19178.46673
+  tps: 13616.71138
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 38146.88795
-  tps: 27084.29045
+  dps: 38094.91102
+  tps: 27047.38682
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 38146.88795
-  tps: 27084.29045
+  dps: 38094.91102
+  tps: 27047.38682
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-MH Instant OH Deadly-mutilate-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 50827.70453
-  tps: 36087.67021
+  dps: 50829.87839
+  tps: 36089.21365
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 22546.42316
-  tps: 16007.96044
+  dps: 22551.91883
+  tps: 16011.86237
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 22546.42316
-  tps: 16007.96044
+  dps: 22551.91883
+  tps: 16011.86237
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-MH Instant OH Deadly-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 25397.18616
-  tps: 18032.00217
+  dps: 25409.69879
+  tps: 18040.88614
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 22144.72704
-  tps: 15722.7562
+  dps: 22137.88884
+  tps: 15717.90107
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-MH Instant OH Instant-mutilate-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 22144.72704
-  tps: 15722.7562
+  dps: 22137.88884
+  tps: 15717.90107
  }
 }
 dps_results: {
@@ -3221,22 +3221,22 @@ dps_results: {
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 12829.20338
-  tps: 9108.7344
+  dps: 12850.57183
+  tps: 9123.906
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 12829.20338
-  tps: 9108.7344
+  dps: 12850.57183
+  tps: 9123.906
  }
 }
 dps_results: {
  key: "TestAssassination-Settings-Orc-p3_assassination-MH Instant OH Instant-mutilate-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 14352.5114
-  tps: 10190.28309
+  dps: 14359.0203
+  tps: 10194.90441
  }
 }
 dps_results: {

--- a/sim/rogue/combat/TestCombat.results
+++ b/sim/rogue/combat/TestCombat.results
@@ -1145,8 +1145,8 @@ dps_results: {
 dps_results: {
  key: "TestCombat-AllItems-MartialIdolofBattle-92128"
  value: {
-  dps: 28519.14833
-  tps: 20248.59531
+  dps: 28652.97501
+  tps: 20343.61226
  }
 }
 dps_results: {
@@ -1320,8 +1320,8 @@ dps_results: {
 dps_results: {
  key: "TestCombat-AllItems-PartisanIdolofBattle-92148"
  value: {
-  dps: 28521.14233
-  tps: 20250.01106
+  dps: 28659.32083
+  tps: 20348.11779
  }
 }
 dps_results: {
@@ -1630,8 +1630,8 @@ dps_results: {
 dps_results: {
  key: "TestCombat-AllItems-ScourgeheartIdolofBattle-92167"
  value: {
-  dps: 28520.40879
-  tps: 20249.49024
+  dps: 28657.73842
+  tps: 20346.99428
  }
 }
 dps_results: {
@@ -1931,8 +1931,8 @@ dps_results: {
 dps_results: {
  key: "TestCombat-AllItems-TheHungerer-69112"
  value: {
-  dps: 30142.33761
-  tps: 21401.0597
+  dps: 30211.61575
+  tps: 21450.24718
  }
 }
 dps_results: {
@@ -2603,169 +2603,169 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Human-p3_combat-Combat-combat-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 36960.02689
-  tps: 26241.61909
+  dps: 37217.5033
+  tps: 26424.42734
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p3_combat-Combat-combat-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 37328.97648
-  tps: 26503.5733
+  dps: 37554.8081
+  tps: 26663.91375
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p3_combat-Combat-combat-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 44887.44159
-  tps: 31870.08353
+  dps: 44921.27752
+  tps: 31894.10704
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p3_combat-Combat-combat-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 21493.3247
-  tps: 15260.26053
+  dps: 21608.56421
+  tps: 15342.08059
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p3_combat-Combat-combat-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 21703.31174
-  tps: 15409.35134
+  dps: 21817.19549
+  tps: 15490.2088
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p3_combat-Combat-combat-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 22463.52119
-  tps: 15949.10005
+  dps: 22506.41311
+  tps: 15979.55331
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p3_combat-MH Deadly OH Deadly-combat-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 32603.73145
-  tps: 23148.64933
+  dps: 32742.15485
+  tps: 23246.92995
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p3_combat-MH Deadly OH Deadly-combat-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 32608.51126
-  tps: 23152.04299
+  dps: 32725.24461
+  tps: 23234.92368
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p3_combat-MH Deadly OH Deadly-combat-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 39212.53104
-  tps: 27840.89704
+  dps: 39237.79209
+  tps: 27858.83238
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p3_combat-MH Deadly OH Deadly-combat-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 19190.90698
-  tps: 13625.54396
+  dps: 19339.71417
+  tps: 13731.19706
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p3_combat-MH Deadly OH Deadly-combat-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 19126.60639
-  tps: 13579.89054
+  dps: 19267.41935
+  tps: 13679.86774
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p3_combat-MH Deadly OH Deadly-combat-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 19893.09929
-  tps: 14124.1005
+  dps: 19931.58699
+  tps: 14151.42676
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p3_combat-MH Deadly OH Instant-combat-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 35258.6541
-  tps: 25033.64441
+  dps: 35435.62638
+  tps: 25159.29473
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p3_combat-MH Deadly OH Instant-combat-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 35518.57859
-  tps: 25218.1908
+  dps: 35640.78987
+  tps: 25304.96081
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p3_combat-MH Deadly OH Instant-combat-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 42606.5243
-  tps: 30250.63225
+  dps: 42638.17179
+  tps: 30273.10197
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p3_combat-MH Deadly OH Instant-combat-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 20620.30958
-  tps: 14640.4198
+  dps: 20759.00534
+  tps: 14738.89379
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p3_combat-MH Deadly OH Instant-combat-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 20745.60509
-  tps: 14729.37962
+  dps: 20903.40962
+  tps: 14841.42083
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p3_combat-MH Deadly OH Instant-combat-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 21392.64075
-  tps: 15188.77493
+  dps: 21433.30351
+  tps: 15217.64549
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p3_combat-MH Instant OH Instant-combat-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 33975.60715
-  tps: 24122.68107
+  dps: 34162.25058
+  tps: 24255.19791
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p3_combat-MH Instant OH Instant-combat-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 34402.42073
-  tps: 24425.71872
+  dps: 34580.4982
+  tps: 24552.15372
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p3_combat-MH Instant OH Instant-combat-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 41955.72012
-  tps: 29788.56129
+  dps: 41987.29764
+  tps: 29810.98133
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p3_combat-MH Instant OH Instant-combat-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 19072.7259
-  tps: 13541.63539
+  dps: 19193.87194
+  tps: 13627.64907
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p3_combat-MH Instant OH Instant-combat-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 19247.01647
-  tps: 13665.38169
+  dps: 19366.68233
+  tps: 13750.34445
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Human-p3_combat-MH Instant OH Instant-combat-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 20143.28128
-  tps: 14301.72971
+  dps: 20176.89487
+  tps: 14325.59535
  }
 }
 dps_results: {
@@ -3107,169 +3107,169 @@ dps_results: {
 dps_results: {
  key: "TestCombat-Settings-Orc-p3_combat-Combat-combat-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 37263.40661
-  tps: 26457.01869
+  dps: 37526.06709
+  tps: 26643.50763
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p3_combat-Combat-combat-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 37636.5816
-  tps: 26721.97293
+  dps: 37865.35613
+  tps: 26884.40285
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p3_combat-Combat-combat-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 45488.44548
-  tps: 32296.79629
+  dps: 45522.27614
+  tps: 32320.81606
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p3_combat-Combat-combat-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 21687.6827
-  tps: 15398.25472
+  dps: 21801.01197
+  tps: 15478.7185
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p3_combat-Combat-combat-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 21898.60176
-  tps: 15548.00725
+  dps: 22010.29646
+  tps: 15627.31049
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p3_combat-Combat-combat-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 22819.904
-  tps: 16202.13184
+  dps: 22862.78901
+  tps: 16232.5802
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p3_combat-MH Deadly OH Deadly-combat-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 32869.46988
-  tps: 23337.32361
+  dps: 33011.47184
+  tps: 23438.14501
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p3_combat-MH Deadly OH Deadly-combat-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 32873.90507
-  tps: 23340.4726
+  dps: 32993.43612
+  tps: 23425.33964
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p3_combat-MH Deadly OH Deadly-combat-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 39741.85102
-  tps: 28216.71422
+  dps: 39767.10828
+  tps: 28234.64688
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p3_combat-MH Deadly OH Deadly-combat-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 19364.0745
-  tps: 13748.4929
+  dps: 19510.22662
+  tps: 13852.2609
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p3_combat-MH Deadly OH Deadly-combat-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 19297.02976
-  tps: 13700.89113
+  dps: 19435.30554
+  tps: 13799.06693
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p3_combat-MH Deadly OH Deadly-combat-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 20207.20125
-  tps: 14347.11289
+  dps: 20245.68283
+  tps: 14374.43481
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p3_combat-MH Deadly OH Instant-combat-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 35550.4391
-  tps: 25240.81176
+  dps: 35734.29518
+  tps: 25371.34958
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p3_combat-MH Deadly OH Instant-combat-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 35813.68623
-  tps: 25427.71722
+  dps: 35938.51724
+  tps: 25516.34724
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p3_combat-MH Deadly OH Instant-combat-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 43178.59112
-  tps: 30656.79969
+  dps: 43210.23372
+  tps: 30679.26594
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p3_combat-MH Deadly OH Instant-combat-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 20807.37505
-  tps: 14773.23628
+  dps: 20941.1752
+  tps: 14868.23439
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p3_combat-MH Deadly OH Instant-combat-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 20932.43803
-  tps: 14862.031
+  dps: 21086.76623
+  tps: 14971.60402
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p3_combat-MH Deadly OH Instant-combat-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 21729.83627
-  tps: 15428.18375
+  dps: 21770.49247
+  tps: 15457.04965
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p3_combat-MH Instant OH Instant-combat-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 34259.88653
-  tps: 24324.51943
+  dps: 34451.18297
+  tps: 24460.33991
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p3_combat-MH Instant OH Instant-combat-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 34691.21429
-  tps: 24630.76215
+  dps: 34872.67503
+  tps: 24759.59927
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p3_combat-MH Instant OH Instant-combat-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 42539.25927
-  tps: 30202.87408
+  dps: 42570.8319
+  tps: 30225.29065
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p3_combat-MH Instant OH Instant-combat-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 19247.12266
-  tps: 13665.45709
+  dps: 19366.60091
+  tps: 13750.28665
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p3_combat-MH Instant OH Instant-combat-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 19422.33796
-  tps: 13789.85995
+  dps: 19540.35491
+  tps: 13873.65198
  }
 }
 dps_results: {
  key: "TestCombat-Settings-Orc-p3_combat-MH Instant OH Instant-combat-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 20475.88481
-  tps: 14537.87822
+  dps: 20509.49315
+  tps: 14561.74013
  }
 }
 dps_results: {

--- a/sim/rogue/subtlety/TestSubtlety.results
+++ b/sim/rogue/subtlety/TestSubtlety.results
@@ -1124,8 +1124,8 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-MartialIdolofBattle-92128"
  value: {
-  dps: 25084.82302
-  tps: 17810.22434
+  dps: 25170.47861
+  tps: 17871.03981
  }
 }
 dps_results: {
@@ -1278,8 +1278,8 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-PartisanIdolofBattle-92148"
  value: {
-  dps: 25086.21997
-  tps: 17811.21618
+  dps: 25170.59657
+  tps: 17871.12357
  }
 }
 dps_results: {
@@ -1588,8 +1588,8 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-ScourgeheartIdolofBattle-92167"
  value: {
-  dps: 25094.48546
-  tps: 17817.08468
+  dps: 25179.84535
+  tps: 17877.6902
  }
 }
 dps_results: {
@@ -1868,8 +1868,8 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-AllItems-TheHungerer-69112"
  value: {
-  dps: 26658.1293
-  tps: 18927.2718
+  dps: 26706.87533
+  tps: 18961.88148
  }
 }
 dps_results: {
@@ -2533,169 +2533,169 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-Settings-Human-p3_subtlety-MH Deadly OH Deadly-subtlety-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 31099.15463
-  tps: 22080.39979
+  dps: 31194.03312
+  tps: 22147.76351
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p3_subtlety-MH Deadly OH Deadly-subtlety-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 31099.15463
-  tps: 22080.39979
+  dps: 31194.03312
+  tps: 22147.76351
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p3_subtlety-MH Deadly OH Deadly-subtlety-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 41340.68861
-  tps: 29351.88891
+  dps: 41373.10358
+  tps: 29374.90354
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p3_subtlety-MH Deadly OH Deadly-subtlety-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17723.66952
-  tps: 12583.80536
+  dps: 17741.20533
+  tps: 12596.25578
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p3_subtlety-MH Deadly OH Deadly-subtlety-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 17723.66952
-  tps: 12583.80536
+  dps: 17741.20533
+  tps: 12596.25578
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p3_subtlety-MH Deadly OH Deadly-subtlety-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 19973.37463
-  tps: 14181.09599
+  dps: 19980.33593
+  tps: 14186.03851
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p3_subtlety-MH Deadly OH Instant-subtlety-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 33481.47516
-  tps: 23771.84737
+  dps: 33563.06554
+  tps: 23829.77654
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p3_subtlety-MH Deadly OH Instant-subtlety-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 33481.47516
-  tps: 23771.84737
+  dps: 33563.06554
+  tps: 23829.77654
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p3_subtlety-MH Deadly OH Instant-subtlety-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 43984.87217
-  tps: 31229.25924
+  dps: 44023.30777
+  tps: 31256.54852
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p3_subtlety-MH Deadly OH Instant-subtlety-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 19118.45934
-  tps: 13574.10613
+  dps: 18993.79046
+  tps: 13485.59123
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p3_subtlety-MH Deadly OH Instant-subtlety-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 19118.45934
-  tps: 13574.10613
+  dps: 18993.79046
+  tps: 13485.59123
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p3_subtlety-MH Deadly OH Instant-subtlety-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 21390.33857
-  tps: 15187.14039
+  dps: 21399.78594
+  tps: 15193.84802
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p3_subtlety-MH Instant OH Instant-subtlety-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 31288.76213
-  tps: 22215.02111
+  dps: 31331.95286
+  tps: 22245.68653
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p3_subtlety-MH Instant OH Instant-subtlety-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 31288.76213
-  tps: 22215.02111
+  dps: 31331.95286
+  tps: 22245.68653
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p3_subtlety-MH Instant OH Instant-subtlety-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 41401.94754
-  tps: 29395.38276
+  dps: 41404.18153
+  tps: 29396.96889
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p3_subtlety-MH Instant OH Instant-subtlety-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17506.5786
-  tps: 12429.67081
+  dps: 17586.32146
+  tps: 12486.28824
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p3_subtlety-MH Instant OH Instant-subtlety-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 17506.5786
-  tps: 12429.67081
+  dps: 17586.32146
+  tps: 12486.28824
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p3_subtlety-MH Instant OH Instant-subtlety-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 19991.31169
-  tps: 14193.8313
+  dps: 19993.65546
+  tps: 14195.49538
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p3_subtlety-Subtlety-subtlety-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 33863.30534
-  tps: 24042.94679
+  dps: 33869.91505
+  tps: 24047.63969
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p3_subtlety-Subtlety-subtlety-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 33863.30534
-  tps: 24042.94679
+  dps: 33869.91505
+  tps: 24047.63969
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p3_subtlety-Subtlety-subtlety-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 43836.78782
-  tps: 31124.11935
+  dps: 43845.72631
+  tps: 31130.46568
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p3_subtlety-Subtlety-subtlety-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 19264.86601
-  tps: 13678.05487
+  dps: 19248.88166
+  tps: 13666.70598
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p3_subtlety-Subtlety-subtlety-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 19264.86601
-  tps: 13678.05487
+  dps: 19248.88166
+  tps: 13666.70598
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Human-p3_subtlety-Subtlety-subtlety-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 21482.63238
-  tps: 15252.66899
+  dps: 21493.11157
+  tps: 15260.10922
  }
 }
 dps_results: {
@@ -3037,169 +3037,169 @@ dps_results: {
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p3_subtlety-MH Deadly OH Deadly-subtlety-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 31360.55244
-  tps: 22265.99223
+  dps: 31470.78896
+  tps: 22344.26016
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p3_subtlety-MH Deadly OH Deadly-subtlety-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 31360.55244
-  tps: 22265.99223
+  dps: 31470.78896
+  tps: 22344.26016
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p3_subtlety-MH Deadly OH Deadly-subtlety-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 41852.04485
-  tps: 29714.95185
+  dps: 41884.45351
+  tps: 29737.96199
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p3_subtlety-MH Deadly OH Deadly-subtlety-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17889.34319
-  tps: 12701.43366
+  dps: 17903.263
+  tps: 12711.31673
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p3_subtlety-MH Deadly OH Deadly-subtlety-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 17889.34319
-  tps: 12701.43366
+  dps: 17903.263
+  tps: 12711.31673
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p3_subtlety-MH Deadly OH Deadly-subtlety-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 20284.40818
-  tps: 14401.92981
+  dps: 20291.3682
+  tps: 14406.87142
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p3_subtlety-MH Deadly OH Instant-subtlety-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 33767.58702
-  tps: 23974.98679
+  dps: 33844.79841
+  tps: 24029.80687
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p3_subtlety-MH Deadly OH Instant-subtlety-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 33767.58702
-  tps: 23974.98679
+  dps: 33844.79841
+  tps: 24029.80687
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p3_subtlety-MH Deadly OH Instant-subtlety-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 44530.32587
-  tps: 31616.53137
+  dps: 44568.75459
+  tps: 31643.81576
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p3_subtlety-MH Deadly OH Instant-subtlety-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 19292.78116
-  tps: 13697.87463
+  dps: 19168.43852
+  tps: 13609.59135
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p3_subtlety-MH Deadly OH Instant-subtlety-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 19292.78116
-  tps: 13697.87463
+  dps: 19168.43852
+  tps: 13609.59135
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p3_subtlety-MH Deadly OH Instant-subtlety-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 21716.73998
-  tps: 15418.88538
+  dps: 21726.18545
+  tps: 15425.59167
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p3_subtlety-MH Instant OH Instant-subtlety-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 31569.97269
-  tps: 22414.68061
+  dps: 31622.24305
+  tps: 22451.79256
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p3_subtlety-MH Instant OH Instant-subtlety-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 31569.97269
-  tps: 22414.68061
+  dps: 31622.24305
+  tps: 22451.79256
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p3_subtlety-MH Instant OH Instant-subtlety-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 41931.88936
-  tps: 29771.64144
+  dps: 41934.12227
+  tps: 29773.22682
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p3_subtlety-MH Instant OH Instant-subtlety-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 17664.44602
-  tps: 12541.75668
+  dps: 17747.08192
+  tps: 12600.42817
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p3_subtlety-MH Instant OH Instant-subtlety-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 17664.44602
-  tps: 12541.75668
+  dps: 17747.08192
+  tps: 12600.42817
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p3_subtlety-MH Instant OH Instant-subtlety-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 20313.25234
-  tps: 14422.40916
+  dps: 20315.59565
+  tps: 14424.07291
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p3_subtlety-Subtlety-subtlety-FullBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 34139.58227
-  tps: 24239.10341
+  dps: 34153.66323
+  tps: 24249.10089
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p3_subtlety-Subtlety-subtlety-FullBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 34139.58227
-  tps: 24239.10341
+  dps: 34153.66323
+  tps: 24249.10089
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p3_subtlety-Subtlety-subtlety-FullBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 44382.77035
-  tps: 31511.76695
+  dps: 44391.70729
+  tps: 31518.11217
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p3_subtlety-Subtlety-subtlety-NoBuffs-0.0yards-LongMultiTarget"
  value: {
-  dps: 19435.67378
-  tps: 13799.32838
+  dps: 19425.88181
+  tps: 13792.37608
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p3_subtlety-Subtlety-subtlety-NoBuffs-0.0yards-LongSingleTarget"
  value: {
-  dps: 19435.67378
-  tps: 13799.32838
+  dps: 19425.88181
+  tps: 13792.37608
  }
 }
 dps_results: {
  key: "TestSubtlety-Settings-Orc-p3_subtlety-Subtlety-subtlety-NoBuffs-0.0yards-ShortSingleTarget"
  value: {
-  dps: 21812.34956
-  tps: 15486.76818
+  dps: 21822.82677
+  tps: 15494.20701
  }
 }
 dps_results: {

--- a/sim/shaman/enhancement/TestEnhancement.results
+++ b/sim/shaman/enhancement/TestEnhancement.results
@@ -1138,8 +1138,8 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-MartialIdolofBattle-92128"
  value: {
-  dps: 46585.62896
-  tps: 30613.72622
+  dps: 46726.32434
+  tps: 30695.10451
  }
 }
 dps_results: {
@@ -1299,8 +1299,8 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-PartisanIdolofBattle-92148"
  value: {
-  dps: 46584.35017
-  tps: 30610.24933
+  dps: 46728.64359
+  tps: 30695.11812
  }
 }
 dps_results: {
@@ -1623,8 +1623,8 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-ScourgeheartIdolofBattle-92167"
  value: {
-  dps: 46591.51384
-  tps: 30615.33407
+  dps: 46734.73041
+  tps: 30698.37502
  }
 }
 dps_results: {
@@ -1924,8 +1924,8 @@ dps_results: {
 dps_results: {
  key: "TestEnhancement-AllItems-TheHungerer-69112"
  value: {
-  dps: 48124.12411
-  tps: 31512.85153
+  dps: 48222.87902
+  tps: 31635.09393
  }
 }
 dps_results: {

--- a/sim/warrior/arms/TestArms.results
+++ b/sim/warrior/arms/TestArms.results
@@ -1131,8 +1131,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-MartialIdolofBattle-92128"
  value: {
-  dps: 52002.07528
-  tps: 32877.00878
+  dps: 52318.00481
+  tps: 33093.84397
  }
 }
 dps_results: {
@@ -1313,8 +1313,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-PartisanIdolofBattle-92148"
  value: {
-  dps: 52016.38041
-  tps: 32888.51133
+  dps: 52322.59129
+  tps: 33101.02326
  }
 }
 dps_results: {
@@ -1609,8 +1609,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-ScourgeheartIdolofBattle-92167"
  value: {
-  dps: 51995.97148
-  tps: 32874.48019
+  dps: 52325.26408
+  tps: 33101.86141
  }
 }
 dps_results: {
@@ -1913,8 +1913,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-TheHungerer-69112"
  value: {
-  dps: 52225.80044
-  tps: 33046.2199
+  dps: 52145.57253
+  tps: 32888.35507
  }
 }
 dps_results: {

--- a/sim/warrior/fury/TestFury.results
+++ b/sim/warrior/fury/TestFury.results
@@ -11,7 +11,7 @@ character_stats_results: {
   final_stats: 412
   final_stats: 692
   final_stats: 0
-  final_stats: 2731.66357
+  final_stats: 2731.66358
   final_stats: 1315
   final_stats: 25247.454
   final_stats: 209
@@ -1152,8 +1152,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-MartialIdolofBattle-92128"
  value: {
-  dps: 59967.71458
-  tps: 41705.80245
+  dps: 60301.57965
+  tps: 41969.31293
  }
 }
 dps_results: {
@@ -1334,8 +1334,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-PartisanIdolofBattle-92148"
  value: {
-  dps: 59965.27994
-  tps: 41706.22435
+  dps: 60311.10195
+  tps: 41975.47351
  }
 }
 dps_results: {
@@ -1651,8 +1651,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-ScourgeheartIdolofBattle-92167"
  value: {
-  dps: 59954.7156
-  tps: 41694.93333
+  dps: 60312.73126
+  tps: 41976.62433
  }
 }
 dps_results: {
@@ -1952,8 +1952,8 @@ dps_results: {
 dps_results: {
  key: "TestFury-AllItems-TheHungerer-69112"
  value: {
-  dps: 60406.37943
-  tps: 42297.62628
+  dps: 60368.92052
+  tps: 42206.71855
  }
 }
 dps_results: {

--- a/sim/warrior/protection/TestProtectionWarrior.results
+++ b/sim/warrior/protection/TestProtectionWarrior.results
@@ -1292,8 +1292,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-MartialIdolofBattle-92128"
  value: {
-  dps: 6494.72595
-  tps: 38664.02399
+  dps: 6556.41922
+  tps: 39040.73443
   hps: 975.96349
  }
 }
@@ -1500,8 +1500,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-PartisanIdolofBattle-92148"
  value: {
-  dps: 6490.19902
-  tps: 38643.0145
+  dps: 6550.14456
+  tps: 39014.52126
   hps: 975.96349
  }
 }
@@ -1857,8 +1857,8 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-ScourgeheartIdolofBattle-92167"
  value: {
-  dps: 6487.81838
-  tps: 38638.50127
+  dps: 6545.18892
+  tps: 38985.95147
   hps: 975.96349
  }
 }
@@ -2177,9 +2177,9 @@ dps_results: {
 dps_results: {
  key: "TestProtectionWarrior-AllItems-TheHungerer-69112"
  value: {
-  dps: 6547.60829
-  tps: 38798.73433
-  hps: 1014.04987
+  dps: 6528.65922
+  tps: 38705.37402
+  hps: 1010.876
  }
 }
 dps_results: {


### PR DESCRIPTION
 On branch bugfix/fix-procs
 Changes to be committed:
	modified:   sim/common/cata/stat_bonus_procs.go
	modified:   sim/death_knight/blood/TestBlood.results
	modified:   sim/death_knight/frost/TestFrost.results
	modified:   sim/death_knight/unholy/TestUnholy.results
	modified:   sim/druid/feral/TestFeral.results
	modified:   sim/druid/guardian/TestGuardian.results
	modified:   sim/hunter/beast_mastery/TestBM.results
	modified:   sim/hunter/marksmanship/TestMM.results
	modified:   sim/hunter/survival/TestSV.results
	modified:   sim/mage/arcane/TestArcane.results
	modified:   sim/paladin/protection/TestProtection.results
	modified:   sim/paladin/retribution/TestRetribution.results
	modified:   sim/priest/shadow/TestShadow.results
	modified:   sim/rogue/assassination/TestAssassination.results
	modified:   sim/rogue/combat/TestCombat.results
	modified:   sim/rogue/subtlety/TestSubtlety.results
	modified:   sim/shaman/enhancement/TestEnhancement.results
	modified:   sim/warrior/arms/TestArms.results
	modified:   sim/warrior/fury/TestFury.results
	modified:   sim/warrior/protection/TestProtectionWarrior.results