### PR TITLE
More trinket fixes

### DIFF
--- a/sim/common/cata/stat_bonus_cds.go
+++ b/sim/common/cata/stat_bonus_cds.go
@@ -76,13 +76,13 @@ func init() {
 	shared.NewSpiritActive(58184, 1926, time.Second*20, time.Minute*2) // Core of Ripeness
 
 	// DODGE
-	shared.NewDodgeActive(67037, 512, time.Second*20, time.Minute*2)   // Binding Promise
-	shared.NewDodgeActive(52352, 1425, time.Second*20, time.Minute*2)  // Figurine - Earthen Guardian
-	shared.NewDodgeActive(59515, 1605, time.Second*20, time.Minute*2)  // Vial of Stolen Memories
-	shared.NewDodgeActive(65109, 1812, time.Second*20, time.Minute*2)  // Vial of Stolen Memories (Heroic)
-	shared.NewDodgeActive(70143, 1700, time.Second*20, time.Minute*2)  // Moonwell Phial
-	shared.NewDodgeActive(232015, 1520, time.Second*20, time.Minute*2) // Brawler's Trophy
-	shared.NewDodgeActive(77117, 2290, time.Second*15, time.Second*90) // Fire of the Deep 397 - Valor Points
+	shared.NewDodgeActive(67037, 512, time.Second*20, time.Minute*2)                                              // Binding Promise
+	shared.NewDodgeActive(52352, 1425, time.Second*20, time.Minute*2)                                             // Figurine - Earthen Guardian
+	shared.NewDodgeActive(59515, 1605, time.Second*20, time.Minute*2)                                             // Vial of Stolen Memories
+	shared.NewDodgeActive(65109, 1812, time.Second*20, time.Minute*2)                                             // Vial of Stolen Memories (Heroic)
+	shared.NewDodgeActive(70143, 1700, time.Second*20, time.Minute*2)                                             // Moonwell Phial
+	shared.NewDodgeActive(232015, 1520, time.Second*20, time.Minute*2)                                            // Brawler's Trophy
+	shared.CreateDefensiveStatActive(77117, time.Second*15, time.Second*90, stats.Stats{stats.DodgeRating: 2290}) // Fire of the Deep 397 - Valor Points - somehow on a different shared CD than the others
 
 	// SpellPower
 	shared.NewSpellPowerActive(61429, 970, time.Second*15, time.Second*90)  // Insignia of the Earthen Lord
@@ -107,10 +107,10 @@ func init() {
 	shared.NewHealthActive(64741, 15315, time.Second*15, time.Minute*2) // Bloodthirsty Gladiator's Emblem of Meditation
 	shared.NewHealthActive(64742, 15315, time.Second*15, time.Minute*2) // Bloodthirsty Gladiator's Emblem of Tenacity
 	shared.NewHealthActive(62048, 15500, time.Second*15, time.Minute*3) // Darkmoon Card: Earthquake
-	shared.NewHealthActive(61026, 16169, time.Second*15, time.Minute*3) // Vicious Gladiator's Emblem of Cruelty
+	shared.NewHealthActive(61026, 16169, time.Second*15, time.Minute*2) // Vicious Gladiator's Emblem of Cruelty
 	shared.NewHealthActive(61028, 16169, time.Second*15, time.Minute*3) // Vicious Gladiator's Emblem of Alacrity
 	shared.NewHealthActive(61029, 16169, time.Second*15, time.Minute*3) // Vicious Gladiator's Emblem of Prowess
-	shared.NewHealthActive(61032, 16169, time.Second*15, time.Minute*3) // Vicious Gladiator's Emblem of Tenacity
+	shared.NewHealthActive(61032, 16169, time.Second*15, time.Minute*2) // Vicious Gladiator's Emblem of Tenacity
 	shared.NewHealthActive(61030, 16169, time.Second*15, time.Minute*3) // Vicious Gladiator's Emblem of Proficiency
 	shared.NewHealthActive(61027, 16169, time.Second*15, time.Minute*3) // Vicious Gladiator's Emblem of Accuracy
 

--- a/sim/death_knight/blood/TestBlood.results
+++ b/sim/death_knight/blood/TestBlood.results
@@ -950,8 +950,8 @@ dps_results: {
 dps_results: {
  key: "TestBlood-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 21869.41602
-  tps: 110028.37918
+  dps: 21971.2473
+  tps: 110542.97145
   hps: 5300.29889
  }
 }
@@ -2768,7 +2768,7 @@ dps_results: {
  value: {
   dps: 22332.07157
   tps: 112492.08978
-  hps: 5396.86183
+  hps: 5410.71328
  }
 }
 dps_results: {
@@ -2792,7 +2792,7 @@ dps_results: {
  value: {
   dps: 21971.2473
   tps: 110542.97145
-  hps: 5387.28811
+  hps: 5401.05871
  }
 }
 dps_results: {

--- a/sim/death_knight/frost/TestFrost.results
+++ b/sim/death_knight/frost/TestFrost.results
@@ -942,9 +942,9 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 49632.07294
-  tps: 47023.3423
-  hps: 1672.55772
+  dps: 49485.49175
+  tps: 46899.47879
+  hps: 1665.75456
  }
 }
 dps_results: {
@@ -2822,9 +2822,9 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 49059.07867
-  tps: 46426.61428
-  hps: 1690.16931
+  dps: 49062.95174
+  tps: 46430.48735
+  hps: 1700.98756
  }
 }
 dps_results: {
@@ -2846,9 +2846,9 @@ dps_results: {
 dps_results: {
  key: "TestFrost-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 48439.03387
-  tps: 45853.02091
-  hps: 1678.72387
+  dps: 48442.90694
+  tps: 45856.89398
+  hps: 1689.38043
  }
 }
 dps_results: {

--- a/sim/druid/feral/TestFeral.results
+++ b/sim/druid/feral/TestFeral.results
@@ -2790,8 +2790,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 48762.46853
-  tps: 66789.20398
+  dps: 48849.0874
+  tps: 67451.80921
   hps: 26.77086
  }
 }
@@ -2814,8 +2814,8 @@ dps_results: {
 dps_results: {
  key: "TestFeral-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 48168.62291
-  tps: 66190.43828
+  dps: 48166.51575
+  tps: 67182.30583
   hps: 26.77086
  }
 }

--- a/sim/druid/guardian/TestGuardian.results
+++ b/sim/druid/guardian/TestGuardian.results
@@ -944,7 +944,7 @@ dps_results: {
  value: {
   dps: 10601.44821
   tps: 53073.64564
-  hps: 355.12858
+  hps: 353.52167
  }
 }
 dps_results: {

--- a/sim/hunter/beast_mastery/TestBM.results
+++ b/sim/hunter/beast_mastery/TestBM.results
@@ -858,8 +858,8 @@ dps_results: {
 dps_results: {
  key: "TestBM-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 24503.31526
-  tps: 15038.17019
+  dps: 24504.50008
+  tps: 15036.94784
  }
 }
 dps_results: {

--- a/sim/hunter/marksmanship/TestMM.results
+++ b/sim/hunter/marksmanship/TestMM.results
@@ -858,8 +858,8 @@ dps_results: {
 dps_results: {
  key: "TestMM-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 22955.31529
-  tps: 20665.61764
+  dps: 22918.86308
+  tps: 20640.17538
  }
 }
 dps_results: {

--- a/sim/mage/arcane/TestArcane.results
+++ b/sim/mage/arcane/TestArcane.results
@@ -830,8 +830,8 @@ dps_results: {
 dps_results: {
  key: "TestArcane-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 34692.45873
-  tps: 31993.29568
+  dps: 34691.32635
+  tps: 31962.84729
  }
 }
 dps_results: {

--- a/sim/paladin/retribution/TestRetribution.results
+++ b/sim/paladin/retribution/TestRetribution.results
@@ -837,8 +837,8 @@ dps_results: {
 dps_results: {
  key: "TestRetribution-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 47517.12601
-  tps: 44980.22972
+  dps: 47544.68695
+  tps: 45018.91424
  }
 }
 dps_results: {

--- a/sim/shaman/elemental/TestElemental.results
+++ b/sim/shaman/elemental/TestElemental.results
@@ -837,8 +837,8 @@ dps_results: {
 dps_results: {
  key: "TestElemental-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 48049.34327
-  tps: 627.24903
+  dps: 48197.59845
+  tps: 632.53476
  }
 }
 dps_results: {

--- a/sim/warlock/affliction/TestAffliction.results
+++ b/sim/warlock/affliction/TestAffliction.results
@@ -809,8 +809,8 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 43836.36811
-  tps: 30316.96293
+  dps: 43828.38411
+  tps: 30267.61431
  }
 }
 dps_results: {
@@ -2323,8 +2323,8 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofCruelty-61026"
  value: {
-  dps: 43791.62663
-  tps: 30094.25072
+  dps: 43755.79666
+  tps: 30038.72501
  }
 }
 dps_results: {
@@ -2344,8 +2344,8 @@ dps_results: {
 dps_results: {
  key: "TestAffliction-AllItems-ViciousGladiator'sEmblemofTenacity-61032"
  value: {
-  dps: 43159.31148
-  tps: 29652.05834
+  dps: 43112.99234
+  tps: 29593.00783
  }
 }
 dps_results: {

--- a/sim/warlock/demonology/TestDemonology.results
+++ b/sim/warlock/demonology/TestDemonology.results
@@ -809,8 +809,8 @@ dps_results: {
 dps_results: {
  key: "TestDemonology-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 45378.51102
-  tps: 21583.25853
+  dps: 45381.30718
+  tps: 21587.3664
  }
 }
 dps_results: {

--- a/sim/warlock/destruction/TestDestruction.results
+++ b/sim/warlock/destruction/TestDestruction.results
@@ -809,8 +809,8 @@ dps_results: {
 dps_results: {
  key: "TestDestruction-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 46700.29901
-  tps: 27306.0139
+  dps: 46797.53963
+  tps: 27324.4604
  }
 }
 dps_results: {

--- a/sim/warrior/arms/TestArms.results
+++ b/sim/warrior/arms/TestArms.results
@@ -830,8 +830,8 @@ dps_results: {
 dps_results: {
  key: "TestArms-AllItems-FireoftheDeep-77117"
  value: {
-  dps: 51204.23029
-  tps: 32398.76273
+  dps: 51304.82696
+  tps: 32433.9826
  }
 }
 dps_results: {


### PR DESCRIPTION
Fixed CD details for Fire of the Deep, Vicious Gladiator's Emblem of Cruelty, and Vicious Gladiator's Emblem of Tenacity.

 On branch bugfix/fix-trinkets
 Changes to be committed:
	modified:   sim/common/cata/stat_bonus_cds.go
	modified:   sim/death_knight/blood/TestBlood.results
	modified:   sim/death_knight/frost/TestFrost.results
	modified:   sim/druid/feral/TestFeral.results
	modified:   sim/druid/guardian/TestGuardian.results
	modified:   sim/hunter/beast_mastery/TestBM.results
	modified:   sim/hunter/marksmanship/TestMM.results
	modified:   sim/mage/arcane/TestArcane.results
	modified:   sim/paladin/retribution/TestRetribution.results
	modified:   sim/shaman/elemental/TestElemental.results
	modified:   sim/warlock/affliction/TestAffliction.results
	modified:   sim/warlock/demonology/TestDemonology.results
	modified:   sim/warlock/destruction/TestDestruction.results
	modified:   sim/warrior/arms/TestArms.results